### PR TITLE
refactor: Exception hierarchy with domain-specific errors (v0.5.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.5.0"
+version = "0.5.1"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "MIT"

--- a/src/chronovista/exceptions.py
+++ b/src/chronovista/exceptions.py
@@ -209,10 +209,209 @@ class PrerequisiteError(ChronovistaError):
         super().__init__(message)
 
 
+class YouTubeAPIError(ChronovistaError):
+    """
+    Exception raised for YouTube API errors.
+
+    This exception wraps errors returned by the YouTube Data API,
+    including client errors (4xx) and server errors (5xx) that are
+    not specifically quota-related.
+
+    Attributes
+    ----------
+    message : str
+        Human-readable error message.
+    status_code : int | None
+        HTTP status code returned by the API.
+    error_reason : str | None
+        The error reason from the API response (e.g., "videoNotFound").
+
+    Examples
+    --------
+    >>> try:
+    ...     video = await youtube_service.get_video(video_id)
+    ... except YouTubeAPIError as e:
+    ...     if e.status_code == 404:
+    ...         print(f"Video not found: {e.error_reason}")
+    """
+
+    def __init__(
+        self,
+        message: str = "YouTube API error occurred",
+        status_code: int | None = None,
+        error_reason: str | None = None,
+    ) -> None:
+        """
+        Initialize YouTubeAPIError.
+
+        Parameters
+        ----------
+        message : str, optional
+            Human-readable error message (default: "YouTube API error occurred").
+        status_code : int | None, optional
+            HTTP status code returned by the API (default: None).
+        error_reason : str | None, optional
+            The error reason from the API response (default: None).
+        """
+        self.status_code: int | None = status_code
+        self.error_reason: str | None = error_reason
+        super().__init__(message)
+
+
+class AuthenticationError(ChronovistaError):
+    """
+    Exception raised for authentication-related failures.
+
+    This exception is raised when OAuth authentication fails,
+    tokens are expired or invalid, or required scopes are missing.
+
+    Attributes
+    ----------
+    message : str
+        Human-readable error message.
+    expired : bool
+        Whether the authentication token has expired.
+    scope : str | None
+        The OAuth scope that caused the error, if applicable.
+
+    Examples
+    --------
+    >>> try:
+    ...     credentials = await oauth_service.get_credentials()
+    ... except AuthenticationError as e:
+    ...     if e.expired:
+    ...         print("Token expired, please re-authenticate")
+    ...     raise typer.Exit(5)
+    """
+
+    def __init__(
+        self,
+        message: str = "Authentication failed",
+        expired: bool = False,
+        scope: str | None = None,
+    ) -> None:
+        """
+        Initialize AuthenticationError.
+
+        Parameters
+        ----------
+        message : str, optional
+            Human-readable error message (default: "Authentication failed").
+        expired : bool, optional
+            Whether the authentication token has expired (default: False).
+        scope : str | None, optional
+            The OAuth scope that caused the error (default: None).
+        """
+        self.expired: bool = expired
+        self.scope: str | None = scope
+        super().__init__(message)
+
+
+class ValidationError(ChronovistaError):
+    """
+    Exception raised for data validation failures.
+
+    This exception is raised when input data fails validation,
+    either from user input, API responses, or database constraints.
+
+    Attributes
+    ----------
+    message : str
+        Human-readable error message.
+    field_name : str | None
+        The name of the field that failed validation.
+    invalid_value : object
+        The value that failed validation.
+
+    Examples
+    --------
+    >>> try:
+    ...     video = VideoCreate.model_validate(data)
+    ... except ValidationError as e:
+    ...     print(f"Invalid {e.field_name}: {e.invalid_value}")
+    """
+
+    def __init__(
+        self,
+        message: str = "Validation failed",
+        field_name: str | None = None,
+        invalid_value: object = None,
+    ) -> None:
+        """
+        Initialize ValidationError.
+
+        Parameters
+        ----------
+        message : str, optional
+            Human-readable error message (default: "Validation failed").
+        field_name : str | None, optional
+            The name of the field that failed validation (default: None).
+        invalid_value : object, optional
+            The value that failed validation (default: None).
+        """
+        self.field_name: str | None = field_name
+        self.invalid_value: object = invalid_value
+        super().__init__(message)
+
+
+class RepositoryError(ChronovistaError):
+    """
+    Exception raised for repository/database operation failures.
+
+    This exception wraps database-related errors such as connection
+    failures, constraint violations, and query errors.
+
+    Attributes
+    ----------
+    message : str
+        Human-readable error message.
+    operation : str | None
+        The database operation that failed (e.g., "insert", "update", "delete").
+    entity_type : str | None
+        The type of entity involved (e.g., "Video", "Channel").
+    original_error : Exception | None
+        The original database exception that caused this error.
+
+    Examples
+    --------
+    >>> try:
+    ...     await video_repository.create(session, video_create)
+    ... except RepositoryError as e:
+    ...     print(f"Failed to {e.operation} {e.entity_type}: {e.message}")
+    """
+
+    def __init__(
+        self,
+        message: str = "Repository operation failed",
+        operation: str | None = None,
+        entity_type: str | None = None,
+        original_error: Exception | None = None,
+    ) -> None:
+        """
+        Initialize RepositoryError.
+
+        Parameters
+        ----------
+        message : str, optional
+            Human-readable error message (default: "Repository operation failed").
+        operation : str | None, optional
+            The database operation that failed (default: None).
+        entity_type : str | None, optional
+            The type of entity involved (default: None).
+        original_error : Exception | None, optional
+            The original database exception (default: None).
+        """
+        self.operation: str | None = operation
+        self.entity_type: str | None = entity_type
+        self.original_error: Exception | None = original_error
+        super().__init__(message)
+
+
 # Exit codes for CLI integration
 EXIT_CODE_SUCCESS = 0
 EXIT_CODE_GENERAL_ERROR = 1
 EXIT_CODE_INVALID_ARGS = 2
 EXIT_CODE_QUOTA_EXCEEDED = 3
 EXIT_CODE_PREREQUISITES_MISSING = 4
+EXIT_CODE_AUTHENTICATION_FAILED = 5
 EXIT_CODE_INTERRUPTED = 130  # Standard Unix signal interrupt exit code

--- a/src/chronovista/parsers/takeout_parser.py
+++ b/src/chronovista/parsers/takeout_parser.py
@@ -16,6 +16,8 @@ from urllib.parse import parse_qs, urlparse
 
 from pydantic import BaseModel, Field
 
+from chronovista.exceptions import ValidationError
+
 
 class WatchHistoryEntry(BaseModel):
     """
@@ -139,10 +141,18 @@ class TakeoutParser:
             with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
         except (json.JSONDecodeError, FileNotFoundError) as e:
-            raise ValueError(f"Failed to parse JSON file {file_path}: {e}")
+            raise ValidationError(
+                message=f"Failed to parse JSON file {file_path}: {e}",
+                field_name="file_path",
+                invalid_value=str(file_path),
+            ) from e
 
         if not isinstance(data, list):
-            raise ValueError("Expected JSON array at root level")
+            raise ValidationError(
+                message="Expected JSON array at root level",
+                field_name="data",
+                invalid_value=type(data).__name__,
+            )
 
         for i, entry in enumerate(data):
             try:

--- a/tests/unit/auth/test_oauth_service.py
+++ b/tests/unit/auth/test_oauth_service.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, Mock, mock_open, patch
 import pytest
 
 from chronovista.auth.oauth_service import YouTubeOAuthService
+from chronovista.exceptions import AuthenticationError
 
 
 class TestYouTubeOAuthService:
@@ -101,7 +102,7 @@ class TestYouTubeOAuthService:
         mock_urlparse.return_value.query = "state=wrong_state"
         mock_parse_qs.return_value = {"state": ["wrong_state"]}
 
-        with pytest.raises(ValueError, match="Invalid state parameter"):
+        with pytest.raises(AuthenticationError, match="Invalid state parameter"):
             oauth_service.authorize_from_callback(
                 "http://localhost:8080?state=wrong_state", "expected_state"
             )
@@ -118,7 +119,7 @@ class TestYouTubeOAuthService:
             "state": ["test_state"],
         }
 
-        with pytest.raises(ValueError, match="Authorization denied: access_denied"):
+        with pytest.raises(AuthenticationError, match="Authorization denied: access_denied"):
             oauth_service.authorize_from_callback(
                 "http://localhost:8080?error=access_denied&state=test_state",
                 "test_state",
@@ -359,7 +360,7 @@ class TestYouTubeOAuthService:
         """Test getting authenticated service when not authenticated."""
         oauth_service.is_authenticated = MagicMock(return_value=False)
 
-        with pytest.raises(ValueError, match="Not authenticated"):
+        with pytest.raises(AuthenticationError, match="Not authenticated"):
             oauth_service.get_authenticated_service()
 
     @patch("chronovista.auth.oauth_service.webbrowser.open")
@@ -534,7 +535,7 @@ class TestYouTubeOAuthServiceInteractive:
         """Test get_authenticated_service when not authenticated."""
         oauth_service.is_authenticated = MagicMock(return_value=False)
 
-        with pytest.raises(ValueError, match="Not authenticated"):
+        with pytest.raises(AuthenticationError, match="Not authenticated"):
             oauth_service.get_authenticated_service()
 
     @patch("chronovista.auth.oauth_service.build")

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import pytest
 from typer.testing import CliRunner
 
+from chronovista import __version__
 from chronovista.cli.main import app
 
 
@@ -20,7 +21,7 @@ def test_cli_version(runner):
     """Test version command."""
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
-    assert "chronovista v0.1.0" in result.stdout
+    assert f"chronovista v{__version__}" in result.stdout
 
 
 def test_cli_help(runner):

--- a/tests/unit/parsers/test_takeout_parser.py
+++ b/tests/unit/parsers/test_takeout_parser.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List
 
 import pytest
 
+from chronovista.exceptions import ValidationError
 from chronovista.parsers.takeout_parser import TakeoutParser, WatchHistoryEntry
 
 
@@ -377,7 +378,7 @@ class TestTakeoutParserFileProcessing:
         file_path = Path(temp_file.name)
 
         try:
-            with pytest.raises(ValueError, match="Failed to parse JSON file"):
+            with pytest.raises(ValidationError, match="Failed to parse JSON file"):
                 list(TakeoutParser.parse_watch_history_file(file_path))
         finally:
             file_path.unlink()
@@ -386,7 +387,7 @@ class TestTakeoutParserFileProcessing:
         """Test parsing non-existent file."""
         file_path = Path("/nonexistent/file.json")
 
-        with pytest.raises(ValueError, match="Failed to parse JSON file"):
+        with pytest.raises(ValidationError, match="Failed to parse JSON file"):
             list(TakeoutParser.parse_watch_history_file(file_path))
 
     def test_parse_watch_history_file_not_array(self):
@@ -398,7 +399,7 @@ class TestTakeoutParserFileProcessing:
         file_path = Path(temp_file.name)
 
         try:
-            with pytest.raises(ValueError, match="Expected JSON array at root level"):
+            with pytest.raises(ValidationError, match="Expected JSON array at root level"):
                 list(TakeoutParser.parse_watch_history_file(file_path))
         finally:
             file_path.unlink()

--- a/tests/unit/services/test_seeding_orchestrator.py
+++ b/tests/unit/services/test_seeding_orchestrator.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from chronovista.exceptions import ValidationError
 from chronovista.services.seeding.base_seeder import (
     BaseSeeder,
     ProgressCallback,
@@ -152,7 +153,7 @@ class TestSeedingOrchestrator:
         seeder2 = MockSeeder("type2", dependencies={"type1"})
         orchestrator.register_seeder(seeder2)
 
-        with pytest.raises(ValueError, match="Missing dependencies.*type1"):
+        with pytest.raises(ValidationError, match="Missing dependencies.*type1"):
             orchestrator._resolve_dependencies({"type2"})
 
     def test_dependency_resolution_circular_dependency(self, orchestrator):
@@ -164,7 +165,7 @@ class TestSeedingOrchestrator:
         orchestrator.register_seeder(seeder1)
         orchestrator.register_seeder(seeder2)
 
-        with pytest.raises(ValueError, match="Circular dependency detected"):
+        with pytest.raises(ValidationError, match="Circular dependency detected"):
             orchestrator._resolve_dependencies({"type1", "type2"})
 
     def test_dependency_resolution_partial_request(self, orchestrator):

--- a/tests/unit/services/test_youtube_service.py
+++ b/tests/unit/services/test_youtube_service.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from chronovista.exceptions import ValidationError, YouTubeAPIError
 from chronovista.services.youtube_service import YouTubeService
 
 pytestmark = pytest.mark.asyncio
@@ -304,7 +305,7 @@ class TestYouTubeService:
         mock_request.execute.return_value = mock_response
         mock_service_client.channels.return_value.list.return_value = mock_request
 
-        with pytest.raises(ValueError, match="No channel found for authenticated user"):
+        with pytest.raises(YouTubeAPIError, match="No channel found for authenticated user"):
             await youtube_service.get_my_channel()
 
     @pytest.mark.asyncio
@@ -348,7 +349,7 @@ class TestYouTubeService:
         mock_request.execute.return_value = mock_response
         mock_service_client.channels.return_value.list.return_value = mock_request
 
-        with pytest.raises(ValueError, match="Channels? UCnonexistent not found"):
+        with pytest.raises(YouTubeAPIError, match="Channels? UCnonexistent not found"):
             await youtube_service.get_channel_details("UCnonexistent")
 
     @pytest.mark.asyncio
@@ -766,7 +767,7 @@ class TestYouTubeServiceEdgeCases:
         video_ids = [f"video{i}" for i in range(100)]
 
         with pytest.raises(
-            ValueError, match="Maximum 50 video IDs allowed per request"
+            ValidationError, match="Maximum 50 video IDs allowed per request"
         ):
             await youtube_service.get_video_details(video_ids)
 
@@ -823,7 +824,7 @@ class TestYouTubeServiceEdgeCases:
         mock_request.execute.return_value = mock_response
         mock_service_client.channels.return_value.list.return_value = mock_request
 
-        with pytest.raises(ValueError, match="No channel found for authenticated user"):
+        with pytest.raises(YouTubeAPIError, match="No channel found for authenticated user"):
             await youtube_service.get_my_channel()
 
     @pytest.mark.asyncio
@@ -959,7 +960,7 @@ class TestYouTubeServiceMissingCoverage:
         mock_request.execute.return_value = mock_response
         mock_service_client.channels.return_value.list.return_value = mock_request
 
-        with pytest.raises(ValueError, match="Channel UCnonexistent not found"):
+        with pytest.raises(YouTubeAPIError, match="Channel UCnonexistent not found"):
             await youtube_service.get_channel_videos("UCnonexistent")
 
     @pytest.mark.asyncio
@@ -1197,12 +1198,12 @@ class TestYouTubeServiceMissingCoverage:
     async def test_get_video_categories_invalid_region_code(self, youtube_service):
         """Test video categories with invalid region code."""
         with pytest.raises(
-            ValueError, match="Invalid region code: ABC. Must be 2 characters"
+            ValidationError, match="Invalid region code: ABC. Must be 2 characters"
         ):
             await youtube_service.get_video_categories("ABC")
 
         with pytest.raises(
-            ValueError, match="Invalid region code: A. Must be 2 characters"
+            ValidationError, match="Invalid region code: A. Must be 2 characters"
         ):
             await youtube_service.get_video_categories("A")
 
@@ -1222,9 +1223,9 @@ class TestYouTubeServiceMissingCoverage:
         # Set mock service
         youtube_service._service = mock_service_client
 
-        # Should raise ValueError
+        # Should raise YouTubeAPIError
         with pytest.raises(
-            ValueError, match="No video categories found for region: US"
+            YouTubeAPIError, match="No video categories found for region: US"
         ):
             await youtube_service.get_video_categories("US")
 
@@ -1243,9 +1244,9 @@ class TestYouTubeServiceMissingCoverage:
         # Set mock service
         youtube_service._service = mock_service_client
 
-        # Should raise ValueError with wrapped error
+        # Should raise YouTubeAPIError with wrapped error
         with pytest.raises(
-            ValueError,
+            YouTubeAPIError,
             match="Failed to fetch video categories for region US: API quota exceeded",
         ):
             await youtube_service.get_video_categories("US")

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,416 @@
+"""
+Tests for custom exceptions module.
+
+This module tests all custom exception classes, their attributes,
+inheritance hierarchy, and exit codes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chronovista.exceptions import (
+    EXIT_CODE_AUTHENTICATION_FAILED,
+    EXIT_CODE_GENERAL_ERROR,
+    EXIT_CODE_INTERRUPTED,
+    EXIT_CODE_INVALID_ARGS,
+    EXIT_CODE_PREREQUISITES_MISSING,
+    EXIT_CODE_QUOTA_EXCEEDED,
+    EXIT_CODE_SUCCESS,
+    AuthenticationError,
+    ChronovistaError,
+    GracefulShutdownException,
+    NetworkError,
+    PrerequisiteError,
+    QuotaExceededException,
+    RepositoryError,
+    ValidationError,
+    YouTubeAPIError,
+)
+
+
+class TestChronovistaError:
+    """Tests for base ChronovistaError exception."""
+
+    def test_base_error_with_message(self) -> None:
+        """Test base error stores message correctly."""
+        error = ChronovistaError("Test error message")
+        assert error.message == "Test error message"
+        assert str(error) == "Test error message"
+
+    def test_base_error_inherits_from_exception(self) -> None:
+        """Test ChronovistaError inherits from Exception."""
+        assert issubclass(ChronovistaError, Exception)
+
+    def test_base_error_can_be_raised(self) -> None:
+        """Test ChronovistaError can be raised and caught."""
+        with pytest.raises(ChronovistaError, match="Test error"):
+            raise ChronovistaError("Test error")
+
+
+class TestQuotaExceededException:
+    """Tests for QuotaExceededException."""
+
+    def test_default_values(self) -> None:
+        """Test default attribute values."""
+        error = QuotaExceededException()
+        assert error.message == "YouTube API quota exceeded"
+        assert error.daily_quota_exceeded is True
+        assert error.videos_processed == 0
+
+    def test_custom_values(self) -> None:
+        """Test custom attribute values."""
+        error = QuotaExceededException(
+            message="Custom quota message",
+            daily_quota_exceeded=False,
+            videos_processed=42,
+        )
+        assert error.message == "Custom quota message"
+        assert error.daily_quota_exceeded is False
+        assert error.videos_processed == 42
+
+    def test_inherits_from_chronovista_error(self) -> None:
+        """Test QuotaExceededException inherits from ChronovistaError."""
+        assert issubclass(QuotaExceededException, ChronovistaError)
+        error = QuotaExceededException()
+        assert isinstance(error, ChronovistaError)
+
+    def test_can_be_caught_as_base_error(self) -> None:
+        """Test exception can be caught as base ChronovistaError."""
+        with pytest.raises(ChronovistaError):
+            raise QuotaExceededException()
+
+
+class TestNetworkError:
+    """Tests for NetworkError exception."""
+
+    def test_default_values(self) -> None:
+        """Test default attribute values."""
+        error = NetworkError()
+        assert error.message == "Network error occurred"
+        assert error.original_error is None
+        assert error.retry_count == 0
+
+    def test_custom_values(self) -> None:
+        """Test custom attribute values."""
+        original = ConnectionError("Connection failed")
+        error = NetworkError(
+            message="Custom network error",
+            original_error=original,
+            retry_count=3,
+        )
+        assert error.message == "Custom network error"
+        assert error.original_error is original
+        assert error.retry_count == 3
+
+    def test_inherits_from_chronovista_error(self) -> None:
+        """Test NetworkError inherits from ChronovistaError."""
+        assert issubclass(NetworkError, ChronovistaError)
+
+
+class TestGracefulShutdownException:
+    """Tests for GracefulShutdownException."""
+
+    def test_default_values(self) -> None:
+        """Test default attribute values."""
+        error = GracefulShutdownException()
+        assert error.message == "Graceful shutdown requested"
+        assert error.signal_received == "SIGINT"
+
+    def test_custom_values(self) -> None:
+        """Test custom attribute values."""
+        error = GracefulShutdownException(
+            message="Shutdown via SIGTERM",
+            signal_received="SIGTERM",
+        )
+        assert error.message == "Shutdown via SIGTERM"
+        assert error.signal_received == "SIGTERM"
+
+    def test_inherits_from_chronovista_error(self) -> None:
+        """Test GracefulShutdownException inherits from ChronovistaError."""
+        assert issubclass(GracefulShutdownException, ChronovistaError)
+
+
+class TestPrerequisiteError:
+    """Tests for PrerequisiteError exception."""
+
+    def test_default_values(self) -> None:
+        """Test default attribute values."""
+        error = PrerequisiteError()
+        assert error.message == "Prerequisite data is missing"
+        assert error.missing_tables == []
+
+    def test_custom_values(self) -> None:
+        """Test custom attribute values."""
+        error = PrerequisiteError(
+            message="Missing required tables",
+            missing_tables=["topic_categories", "video_categories"],
+        )
+        assert error.message == "Missing required tables"
+        assert error.missing_tables == ["topic_categories", "video_categories"]
+
+    def test_none_missing_tables_becomes_empty_list(self) -> None:
+        """Test None missing_tables defaults to empty list."""
+        error = PrerequisiteError(missing_tables=None)
+        assert error.missing_tables == []
+
+    def test_inherits_from_chronovista_error(self) -> None:
+        """Test PrerequisiteError inherits from ChronovistaError."""
+        assert issubclass(PrerequisiteError, ChronovistaError)
+
+
+class TestYouTubeAPIError:
+    """Tests for YouTubeAPIError exception."""
+
+    def test_default_values(self) -> None:
+        """Test default attribute values."""
+        error = YouTubeAPIError()
+        assert error.message == "YouTube API error occurred"
+        assert error.status_code is None
+        assert error.error_reason is None
+
+    def test_custom_values(self) -> None:
+        """Test custom attribute values."""
+        error = YouTubeAPIError(
+            message="Video not found",
+            status_code=404,
+            error_reason="videoNotFound",
+        )
+        assert error.message == "Video not found"
+        assert error.status_code == 404
+        assert error.error_reason == "videoNotFound"
+
+    def test_inherits_from_chronovista_error(self) -> None:
+        """Test YouTubeAPIError inherits from ChronovistaError."""
+        assert issubclass(YouTubeAPIError, ChronovistaError)
+
+    def test_can_be_caught_as_base_error(self) -> None:
+        """Test exception can be caught as base ChronovistaError."""
+        with pytest.raises(ChronovistaError):
+            raise YouTubeAPIError(status_code=403)
+
+    def test_status_code_types(self) -> None:
+        """Test various HTTP status codes."""
+        # Client errors
+        error_400 = YouTubeAPIError(status_code=400, error_reason="badRequest")
+        assert error_400.status_code == 400
+
+        # Not found
+        error_404 = YouTubeAPIError(status_code=404, error_reason="notFound")
+        assert error_404.status_code == 404
+
+        # Server errors
+        error_500 = YouTubeAPIError(status_code=500, error_reason="internalError")
+        assert error_500.status_code == 500
+
+
+class TestAuthenticationError:
+    """Tests for AuthenticationError exception."""
+
+    def test_default_values(self) -> None:
+        """Test default attribute values."""
+        error = AuthenticationError()
+        assert error.message == "Authentication failed"
+        assert error.expired is False
+        assert error.scope is None
+
+    def test_custom_values(self) -> None:
+        """Test custom attribute values."""
+        error = AuthenticationError(
+            message="Token expired",
+            expired=True,
+            scope="https://www.googleapis.com/auth/youtube.readonly",
+        )
+        assert error.message == "Token expired"
+        assert error.expired is True
+        assert error.scope == "https://www.googleapis.com/auth/youtube.readonly"
+
+    def test_inherits_from_chronovista_error(self) -> None:
+        """Test AuthenticationError inherits from ChronovistaError."""
+        assert issubclass(AuthenticationError, ChronovistaError)
+
+    def test_expired_token_scenario(self) -> None:
+        """Test typical expired token error."""
+        error = AuthenticationError(
+            message="Access token has expired",
+            expired=True,
+        )
+        assert error.expired is True
+        assert error.scope is None
+
+    def test_missing_scope_scenario(self) -> None:
+        """Test typical missing scope error."""
+        error = AuthenticationError(
+            message="Missing required scope",
+            expired=False,
+            scope="https://www.googleapis.com/auth/youtube.force-ssl",
+        )
+        assert error.expired is False
+        assert "force-ssl" in (error.scope or "")
+
+
+class TestValidationError:
+    """Tests for ValidationError exception."""
+
+    def test_default_values(self) -> None:
+        """Test default attribute values."""
+        error = ValidationError()
+        assert error.message == "Validation failed"
+        assert error.field_name is None
+        assert error.invalid_value is None
+
+    def test_custom_values(self) -> None:
+        """Test custom attribute values."""
+        error = ValidationError(
+            message="Invalid video ID format",
+            field_name="video_id",
+            invalid_value="invalid-id-format",
+        )
+        assert error.message == "Invalid video ID format"
+        assert error.field_name == "video_id"
+        assert error.invalid_value == "invalid-id-format"
+
+    def test_inherits_from_chronovista_error(self) -> None:
+        """Test ValidationError inherits from ChronovistaError."""
+        assert issubclass(ValidationError, ChronovistaError)
+
+    def test_various_invalid_value_types(self) -> None:
+        """Test invalid_value can be any type."""
+        # String value
+        error_str = ValidationError(field_name="title", invalid_value="")
+        assert error_str.invalid_value == ""
+
+        # Integer value
+        error_int = ValidationError(field_name="count", invalid_value=-1)
+        assert error_int.invalid_value == -1
+
+        # None value
+        error_none = ValidationError(field_name="required_field", invalid_value=None)
+        assert error_none.invalid_value is None
+
+        # List value
+        error_list = ValidationError(field_name="tags", invalid_value=[])
+        assert error_list.invalid_value == []
+
+
+class TestRepositoryError:
+    """Tests for RepositoryError exception."""
+
+    def test_default_values(self) -> None:
+        """Test default attribute values."""
+        error = RepositoryError()
+        assert error.message == "Repository operation failed"
+        assert error.operation is None
+        assert error.entity_type is None
+        assert error.original_error is None
+
+    def test_custom_values(self) -> None:
+        """Test custom attribute values."""
+        original = ValueError("Constraint violation")
+        error = RepositoryError(
+            message="Failed to insert video",
+            operation="insert",
+            entity_type="Video",
+            original_error=original,
+        )
+        assert error.message == "Failed to insert video"
+        assert error.operation == "insert"
+        assert error.entity_type == "Video"
+        assert error.original_error is original
+
+    def test_inherits_from_chronovista_error(self) -> None:
+        """Test RepositoryError inherits from ChronovistaError."""
+        assert issubclass(RepositoryError, ChronovistaError)
+
+    def test_various_operations(self) -> None:
+        """Test various database operations."""
+        operations = ["insert", "update", "delete", "select", "upsert"]
+        for op in operations:
+            error = RepositoryError(operation=op)
+            assert error.operation == op
+
+    def test_various_entity_types(self) -> None:
+        """Test various entity types."""
+        entities = ["Video", "Channel", "Playlist", "UserVideo", "Transcript"]
+        for entity in entities:
+            error = RepositoryError(entity_type=entity)
+            assert error.entity_type == entity
+
+
+class TestExitCodes:
+    """Tests for CLI exit codes."""
+
+    def test_exit_code_values(self) -> None:
+        """Test exit code values are correct."""
+        assert EXIT_CODE_SUCCESS == 0
+        assert EXIT_CODE_GENERAL_ERROR == 1
+        assert EXIT_CODE_INVALID_ARGS == 2
+        assert EXIT_CODE_QUOTA_EXCEEDED == 3
+        assert EXIT_CODE_PREREQUISITES_MISSING == 4
+        assert EXIT_CODE_AUTHENTICATION_FAILED == 5
+        assert EXIT_CODE_INTERRUPTED == 130
+
+    def test_exit_codes_are_unique(self) -> None:
+        """Test all exit codes have unique values."""
+        exit_codes = [
+            EXIT_CODE_SUCCESS,
+            EXIT_CODE_GENERAL_ERROR,
+            EXIT_CODE_INVALID_ARGS,
+            EXIT_CODE_QUOTA_EXCEEDED,
+            EXIT_CODE_PREREQUISITES_MISSING,
+            EXIT_CODE_AUTHENTICATION_FAILED,
+            EXIT_CODE_INTERRUPTED,
+        ]
+        assert len(exit_codes) == len(set(exit_codes))
+
+    def test_interrupted_follows_unix_convention(self) -> None:
+        """Test interrupted exit code follows Unix convention (128 + signal)."""
+        # SIGINT is signal 2, so 128 + 2 = 130
+        assert EXIT_CODE_INTERRUPTED == 130
+
+
+class TestExceptionHierarchy:
+    """Tests for exception inheritance hierarchy."""
+
+    def test_all_exceptions_inherit_from_base(self) -> None:
+        """Test all custom exceptions inherit from ChronovistaError."""
+        exception_classes = [
+            QuotaExceededException,
+            NetworkError,
+            GracefulShutdownException,
+            PrerequisiteError,
+            YouTubeAPIError,
+            AuthenticationError,
+            ValidationError,
+            RepositoryError,
+        ]
+        for exc_class in exception_classes:
+            assert issubclass(exc_class, ChronovistaError), (
+                f"{exc_class.__name__} does not inherit from ChronovistaError"
+            )
+
+    def test_exception_message_propagation(self) -> None:
+        """Test message propagation through inheritance chain."""
+        error = YouTubeAPIError("Custom message")
+        # Message accessible via attribute
+        assert error.message == "Custom message"
+        # Message accessible via str()
+        assert str(error) == "Custom message"
+        # Message accessible via args
+        assert error.args[0] == "Custom message"
+
+    def test_catching_with_base_class(self) -> None:
+        """Test all exceptions can be caught with base class."""
+        exceptions_to_raise = [
+            QuotaExceededException("quota"),
+            NetworkError("network"),
+            GracefulShutdownException("shutdown"),
+            PrerequisiteError("prereq"),
+            YouTubeAPIError("api"),
+            AuthenticationError("auth"),
+            ValidationError("validation"),
+            RepositoryError("repo"),
+        ]
+        for exc in exceptions_to_raise:
+            with pytest.raises(ChronovistaError):
+                raise exc


### PR DESCRIPTION
## Summary

- Add domain-specific exception classes: `YouTubeAPIError`, `AuthenticationError`, `ValidationError`, `RepositoryError`
- Integrate exceptions into services (youtube_service, oauth_service, takeout_parser, orchestrator, seeders)
- Add `EXIT_CODE_AUTHENTICATION_FAILED = 5` for CLI error handling
- Bump version to v0.5.1

## Changes

| File | Changes |
|------|---------|
| `exceptions.py` | 4 new exception classes with typed attributes |
| `youtube_service.py` | API errors → `YouTubeAPIError`, input validation → `ValidationError` |
| `oauth_service.py` | Auth failures → `AuthenticationError` |
| `takeout_parser.py` | Parse errors → `ValidationError` |
| `orchestrator.py` | Config errors → `ValidationError` |
| `seeders.py` | Graceful degradation handles `YouTubeAPIError` |

## Test plan

- [x] All 3238 unit tests passing
- [x] All files pass `mypy --strict`
- [x] Exception tests cover inheritance, attributes, exit codes