### PR TITLE
fix: sync saved_to_playlist flag after all seeders complete

### DIFF
--- a/src/chronovista/services/seeding/playlist_membership_seeder.py
+++ b/src/chronovista/services/seeding/playlist_membership_seeder.py
@@ -22,7 +22,6 @@ from ...models.video import VideoCreate
 from ...repositories.channel_repository import ChannelRepository
 from ...repositories.playlist_membership_repository import PlaylistMembershipRepository
 from ...repositories.playlist_repository import PlaylistRepository
-from ...repositories.user_video_repository import UserVideoRepository
 from ...repositories.video_repository import VideoRepository
 from .base_seeder import BaseSeeder, ProgressCallback, SeedResult
 
@@ -45,7 +44,6 @@ class PlaylistMembershipSeeder(BaseSeeder):
         self.video_repo = VideoRepository()
         self.playlist_repo = PlaylistRepository()
         self.channel_repo = ChannelRepository()
-        self.user_video_repo = UserVideoRepository()
 
     def get_data_type(self) -> str:
         return "playlist_memberships"
@@ -173,13 +171,6 @@ class PlaylistMembershipSeeder(BaseSeeder):
                 logger.error(f"Failed to process playlist {playlist.name}: {e}")
                 result.failed += len(playlist.videos)
                 result.errors.append(f"Playlist {playlist.name}: {str(e)}")
-
-        # Sync saved_to_playlist flags in user_videos table
-        # This updates user_videos.saved_to_playlist=True for videos that are in playlists
-        synced_count = await self.user_video_repo.sync_saved_to_playlist_flags(session)
-        await session.commit()
-        if synced_count > 0:
-            logger.info(f"🔄 Synced saved_to_playlist flag for {synced_count} user videos")
 
         # Calculate duration
         result.duration_seconds = (datetime.now() - start_time).total_seconds()


### PR DESCRIPTION
## Summary

The `saved_to_playlist` field in `user_videos` was always `false` because the sync was running during `PlaylistMembershipSeeder` **before** `user_videos` were seeded.

## Root Cause

Seeding order: `playlist_memberships` could run before `user_videos` since they don't depend on each other. The sync was inside `PlaylistMembershipSeeder.seed()`, so it ran before any `user_videos` existed.

## Fix

Moved the sync to `SeedingOrchestrator` so it runs **after all seeders complete**.

## Changes

- **`orchestrator.py`**: Added post-seeding sync that only runs when both `user_videos` and `playlist_memberships` are processed
- **`playlist_membership_seeder.py`**: Removed sync call and `UserVideoRepository` dependency
- **Tests**: Moved sync tests from seeder to orchestrator

## Verification

After fix: **17,986 user_videos** correctly have `saved_to_playlist = true`

## Test Plan

- [x] Unit tests pass (3041 tests)
- [x] Database verification with fresh seed
- [x] Confirmed `saved_to_playlist = true` count matches videos in playlists