### PR TITLE
refactor(playlists): make channel_id nullable for user playlists (P2-9)

### DIFF
--- a/src/chronovista/cli/commands/playlist.py
+++ b/src/chronovista/cli/commands/playlist.py
@@ -439,8 +439,10 @@ def _display_playlist_details(playlist: PlaylistDB) -> None:
     if hasattr(playlist, "channel") and playlist.channel:
         channel_info = f"{playlist.channel_id} ({playlist.channel.title})"
         details_lines.append(f"Channel:        {channel_info}")
-    else:
+    elif playlist.channel_id:
         details_lines.append(f"Channel:        {playlist.channel_id}")
+    else:
+        details_lines.append("Channel:        (not linked - user playlist from Takeout)")
 
     details_lines.extend(
         [

--- a/src/chronovista/cli/sync/transformers.py
+++ b/src/chronovista/cli/sync/transformers.py
@@ -309,7 +309,7 @@ class DataTransformers:
             description=snippet.description if snippet else None,
             default_language=default_language,
             privacy_status=privacy_status,
-            channel_id=snippet.channel_id if snippet else "",
+            channel_id=snippet.channel_id if snippet else None,
             video_count=video_count,
             published_at=published_at,
         )

--- a/src/chronovista/db/migrations/versions/a58e6cd3c0ce_make_playlist_channel_id_nullable.py
+++ b/src/chronovista/db/migrations/versions/a58e6cd3c0ce_make_playlist_channel_id_nullable.py
@@ -1,0 +1,128 @@
+"""make playlist channel_id nullable
+
+Revision ID: a58e6cd3c0ce
+Revises: 634986073757
+Create Date: 2026-01-25 05:47:55.891174
+
+This migration makes the channel_id column in playlists table nullable to support
+system playlists that are not associated with any specific channel.
+
+Changes:
+1. ALTER playlists.channel_id to allow NULL values
+2. UPDATE playlists to set channel_id=NULL for placeholder channel (UC7cf78b0e4c29369fd64711)
+3. DELETE the placeholder channel record after updating playlists
+
+The foreign key constraint to channels.channel_id is preserved, just allows NULL.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a58e6cd3c0ce"
+down_revision = "634986073757"
+branch_labels = None
+depends_on = None
+
+# Configure logging
+logger = logging.getLogger("alembic.runtime.migration")
+
+# Placeholder channel ID to be removed
+PLACEHOLDER_CHANNEL_ID = "UC7cf78b0e4c29369fd64711"
+
+
+def upgrade() -> None:
+    """
+    Make playlist.channel_id nullable and clean up placeholder channel.
+
+    Steps:
+    1. Make channel_id column nullable
+    2. Set channel_id to NULL for all playlists using placeholder channel
+    3. Delete the placeholder channel record (now safe since no FK references)
+    """
+    logger.info("Starting make_playlist_channel_id_nullable migration (a58e6cd3c0ce)")
+
+    # Step 1: Make channel_id nullable
+    logger.info("Making playlists.channel_id nullable")
+    op.alter_column(
+        "playlists",
+        "channel_id",
+        existing_type=sa.String(24),
+        nullable=True,
+    )
+    logger.info("playlists.channel_id is now nullable")
+
+    # Step 2: Update playlists to set placeholder channel_id to NULL
+    logger.info(
+        f"Setting channel_id=NULL for playlists using placeholder channel {PLACEHOLDER_CHANNEL_ID}"
+    )
+    connection = op.get_bind()
+    result = connection.execute(
+        sa.text(
+            """
+            UPDATE playlists
+            SET channel_id = NULL
+            WHERE channel_id = :placeholder_id
+        """
+        ),
+        {"placeholder_id": PLACEHOLDER_CHANNEL_ID},
+    )
+    rows_updated = result.rowcount
+    logger.info(f"Updated {rows_updated} playlist(s) to have NULL channel_id")
+
+    # Step 3: Delete the placeholder channel
+    logger.info(f"Deleting placeholder channel {PLACEHOLDER_CHANNEL_ID}")
+    result = connection.execute(
+        sa.text(
+            """
+            DELETE FROM channels
+            WHERE channel_id = :placeholder_id
+        """
+        ),
+        {"placeholder_id": PLACEHOLDER_CHANNEL_ID},
+    )
+    rows_deleted = result.rowcount
+    logger.info(f"Deleted {rows_deleted} placeholder channel record(s)")
+
+    logger.info("Migration completed successfully - channel_id is now nullable")
+
+
+def downgrade() -> None:
+    """
+    Make playlist.channel_id NOT NULL again.
+
+    WARNING: This operation will FAIL if any playlists have NULL channel_id.
+    This is expected behavior - downgrade is not supported if NULL values exist.
+
+    To manually downgrade:
+    1. Ensure all playlists have a valid channel_id
+    2. Then run: ALTER TABLE playlists ALTER COLUMN channel_id SET NOT NULL
+    """
+    logger.info(
+        "Starting rollback of make_playlist_channel_id_nullable migration (a58e6cd3c0ce)"
+    )
+
+    logger.warning(
+        "WARNING: Downgrade will FAIL if any playlists have NULL channel_id"
+    )
+    logger.warning(
+        "You must manually assign channel_id values before downgrading"
+    )
+
+    # Attempt to make column NOT NULL (will fail if NULL values exist)
+    logger.info("Making playlists.channel_id NOT NULL")
+    op.alter_column(
+        "playlists",
+        "channel_id",
+        existing_type=sa.String(24),
+        nullable=False,
+    )
+
+    logger.info(
+        "Rollback completed - channel_id is now NOT NULL (no NULL values existed)"
+    )

--- a/src/chronovista/db/models.py
+++ b/src/chronovista/db/models.py
@@ -544,9 +544,9 @@ class Playlist(Base):
         String(20), default="private"
     )  # private, public, unlisted
 
-    # Channel association
-    channel_id: Mapped[str] = mapped_column(
-        String(24), ForeignKey("channels.channel_id")
+    # Channel association (nullable to support system playlists)
+    channel_id: Mapped[Optional[str]] = mapped_column(
+        String(24), ForeignKey("channels.channel_id"), nullable=True
     )
 
     # Metadata
@@ -574,7 +574,7 @@ class Playlist(Base):
     )
 
     # Relationships
-    channel: Mapped["Channel"] = relationship("Channel")
+    channel: Mapped[Optional["Channel"]] = relationship("Channel")
     memberships: Mapped[list["PlaylistMembership"]] = relationship(
         "PlaylistMembership",
         back_populates="playlist",

--- a/src/chronovista/models/playlist.py
+++ b/src/chronovista/models/playlist.py
@@ -31,9 +31,9 @@ class PlaylistBase(BaseModel):
     privacy_status: PrivacyStatus = Field(
         default=PrivacyStatus.PRIVATE, description="Playlist privacy setting"
     )
-    channel_id: ChannelId = Field(
-        ...,
-        description="Channel ID that owns the playlist (validated)",
+    channel_id: Optional[ChannelId] = Field(
+        default=None,
+        description="Channel ID that owns the playlist. NULL for user playlists from Takeout until linked via OAuth.",
     )
     video_count: int = Field(
         default=0, ge=0, description="Number of videos in playlist"
@@ -104,6 +104,10 @@ class PlaylistUpdate(BaseModel):
     description: Optional[str] = None
     default_language: Optional[LanguageCode] = None
     privacy_status: Optional[PrivacyStatus] = None
+    channel_id: Optional[ChannelId] = Field(
+        default=None,
+        description="Channel ID to link playlist to after OAuth authentication",
+    )
     video_count: Optional[int] = Field(None, ge=0)
     published_at: Optional[datetime] = None
     deleted_flag: Optional[bool] = None

--- a/src/chronovista/services/enrichment/enrichment_service.py
+++ b/src/chronovista/services/enrichment/enrichment_service.py
@@ -2486,6 +2486,10 @@ class EnrichmentService:
                 if api_data.snippet and api_data.snippet.default_language:
                     playlist.default_language = api_data.snippet.default_language
 
+                # Update channel_id (link playlist to owner channel)
+                if api_data.snippet and api_data.snippet.channel_id:
+                    playlist.channel_id = api_data.snippet.channel_id
+
                 playlists_updated += 1
                 logger.debug(f"Updated playlist {playlist_id}: {playlist.title}")
 

--- a/tests/integration/test_playlist_integration.py
+++ b/tests/integration/test_playlist_integration.py
@@ -44,7 +44,6 @@ from chronovista.repositories.playlist_repository import PlaylistRepository
 from chronovista.services.seeding.playlist_seeder import (
     PlaylistSeeder,
     generate_internal_playlist_id,
-    generate_user_channel_id,
 )
 from tests.factories.takeout_playlist_factory import (
     TakeoutPlaylistFactory,

--- a/tests/unit/models/test_playlist.py
+++ b/tests/unit/models/test_playlist.py
@@ -93,8 +93,10 @@ class TestPlaylistBase:
         assert len(playlist.playlist_id) <= 50
         assert len(playlist.title) >= 1
         assert len(playlist.title) <= 255
-        assert len(playlist.channel_id) >= 20
-        assert len(playlist.channel_id) <= 24
+        # channel_id is now optional - check if present
+        if playlist.channel_id is not None:
+            assert len(playlist.channel_id) >= 20
+            assert len(playlist.channel_id) <= 24
         assert playlist.privacy_status in ["private", "public", "unlisted"]
         assert playlist.video_count >= 0
 


### PR DESCRIPTION
## Summary

This PR makes `Playlist.channel_id` nullable to properly support user playlists from Google Takeout imports that don't have a known YouTube channel ID.

## Changes

### Database & Models
- **Alembic migration** (`a58e6cd3c0ce`): Makes `channel_id` nullable, updates existing playlists to NULL, deletes placeholder channel
- **SQLAlchemy model** (`db/models.py`): Added `nullable=True` to `channel_id` column
- **Pydantic models** (`models/playlist.py`): Made `channel_id` Optional with None default

### Services & Repositories
- **PlaylistSeeder** (`services/seeding/playlist_seeder.py`): 
  - Removed placeholder channel logic (`generate_user_channel_id`, `_ensure_user_channel_exists`)
  - Now uses `channel_id=None` for Takeout imports
  - Added `delete_by_null_channel_id` method
- **Playlist repository** (`repositories/playlist_repository.py`): 
  - Fixed grouping for NULL channel_id using `func.coalesce()`
  - Added `delete_by_null_channel_id` method

### CLI & Transformers
- **CLI playlist show** (`cli/commands/playlist.py`): Added NULL channel handling display
- **Sync transformer** (`cli/sync/transformers.py`): Changed empty string to None

### Tests
- Updated 19 tests to reflect new API
- Fixed type annotations in test files

## Validation Results

- ✅ 3,589 tests pass
- ✅ mypy clean (no type errors)
- ✅ Re-seeding works (290 playlists with NULL channel_id)
- ✅ Enrichment works (0 errors, 286 playlists updated)
- ✅ No placeholder channel created

## Test Plan

- [x] Run full test suite: `pytest`
- [x] Run type checker: `mypy src/chronovista`
- [x] Test re-seeding with Takeout data
- [x] Test playlist enrichment
- [x] Verify no placeholder channel creation
- [x] Test CLI playlist show with NULL channel_id