### PR TITLE
chore: Complete type safety cleanup (P0-2, P2-6)

### DIFF
--- a/src/chronovista/repositories/channel_topic_repository.py
+++ b/src/chronovista/repositories/channel_topic_repository.py
@@ -30,19 +30,17 @@ class ChannelTopicRepository(
     def __init__(self) -> None:
         super().__init__(ChannelTopicDB)
 
-    async def get(self, session: AsyncSession, id: Any) -> Optional[ChannelTopicDB]:
+    async def get(
+        self, session: AsyncSession, id: Tuple[str, str]
+    ) -> Optional[ChannelTopicDB]:
         """Get channel topic by composite key tuple (channel_id, topic_id)."""
-        if isinstance(id, tuple) and len(id) == 2:
-            channel_id, topic_id = id
-            return await self.get_by_composite_key(session, channel_id, topic_id)
-        return None
+        channel_id, topic_id = id
+        return await self.get_by_composite_key(session, channel_id, topic_id)
 
-    async def exists(self, session: AsyncSession, id: Any) -> bool:
+    async def exists(self, session: AsyncSession, id: Tuple[str, str]) -> bool:
         """Check if channel topic exists by composite key tuple (channel_id, topic_id)."""
-        if isinstance(id, tuple) and len(id) == 2:
-            channel_id, topic_id = id
-            return await self.exists_by_composite_key(session, channel_id, topic_id)
-        return False
+        channel_id, topic_id = id
+        return await self.exists_by_composite_key(session, channel_id, topic_id)
 
     async def get_by_composite_key(
         self, session: AsyncSession, channel_id: str, topic_id: str

--- a/src/chronovista/repositories/video_localization_repository.py
+++ b/src/chronovista/repositories/video_localization_repository.py
@@ -39,20 +39,16 @@ class VideoLocalizationRepository(
         super().__init__(VideoLocalizationDB)
 
     async def get(
-        self, session: AsyncSession, id: Any
+        self, session: AsyncSession, id: Tuple[str, str]
     ) -> Optional[VideoLocalizationDB]:
         """Get video localization by composite key tuple (video_id, language_code)."""
-        if isinstance(id, tuple) and len(id) == 2:
-            video_id, language_code = id
-            return await self.get_by_composite_key(session, video_id, language_code)
-        return None
+        video_id, language_code = id
+        return await self.get_by_composite_key(session, video_id, language_code)
 
-    async def exists(self, session: AsyncSession, id: Any) -> bool:
+    async def exists(self, session: AsyncSession, id: Tuple[str, str]) -> bool:
         """Check if video localization exists by composite key tuple (video_id, language_code)."""
-        if isinstance(id, tuple) and len(id) == 2:
-            video_id, language_code = id
-            return await self.exists_by_composite_key(session, video_id, language_code)
-        return False
+        video_id, language_code = id
+        return await self.exists_by_composite_key(session, video_id, language_code)
 
     async def get_by_composite_key(
         self, session: AsyncSession, video_id: str, language_code: str

--- a/src/chronovista/repositories/video_tag_repository.py
+++ b/src/chronovista/repositories/video_tag_repository.py
@@ -31,19 +31,17 @@ class VideoTagRepository(
     def __init__(self) -> None:
         super().__init__(VideoTagDB)
 
-    async def get(self, session: AsyncSession, id: Any) -> Optional[VideoTagDB]:
+    async def get(
+        self, session: AsyncSession, id: Tuple[str, str]
+    ) -> Optional[VideoTagDB]:
         """Get video tag by composite key tuple (video_id, tag)."""
-        if isinstance(id, tuple) and len(id) == 2:
-            video_id, tag = id
-            return await self.get_by_composite_key(session, video_id, tag)
-        return None
+        video_id, tag = id
+        return await self.get_by_composite_key(session, video_id, tag)
 
-    async def exists(self, session: AsyncSession, id: Any) -> bool:
+    async def exists(self, session: AsyncSession, id: Tuple[str, str]) -> bool:
         """Check if video tag exists by composite key tuple (video_id, tag)."""
-        if isinstance(id, tuple) and len(id) == 2:
-            video_id, tag = id
-            return await self.exists_by_composite_key(session, video_id, tag)
-        return False
+        video_id, tag = id
+        return await self.exists_by_composite_key(session, video_id, tag)
 
     async def get_by_composite_key(
         self, session: AsyncSession, video_id: str, tag: str

--- a/src/chronovista/repositories/video_topic_repository.py
+++ b/src/chronovista/repositories/video_topic_repository.py
@@ -31,19 +31,17 @@ class VideoTopicRepository(
     def __init__(self) -> None:
         super().__init__(VideoTopicDB)
 
-    async def get(self, session: AsyncSession, id: Any) -> Optional[VideoTopicDB]:
+    async def get(
+        self, session: AsyncSession, id: Tuple[str, str]
+    ) -> Optional[VideoTopicDB]:
         """Get video topic by composite key tuple (video_id, topic_id)."""
-        if isinstance(id, tuple) and len(id) == 2:
-            video_id, topic_id = id
-            return await self.get_by_composite_key(session, video_id, topic_id)
-        return None
+        video_id, topic_id = id
+        return await self.get_by_composite_key(session, video_id, topic_id)
 
-    async def exists(self, session: AsyncSession, id: Any) -> bool:
+    async def exists(self, session: AsyncSession, id: Tuple[str, str]) -> bool:
         """Check if video topic exists by composite key tuple (video_id, topic_id)."""
-        if isinstance(id, tuple) and len(id) == 2:
-            video_id, topic_id = id
-            return await self.exists_by_composite_key(session, video_id, topic_id)
-        return False
+        video_id, topic_id = id
+        return await self.exists_by_composite_key(session, video_id, topic_id)
 
     async def get_by_composite_key(
         self, session: AsyncSession, video_id: str, topic_id: str

--- a/src/chronovista/services/youtube_service.py
+++ b/src/chronovista/services/youtube_service.py
@@ -21,6 +21,7 @@ from googleapiclient.errors import HttpError
 from pydantic import ValidationError as PydanticValidationError
 
 from chronovista.auth import youtube_oauth
+from chronovista.config.settings import settings
 from chronovista.exceptions import (
     NetworkError,
     QuotaExceededException,
@@ -42,8 +43,9 @@ from chronovista.models.youtube_types import ChannelId, PlaylistId, VideoId
 logger = logging.getLogger(__name__)
 
 # Retry configuration for transient failures (FR-052)
-MAX_RETRIES = 3
-RETRY_DELAYS = [1.0, 2.0, 4.0]  # Exponential backoff: 1s, 2s, 4s
+# Uses settings.retry_attempts and settings.retry_backoff for configurability
+MAX_RETRIES = settings.retry_attempts
+RETRY_DELAYS = [1.0 * (settings.retry_backoff**i) for i in range(settings.retry_attempts)]
 
 # HTTP status codes
 HTTP_BAD_REQUEST = 400

--- a/tests/unit/repositories/test_channel_topic_repository.py
+++ b/tests/unit/repositories/test_channel_topic_repository.py
@@ -378,14 +378,7 @@ class TestChannelTopicRepository:
             mock_session, TestIds.TEST_CHANNEL_1, TestIds.MUSIC_TOPIC
         )
 
-    @pytest.mark.asyncio
-    async def test_get_with_invalid_id(self, repository, mock_session):
-        """Test get method with invalid ID format."""
-        result = await repository.get(mock_session, "invalid_id")
-        assert result is None
-
-        result = await repository.get(mock_session, ("single_element",))
-        assert result is None
+    # Note: test_get_with_invalid_id removed - type system now enforces Tuple[str, str]
 
     @pytest.mark.asyncio
     async def test_exists_with_valid_tuple(self, repository, mock_session):
@@ -401,14 +394,7 @@ class TestChannelTopicRepository:
             mock_session, TestIds.TEST_CHANNEL_1, TestIds.MUSIC_TOPIC
         )
 
-    @pytest.mark.asyncio
-    async def test_exists_with_invalid_id(self, repository, mock_session):
-        """Test exists method with invalid ID format."""
-        result = await repository.exists(mock_session, "invalid_id")
-        assert result is False
-
-        result = await repository.exists(mock_session, ("single_element",))
-        assert result is False
+    # Note: test_exists_with_invalid_id removed - type system now enforces Tuple[str, str]
 
     @pytest.mark.asyncio
     async def test_replace_channel_topics(self, repository, mock_session):

--- a/tests/unit/repositories/test_topic_category_repository.py
+++ b/tests/unit/repositories/test_topic_category_repository.py
@@ -288,6 +288,7 @@ class TestTopicCategoryRepository:
             MagicMock(scalar=lambda: 0),  # root_topics
             empty_result,  # type_result
             empty_result,  # popular_result
+            MagicMock(scalar=lambda: 0),  # parent_count (for avg_children calc)
         ]
 
         result = await repository.get_topic_statistics(mock_session)
@@ -297,6 +298,8 @@ class TestTopicCategoryRepository:
         assert result.root_topics == 0
         assert result.topic_type_distribution == {}
         assert result.most_popular_topics == []
+        assert result.avg_children_per_topic == 0.0
+        assert result.max_hierarchy_depth == 0
 
     @pytest.mark.asyncio
     async def test_delete_by_topic_id(

--- a/tests/unit/repositories/test_video_localization_repository.py
+++ b/tests/unit/repositories/test_video_localization_repository.py
@@ -145,16 +145,7 @@ class TestVideoLocalizationRepository:
         # Assert
         assert result == expected_localization
 
-    @pytest.mark.asyncio
-    async def test_get_with_invalid_id(
-        self, repository: VideoLocalizationRepository, mock_session: AsyncMock
-    ):
-        """Test get method with invalid ID format."""
-        # Act
-        result = await repository.get(mock_session, "invalid_id")
-
-        # Assert
-        assert result is None
+    # Note: test_get_with_invalid_id removed - type system now enforces Tuple[str, str]
 
     @pytest.mark.asyncio
     async def test_exists_by_composite_key_true(

--- a/tests/unit/repositories/test_video_tag_repository.py
+++ b/tests/unit/repositories/test_video_tag_repository.py
@@ -599,14 +599,7 @@ class TestVideoTagRepositoryIntegration:
             assert result is not None
             mock_get.assert_called_once_with(mock_session, "dQw4w9WgXcQ", "music")
 
-    @pytest.mark.asyncio
-    async def test_base_get_with_invalid_key(
-        self, repository: VideoTagRepository, mock_session: MagicMock
-    ):
-        """Test base get method with invalid key format."""
-        result = await repository.get(mock_session, "invalid_key")
-
-        assert result is None
+    # Note: test_base_get_with_invalid_key removed - type system now enforces Tuple[str, str]
 
     @pytest.mark.asyncio
     async def test_base_exists_with_composite_key(

--- a/tests/unit/repositories/test_video_topic_repository.py
+++ b/tests/unit/repositories/test_video_topic_repository.py
@@ -377,14 +377,7 @@ class TestVideoTopicRepository:
             mock_session, TestIds.TEST_VIDEO_1, TestIds.MUSIC_TOPIC
         )
 
-    @pytest.mark.asyncio
-    async def test_get_with_invalid_id(self, repository, mock_session):
-        """Test get method with invalid ID format."""
-        result = await repository.get(mock_session, "invalid_id")
-        assert result is None
-
-        result = await repository.get(mock_session, ("single_element",))
-        assert result is None
+    # Note: test_get_with_invalid_id removed - type system now enforces Tuple[str, str]
 
     @pytest.mark.asyncio
     async def test_exists_with_valid_tuple(self, repository, mock_session):
@@ -400,14 +393,7 @@ class TestVideoTopicRepository:
             mock_session, TestIds.TEST_VIDEO_1, TestIds.MUSIC_TOPIC
         )
 
-    @pytest.mark.asyncio
-    async def test_exists_with_invalid_id(self, repository, mock_session):
-        """Test exists method with invalid ID format."""
-        result = await repository.exists(mock_session, "invalid_id")
-        assert result is False
-
-        result = await repository.exists(mock_session, ("single_element",))
-        assert result is False
+    # Note: test_exists_with_invalid_id removed - type system now enforces Tuple[str, str]
 
     @pytest.mark.asyncio
     async def test_replace_video_topics(self, repository, mock_session):


### PR DESCRIPTION
## Summary

- **P0-2**: Fix 4 repository ID types from `id: Any` → `id: Tuple[str, str]`
- **P2-6**: Wire retry settings (`settings.retry_attempts`, `settings.retry_backoff`) in youtube_service.py
- **Bonus**: Implement `avg_children_per_topic` calculation in topic_category_repository

## Changes

| File | Change |
|------|--------|
| `video_tag_repository.py` | `id: Any` → `id: Tuple[str, str]` |
| `video_topic_repository.py` | `id: Any` → `id: Tuple[str, str]` |
| `channel_topic_repository.py` | `id: Any` → `id: Tuple[str, str]` |
| `video_localization_repository.py` | `id: Any` → `id: Tuple[str, str]` |
| `youtube_service.py` | Use `settings.retry_*` instead of hardcoded values |
| `topic_category_repository.py` | Implement actual `avg_children_per_topic` calc |

## Test Updates

- Removed 6 tests for invalid ID formats (type system now prevents invalid calls at compile-time)
- Updated `test_get_topic_statistics_no_data` to account for new query

## Test plan

- [x] All 3294 tests passing
- [x] `mypy --strict` passes on all modified files
- [x] No version bump needed (internal refactoring only)