### PR TITLE
feat(api): Complete Entity API Coverage (Feature 011)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [0.14.0] - 2026-02-04
+
+### Added
+- REST API endpoints for channels: list, detail, videos-by-channel (`/api/v1/channels`)
+- REST API endpoints for playlists: list, detail, videos-by-playlist (`/api/v1/playlists`)
+- REST API endpoints for topics: list, detail, videos-by-topic (`/api/v1/topics`)
+- Standardized error handling with ErrorCode enum and centralized exception handlers
+- Support for topic IDs with slashes (e.g., `/m/098wr`) using path converter
+
+### Changed
+- Retrofitted existing F010 endpoints (videos, transcripts, search, preferences, sync) to use typed exceptions
+- All 20 API endpoints now return consistent ErrorResponse format
+
+### Fixed
+- Topic IDs containing slashes now work correctly in URL paths
+- Removed orphaned YouTube category IDs from topic_categories table (they belong in video_categories)
+
 ## [0.13.0] - 2026-02-03
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive user guide and API reference
 - Architecture documentation
 
+## [0.14.0] - 2026-02-04
+
+### Added
+- **Feature 011: Complete Entity API Coverage**
+  - REST API endpoints for channels: list, detail, videos-by-channel (`/api/v1/channels`)
+  - REST API endpoints for playlists: list, detail, videos-by-playlist (`/api/v1/playlists`)
+  - REST API endpoints for topics: list, detail, videos-by-topic (`/api/v1/topics`)
+  - Standardized error handling with ErrorCode enum and centralized exception handlers
+  - Support for topic IDs with slashes (e.g., `/m/098wr`) using path converter
+
+### Changed
+- Retrofitted existing F010 endpoints (videos, transcripts, search, preferences, sync) to use typed exceptions
+- All 20 API endpoints now return consistent ErrorResponse format
+
+### Fixed
+- Topic IDs containing slashes now work correctly in URL paths
+- Removed orphaned YouTube category IDs from topic_categories table (they belong in video_categories)
+
 ## [0.13.0] - 2026-02-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.13.0"
+version = "0.14.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/exception_handlers.py
+++ b/src/chronovista/api/exception_handlers.py
@@ -1,0 +1,224 @@
+"""Centralized exception handlers for FastAPI.
+
+This module provides centralized exception handling for the chronovista API,
+converting domain exceptions to standardized ErrorResponse JSON format.
+
+All API endpoints use these handlers to ensure consistent error response
+structure across the entire API surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from chronovista.api.schemas.responses import ApiError, ErrorCode, ErrorResponse
+from chronovista.exceptions import (
+    APIError,
+    AuthenticationError,
+    RepositoryError,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+async def api_error_handler(request: Request, exc: APIError) -> JSONResponse:
+    """Handle APIError subclasses and convert to ErrorResponse JSON.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming FastAPI request.
+    exc : APIError
+        The APIError exception that was raised.
+
+    Returns
+    -------
+    JSONResponse
+        JSON response with ErrorResponse format.
+    """
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=ErrorResponse(error=exc.to_api_error()).model_dump(),
+    )
+
+
+async def validation_error_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Handle Pydantic RequestValidationError and convert to ErrorResponse JSON.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming FastAPI request.
+    exc : RequestValidationError
+        The Pydantic validation error.
+
+    Returns
+    -------
+    JSONResponse
+        JSON response with ErrorResponse format and validation details.
+    """
+    # Format validation errors for the response
+    errors = []
+    for error in exc.errors():
+        errors.append({
+            "loc": list(error.get("loc", [])),
+            "msg": error.get("msg", ""),
+            "type": error.get("type", ""),
+        })
+
+    return JSONResponse(
+        status_code=422,
+        content=ErrorResponse(
+            error=ApiError(
+                code=ErrorCode.VALIDATION_ERROR.value,
+                message="Request validation failed",
+                details={"errors": errors},
+            )
+        ).model_dump(),
+    )
+
+
+async def auth_error_handler(
+    request: Request, exc: AuthenticationError
+) -> JSONResponse:
+    """Handle AuthenticationError and convert to ErrorResponse JSON.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming FastAPI request.
+    exc : AuthenticationError
+        The authentication error.
+
+    Returns
+    -------
+    JSONResponse
+        JSON response with 401 status and ErrorResponse format.
+    """
+    return JSONResponse(
+        status_code=401,
+        content=ErrorResponse(
+            error=ApiError(
+                code=ErrorCode.NOT_AUTHENTICATED.value,
+                message=str(exc),
+            )
+        ).model_dump(),
+    )
+
+
+async def repository_error_handler(
+    request: Request, exc: RepositoryError
+) -> JSONResponse:
+    """Handle RepositoryError and convert to ErrorResponse JSON.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming FastAPI request.
+    exc : RepositoryError
+        The repository/database error.
+
+    Returns
+    -------
+    JSONResponse
+        JSON response with 500 status and ErrorResponse format.
+        Internal details are not exposed to the client.
+    """
+    # Log the actual error for debugging
+    logger.error(
+        "Repository error: %s (operation=%s, entity=%s)",
+        exc.message,
+        exc.operation,
+        exc.entity_type,
+        exc_info=exc.original_error,
+    )
+
+    return JSONResponse(
+        status_code=500,
+        content=ErrorResponse(
+            error=ApiError(
+                code=ErrorCode.DATABASE_ERROR.value,
+                message="An internal database error occurred. Please try again.",
+            )
+        ).model_dump(),
+    )
+
+
+async def generic_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Handle unexpected exceptions and convert to ErrorResponse JSON.
+
+    This is the catch-all handler for any unhandled exceptions.
+    Internal error details are not exposed to the client for security.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming FastAPI request.
+    exc : Exception
+        The unhandled exception.
+
+    Returns
+    -------
+    JSONResponse
+        JSON response with 500 status and generic error message.
+    """
+    # Log the full exception for debugging
+    logger.exception("Unhandled exception: %s", exc)
+
+    return JSONResponse(
+        status_code=500,
+        content=ErrorResponse(
+            error=ApiError(
+                code=ErrorCode.INTERNAL_ERROR.value,
+                message="An unexpected error occurred. Please try again later.",
+            )
+        ).model_dump(),
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register all exception handlers on the FastAPI app.
+
+    This function registers handlers for:
+    - APIError and its subclasses (NotFoundError, BadRequestError, etc.)
+    - RequestValidationError (Pydantic validation)
+    - AuthenticationError
+    - RepositoryError
+    - Generic Exception (catch-all)
+
+    Parameters
+    ----------
+    app : FastAPI
+        The FastAPI application instance.
+
+    Examples
+    --------
+    >>> from fastapi import FastAPI
+    >>> from chronovista.api.exception_handlers import register_exception_handlers
+    >>> app = FastAPI()
+    >>> register_exception_handlers(app)
+    """
+    # Register APIError handler (handles all subclasses too)
+    app.add_exception_handler(APIError, api_error_handler)  # type: ignore[arg-type]
+
+    # Register Pydantic validation error handler
+    app.add_exception_handler(RequestValidationError, validation_error_handler)  # type: ignore[arg-type]
+
+    # Register authentication error handler
+    app.add_exception_handler(AuthenticationError, auth_error_handler)  # type: ignore[arg-type]
+
+    # Register repository error handler
+    app.add_exception_handler(RepositoryError, repository_error_handler)  # type: ignore[arg-type]
+
+    # Register generic catch-all handler
+    app.add_exception_handler(Exception, generic_error_handler)

--- a/src/chronovista/api/main.py
+++ b/src/chronovista/api/main.py
@@ -9,7 +9,18 @@ from fastapi import FastAPI, Request
 from starlette.middleware.base import RequestResponseEndpoint
 from starlette.responses import Response
 
-from chronovista.api.routers import health, preferences, search, sync, transcripts, videos
+from chronovista.api.exception_handlers import register_exception_handlers
+from chronovista.api.routers import (
+    channels,
+    health,
+    playlists,
+    preferences,
+    search,
+    sync,
+    topics,
+    transcripts,
+    videos,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +46,9 @@ app = FastAPI(
     version="1.0.0",
     lifespan=lifespan,
 )
+
+# Register centralized exception handlers for consistent error responses
+register_exception_handlers(app)
 
 
 def _is_sensitive_path(path: str) -> bool:
@@ -123,6 +137,9 @@ async def log_requests(
 
 # Mount routers under /api/v1 prefix (FR-028 versioning)
 app.include_router(health.router, prefix="/api/v1", tags=["health"])
+app.include_router(channels.router, prefix="/api/v1", tags=["channels"])
+app.include_router(playlists.router, prefix="/api/v1", tags=["playlists"])
+app.include_router(topics.router, prefix="/api/v1", tags=["topics"])
 app.include_router(videos.router, prefix="/api/v1", tags=["videos"])
 app.include_router(transcripts.router, prefix="/api/v1", tags=["transcripts"])
 app.include_router(search.router, prefix="/api/v1", tags=["search"])

--- a/src/chronovista/api/routers/channels.py
+++ b/src/chronovista/api/routers/channels.py
@@ -1,0 +1,316 @@
+"""Channel API endpoints.
+
+This module provides REST API endpoints for channel operations:
+- GET /channels - List channels with pagination and filtering
+- GET /channels/{channel_id} - Get channel details by ID
+- GET /channels/{channel_id}/videos - Get videos belonging to a channel
+
+All endpoints require authentication via the require_auth dependency.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Path, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.schemas.channels import (
+    ChannelDetail,
+    ChannelDetailResponse,
+    ChannelListItem,
+    ChannelListResponse,
+)
+from chronovista.api.schemas.responses import PaginationMeta
+from chronovista.api.schemas.videos import (
+    TranscriptSummary,
+    VideoListItem,
+    VideoListResponse,
+)
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import Video as VideoDB
+from chronovista.db.models import VideoTranscript
+from chronovista.exceptions import NotFoundError
+
+router = APIRouter(dependencies=[Depends(require_auth)])
+
+
+def _build_transcript_summary(transcripts: List[VideoTranscript]) -> TranscriptSummary:
+    """
+    Build transcript summary from transcript list.
+
+    Parameters
+    ----------
+    transcripts : List[VideoTranscript]
+        List of transcript database models.
+
+    Returns
+    -------
+    TranscriptSummary
+        Summary containing count, languages, and manual indicator.
+    """
+    if not transcripts:
+        return TranscriptSummary(count=0, languages=[], has_manual=False)
+
+    languages = list({t.language_code for t in transcripts})
+    has_manual = any(t.is_cc or t.transcript_type == "MANUAL" for t in transcripts)
+
+    return TranscriptSummary(
+        count=len(transcripts),
+        languages=sorted(languages),
+        has_manual=has_manual,
+    )
+
+
+@router.get("/channels", response_model=ChannelListResponse)
+async def list_channels(
+    limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+    offset: int = Query(default=0, ge=0, description="Number of items to skip"),
+    has_videos: Optional[bool] = Query(
+        default=None, description="Filter to channels with/without videos"
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> ChannelListResponse:
+    """
+    List all channels with pagination.
+
+    Returns a paginated list of channels, ordered by video count descending.
+    Optionally filter to channels that have (or don't have) videos.
+
+    Parameters
+    ----------
+    limit : int
+        Items per page (1-100, default 20).
+    offset : int
+        Number of items to skip (default 0).
+    has_videos : Optional[bool]
+        If True, return only channels with videos.
+        If False, return only channels without videos.
+        If None, return all channels.
+    db : AsyncSession
+        Database session from dependency.
+
+    Returns
+    -------
+    ChannelListResponse
+        Paginated list of channels with metadata.
+    """
+    # Build base query
+    query = select(ChannelDB)
+
+    # Apply has_videos filter
+    if has_videos is True:
+        query = query.where(ChannelDB.video_count > 0)
+    elif has_videos is False:
+        query = query.where(
+            (ChannelDB.video_count == 0) | (ChannelDB.video_count.is_(None))
+        )
+
+    # Count total before pagination
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await db.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Apply ordering and pagination (video_count DESC per spec)
+    query = (
+        query.order_by(ChannelDB.video_count.desc().nulls_last())
+        .offset(offset)
+        .limit(limit)
+    )
+
+    # Execute query
+    result = await db.execute(query)
+    channels = result.scalars().all()
+
+    # Transform to response items
+    items: List[ChannelListItem] = []
+    for channel in channels:
+        items.append(
+            ChannelListItem(
+                channel_id=channel.channel_id,
+                title=channel.title,
+                description=channel.description,
+                subscriber_count=channel.subscriber_count,
+                video_count=channel.video_count,
+                thumbnail_url=channel.thumbnail_url,
+                custom_url=None,  # Not yet persisted in DB
+            )
+        )
+
+    return ChannelListResponse(
+        data=items,
+        pagination=PaginationMeta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            has_more=(offset + limit) < total,
+        ),
+    )
+
+
+@router.get("/channels/{channel_id}", response_model=ChannelDetailResponse)
+async def get_channel(
+    channel_id: str = Path(
+        ...,
+        min_length=24,
+        max_length=24,
+        description="YouTube channel ID (24 characters)",
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> ChannelDetailResponse:
+    """
+    Get channel details by ID.
+
+    Returns full channel metadata including subscription status and timestamps.
+
+    Parameters
+    ----------
+    channel_id : str
+        YouTube channel ID (exactly 24 characters).
+    db : AsyncSession
+        Database session from dependency.
+
+    Returns
+    -------
+    ChannelDetailResponse
+        Full channel details.
+
+    Raises
+    ------
+    NotFoundError
+        If channel with given ID does not exist.
+    """
+    # Query channel by ID
+    result = await db.execute(
+        select(ChannelDB).where(ChannelDB.channel_id == channel_id)
+    )
+    channel = result.scalar_one_or_none()
+
+    if not channel:
+        raise NotFoundError(
+            resource_type="Channel",
+            identifier=channel_id,
+            hint="Verify the channel ID or run a sync.",
+        )
+
+    # Build response
+    detail = ChannelDetail(
+        channel_id=channel.channel_id,
+        title=channel.title,
+        description=channel.description,
+        subscriber_count=channel.subscriber_count,
+        video_count=channel.video_count,
+        thumbnail_url=channel.thumbnail_url,
+        custom_url=None,  # Not yet persisted in DB
+        default_language=channel.default_language,
+        country=channel.country,
+        is_subscribed=channel.is_subscribed,
+        created_at=channel.created_at,
+        updated_at=channel.updated_at,
+    )
+
+    return ChannelDetailResponse(data=detail)
+
+
+@router.get("/channels/{channel_id}/videos", response_model=VideoListResponse)
+async def get_channel_videos(
+    channel_id: str = Path(
+        ...,
+        min_length=24,
+        max_length=24,
+        description="YouTube channel ID (24 characters)",
+    ),
+    limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+    offset: int = Query(default=0, ge=0, description="Number of items to skip"),
+    db: AsyncSession = Depends(get_db),
+) -> VideoListResponse:
+    """
+    Get videos belonging to a channel.
+
+    Returns a paginated list of videos for the specified channel,
+    ordered by upload date descending.
+
+    Parameters
+    ----------
+    channel_id : str
+        YouTube channel ID (exactly 24 characters).
+    limit : int
+        Items per page (1-100, default 20).
+    offset : int
+        Number of items to skip (default 0).
+    db : AsyncSession
+        Database session from dependency.
+
+    Returns
+    -------
+    VideoListResponse
+        Paginated list of videos with metadata.
+
+    Raises
+    ------
+    NotFoundError
+        If channel with given ID does not exist.
+    """
+    # First verify the channel exists
+    channel_result = await db.execute(
+        select(ChannelDB.channel_id).where(ChannelDB.channel_id == channel_id)
+    )
+    if not channel_result.scalar_one_or_none():
+        raise NotFoundError(
+            resource_type="Channel",
+            identifier=channel_id,
+            hint="Verify the channel ID or run a sync.",
+        )
+
+    # Build video query with eager loading
+    query = (
+        select(VideoDB)
+        .where(VideoDB.channel_id == channel_id)
+        .where(VideoDB.deleted_flag.is_(False))
+        .options(selectinload(VideoDB.transcripts))
+        .options(selectinload(VideoDB.channel))
+    )
+
+    # Count total before pagination
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await db.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Apply ordering and pagination
+    query = query.order_by(VideoDB.upload_date.desc()).offset(offset).limit(limit)
+
+    # Execute query
+    result = await db.execute(query)
+    videos = result.scalars().all()
+
+    # Transform to response items
+    items: List[VideoListItem] = []
+    for video in videos:
+        transcript_summary = _build_transcript_summary(list(video.transcripts))
+        channel_title = video.channel.title if video.channel else None
+
+        items.append(
+            VideoListItem(
+                video_id=video.video_id,
+                title=video.title,
+                channel_id=video.channel_id,
+                channel_title=channel_title,
+                upload_date=video.upload_date,
+                duration=video.duration,
+                view_count=video.view_count,
+                transcript_summary=transcript_summary,
+            )
+        )
+
+    return VideoListResponse(
+        data=items,
+        pagination=PaginationMeta(
+            total=total,
+            limit=limit,
+            offset=offset,
+            has_more=(offset + limit) < total,
+        ),
+    )

--- a/src/chronovista/api/routers/playlists.py
+++ b/src/chronovista/api/routers/playlists.py
@@ -1,0 +1,327 @@
+"""Playlist list and detail endpoints.
+
+This module provides API endpoints for playlist management,
+including list with linked/unlinked filters, detail view,
+and video listing with position ordering.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Path, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.schemas.playlists import (
+    PlaylistDetail,
+    PlaylistDetailResponse,
+    PlaylistListItem,
+    PlaylistListResponse,
+    PlaylistVideoListItem,
+    PlaylistVideoListResponse,
+)
+from chronovista.api.schemas.responses import PaginationMeta
+from chronovista.api.schemas.videos import TranscriptSummary
+from chronovista.db.models import Playlist as PlaylistDB
+from chronovista.db.models import PlaylistMembership, Video as VideoDB, VideoTranscript
+from chronovista.exceptions import BadRequestError, NotFoundError
+
+
+router = APIRouter(dependencies=[Depends(require_auth)])
+
+
+def build_transcript_summary(transcripts: List[VideoTranscript]) -> TranscriptSummary:
+    """Build transcript summary from transcript list.
+
+    Parameters
+    ----------
+    transcripts : List[VideoTranscript]
+        List of transcript database models.
+
+    Returns
+    -------
+    TranscriptSummary
+        Summary containing count, languages, and manual indicator.
+    """
+    if not transcripts:
+        return TranscriptSummary(count=0, languages=[], has_manual=False)
+
+    languages = list({t.language_code for t in transcripts})
+    has_manual = any(t.is_cc or t.transcript_type == "MANUAL" for t in transcripts)
+
+    return TranscriptSummary(
+        count=len(transcripts),
+        languages=sorted(languages),
+        has_manual=has_manual,
+    )
+
+
+@router.get("/playlists", response_model=PlaylistListResponse)
+async def list_playlists(
+    session: AsyncSession = Depends(get_db),
+    linked: Optional[bool] = Query(
+        None,
+        description="Filter for YouTube-linked playlists (PL/LL/WL/HL prefix)",
+    ),
+    unlinked: Optional[bool] = Query(
+        None,
+        description="Filter for internal playlists (int_ prefix)",
+    ),
+    limit: int = Query(20, ge=1, le=100, description="Items per page"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+) -> PlaylistListResponse:
+    """List playlists with pagination and filters.
+
+    Supports filtering by linked/unlinked status. These filters are
+    mutually exclusive - if both are set to True, a 400 error is returned.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session from dependency.
+    linked : Optional[bool]
+        Filter for YouTube-linked playlists (PL/LL/WL/HL prefix).
+    unlinked : Optional[bool]
+        Filter for internal playlists (int_ prefix).
+    limit : int
+        Items per page (1-100, default 20).
+    offset : int
+        Pagination offset (default 0).
+
+    Returns
+    -------
+    PlaylistListResponse
+        Paginated list of playlists with metadata.
+
+    Raises
+    ------
+    BadRequestError
+        If both linked=true and unlinked=true are specified.
+    """
+    # Validate mutually exclusive filters
+    if linked is True and unlinked is True:
+        raise BadRequestError(
+            message="Cannot specify both 'linked=true' and 'unlinked=true'. "
+            "These filters are mutually exclusive.",
+            details={"field": "linked,unlinked", "constraint": "mutually_exclusive"},
+            mutually_exclusive=True,
+        )
+
+    # Build base query
+    query = select(PlaylistDB).where(PlaylistDB.deleted_flag.is_(False))
+
+    # Apply linked/unlinked filters
+    if linked is True:
+        # YouTube-linked playlists start with PL, LL, WL, or HL
+        query = query.where(
+            (PlaylistDB.playlist_id.like("PL%"))
+            | (PlaylistDB.playlist_id.like("LL%"))
+            | (PlaylistDB.playlist_id.like("WL%"))
+            | (PlaylistDB.playlist_id.like("HL%"))
+        )
+    elif unlinked is True:
+        # Internal playlists start with int_
+        query = query.where(PlaylistDB.playlist_id.like("int_%"))
+    elif linked is False:
+        # linked=false means unlinked playlists
+        query = query.where(PlaylistDB.playlist_id.like("int_%"))
+    elif unlinked is False:
+        # unlinked=false means linked playlists
+        query = query.where(
+            (PlaylistDB.playlist_id.like("PL%"))
+            | (PlaylistDB.playlist_id.like("LL%"))
+            | (PlaylistDB.playlist_id.like("WL%"))
+            | (PlaylistDB.playlist_id.like("HL%"))
+        )
+
+    # Get total count (before pagination)
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await session.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Apply pagination and ordering (updated_at DESC per spec)
+    query = query.order_by(PlaylistDB.updated_at.desc()).offset(offset).limit(limit)
+
+    # Execute query
+    result = await session.execute(query)
+    playlists = result.scalars().all()
+
+    # Transform to response items
+    items = [PlaylistListItem.model_validate(p) for p in playlists]
+
+    # Build pagination
+    pagination = PaginationMeta(
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=(offset + limit) < total,
+    )
+
+    return PlaylistListResponse(data=items, pagination=pagination)
+
+
+@router.get("/playlists/{playlist_id}", response_model=PlaylistDetailResponse)
+async def get_playlist(
+    playlist_id: str = Path(
+        ...,
+        min_length=2,
+        max_length=50,
+        description="Playlist ID (YouTube or internal)",
+    ),
+    session: AsyncSession = Depends(get_db),
+) -> PlaylistDetailResponse:
+    """Get playlist details by ID.
+
+    Accepts both YouTube IDs (PL prefix) and internal IDs (int_ prefix).
+
+    Parameters
+    ----------
+    playlist_id : str
+        Playlist ID (YouTube: PL prefix, 30-50 chars; System: LL/WL/HL;
+        Internal: int_ prefix, 36 chars total).
+    session : AsyncSession
+        Database session from dependency.
+
+    Returns
+    -------
+    PlaylistDetailResponse
+        Full playlist details.
+
+    Raises
+    ------
+    NotFoundError
+        If playlist not found.
+    """
+    # Query playlist
+    query = (
+        select(PlaylistDB)
+        .where(PlaylistDB.playlist_id == playlist_id)
+        .where(PlaylistDB.deleted_flag.is_(False))
+    )
+
+    result = await session.execute(query)
+    playlist = result.scalar_one_or_none()
+
+    if not playlist:
+        raise NotFoundError(
+            resource_type="Playlist",
+            identifier=playlist_id,
+            hint="Verify the playlist ID or run a sync.",
+        )
+
+    return PlaylistDetailResponse(data=PlaylistDetail.model_validate(playlist))
+
+
+@router.get(
+    "/playlists/{playlist_id}/videos", response_model=PlaylistVideoListResponse
+)
+async def get_playlist_videos(
+    playlist_id: str = Path(
+        ...,
+        min_length=2,
+        max_length=50,
+        description="Playlist ID (YouTube or internal)",
+    ),
+    limit: int = Query(20, ge=1, le=100, description="Items per page"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    session: AsyncSession = Depends(get_db),
+) -> PlaylistVideoListResponse:
+    """Get videos in a playlist with position ordering.
+
+    Returns videos ordered by their position in the playlist (ASC).
+    Includes deleted_flag to preserve position integrity even for
+    videos that have been deleted from YouTube.
+
+    Parameters
+    ----------
+    playlist_id : str
+        Playlist ID (YouTube or internal).
+    limit : int
+        Items per page (1-100, default 20).
+    offset : int
+        Pagination offset (default 0).
+    session : AsyncSession
+        Database session from dependency.
+
+    Returns
+    -------
+    PlaylistVideoListResponse
+        Paginated list of videos in playlist order.
+
+    Raises
+    ------
+    NotFoundError
+        If playlist not found.
+    """
+    # First verify playlist exists
+    playlist_query = select(PlaylistDB.playlist_id).where(
+        PlaylistDB.playlist_id == playlist_id
+    )
+    playlist_result = await session.execute(playlist_query)
+    if not playlist_result.scalar_one_or_none():
+        raise NotFoundError(
+            resource_type="Playlist",
+            identifier=playlist_id,
+        )
+
+    # Build query for membership with video data
+    # Join PlaylistMembership with Video to get all video details
+    query = (
+        select(PlaylistMembership, VideoDB)
+        .join(VideoDB, PlaylistMembership.video_id == VideoDB.video_id)
+        .where(PlaylistMembership.playlist_id == playlist_id)
+        .options(selectinload(VideoDB.transcripts))
+        .options(selectinload(VideoDB.channel))
+    )
+
+    # Get total count (before pagination)
+    count_query = select(func.count()).select_from(
+        select(PlaylistMembership)
+        .where(PlaylistMembership.playlist_id == playlist_id)
+        .subquery()
+    )
+    total_result = await session.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Apply ordering (position ASC) and pagination
+    query = (
+        query.order_by(PlaylistMembership.position.asc()).offset(offset).limit(limit)
+    )
+
+    # Execute query
+    result = await session.execute(query)
+    rows = result.all()
+
+    # Transform to response items
+    items: List[PlaylistVideoListItem] = []
+    for membership, video in rows:
+        transcript_summary = build_transcript_summary(list(video.transcripts))
+        channel_title = video.channel.title if video.channel else None
+
+        items.append(
+            PlaylistVideoListItem(
+                video_id=video.video_id,
+                title=video.title,
+                channel_id=video.channel_id,
+                channel_title=channel_title,
+                upload_date=video.upload_date,
+                duration=video.duration,
+                view_count=video.view_count,
+                transcript_summary=transcript_summary,
+                position=membership.position,
+                deleted_flag=video.deleted_flag,
+            )
+        )
+
+    # Build pagination
+    pagination = PaginationMeta(
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=(offset + limit) < total,
+    )
+
+    return PlaylistVideoListResponse(data=items, pagination=pagination)

--- a/src/chronovista/api/routers/search.py
+++ b/src/chronovista/api/routers/search.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,6 +13,7 @@ from chronovista.db.models import Channel as ChannelDB
 from chronovista.db.models import TranscriptSegment as SegmentDB
 from chronovista.db.models import Video as VideoDB
 from chronovista.db.models import VideoTranscript as TranscriptDB
+from chronovista.exceptions import BadRequestError
 
 
 router = APIRouter(dependencies=[Depends(require_auth)])
@@ -79,18 +80,15 @@ async def search_segments(
 
     Raises
     ------
-    HTTPException
-        400 if search query is empty after stripping whitespace.
+    BadRequestError
+        If search query is empty after stripping whitespace (400).
     """
     # Validate and clean query
     query_text = q.strip()
     if not query_text:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "code": "VALIDATION_ERROR",
-                "message": "Search query cannot be empty",
-            },
+        raise BadRequestError(
+            message="Search query cannot be empty",
+            details={"field": "q", "constraint": "non_empty"},
         )
 
     # Split query into terms for multi-word search (implicit AND)

--- a/src/chronovista/api/routers/topics.py
+++ b/src/chronovista/api/routers/topics.py
@@ -1,0 +1,383 @@
+"""Topic list and detail endpoints.
+
+This module provides API endpoints for accessing topic (TopicCategory) data
+with aggregated video and channel counts. The database entity is TopicCategory,
+but the API exposes it as "Topic" for simplicity.
+
+Route Order: The videos endpoint MUST be defined before the detail endpoint
+because the detail endpoint uses :path which would otherwise greedily match
+requests to /topics/{topic_id}/videos.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Union
+
+from fastapi import APIRouter, Depends, Path, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.schemas.responses import PaginationMeta
+from chronovista.api.schemas.topics import (
+    TopicDetail,
+    TopicDetailResponse,
+    TopicListItem,
+    TopicListResponse,
+)
+from chronovista.api.schemas.videos import VideoListItem, VideoListResponse
+from chronovista.db.models import ChannelTopic, TopicCategory, Video, VideoTopic
+from chronovista.exceptions import NotFoundError
+
+
+router = APIRouter(dependencies=[Depends(require_auth)])
+
+
+@router.get("/topics", response_model=TopicListResponse)
+async def list_topics(
+    session: AsyncSession = Depends(get_db),
+    limit: int = Query(20, ge=1, le=100, description="Items per page"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+) -> TopicListResponse:
+    """
+    List topics with pagination and aggregated counts.
+
+    Returns topics sorted by video_count in descending order by default.
+    Includes aggregated video_count and channel_count for each topic.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session from dependency.
+    limit : int
+        Items per page (1-100, default 20).
+    offset : int
+        Pagination offset (default 0).
+
+    Returns
+    -------
+    TopicListResponse
+        Paginated list of topics with metadata.
+    """
+    # Subquery for video count
+    video_count_subq = (
+        select(func.count(VideoTopic.video_id))
+        .where(VideoTopic.topic_id == TopicCategory.topic_id)
+        .correlate(TopicCategory)
+        .scalar_subquery()
+    )
+
+    # Subquery for channel count
+    channel_count_subq = (
+        select(func.count(ChannelTopic.channel_id))
+        .where(ChannelTopic.topic_id == TopicCategory.topic_id)
+        .correlate(TopicCategory)
+        .scalar_subquery()
+    )
+
+    # Main query with counts - selecting specific columns for aggregation
+    query = select(
+        TopicCategory.topic_id,
+        TopicCategory.category_name.label("name"),
+        video_count_subq.label("video_count"),
+        channel_count_subq.label("channel_count"),
+    )
+
+    # Get total count (before pagination)
+    count_query = select(func.count()).select_from(TopicCategory)
+    total_result = await session.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Apply ordering (video_count DESC per spec) and pagination
+    query = (
+        query.order_by(video_count_subq.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+
+    # Execute query
+    result = await session.execute(query)
+    rows = result.all()
+
+    # Transform to response items
+    items: List[TopicListItem] = []
+    for row in rows:
+        items.append(
+            TopicListItem(
+                topic_id=row.topic_id,
+                name=row.name,
+                video_count=row.video_count or 0,
+                channel_count=row.channel_count or 0,
+            )
+        )
+
+    # Build pagination
+    pagination = PaginationMeta(
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=(offset + limit) < total,
+    )
+
+    return TopicListResponse(data=items, pagination=pagination)
+
+
+# IMPORTANT: This endpoint MUST be defined before the detail endpoint below
+# because /topics/{topic_id:path} would otherwise greedily match this URL pattern.
+@router.get("/topics/{topic_id}/videos", response_model=VideoListResponse)
+async def get_topic_videos(
+    topic_id: str = Path(
+        ...,
+        description="Topic ID (knowledge graph format like /m/xxx or alphanumeric). "
+        "Note: For IDs with slashes (e.g., /m/019_rr), URL-encode the ID "
+        "(e.g., %2Fm%2F019_rr) for this endpoint.",
+        examples=["gaming", "%2Fm%2F019_rr"],
+    ),
+    limit: int = Query(20, ge=1, le=100, description="Items per page"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    session: AsyncSession = Depends(get_db),
+) -> VideoListResponse:
+    """
+    Get videos associated with a topic.
+
+    Returns videos that have been classified with the specified topic,
+    ordered by upload date descending.
+
+    Parameters
+    ----------
+    topic_id : str
+        Topic ID (knowledge graph format like /m/xxx or alphanumeric).
+    limit : int
+        Items per page (1-100, default 20).
+    offset : int
+        Pagination offset (default 0).
+    session : AsyncSession
+        Database session from dependency.
+
+    Returns
+    -------
+    VideoListResponse
+        Paginated list of videos with the topic.
+
+    Raises
+    ------
+    NotFoundError
+        404 if topic not found.
+    """
+    # Verify topic exists
+    topic_result = await session.execute(
+        select(TopicCategory.topic_id).where(TopicCategory.topic_id == topic_id)
+    )
+    if not topic_result.scalar_one_or_none():
+        raise NotFoundError(
+            resource_type="Topic",
+            identifier=topic_id,
+            hint="Verify the topic ID or check available topics.",
+        )
+
+    # Build query for videos with this topic
+    query = (
+        select(Video)
+        .join(VideoTopic, Video.video_id == VideoTopic.video_id)
+        .where(VideoTopic.topic_id == topic_id)
+        .where(Video.deleted_flag.is_(False))
+        .options(selectinload(Video.transcripts))
+        .options(selectinload(Video.channel))
+    )
+
+    # Get total count (before pagination)
+    count_query = (
+        select(func.count(Video.video_id))
+        .select_from(Video)
+        .join(VideoTopic, Video.video_id == VideoTopic.video_id)
+        .where(VideoTopic.topic_id == topic_id)
+        .where(Video.deleted_flag.is_(False))
+    )
+    total_result = await session.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Apply ordering and pagination
+    query = query.order_by(Video.upload_date.desc()).offset(offset).limit(limit)
+
+    # Execute query
+    result = await session.execute(query)
+    videos = result.scalars().all()
+
+    # Transform to response items (reusing pattern from videos router)
+    items: List[VideoListItem] = []
+    for video in videos:
+        # Build transcript summary
+        transcripts = list(video.transcripts) if video.transcripts else []
+        transcript_count = len(transcripts)
+        languages = list({t.language_code for t in transcripts})
+        has_manual = any(
+            t.is_cc or t.transcript_type == "MANUAL" for t in transcripts
+        )
+
+        from chronovista.api.schemas.videos import TranscriptSummary
+
+        transcript_summary = TranscriptSummary(
+            count=transcript_count,
+            languages=sorted(languages),
+            has_manual=has_manual,
+        )
+
+        channel_title = video.channel.title if video.channel else None
+
+        items.append(
+            VideoListItem(
+                video_id=video.video_id,
+                title=video.title,
+                channel_id=video.channel_id,
+                channel_title=channel_title,
+                upload_date=video.upload_date,
+                duration=video.duration,
+                view_count=video.view_count,
+                transcript_summary=transcript_summary,
+            )
+        )
+
+    # Build pagination
+    pagination = PaginationMeta(
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=(offset + limit) < total,
+    )
+
+    return VideoListResponse(data=items, pagination=pagination)
+
+
+# IMPORTANT: This endpoint uses :path which greedily matches all remaining path segments.
+# It MUST be defined after the /topics/{topic_id}/videos endpoint above.
+# When a slash-containing topic_id is used with /videos, this route will match
+# and we need to handle it by forwarding to get_topic_videos.
+@router.get(
+    "/topics/{topic_id:path}",
+    response_model=Union[TopicDetailResponse, VideoListResponse],
+    responses={
+        200: {
+            "description": "Topic details or videos list if path ends with /videos",
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "topic_detail": {
+                            "summary": "Topic detail response",
+                            "value": {"data": {"topic_id": "/m/098wr", "name": "Society"}},
+                        },
+                        "topic_videos": {
+                            "summary": "Topic videos response (when path ends with /videos)",
+                            "value": {"data": [], "pagination": {"total": 0}},
+                        },
+                    }
+                }
+            },
+        }
+    },
+)
+async def get_topic(
+    topic_id: str = Path(
+        ...,
+        description="Topic ID (knowledge graph format like /m/xxx or alphanumeric). "
+        "Supports slashes in IDs without URL encoding. "
+        "If path ends with /videos, returns videos for that topic.",
+        examples=["/m/019_rr", "gaming", "/m/098wr/videos"],
+    ),
+    session: AsyncSession = Depends(get_db),
+    limit: int = Query(20, ge=1, le=100, description="Items per page (for /videos)"),
+    offset: int = Query(0, ge=0, description="Pagination offset (for /videos)"),
+) -> Union[TopicDetailResponse, VideoListResponse]:
+    """
+    Get topic details by ID.
+
+    Returns full topic metadata including aggregated video and channel counts.
+    Also handles /videos sub-path for topic IDs containing slashes.
+
+    Parameters
+    ----------
+    topic_id : str
+        Topic ID (knowledge graph format like /m/xxx or alphanumeric).
+    session : AsyncSession
+        Database session from dependency.
+    limit : int
+        Items per page (used when path ends with /videos).
+    offset : int
+        Pagination offset (used when path ends with /videos).
+
+    Returns
+    -------
+    TopicDetailResponse
+        Full topic details with aggregated counts.
+
+    Raises
+    ------
+    NotFoundError
+        404 if topic not found.
+    """
+    # Handle /videos suffix - forward to videos logic for slash-containing topic IDs
+    # This happens because :path greedily matches /m/098wr/videos as topic_id
+    if topic_id.endswith("/videos"):
+        actual_topic_id = topic_id[:-7]  # Remove "/videos" suffix
+        return await get_topic_videos(
+            topic_id=actual_topic_id,
+            limit=limit,
+            offset=offset,
+            session=session,
+        )
+
+    # Subquery for video count
+    video_count_subq = (
+        select(func.count(VideoTopic.video_id))
+        .where(VideoTopic.topic_id == TopicCategory.topic_id)
+        .correlate(TopicCategory)
+        .scalar_subquery()
+    )
+
+    # Subquery for channel count
+    channel_count_subq = (
+        select(func.count(ChannelTopic.channel_id))
+        .where(ChannelTopic.topic_id == TopicCategory.topic_id)
+        .correlate(TopicCategory)
+        .scalar_subquery()
+    )
+
+    # Query topic with counts
+    query = select(
+        TopicCategory.topic_id,
+        TopicCategory.category_name.label("name"),
+        TopicCategory.parent_topic_id,
+        TopicCategory.topic_type,
+        TopicCategory.wikipedia_url,
+        TopicCategory.normalized_name,
+        TopicCategory.source,
+        TopicCategory.created_at,
+        video_count_subq.label("video_count"),
+        channel_count_subq.label("channel_count"),
+    ).where(TopicCategory.topic_id == topic_id)
+
+    result = await session.execute(query)
+    row = result.one_or_none()
+
+    if not row:
+        raise NotFoundError(
+            resource_type="Topic",
+            identifier=topic_id,
+            hint="Verify the topic ID or check available topics.",
+        )
+
+    # Build response
+    detail = TopicDetail(
+        topic_id=row.topic_id,
+        name=row.name,
+        video_count=row.video_count or 0,
+        channel_count=row.channel_count or 0,
+        parent_topic_id=row.parent_topic_id,
+        topic_type=row.topic_type,
+        wikipedia_url=row.wikipedia_url,
+        normalized_name=row.normalized_name,
+        source=row.source,
+        created_at=row.created_at,
+    )
+
+    return TopicDetailResponse(data=detail)

--- a/src/chronovista/api/schemas/__init__.py
+++ b/src/chronovista/api/schemas/__init__.py
@@ -1,0 +1,72 @@
+"""API schema exports.
+
+This module provides a centralized export of all API schemas for convenient
+imports throughout the application.
+"""
+
+from chronovista.api.schemas.channels import (
+    ChannelDetail,
+    ChannelDetailResponse,
+    ChannelListItem,
+    ChannelListResponse,
+)
+from chronovista.api.schemas.playlists import (
+    PlaylistDetail,
+    PlaylistDetailResponse,
+    PlaylistListItem,
+    PlaylistListResponse,
+    PlaylistVideoListItem,
+    PlaylistVideoListResponse,
+)
+from chronovista.api.schemas.responses import (
+    ApiError,
+    ApiResponse,
+    ErrorCode,
+    ErrorResponse,
+    PaginationMeta,
+)
+from chronovista.api.schemas.topics import (
+    TopicDetail,
+    TopicDetailResponse,
+    TopicListItem,
+    TopicListResponse,
+)
+from chronovista.api.schemas.videos import (
+    TranscriptSummary,
+    VideoDetail,
+    VideoDetailResponse,
+    VideoListItem,
+    VideoListResponse,
+)
+
+__all__ = [
+    # Channels
+    "ChannelDetail",
+    "ChannelDetailResponse",
+    "ChannelListItem",
+    "ChannelListResponse",
+    # Playlists
+    "PlaylistDetail",
+    "PlaylistDetailResponse",
+    "PlaylistListItem",
+    "PlaylistListResponse",
+    "PlaylistVideoListItem",
+    "PlaylistVideoListResponse",
+    # Responses
+    "ApiError",
+    "ApiResponse",
+    "ErrorCode",
+    "ErrorResponse",
+    "PaginationMeta",
+    # Topics
+    "TopicDetail",
+    "TopicDetailResponse",
+    "TopicListItem",
+    "TopicListResponse",
+    # Videos
+    "TranscriptSummary",
+    "VideoDetail",
+    "VideoDetailResponse",
+    "VideoListItem",
+    "VideoListResponse",
+]

--- a/src/chronovista/api/schemas/channels.py
+++ b/src/chronovista/api/schemas/channels.py
@@ -1,0 +1,116 @@
+"""Channel API response schemas.
+
+This module defines Pydantic schemas for channel list and detail endpoints,
+following the established pattern from videos.py with List/Detail separation
+and response wrappers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from chronovista.api.schemas.responses import PaginationMeta
+
+
+class ChannelListItem(BaseModel):
+    """Channel summary for list responses.
+
+    Provides minimal channel information for efficient list rendering.
+    Fields are mapped directly from the Channel database model.
+
+    Attributes
+    ----------
+    channel_id : str
+        YouTube channel ID (24 characters).
+    title : str
+        Channel title.
+    description : Optional[str]
+        Channel description (may be truncated in list view).
+    subscriber_count : Optional[int]
+        Number of subscribers.
+    video_count : Optional[int]
+        Number of videos on the channel.
+    thumbnail_url : Optional[str]
+        URL to channel thumbnail image.
+    custom_url : Optional[str]
+        Custom channel URL (e.g., @username). Currently always None
+        as this field is not yet persisted in the database.
+    """
+
+    model_config = ConfigDict(strict=True, from_attributes=True)
+
+    channel_id: str = Field(..., description="YouTube channel ID (24 chars)")
+    title: str = Field(..., description="Channel title")
+    description: Optional[str] = Field(None, description="Channel description")
+    subscriber_count: Optional[int] = Field(None, description="Subscriber count")
+    video_count: Optional[int] = Field(None, description="Number of videos")
+    thumbnail_url: Optional[str] = Field(None, description="Channel thumbnail URL")
+    custom_url: Optional[str] = Field(
+        default=None,
+        description="Custom channel URL (e.g., @username). Currently always None.",
+    )
+
+
+class ChannelDetail(ChannelListItem):
+    """Full channel details for single resource response.
+
+    Extends ChannelListItem with additional metadata fields including
+    language, country, subscription status, and timestamps.
+
+    Attributes
+    ----------
+    default_language : Optional[str]
+        Default language code for the channel (BCP-47).
+    country : Optional[str]
+        Country code (ISO 3166-1 alpha-2).
+    is_subscribed : bool
+        Whether the user is subscribed to this channel.
+    created_at : datetime
+        Record creation timestamp.
+    updated_at : datetime
+        Last update timestamp.
+    """
+
+    default_language: Optional[str] = Field(None, description="Default language code")
+    country: Optional[str] = Field(None, description="Country code (ISO 3166-1)")
+    is_subscribed: bool = Field(False, description="Whether user is subscribed")
+    created_at: datetime = Field(..., description="Record creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+
+class ChannelListResponse(BaseModel):
+    """Response wrapper for channel list.
+
+    Contains a list of channel items with pagination metadata.
+
+    Attributes
+    ----------
+    data : List[ChannelListItem]
+        List of channel summary items.
+    pagination : PaginationMeta
+        Pagination metadata (total, limit, offset, has_more).
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    data: List[ChannelListItem]
+    pagination: PaginationMeta
+
+
+class ChannelDetailResponse(BaseModel):
+    """Response wrapper for single channel.
+
+    Contains full channel details for a single resource.
+
+    Attributes
+    ----------
+    data : ChannelDetail
+        Full channel details.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    data: ChannelDetail

--- a/src/chronovista/api/schemas/playlists.py
+++ b/src/chronovista/api/schemas/playlists.py
@@ -1,0 +1,175 @@
+"""Playlist API response schemas.
+
+This module defines Pydantic schemas for playlist API endpoints,
+including list/detail responses and video position tracking.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from chronovista.api.schemas.responses import PaginationMeta
+from chronovista.api.schemas.videos import TranscriptSummary
+
+
+class PlaylistListItem(BaseModel):
+    """Playlist summary for list responses.
+
+    The is_linked field is derived at runtime from the playlist_id prefix:
+    - True if ID starts with PL, LL, WL, or HL (YouTube-linked)
+    - False if ID starts with int_ (internal/unlinked)
+    """
+
+    model_config = ConfigDict(strict=True, from_attributes=True)
+
+    playlist_id: str = Field(..., description="Playlist ID (YouTube, system, or internal)")
+    title: str = Field(..., description="Playlist title")
+    description: Optional[str] = Field(None, description="Playlist description")
+    video_count: int = Field(0, description="Number of videos in playlist")
+    privacy_status: str = Field(..., description="Privacy status: public, private, unlisted")
+    is_linked: bool = Field(..., description="Whether playlist is linked to YouTube")
+
+    @model_validator(mode="before")
+    @classmethod
+    def derive_is_linked(cls, data: Any) -> Any:
+        """Derive is_linked from playlist_id prefix.
+
+        Parameters
+        ----------
+        data : Any
+            Input data (dict or ORM model).
+
+        Returns
+        -------
+        Any
+            Data with is_linked field populated.
+        """
+        if isinstance(data, dict):
+            playlist_id = data.get("playlist_id", "")
+            data["is_linked"] = playlist_id.startswith(("PL", "LL", "WL", "HL"))
+        elif hasattr(data, "playlist_id"):
+            # ORM model - convert to dict with is_linked
+            playlist_id = getattr(data, "playlist_id", "")
+            return {
+                "playlist_id": playlist_id,
+                "title": getattr(data, "title", ""),
+                "description": getattr(data, "description", None),
+                "video_count": getattr(data, "video_count", 0),
+                "privacy_status": getattr(data, "privacy_status", "private"),
+                "is_linked": playlist_id.startswith(("PL", "LL", "WL", "HL")),
+            }
+        return data
+
+
+class PlaylistDetail(PlaylistListItem):
+    """Full playlist details for single resource response.
+
+    Extends PlaylistListItem with additional fields including
+    channel ownership, timestamps, and playlist type.
+    """
+
+    model_config = ConfigDict(strict=True, from_attributes=True)
+
+    default_language: Optional[str] = Field(None, description="Default language code")
+    channel_id: Optional[str] = Field(None, description="Owner channel ID")
+    published_at: Optional[datetime] = Field(None, description="Playlist creation date")
+    deleted_flag: bool = Field(False, description="Whether playlist is marked deleted")
+    playlist_type: str = Field("regular", description="Playlist type")
+    created_at: datetime = Field(..., description="Record creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+    @model_validator(mode="before")
+    @classmethod
+    def derive_is_linked_detail(cls, data: Any) -> Any:
+        """Derive is_linked from playlist_id prefix for detail view.
+
+        Parameters
+        ----------
+        data : Any
+            Input data (dict or ORM model).
+
+        Returns
+        -------
+        Any
+            Data with is_linked field populated.
+        """
+        if isinstance(data, dict):
+            playlist_id = data.get("playlist_id", "")
+            data["is_linked"] = playlist_id.startswith(("PL", "LL", "WL", "HL"))
+        elif hasattr(data, "playlist_id"):
+            # ORM model - convert to dict with all fields
+            playlist_id = getattr(data, "playlist_id", "")
+            return {
+                "playlist_id": playlist_id,
+                "title": getattr(data, "title", ""),
+                "description": getattr(data, "description", None),
+                "video_count": getattr(data, "video_count", 0),
+                "privacy_status": getattr(data, "privacy_status", "private"),
+                "is_linked": playlist_id.startswith(("PL", "LL", "WL", "HL")),
+                "default_language": getattr(data, "default_language", None),
+                "channel_id": getattr(data, "channel_id", None),
+                "published_at": getattr(data, "published_at", None),
+                "deleted_flag": getattr(data, "deleted_flag", False),
+                "playlist_type": getattr(data, "playlist_type", "regular"),
+                "created_at": getattr(data, "created_at"),
+                "updated_at": getattr(data, "updated_at"),
+            }
+        return data
+
+
+class PlaylistVideoListItem(BaseModel):
+    """Video item in playlist context with position.
+
+    Extends video information with playlist-specific position
+    and includes deleted_flag to preserve position integrity.
+    """
+
+    model_config = ConfigDict(strict=True, from_attributes=True)
+
+    # Video fields (matching VideoListItem structure)
+    video_id: str = Field(..., description="YouTube video ID (11 chars)")
+    title: str = Field(..., description="Video title")
+    channel_id: Optional[str] = Field(None, description="Channel ID (24 chars)")
+    channel_title: Optional[str] = Field(None, description="Channel name")
+    upload_date: datetime = Field(..., description="Video upload date")
+    duration: int = Field(..., description="Duration in seconds")
+    view_count: Optional[int] = Field(None, description="View count")
+    transcript_summary: TranscriptSummary = Field(
+        ..., description="Transcript availability summary"
+    )
+
+    # Playlist-specific fields
+    position: int = Field(..., description="Position in playlist (0-indexed)")
+    deleted_flag: bool = Field(
+        False,
+        description="Whether video was deleted from YouTube (included to preserve position integrity)",
+    )
+
+
+class PlaylistListResponse(BaseModel):
+    """Response wrapper for playlist list."""
+
+    model_config = ConfigDict(strict=True)
+
+    data: List[PlaylistListItem]
+    pagination: PaginationMeta
+
+
+class PlaylistDetailResponse(BaseModel):
+    """Response wrapper for single playlist."""
+
+    model_config = ConfigDict(strict=True)
+
+    data: PlaylistDetail
+
+
+class PlaylistVideoListResponse(BaseModel):
+    """Response wrapper for playlist video list."""
+
+    model_config = ConfigDict(strict=True)
+
+    data: List[PlaylistVideoListItem]
+    pagination: PaginationMeta

--- a/src/chronovista/api/schemas/responses.py
+++ b/src/chronovista/api/schemas/responses.py
@@ -1,8 +1,47 @@
 """API response envelope schemas."""
 
+from __future__ import annotations
+
+from enum import Enum
 from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, ConfigDict
+
+
+class ErrorCode(str, Enum):
+    """Standardized error codes for API responses.
+
+    These codes provide machine-readable error identification for API consumers.
+    Each code maps to a specific HTTP status code range.
+
+    4xx Client Errors:
+        NOT_FOUND: Resource does not exist (404)
+        BAD_REQUEST: Invalid request parameters (400)
+        VALIDATION_ERROR: Request validation failed (422)
+        NOT_AUTHENTICATED: Authentication required (401)
+        FORBIDDEN: Access denied (403)
+        CONFLICT: Resource conflict (409)
+        MUTUALLY_EXCLUSIVE: Conflicting parameters provided (400)
+
+    5xx Server Errors:
+        INTERNAL_ERROR: Unexpected server error (500)
+        DATABASE_ERROR: Database operation failed (500)
+        SERVICE_UNAVAILABLE: Service temporarily unavailable (503)
+    """
+
+    # 4xx Client Errors
+    NOT_FOUND = "NOT_FOUND"
+    BAD_REQUEST = "BAD_REQUEST"
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    NOT_AUTHENTICATED = "NOT_AUTHENTICATED"
+    FORBIDDEN = "FORBIDDEN"
+    CONFLICT = "CONFLICT"
+    MUTUALLY_EXCLUSIVE = "MUTUALLY_EXCLUSIVE"
+
+    # 5xx Server Errors
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+    DATABASE_ERROR = "DATABASE_ERROR"
+    SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE"
 
 T = TypeVar("T")
 

--- a/src/chronovista/api/schemas/topics.py
+++ b/src/chronovista/api/schemas/topics.py
@@ -1,0 +1,73 @@
+"""Topic API schemas for list and detail endpoints.
+
+This module defines Pydantic models for the Topic API endpoints following
+the established patterns from videos.py with List/Detail separation and
+response wrappers. The database entity is TopicCategory, but the API
+exposes it as "Topic" for simplicity.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from chronovista.api.schemas.responses import PaginationMeta
+
+
+class TopicListItem(BaseModel):
+    """Topic summary for list responses.
+
+    Maps from TopicCategory database model with aggregated counts.
+
+    Field Mapping:
+        topic_id: Direct from topic_id
+        name: Renamed from category_name
+        video_count: Aggregated from video_topics
+        channel_count: Aggregated from channel_topics
+    """
+
+    model_config = ConfigDict(strict=True, from_attributes=True)
+
+    topic_id: str = Field(..., description="Topic ID (e.g., /m/019_rr)")
+    name: str = Field(..., description="Topic name")
+    video_count: int = Field(0, description="Number of videos with this topic")
+    channel_count: int = Field(0, description="Number of channels with this topic")
+
+
+class TopicDetail(TopicListItem):
+    """Full topic details for single resource response.
+
+    Extends TopicListItem with additional metadata fields.
+    """
+
+    parent_topic_id: Optional[str] = Field(None, description="Parent topic ID")
+    topic_type: str = Field("youtube", description="Topic type: youtube or custom")
+    wikipedia_url: Optional[str] = Field(None, description="Wikipedia URL for topic")
+    normalized_name: Optional[str] = Field(None, description="Normalized topic name")
+    source: str = Field("seeded", description="Topic source: seeded or dynamic")
+    created_at: datetime = Field(..., description="Record creation timestamp")
+
+
+class TopicListResponse(BaseModel):
+    """Response wrapper for topic list endpoint.
+
+    Follows standard API response format with data and pagination.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    data: List[TopicListItem]
+    pagination: PaginationMeta
+
+
+class TopicDetailResponse(BaseModel):
+    """Response wrapper for single topic endpoint.
+
+    Follows standard API response format with data.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    data: TopicDetail

--- a/src/chronovista/cli/commands/seed.py
+++ b/src/chronovista/cli/commands/seed.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
@@ -23,8 +22,7 @@ from chronovista.config.database import db_manager
 from chronovista.container import container
 from chronovista.services.enrichment.seeders import TopicSeeder
 
-if TYPE_CHECKING:
-    from chronovista.services.enrichment.seeders import CategorySeeder
+from chronovista.services.enrichment.seeders import CategorySeeder
 
 console = Console()
 

--- a/src/chronovista/models/playlist_membership.py
+++ b/src/chronovista/models/playlist_membership.py
@@ -8,15 +8,14 @@ and metadata from Google Takeout data.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
 from .youtube_types import PlaylistId, VideoId
 
-if TYPE_CHECKING:
-    from .playlist import Playlist
-    from .video import Video
+from .playlist import Playlist
+from .video import Video
 
 
 class PlaylistMembershipBase(BaseModel):

--- a/src/chronovista/services/enrichment/enrichment_service.py
+++ b/src/chronovista/services/enrichment/enrichment_service.py
@@ -17,7 +17,7 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import unquote
 
 from pydantic import BaseModel, Field
@@ -45,19 +45,18 @@ from chronovista.models.enrichment_report import (
 )
 from chronovista.services.enrichment.shutdown_handler import get_shutdown_handler
 
-if TYPE_CHECKING:
-    from chronovista.repositories.channel_repository import ChannelRepository
-    from chronovista.repositories.playlist_repository import PlaylistRepository
-    from chronovista.repositories.topic_category_repository import (
-        TopicCategoryRepository,
-    )
-    from chronovista.repositories.video_category_repository import (
-        VideoCategoryRepository,
-    )
-    from chronovista.repositories.video_repository import VideoRepository
-    from chronovista.repositories.video_tag_repository import VideoTagRepository
-    from chronovista.repositories.video_topic_repository import VideoTopicRepository
-    from chronovista.services.youtube_service import YouTubeService
+from chronovista.repositories.channel_repository import ChannelRepository
+from chronovista.repositories.playlist_repository import PlaylistRepository
+from chronovista.repositories.topic_category_repository import (
+    TopicCategoryRepository,
+)
+from chronovista.repositories.video_category_repository import (
+    VideoCategoryRepository,
+)
+from chronovista.repositories.video_repository import VideoRepository
+from chronovista.repositories.video_tag_repository import VideoTagRepository
+from chronovista.repositories.video_topic_repository import VideoTopicRepository
+from chronovista.services.youtube_service import YouTubeService
 
 logger = logging.getLogger(__name__)
 

--- a/src/chronovista/services/interfaces/takeout_service_interface.py
+++ b/src/chronovista/services/interfaces/takeout_service_interface.py
@@ -10,7 +10,7 @@ This interface defines the contract for Takeout data parsing, enabling:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List
+from typing import List
 
 from ...models.takeout import (
     ContentGap,

--- a/src/chronovista/services/segment_service.py
+++ b/src/chronovista/services/segment_service.py
@@ -11,10 +11,8 @@ from __future__ import annotations
 import json
 import re
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, Sequence
-
-if TYPE_CHECKING:
-    from chronovista.models.transcript_segment import TranscriptSegment
+from typing import Optional, Sequence
+from chronovista.models.transcript_segment import TranscriptSegment
 
 
 class OutputFormat(str, Enum):

--- a/tests/integration/api/test_channel_endpoints.py
+++ b/tests/integration/api/test_channel_endpoints.py
@@ -1,0 +1,599 @@
+"""Integration tests for channel API endpoints (Feature 011 - US1).
+
+This module provides integration tests for the channel endpoints:
+- GET /api/v1/channels - List channels with pagination
+- GET /api/v1/channels/{channel_id} - Get channel details
+- GET /api/v1/channels/{channel_id}/videos - Get channel videos
+
+Tests cover:
+- Authentication requirements (T018)
+- List/pagination functionality (T016)
+- Detail and not_found handling (T017)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import Video as VideoDB
+
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+async def sample_channel(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a sample channel in the database for testing.
+
+    Returns channel data dict with channel_id for use in tests.
+    """
+    async with integration_session_factory() as session:
+        # Create a test channel (channel_id must be exactly 24 chars starting with UC)
+        channel = ChannelDB(
+            channel_id="UCtest123456789012345678",
+            title="Test Channel",
+            description="A test channel for integration tests",
+            subscriber_count=1000,
+            video_count=50,
+            thumbnail_url="https://example.com/thumbnail.jpg",
+            is_subscribed=True,
+            default_language="en",
+            country="US",
+        )
+
+        # Check if channel already exists
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            # Return existing channel data
+            return {
+                "channel_id": existing.channel_id,
+                "title": existing.title,
+                "description": existing.description,
+                "subscriber_count": existing.subscriber_count,
+                "video_count": existing.video_count,
+            }
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {
+            "channel_id": channel.channel_id,
+            "title": channel.title,
+            "description": channel.description,
+            "subscriber_count": channel.subscriber_count,
+            "video_count": channel.video_count,
+        }
+
+
+@pytest.fixture
+async def sample_channel_with_videos(
+    integration_session_factory,
+    sample_channel: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Create a sample channel with associated videos.
+
+    Returns channel data dict including video_ids for testing.
+    """
+    async with integration_session_factory() as session:
+        channel_id = sample_channel["channel_id"]
+        video_ids = []
+
+        # Create sample videos for the channel
+        for i in range(3):
+            video_id = f"testvid{i:04d}"
+            video = VideoDB(
+                video_id=video_id,
+                channel_id=channel_id,
+                title=f"Test Video {i + 1}",
+                description=f"Description for test video {i + 1}",
+                upload_date=datetime(2024, 1, 15 + i, tzinfo=timezone.utc),
+                duration=300 + (i * 60),
+                view_count=1000 * (i + 1),
+                made_for_kids=False,
+                deleted_flag=False,
+            )
+
+            # Check if video already exists
+            result = await session.execute(
+                select(VideoDB).where(VideoDB.video_id == video.video_id)
+            )
+            existing = result.scalar_one_or_none()
+
+            if not existing:
+                session.add(video)
+
+            video_ids.append(video_id)
+
+        await session.commit()
+
+        return {
+            **sample_channel,
+            "video_ids": video_ids,
+        }
+
+
+@pytest.fixture
+async def channel_without_videos(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a channel with no videos for testing has_videos filter.
+
+    Returns channel data dict.
+    """
+    async with integration_session_factory() as session:
+        # Channel ID must be exactly 24 chars starting with UC
+        channel = ChannelDB(
+            channel_id="UCempty12345678901234567",
+            title="Empty Channel",
+            description="A channel with no videos",
+            subscriber_count=100,
+            video_count=0,
+            is_subscribed=False,
+        )
+
+        # Check if channel already exists
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            return {
+                "channel_id": existing.channel_id,
+                "title": existing.title,
+                "video_count": existing.video_count,
+            }
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {
+            "channel_id": channel.channel_id,
+            "title": channel.title,
+            "video_count": channel.video_count,
+        }
+
+
+# =============================================================================
+# T018: Authentication Tests
+# =============================================================================
+
+
+class TestChannelAuth:
+    """Tests for channel endpoint authentication requirements (T018)."""
+
+    async def test_list_channels_requires_auth(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that channel list requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get("/api/v1/channels")
+            assert response.status_code == 401
+
+    async def test_get_channel_requires_auth(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that channel detail requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get(
+                "/api/v1/channels/UCtest123456789012345678"
+            )
+            assert response.status_code == 401
+
+    async def test_get_channel_videos_requires_auth(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that channel videos endpoint requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get(
+                "/api/v1/channels/UCtest123456789012345678/videos"
+            )
+            assert response.status_code == 401
+
+
+# =============================================================================
+# T016: List and Pagination Tests
+# =============================================================================
+
+
+class TestListChannels:
+    """Tests for GET /api/v1/channels endpoint (T016)."""
+
+    async def test_list_channels_returns_paginated_response(
+        self,
+        async_client: AsyncClient,
+        sample_channel: Dict[str, Any],
+    ) -> None:
+        """Test channel list returns paginated response structure."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels")
+            assert response.status_code == 200
+            data = response.json()
+            assert "data" in data
+            assert "pagination" in data
+            assert isinstance(data["data"], list)
+
+    async def test_list_channels_pagination_metadata(
+        self,
+        async_client: AsyncClient,
+        sample_channel: Dict[str, Any],
+    ) -> None:
+        """Test pagination metadata contains required fields."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels?limit=10&offset=0")
+            assert response.status_code == 200
+            data = response.json()
+
+            pagination = data["pagination"]
+            assert "total" in pagination
+            assert "limit" in pagination
+            assert "offset" in pagination
+            assert "has_more" in pagination
+            assert pagination["limit"] == 10
+            assert pagination["offset"] == 0
+
+    async def test_list_channels_default_pagination(
+        self,
+        async_client: AsyncClient,
+        sample_channel: Dict[str, Any],
+    ) -> None:
+        """Test default pagination values (limit=20, offset=0)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels")
+            assert response.status_code == 200
+            data = response.json()
+
+            assert data["pagination"]["limit"] == 20
+            assert data["pagination"]["offset"] == 0
+
+    async def test_list_channels_limit_validation_max(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test limit validation (max 100)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels?limit=200")
+            assert response.status_code == 422
+
+    async def test_list_channels_limit_validation_min(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test limit validation (min 1)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels?limit=0")
+            assert response.status_code == 422
+
+    async def test_list_channels_offset_validation(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test offset validation (must be >= 0)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels?offset=-1")
+            assert response.status_code == 422
+
+    async def test_list_channels_item_structure(
+        self,
+        async_client: AsyncClient,
+        sample_channel: Dict[str, Any],
+    ) -> None:
+        """Test channel list items have correct structure."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels")
+            assert response.status_code == 200
+            data = response.json()
+
+            if data["data"]:
+                channel = data["data"][0]
+                assert "channel_id" in channel
+                assert "title" in channel
+                assert "description" in channel
+                assert "subscriber_count" in channel
+                assert "video_count" in channel
+                assert "thumbnail_url" in channel
+                assert "custom_url" in channel
+
+    async def test_list_channels_has_videos_filter_true(
+        self,
+        async_client: AsyncClient,
+        sample_channel: Dict[str, Any],
+        channel_without_videos: Dict[str, Any],
+    ) -> None:
+        """Test has_videos=true filter returns only channels with videos."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels?has_videos=true")
+            assert response.status_code == 200
+            data = response.json()
+
+            # All returned channels should have video_count > 0
+            for channel in data["data"]:
+                assert channel["video_count"] is not None
+                assert channel["video_count"] > 0
+
+    async def test_list_channels_has_videos_filter_false(
+        self,
+        async_client: AsyncClient,
+        channel_without_videos: Dict[str, Any],
+    ) -> None:
+        """Test has_videos=false filter returns only channels without videos."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels?has_videos=false")
+            assert response.status_code == 200
+            data = response.json()
+
+            # All returned channels should have video_count == 0 or None
+            for channel in data["data"]:
+                assert channel["video_count"] is None or channel["video_count"] == 0
+
+    async def test_list_channels_ordered_by_video_count(
+        self,
+        async_client: AsyncClient,
+        sample_channel: Dict[str, Any],
+        channel_without_videos: Dict[str, Any],
+    ) -> None:
+        """Test channels are ordered by video_count descending."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels")
+            assert response.status_code == 200
+            data = response.json()
+
+            if len(data["data"]) >= 2:
+                # Verify descending order (accounting for nulls)
+                video_counts = [
+                    c.get("video_count") or 0 for c in data["data"]
+                ]
+                for i in range(len(video_counts) - 1):
+                    assert video_counts[i] >= video_counts[i + 1]
+
+
+# =============================================================================
+# T017: Detail and Not Found Tests
+# =============================================================================
+
+
+class TestChannelDetail:
+    """Tests for GET /api/v1/channels/{channel_id} endpoint (T017)."""
+
+    async def test_get_channel_detail(
+        self,
+        async_client: AsyncClient,
+        sample_channel: Dict[str, Any],
+    ) -> None:
+        """Test getting channel details by ID."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                f"/api/v1/channels/{sample_channel['channel_id']}"
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"]["channel_id"] == sample_channel["channel_id"]
+            assert data["data"]["title"] == sample_channel["title"]
+
+    async def test_get_channel_detail_structure(
+        self,
+        async_client: AsyncClient,
+        sample_channel: Dict[str, Any],
+    ) -> None:
+        """Test channel detail response has all expected fields."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                f"/api/v1/channels/{sample_channel['channel_id']}"
+            )
+            assert response.status_code == 200
+            data = response.json()
+
+            channel = data["data"]
+            # ChannelListItem fields
+            assert "channel_id" in channel
+            assert "title" in channel
+            assert "description" in channel
+            assert "subscriber_count" in channel
+            assert "video_count" in channel
+            assert "thumbnail_url" in channel
+            assert "custom_url" in channel
+            # ChannelDetail additional fields
+            assert "default_language" in channel
+            assert "country" in channel
+            assert "is_subscribed" in channel
+            assert "created_at" in channel
+            assert "updated_at" in channel
+
+    async def test_get_channel_not_found(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 response for non-existent channel."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/channels/UC0000000000000000000000"
+            )
+            assert response.status_code == 404
+            data = response.json()
+            # Typed exceptions use ErrorResponse format with "error" wrapper
+            assert "error" in data
+            assert data["error"]["code"] == "NOT_FOUND"
+            assert "Channel" in data["error"]["message"]
+
+    async def test_get_channel_actionable_error_message(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that 404 error has actionable hint."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/channels/UC0000000000000000000000"
+            )
+            data = response.json()
+            # Check for actionable guidance in message
+            assert "Verify the channel ID or run a sync" in data["error"]["message"]
+
+    async def test_get_channel_id_validation_too_short(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test channel_id must be exactly 24 characters (too short)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/channels/short")
+            assert response.status_code == 422
+
+    async def test_get_channel_id_validation_too_long(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test channel_id must be exactly 24 characters (too long)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/channels/UC0000000000000000000000000000000000"
+            )
+            assert response.status_code == 422
+
+
+# =============================================================================
+# Channel Videos Tests (T014)
+# =============================================================================
+
+
+class TestChannelVideos:
+    """Tests for GET /api/v1/channels/{channel_id}/videos endpoint."""
+
+    async def test_get_channel_videos_returns_videos(
+        self,
+        async_client: AsyncClient,
+        sample_channel_with_videos: Dict[str, Any],
+    ) -> None:
+        """Test getting videos for a channel returns video list."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                f"/api/v1/channels/{sample_channel_with_videos['channel_id']}/videos"
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert "data" in data
+            assert "pagination" in data
+            assert isinstance(data["data"], list)
+
+    async def test_get_channel_videos_empty_channel(
+        self,
+        async_client: AsyncClient,
+        channel_without_videos: Dict[str, Any],
+    ) -> None:
+        """Test getting videos for channel with no videos returns empty list."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                f"/api/v1/channels/{channel_without_videos['channel_id']}/videos"
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"] == []
+            assert data["pagination"]["total"] == 0
+
+    async def test_get_channel_videos_not_found_channel(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 when channel does not exist."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/channels/UC0000000000000000000000/videos"
+            )
+            assert response.status_code == 404
+            data = response.json()
+            assert data["error"]["code"] == "NOT_FOUND"
+
+    async def test_get_channel_videos_pagination(
+        self,
+        async_client: AsyncClient,
+        sample_channel_with_videos: Dict[str, Any],
+    ) -> None:
+        """Test pagination works for channel videos."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                f"/api/v1/channels/{sample_channel_with_videos['channel_id']}/videos"
+                "?limit=2&offset=0"
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["pagination"]["limit"] == 2
+            assert data["pagination"]["offset"] == 0
+
+    async def test_get_channel_videos_item_structure(
+        self,
+        async_client: AsyncClient,
+        sample_channel_with_videos: Dict[str, Any],
+    ) -> None:
+        """Test video list items have correct structure."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                f"/api/v1/channels/{sample_channel_with_videos['channel_id']}/videos"
+            )
+            assert response.status_code == 200
+            data = response.json()
+
+            if data["data"]:
+                video = data["data"][0]
+                assert "video_id" in video
+                assert "title" in video
+                assert "channel_id" in video
+                assert "upload_date" in video
+                assert "duration" in video
+                assert "transcript_summary" in video
+
+    async def test_get_channel_videos_ordered_by_upload_date(
+        self,
+        async_client: AsyncClient,
+        sample_channel_with_videos: Dict[str, Any],
+    ) -> None:
+        """Test videos are ordered by upload_date descending."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                f"/api/v1/channels/{sample_channel_with_videos['channel_id']}/videos"
+            )
+            assert response.status_code == 200
+            data = response.json()
+
+            if len(data["data"]) >= 2:
+                dates = [v["upload_date"] for v in data["data"]]
+                # Verify descending order
+                for i in range(len(dates) - 1):
+                    assert dates[i] >= dates[i + 1]

--- a/tests/integration/api/test_f010_regression.py
+++ b/tests/integration/api/test_f010_regression.py
@@ -1,0 +1,264 @@
+"""Regression tests for F010 typed exception retrofit.
+
+These tests verify that the retrofitted F010 endpoints return ErrorResponse format
+with standardized error.code, error.message, and error.details fields.
+
+The migration from raw HTTPException to typed exceptions (NotFoundError,
+BadRequestError, ConflictError) should maintain backward compatibility while
+providing consistent error response structure.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestVideosRouterErrorResponse:
+    """Verify videos router returns ErrorResponse format."""
+
+    async def test_video_not_found_returns_error_response_format(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 for video returns ErrorResponse with error.code and error.message."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/videos/NONEXISTENT")
+
+            assert response.status_code == 404
+            data = response.json()
+
+            # Verify ErrorResponse format
+            assert "error" in data
+            error = data["error"]
+            assert "code" in error
+            assert "message" in error
+            assert error["code"] == "NOT_FOUND"
+            assert "Video" in error["message"]
+            assert "NONEXISTENT" in error["message"]
+
+    async def test_video_not_found_includes_details(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 includes details with resource_type and identifier."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/videos/xyzABCDEFGH")
+
+            assert response.status_code == 404
+            data = response.json()
+
+            # Verify details structure
+            assert "error" in data
+            details = data["error"].get("details")
+            assert details is not None
+            assert details["resource_type"] == "Video"
+            assert details["identifier"] == "xyzABCDEFGH"
+
+
+class TestTranscriptsRouterErrorResponse:
+    """Verify transcripts router returns ErrorResponse format."""
+
+    async def test_transcript_video_not_found_returns_error_response(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 for transcript languages returns ErrorResponse format."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/videos/NONEXISTENT/transcript/languages"
+            )
+
+            assert response.status_code == 404
+            data = response.json()
+
+            # Verify ErrorResponse format
+            assert "error" in data
+            error = data["error"]
+            assert error["code"] == "NOT_FOUND"
+            assert "Video" in error["message"]
+
+    async def test_transcript_not_found_returns_error_response(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 for missing transcript returns ErrorResponse format."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/videos/NONEXISTENT/transcript")
+
+            assert response.status_code == 404
+            data = response.json()
+
+            # Verify ErrorResponse format
+            assert "error" in data
+            error = data["error"]
+            assert error["code"] == "NOT_FOUND"
+            assert "Transcript" in error["message"]
+
+
+class TestSearchRouterErrorResponse:
+    """Verify search router returns ErrorResponse format."""
+
+    async def test_empty_search_query_returns_error_response(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 400 for empty search query returns ErrorResponse format."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # Query with only whitespace
+            response = await async_client.get("/api/v1/search/segments?q=%20%20")
+
+            assert response.status_code == 400
+            data = response.json()
+
+            # Verify ErrorResponse format
+            assert "error" in data
+            error = data["error"]
+            assert error["code"] == "BAD_REQUEST"
+            assert "empty" in error["message"].lower()
+
+
+class TestPreferencesRouterErrorResponse:
+    """Verify preferences router returns ErrorResponse format."""
+
+    async def test_invalid_language_code_returns_error_response(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 400 for invalid language code returns ErrorResponse format."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.put(
+                "/api/v1/preferences/languages",
+                json={
+                    "preferences": [
+                        {"language_code": "invalid-code", "preference_type": "fluent"}
+                    ]
+                },
+            )
+
+            assert response.status_code == 400
+            data = response.json()
+
+            # Verify ErrorResponse format
+            assert "error" in data
+            error = data["error"]
+            assert error["code"] == "BAD_REQUEST"
+            assert "Invalid language codes" in error["message"]
+            assert "details" in error
+            assert "invalid_values" in error["details"]
+
+    async def test_invalid_preference_type_returns_error_response(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 400 for invalid preference type returns ErrorResponse format."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.put(
+                "/api/v1/preferences/languages",
+                json={
+                    "preferences": [
+                        {"language_code": "en", "preference_type": "invalid-type"}
+                    ]
+                },
+            )
+
+            assert response.status_code == 400
+            data = response.json()
+
+            # Verify ErrorResponse format
+            assert "error" in data
+            error = data["error"]
+            assert error["code"] == "BAD_REQUEST"
+            assert "Invalid preference types" in error["message"]
+
+
+class TestSyncRouterErrorResponse:
+    """Verify sync router returns ErrorResponse format."""
+
+    async def test_sync_conflict_returns_error_response(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 409 for sync conflict returns ErrorResponse format."""
+        with (
+            patch("chronovista.api.deps.youtube_oauth") as mock_oauth,
+            patch(
+                "chronovista.api.routers.sync.sync_manager"
+            ) as mock_sync_manager,
+        ):
+            mock_oauth.is_authenticated.return_value = True
+            mock_sync_manager.is_sync_running.return_value = True
+
+            # Create a mock status object
+            from unittest.mock import MagicMock
+            from datetime import datetime, timezone
+
+            mock_status = MagicMock()
+            mock_status.operation_id = "test_op_123"
+            mock_status.operation_type = MagicMock()
+            mock_status.operation_type.value = "subscriptions"
+            mock_status.started_at = datetime.now(timezone.utc)
+            mock_sync_manager.get_current_status.return_value = mock_status
+
+            response = await async_client.post("/api/v1/sync/subscriptions")
+
+            assert response.status_code == 409
+            data = response.json()
+
+            # Verify ErrorResponse format
+            assert "error" in data
+            error = data["error"]
+            assert error["code"] == "CONFLICT"
+            assert "already in progress" in error["message"].lower()
+            assert "details" in error
+            assert "operation_id" in error["details"]
+
+
+class TestErrorResponseStructureConsistency:
+    """Verify consistent ErrorResponse structure across all endpoints."""
+
+    async def test_all_404_errors_have_consistent_structure(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that all 404 errors have the same structure."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            # Test multiple 404 scenarios
+            endpoints = [
+                "/api/v1/videos/NONEXISTENT",
+                "/api/v1/videos/NONEXISTENT/transcript/languages",
+                "/api/v1/videos/NONEXISTENT/transcript",
+            ]
+
+            for endpoint in endpoints:
+                response = await async_client.get(endpoint)
+                assert response.status_code == 404, f"Failed for {endpoint}"
+                data = response.json()
+
+                # All should have error wrapper
+                assert "error" in data, f"Missing error wrapper in {endpoint}"
+                error = data["error"]
+
+                # All should have required fields
+                assert "code" in error, f"Missing code in {endpoint}"
+                assert "message" in error, f"Missing message in {endpoint}"
+                assert error["code"] == "NOT_FOUND", f"Wrong code in {endpoint}"
+
+    async def test_error_response_does_not_have_detail_key(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that new format uses 'error' not 'detail'."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/videos/NONEXISTENT")
+
+            assert response.status_code == 404
+            data = response.json()
+
+            # Should use 'error' not 'detail' (old format)
+            assert "error" in data
+            assert "detail" not in data

--- a/tests/integration/api/test_playlist_endpoints.py
+++ b/tests/integration/api/test_playlist_endpoints.py
@@ -1,0 +1,370 @@
+"""Integration tests for playlist API endpoints (US2: T019-T027).
+
+Tests cover:
+- T025: List/filter tests (linked, unlinked)
+- T026: Mutually exclusive filter error test (400 MUTUALLY_EXCLUSIVE)
+- T027: Video ordering and auth tests
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestListPlaylists:
+    """Tests for GET /api/v1/playlists endpoint."""
+
+    async def test_list_playlists_requires_auth(self, async_client: AsyncClient) -> None:
+        """Test that playlist list requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get("/api/v1/playlists")
+            assert response.status_code == 401
+
+    async def test_list_playlists_returns_paginated_response(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test playlist list returns paginated response structure."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists")
+            assert response.status_code == 200
+            data = response.json()
+            assert "data" in data
+            assert "pagination" in data
+            assert isinstance(data["data"], list)
+
+    async def test_list_playlists_pagination_metadata(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test pagination metadata contains required fields."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists?limit=10&offset=0")
+            assert response.status_code == 200
+            data = response.json()
+
+            pagination = data["pagination"]
+            assert "total" in pagination
+            assert "limit" in pagination
+            assert "offset" in pagination
+            assert "has_more" in pagination
+            assert pagination["limit"] == 10
+            assert pagination["offset"] == 0
+
+    async def test_list_playlists_default_pagination(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test default pagination values (limit=20, offset=0)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists")
+            assert response.status_code == 200
+            data = response.json()
+
+            assert data["pagination"]["limit"] == 20
+            assert data["pagination"]["offset"] == 0
+
+    async def test_list_playlists_limit_validation(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test limit validation (max 100)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # Over max
+            response = await async_client.get("/api/v1/playlists?limit=200")
+            assert response.status_code == 422  # Validation error
+
+    async def test_list_playlists_offset_validation(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test offset validation (must be >= 0)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists?offset=-1")
+            assert response.status_code == 422  # Validation error
+
+
+class TestPlaylistFilters:
+    """Tests for playlist list filters (T025)."""
+
+    async def test_linked_filter_true(self, async_client: AsyncClient) -> None:
+        """Test linked=true filter for YouTube-linked playlists."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists?linked=true")
+            assert response.status_code == 200
+            data = response.json()
+            # All returned playlists should be linked (is_linked=true)
+            for playlist in data["data"]:
+                assert playlist["is_linked"] is True
+
+    async def test_linked_filter_false(self, async_client: AsyncClient) -> None:
+        """Test linked=false filter for internal playlists."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists?linked=false")
+            assert response.status_code == 200
+            data = response.json()
+            # All returned playlists should be unlinked (is_linked=false)
+            for playlist in data["data"]:
+                assert playlist["is_linked"] is False
+
+    async def test_unlinked_filter_true(self, async_client: AsyncClient) -> None:
+        """Test unlinked=true filter for internal playlists."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists?unlinked=true")
+            assert response.status_code == 200
+            data = response.json()
+            # All returned playlists should be unlinked (is_linked=false)
+            for playlist in data["data"]:
+                assert playlist["is_linked"] is False
+
+    async def test_unlinked_filter_false(self, async_client: AsyncClient) -> None:
+        """Test unlinked=false filter for YouTube-linked playlists."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists?unlinked=false")
+            assert response.status_code == 200
+            data = response.json()
+            # All returned playlists should be linked (is_linked=true)
+            for playlist in data["data"]:
+                assert playlist["is_linked"] is True
+
+
+class TestPlaylistMutuallyExclusiveFilters:
+    """Tests for mutually exclusive filter error (T026)."""
+
+    async def test_linked_and_unlinked_both_true_returns_400(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that linked=true and unlinked=true returns 400 MUTUALLY_EXCLUSIVE."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/playlists?linked=true&unlinked=true"
+            )
+            assert response.status_code == 400
+            data = response.json()
+            # Typed exceptions use ErrorResponse format with "error" wrapper
+            assert data["error"]["code"] == "MUTUALLY_EXCLUSIVE"
+            assert "mutually exclusive" in data["error"]["message"].lower()
+            assert data["error"]["details"]["field"] == "linked,unlinked"
+            assert data["error"]["details"]["constraint"] == "mutually_exclusive"
+
+    async def test_linked_true_unlinked_false_is_valid(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that linked=true and unlinked=false is valid (not both true)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/playlists?linked=true&unlinked=false"
+            )
+            # Should succeed - only both=true triggers the error
+            assert response.status_code == 200
+
+    async def test_linked_false_unlinked_true_is_valid(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that linked=false and unlinked=true is valid (not both true)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/playlists?linked=false&unlinked=true"
+            )
+            # Should succeed - only both=true triggers the error
+            assert response.status_code == 200
+
+
+class TestPlaylistDetail:
+    """Tests for GET /api/v1/playlists/{playlist_id} endpoint."""
+
+    async def test_get_playlist_requires_auth(self, async_client: AsyncClient) -> None:
+        """Test that playlist detail requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get("/api/v1/playlists/PLtest123456789012345678901234")
+            assert response.status_code == 401
+
+    async def test_get_playlist_404_for_nonexistent(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 response for non-existent playlist."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists/PLnonexistent123456789012345")
+            assert response.status_code == 404
+            data = response.json()
+            # Typed exceptions use ErrorResponse format with "error" wrapper
+            assert data["error"]["code"] == "NOT_FOUND"
+            assert "Playlist" in data["error"]["message"]
+
+    async def test_get_playlist_actionable_error_message(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that 404 error has actionable message."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists/PLnonexistent123456789012345")
+            data = response.json()
+            # Check actionable guidance
+            assert "Verify the playlist ID or run a sync" in data["error"]["message"]
+
+    async def test_get_playlist_accepts_youtube_id(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test playlist detail accepts YouTube IDs (PL prefix)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # PL-prefixed ID (YouTube format)
+            response = await async_client.get("/api/v1/playlists/PLtest123456789012345678901234")
+            # Should be 404 (not found) not 422 (validation error)
+            assert response.status_code == 404
+
+    async def test_get_playlist_accepts_internal_id(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test playlist detail accepts internal IDs (int_ prefix)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # int_-prefixed ID (internal format)
+            response = await async_client.get(
+                "/api/v1/playlists/int_12345678-1234-1234-1234-123456789012"
+            )
+            # Should be 404 (not found) not 422 (validation error)
+            assert response.status_code == 404
+
+    async def test_get_playlist_accepts_system_ids(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test playlist detail accepts system playlist IDs (LL/WL/HL)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            for system_id in ["LL", "WL", "HL"]:
+                response = await async_client.get(f"/api/v1/playlists/{system_id}")
+                # Should be 404 (not found) not 422 (validation error)
+                assert response.status_code == 404
+
+
+class TestPlaylistVideos:
+    """Tests for GET /api/v1/playlists/{playlist_id}/videos endpoint (T027)."""
+
+    async def test_get_playlist_videos_requires_auth(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that playlist videos requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get(
+                "/api/v1/playlists/PLtest123456789012345678901234/videos"
+            )
+            assert response.status_code == 401
+
+    async def test_get_playlist_videos_404_for_nonexistent_playlist(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 response for videos of non-existent playlist."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/playlists/PLnonexistent123456789012345/videos"
+            )
+            assert response.status_code == 404
+            data = response.json()
+            assert data["error"]["code"] == "NOT_FOUND"
+
+    async def test_get_playlist_videos_returns_paginated_response(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test playlist videos returns paginated response structure."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # Even if playlist doesn't exist, we should get 404 not a validation error
+            response = await async_client.get(
+                "/api/v1/playlists/PLtest123456789012345678901234/videos"
+            )
+            # Will be 404 since playlist doesn't exist in test db
+            assert response.status_code == 404
+
+    async def test_get_playlist_videos_pagination_params(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that pagination parameters are validated."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # Invalid limit
+            response = await async_client.get(
+                "/api/v1/playlists/PLtest123456789012345678901234/videos?limit=200"
+            )
+            assert response.status_code == 422
+
+            # Invalid offset
+            response = await async_client.get(
+                "/api/v1/playlists/PLtest123456789012345678901234/videos?offset=-1"
+            )
+            assert response.status_code == 422
+
+
+class TestPlaylistItemStructure:
+    """Tests for playlist list item structure."""
+
+    async def test_playlist_list_item_has_is_linked_field(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test playlist list items include is_linked field."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists?limit=1")
+            assert response.status_code == 200
+            data = response.json()
+
+            # If there are playlists, check structure
+            if data["data"]:
+                playlist = data["data"][0]
+                assert "playlist_id" in playlist
+                assert "title" in playlist
+                assert "video_count" in playlist
+                assert "privacy_status" in playlist
+                assert "is_linked" in playlist
+                assert isinstance(playlist["is_linked"], bool)
+
+    async def test_is_linked_derived_from_pl_prefix(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test is_linked is True for PL-prefixed playlists."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # Use linked filter to get YouTube playlists
+            response = await async_client.get("/api/v1/playlists?linked=true&limit=10")
+            assert response.status_code == 200
+            data = response.json()
+
+            # All returned playlists should be linked and have PL/LL/WL/HL prefix
+            for playlist in data["data"]:
+                assert playlist["is_linked"] is True
+                prefix = playlist["playlist_id"][:2]
+                assert prefix in ["PL", "LL", "WL", "HL"]
+
+    async def test_is_linked_derived_from_int_prefix(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test is_linked is False for int_-prefixed playlists."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # Use unlinked filter to get internal playlists
+            response = await async_client.get("/api/v1/playlists?unlinked=true&limit=10")
+            assert response.status_code == 200
+            data = response.json()
+
+            # All returned playlists should be unlinked and have int_ prefix
+            for playlist in data["data"]:
+                assert playlist["is_linked"] is False
+                assert playlist["playlist_id"].startswith("int_")

--- a/tests/integration/api/test_preferences_api.py
+++ b/tests/integration/api/test_preferences_api.py
@@ -211,8 +211,8 @@ class TestUpdateLanguagePreferences:
             )
             assert response.status_code == 400
             data = response.json()
-            assert data["detail"]["code"] == "INVALID_LANGUAGE_CODE"
-            assert "invalid-code" in data["detail"]["message"]
+            assert data["error"]["code"] == "BAD_REQUEST"
+            assert "invalid-code" in data["error"]["message"]
 
     async def test_update_preferences_invalid_preference_type(
         self, async_client: AsyncClient
@@ -231,8 +231,8 @@ class TestUpdateLanguagePreferences:
             )
             assert response.status_code == 400
             data = response.json()
-            assert data["detail"]["code"] == "INVALID_PREFERENCE_TYPE"
-            assert "invalid_type" in data["detail"]["message"]
+            assert data["error"]["code"] == "BAD_REQUEST"
+            assert "invalid_type" in data["error"]["message"]
 
     async def test_update_preferences_valid_types(
         self, async_client: AsyncClient

--- a/tests/integration/api/test_search_api.py
+++ b/tests/integration/api/test_search_api.py
@@ -65,7 +65,7 @@ class TestSearchSegments:
             response = await async_client.get("/api/v1/search/segments?q=%20%20")
             assert response.status_code == 400  # Bad request for empty query
             data = response.json()
-            assert data["detail"]["code"] == "VALIDATION_ERROR"
+            assert data["error"]["code"] == "BAD_REQUEST"
 
     async def test_search_empty_results(self, async_client: AsyncClient) -> None:
         """Test empty results for non-matching query."""

--- a/tests/integration/api/test_sync_api.py
+++ b/tests/integration/api/test_sync_api.py
@@ -296,7 +296,7 @@ class TestConflictHandling:
             response2 = await async_client.post("/api/v1/sync/videos")
             assert response2.status_code == 409
             data = response2.json()
-            assert data["detail"]["code"] == "SYNC_IN_PROGRESS"
+            assert data["error"]["code"] == "CONFLICT"
 
             # Cleanup
             sync_manager.complete_operation(success=True)
@@ -319,8 +319,8 @@ class TestConflictHandling:
             data = response2.json()
 
             # Check that details include current operation info
-            assert "details" in data["detail"]
-            details = data["detail"]["details"]
+            assert "details" in data["error"]
+            details = data["error"]["details"]
             assert "operation_id" in details
             assert details["operation_id"] == first_operation_id
             assert "operation_type" in details
@@ -346,7 +346,7 @@ class TestConflictHandling:
             data = response.json()
 
             # Verify message is helpful
-            message = data["detail"]["message"]
+            message = data["error"]["message"]
             assert "in progress" in message.lower()
             assert "wait" in message.lower() or "check status" in message.lower()
 
@@ -536,7 +536,7 @@ class TestTranscriptSyncRequestValidation:
             assert response.status_code == 422
             data = response.json()
             # Check that error mentions empty video IDs
-            assert "detail" in data
+            assert "error" in data
 
     async def test_whitespace_only_video_ids_are_rejected(
         self, async_client: AsyncClient

--- a/tests/integration/api/test_topic_endpoints.py
+++ b/tests/integration/api/test_topic_endpoints.py
@@ -1,0 +1,648 @@
+"""Integration tests for topic API endpoints (US3).
+
+Tests for GET /api/v1/topics, GET /api/v1/topics/{topic_id}, and
+GET /api/v1/topics/{topic_id}/videos endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import (
+    Channel,
+    ChannelTopic,
+    TopicCategory,
+    Video,
+    VideoTopic,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestListTopics:
+    """Tests for GET /api/v1/topics endpoint."""
+
+    async def test_list_topics_requires_auth(self, async_client: AsyncClient) -> None:
+        """Test that topic list requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get("/api/v1/topics")
+            assert response.status_code == 401
+
+    async def test_list_topics_returns_paginated_response(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test topic list returns paginated response structure."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics")
+            assert response.status_code == 200
+            data = response.json()
+            assert "data" in data
+            assert "pagination" in data
+            assert isinstance(data["data"], list)
+
+    async def test_list_topics_pagination_metadata(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test pagination metadata contains required fields."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics?limit=10&offset=0")
+            assert response.status_code == 200
+            data = response.json()
+
+            pagination = data["pagination"]
+            assert "total" in pagination
+            assert "limit" in pagination
+            assert "offset" in pagination
+            assert "has_more" in pagination
+            assert pagination["limit"] == 10
+            assert pagination["offset"] == 0
+
+    async def test_list_topics_default_pagination(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test default pagination values (limit=20, offset=0)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics")
+            assert response.status_code == 200
+            data = response.json()
+
+            assert data["pagination"]["limit"] == 20
+            assert data["pagination"]["offset"] == 0
+
+    async def test_list_topics_limit_validation(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test limit validation (max 100)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # Over max
+            response = await async_client.get("/api/v1/topics?limit=200")
+            assert response.status_code == 422  # Validation error
+
+    async def test_list_topics_offset_validation(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test offset validation (must be >= 0)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics?offset=-1")
+            assert response.status_code == 422  # Validation error
+
+    async def test_list_topics_item_structure(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test topic list items have correct structure."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics?limit=1")
+            assert response.status_code == 200
+            data = response.json()
+
+            if data["data"]:  # If there are topics
+                topic = data["data"][0]
+                assert "topic_id" in topic
+                assert "name" in topic
+                assert "video_count" in topic
+                assert "channel_count" in topic
+
+    async def test_list_topics_has_more_calculation(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test has_more is correctly calculated."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics?limit=100&offset=0")
+            assert response.status_code == 200
+            data = response.json()
+
+            total = data["pagination"]["total"]
+            limit = data["pagination"]["limit"]
+            offset = data["pagination"]["offset"]
+            has_more = data["pagination"]["has_more"]
+
+            # Verify has_more logic
+            assert has_more == ((offset + limit) < total)
+
+
+class TestListTopicsWithCounts:
+    """Tests for GET /api/v1/topics with video_count and channel_count aggregation."""
+
+    async def test_list_topics_includes_video_count(
+        self,
+        async_client: AsyncClient,
+        integration_session_factory,
+    ) -> None:
+        """Test that topic list includes aggregated video_count."""
+        # Create test data
+        async with integration_session_factory() as session:
+            # Clean up any existing test data
+            await session.execute(delete(VideoTopic))
+            await session.execute(delete(Video))
+            await session.execute(delete(ChannelTopic))
+            await session.execute(delete(Channel))
+            await session.execute(delete(TopicCategory))
+            await session.commit()
+
+            # Create a topic
+            topic = TopicCategory(
+                topic_id="test_topic_001",
+                category_name="Test Topic",
+                topic_type="youtube",
+                source="seeded",
+            )
+            session.add(topic)
+            await session.flush()
+
+            # Create a channel for the video
+            channel = Channel(
+                channel_id="UC" + "X" * 22,
+                title="Test Channel",
+                is_subscribed=False,
+            )
+            session.add(channel)
+            await session.flush()
+
+            # Create videos associated with topic
+            video1 = Video(
+                video_id="test_vid_001",
+                channel_id=channel.channel_id,
+                title="Test Video 1",
+                upload_date=datetime.now(timezone.utc),
+                duration=300,
+            )
+            video2 = Video(
+                video_id="test_vid_002",
+                channel_id=channel.channel_id,
+                title="Test Video 2",
+                upload_date=datetime.now(timezone.utc),
+                duration=400,
+            )
+            session.add_all([video1, video2])
+            await session.flush()
+
+            # Create video-topic relationships
+            vt1 = VideoTopic(video_id=video1.video_id, topic_id=topic.topic_id)
+            vt2 = VideoTopic(video_id=video2.video_id, topic_id=topic.topic_id)
+            session.add_all([vt1, vt2])
+            await session.commit()
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics")
+            assert response.status_code == 200
+            data = response.json()
+
+            # Find our test topic
+            test_topic = None
+            for topic in data["data"]:
+                if topic["topic_id"] == "test_topic_001":
+                    test_topic = topic
+                    break
+
+            assert test_topic is not None, "Test topic not found in response"
+            assert test_topic["video_count"] == 2
+            assert test_topic["name"] == "Test Topic"
+
+        # Cleanup
+        async with integration_session_factory() as session:
+            await session.execute(delete(VideoTopic))
+            await session.execute(delete(Video))
+            await session.execute(delete(ChannelTopic))
+            await session.execute(delete(Channel))
+            await session.execute(delete(TopicCategory))
+            await session.commit()
+
+    async def test_list_topics_includes_channel_count(
+        self,
+        async_client: AsyncClient,
+        integration_session_factory,
+    ) -> None:
+        """Test that topic list includes aggregated channel_count."""
+        # Create test data
+        async with integration_session_factory() as session:
+            # Clean up any existing test data
+            await session.execute(delete(VideoTopic))
+            await session.execute(delete(Video))
+            await session.execute(delete(ChannelTopic))
+            await session.execute(delete(Channel))
+            await session.execute(delete(TopicCategory))
+            await session.commit()
+
+            # Create a topic
+            topic = TopicCategory(
+                topic_id="test_topic_002",
+                category_name="Test Topic 2",
+                topic_type="youtube",
+                source="seeded",
+            )
+            session.add(topic)
+            await session.flush()
+
+            # Create channels
+            channel1 = Channel(
+                channel_id="UC" + "Y" * 22,
+                title="Test Channel 1",
+                is_subscribed=False,
+            )
+            channel2 = Channel(
+                channel_id="UC" + "Z" * 22,
+                title="Test Channel 2",
+                is_subscribed=False,
+            )
+            session.add_all([channel1, channel2])
+            await session.flush()
+
+            # Create channel-topic relationships
+            ct1 = ChannelTopic(channel_id=channel1.channel_id, topic_id=topic.topic_id)
+            ct2 = ChannelTopic(channel_id=channel2.channel_id, topic_id=topic.topic_id)
+            session.add_all([ct1, ct2])
+            await session.commit()
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics")
+            assert response.status_code == 200
+            data = response.json()
+
+            # Find our test topic
+            test_topic = None
+            for topic in data["data"]:
+                if topic["topic_id"] == "test_topic_002":
+                    test_topic = topic
+                    break
+
+            assert test_topic is not None, "Test topic not found in response"
+            assert test_topic["channel_count"] == 2
+            assert test_topic["name"] == "Test Topic 2"
+
+        # Cleanup
+        async with integration_session_factory() as session:
+            await session.execute(delete(ChannelTopic))
+            await session.execute(delete(Channel))
+            await session.execute(delete(TopicCategory))
+            await session.commit()
+
+
+class TestTopicDetail:
+    """Tests for GET /api/v1/topics/{topic_id} endpoint."""
+
+    async def test_get_topic_requires_auth(self, async_client: AsyncClient) -> None:
+        """Test that topic detail requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get("/api/v1/topics/gaming")
+            assert response.status_code == 401
+
+    async def test_get_topic_returns_detail(
+        self,
+        async_client: AsyncClient,
+        integration_session_factory,
+    ) -> None:
+        """Test topic detail returns correct structure."""
+        # Create test topic
+        async with integration_session_factory() as session:
+            await session.execute(delete(TopicCategory).where(
+                TopicCategory.topic_id == "test_detail_topic"
+            ))
+            await session.commit()
+
+            topic = TopicCategory(
+                topic_id="test_detail_topic",
+                category_name="Test Detail Topic",
+                topic_type="youtube",
+                source="seeded",
+                wikipedia_url="https://en.wikipedia.org/wiki/Test",
+                normalized_name="test detail topic",
+            )
+            session.add(topic)
+            await session.commit()
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics/test_detail_topic")
+            assert response.status_code == 200
+            data = response.json()
+
+            assert "data" in data
+            topic_data = data["data"]
+            assert topic_data["topic_id"] == "test_detail_topic"
+            assert topic_data["name"] == "Test Detail Topic"
+            assert topic_data["topic_type"] == "youtube"
+            assert topic_data["source"] == "seeded"
+            assert "video_count" in topic_data
+            assert "channel_count" in topic_data
+            assert "created_at" in topic_data
+
+        # Cleanup
+        async with integration_session_factory() as session:
+            await session.execute(delete(TopicCategory).where(
+                TopicCategory.topic_id == "test_detail_topic"
+            ))
+            await session.commit()
+
+    async def test_get_topic_404_for_nonexistent(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 response for non-existent topic."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics/nonexistent_topic_xyz")
+            assert response.status_code == 404
+            data = response.json()
+            assert "error" in data
+            assert data["error"]["code"] == "NOT_FOUND"
+            assert "Topic" in data["error"]["message"]
+
+    async def test_get_topic_actionable_error_message(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that 404 error has actionable message."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics/nonexistent_topic")
+            data = response.json()
+            # Check actionable guidance
+            assert "Verify the topic ID" in data["error"]["message"]
+
+    async def test_get_topic_with_alphanumeric_id(
+        self,
+        async_client: AsyncClient,
+        integration_session_factory,
+    ) -> None:
+        """Test topic lookup with alphanumeric format ID.
+
+        Note: Knowledge graph format IDs (like /m/xxx) contain slashes which
+        require special path handling. This test verifies the more common
+        alphanumeric format works correctly.
+        """
+        # Create test topic with alphanumeric ID
+        async with integration_session_factory() as session:
+            await session.execute(delete(TopicCategory).where(
+                TopicCategory.topic_id == "m_test123_alpha"
+            ))
+            await session.commit()
+
+            topic = TopicCategory(
+                topic_id="m_test123_alpha",
+                category_name="Alphanumeric Topic",
+                topic_type="youtube",
+                source="seeded",
+            )
+            session.add(topic)
+            await session.commit()
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/topics/m_test123_alpha")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"]["topic_id"] == "m_test123_alpha"
+
+        # Cleanup
+        async with integration_session_factory() as session:
+            await session.execute(delete(TopicCategory).where(
+                TopicCategory.topic_id == "m_test123_alpha"
+            ))
+            await session.commit()
+
+
+class TestTopicVideos:
+    """Tests for GET /api/v1/topics/{topic_id}/videos endpoint."""
+
+    async def test_get_topic_videos_requires_auth(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that topic videos requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get("/api/v1/topics/gaming/videos")
+            assert response.status_code == 401
+
+    async def test_get_topic_videos_404_for_nonexistent_topic(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 404 when topic doesn't exist."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/topics/nonexistent_topic_xyz/videos"
+            )
+            assert response.status_code == 404
+            data = response.json()
+            assert data["error"]["code"] == "NOT_FOUND"
+
+    async def test_get_topic_videos_returns_paginated_response(
+        self,
+        async_client: AsyncClient,
+        integration_session_factory,
+    ) -> None:
+        """Test topic videos returns paginated response structure."""
+        # Create test data
+        async with integration_session_factory() as session:
+            # Clean up any existing test data
+            await session.execute(delete(VideoTopic))
+            await session.execute(delete(Video))
+            await session.execute(delete(Channel))
+            await session.execute(delete(TopicCategory).where(
+                TopicCategory.topic_id == "test_videos_topic"
+            ))
+            await session.commit()
+
+            # Create topic
+            topic = TopicCategory(
+                topic_id="test_videos_topic",
+                category_name="Videos Test Topic",
+                topic_type="youtube",
+                source="seeded",
+            )
+            session.add(topic)
+
+            # Create channel
+            channel = Channel(
+                channel_id="UC" + "V" * 22,
+                title="Videos Test Channel",
+                is_subscribed=False,
+            )
+            session.add(channel)
+            await session.flush()
+
+            # Create video
+            video = Video(
+                video_id="vid_test_00",
+                channel_id=channel.channel_id,
+                title="Test Video",
+                upload_date=datetime.now(timezone.utc),
+                duration=300,
+            )
+            session.add(video)
+            await session.flush()
+
+            # Create video-topic relationship
+            vt = VideoTopic(video_id=video.video_id, topic_id=topic.topic_id)
+            session.add(vt)
+            await session.commit()
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/topics/test_videos_topic/videos"
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert "data" in data
+            assert "pagination" in data
+            assert isinstance(data["data"], list)
+            assert len(data["data"]) >= 1
+
+            # Check video structure
+            video = data["data"][0]
+            assert "video_id" in video
+            assert "title" in video
+            assert "upload_date" in video
+            assert "transcript_summary" in video
+
+        # Cleanup
+        async with integration_session_factory() as session:
+            await session.execute(delete(VideoTopic))
+            await session.execute(delete(Video))
+            await session.execute(delete(Channel))
+            await session.execute(delete(TopicCategory).where(
+                TopicCategory.topic_id == "test_videos_topic"
+            ))
+            await session.commit()
+
+    async def test_get_topic_videos_pagination(
+        self,
+        async_client: AsyncClient,
+        integration_session_factory,
+    ) -> None:
+        """Test topic videos pagination parameters."""
+        # Create test data with multiple videos
+        async with integration_session_factory() as session:
+            # Clean up
+            await session.execute(delete(VideoTopic))
+            await session.execute(delete(Video))
+            await session.execute(delete(Channel))
+            await session.execute(delete(TopicCategory).where(
+                TopicCategory.topic_id == "test_pagination_topic"
+            ))
+            await session.commit()
+
+            # Create topic
+            topic = TopicCategory(
+                topic_id="test_pagination_topic",
+                category_name="Pagination Test Topic",
+                topic_type="youtube",
+                source="seeded",
+            )
+            session.add(topic)
+
+            # Create channel
+            channel = Channel(
+                channel_id="UC" + "P" * 22,
+                title="Pagination Test Channel",
+                is_subscribed=False,
+            )
+            session.add(channel)
+            await session.flush()
+
+            # Create multiple videos
+            videos = []
+            for i in range(5):
+                video = Video(
+                    video_id=f"pag_test_{i:02d}",
+                    channel_id=channel.channel_id,
+                    title=f"Pagination Test Video {i}",
+                    upload_date=datetime.now(timezone.utc),
+                    duration=300 + i * 10,
+                )
+                videos.append(video)
+            session.add_all(videos)
+            await session.flush()
+
+            # Create video-topic relationships
+            for video in videos:
+                vt = VideoTopic(video_id=video.video_id, topic_id=topic.topic_id)
+                session.add(vt)
+            await session.commit()
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            # Test with limit
+            response = await async_client.get(
+                "/api/v1/topics/test_pagination_topic/videos?limit=2&offset=0"
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["data"]) == 2
+            assert data["pagination"]["limit"] == 2
+            assert data["pagination"]["offset"] == 0
+            assert data["pagination"]["total"] == 5
+            assert data["pagination"]["has_more"] is True
+
+            # Test with offset
+            response = await async_client.get(
+                "/api/v1/topics/test_pagination_topic/videos?limit=2&offset=4"
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["data"]) == 1
+            assert data["pagination"]["has_more"] is False
+
+        # Cleanup
+        async with integration_session_factory() as session:
+            await session.execute(delete(VideoTopic))
+            await session.execute(delete(Video))
+            await session.execute(delete(Channel))
+            await session.execute(delete(TopicCategory).where(
+                TopicCategory.topic_id == "test_pagination_topic"
+            ))
+            await session.commit()
+
+
+class TestTopicAuthRequirements:
+    """Tests for authentication requirements on all topic endpoints (T035)."""
+
+    async def test_list_topics_requires_auth(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test GET /topics requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get("/api/v1/topics")
+            assert response.status_code == 401
+            data = response.json()
+            assert data["detail"]["code"] == "NOT_AUTHENTICATED"
+
+    async def test_get_topic_requires_auth(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test GET /topics/{topic_id} requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get("/api/v1/topics/gaming")
+            assert response.status_code == 401
+            data = response.json()
+            assert data["detail"]["code"] == "NOT_AUTHENTICATED"
+
+    async def test_get_topic_videos_requires_auth(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test GET /topics/{topic_id}/videos requires authentication."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = False
+            response = await async_client.get("/api/v1/topics/gaming/videos")
+            assert response.status_code == 401
+            data = response.json()
+            assert data["detail"]["code"] == "NOT_AUTHENTICATED"

--- a/tests/integration/api/test_transcripts_api.py
+++ b/tests/integration/api/test_transcripts_api.py
@@ -62,8 +62,9 @@ class TestTranscriptLanguages:
             )
             assert response.status_code == 404
             data = response.json()
-            assert "detail" in data
-            assert data["detail"]["code"] == "NOT_FOUND"
+            # 404 errors should use the new ErrorResponse format
+            assert "error" in data
+            assert data["error"]["code"] == "NOT_FOUND"
 
     async def test_get_languages_video_id_validation(
         self, async_client: AsyncClient
@@ -123,8 +124,9 @@ class TestTranscriptFull:
             response = await async_client.get("/api/v1/videos/NONEXISTENT/transcript")
             assert response.status_code == 404
             data = response.json()
-            assert "detail" in data
-            assert data["detail"]["code"] == "NOT_FOUND"
+            # 404 errors should use the new ErrorResponse format
+            assert "error" in data
+            assert data["error"]["code"] == "NOT_FOUND"
 
     async def test_get_transcript_404_for_missing_language(
         self, async_client: AsyncClient

--- a/tests/integration/api/test_videos_api.py
+++ b/tests/integration/api/test_videos_api.py
@@ -224,9 +224,10 @@ class TestVideoDetail:
             response = await async_client.get("/api/v1/videos/NONEXISTENT")
             assert response.status_code == 404
             data = response.json()
-            assert "detail" in data
-            assert data["detail"]["code"] == "NOT_FOUND"
-            assert "Video 'NONEXISTENT' not found" in data["detail"]["message"]
+            assert "error" in data
+            assert data["error"]["code"] == "NOT_FOUND"
+            assert "Video" in data["error"]["message"]
+            assert "NONEXISTENT" in data["error"]["message"]
 
     async def test_get_video_actionable_error_message(
         self, async_client: AsyncClient
@@ -236,8 +237,8 @@ class TestVideoDetail:
             mock_oauth.is_authenticated.return_value = True
             response = await async_client.get("/api/v1/videos/NONEXISTENT")
             data = response.json()
-            # Check actionable guidance
-            assert "Verify the video ID or run a sync" in data["detail"]["message"]
+            # Check actionable guidance (hint is appended to message)
+            assert "sync" in data["error"]["message"].lower()
 
     async def test_get_video_id_validation_too_short(
         self, async_client: AsyncClient

--- a/tests/integration/enrichment/test_enrichment_validation.py
+++ b/tests/integration/enrichment/test_enrichment_validation.py
@@ -16,11 +16,9 @@ all documented success criteria are met.
 from __future__ import annotations
 
 import json
-import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from typer.testing import CliRunner

--- a/tests/unit/api/test_exception_handlers.py
+++ b/tests/unit/api/test_exception_handlers.py
@@ -1,0 +1,417 @@
+"""Unit tests for API exception handlers.
+
+Tests centralized exception handling for FastAPI endpoints,
+ensuring all exception types return correct HTTP status codes
+and ErrorResponse format.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel, Field
+
+from chronovista.api.exception_handlers import (
+    api_error_handler,
+    auth_error_handler,
+    generic_error_handler,
+    register_exception_handlers,
+    repository_error_handler,
+    validation_error_handler,
+)
+from chronovista.api.schemas.responses import ErrorCode
+from chronovista.exceptions import (
+    APIError,
+    APIValidationError,
+    AuthenticationError,
+    BadRequestError,
+    ConflictError,
+    NotFoundError,
+    RepositoryError,
+)
+
+# Mark all tests as async
+pytestmark = pytest.mark.asyncio
+
+
+class TestNotFoundError:
+    """Tests for NotFoundError exception handling."""
+
+    async def test_not_found_error_returns_404(self) -> None:
+        """Test NotFoundError returns 404 with correct format."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_not_found() -> None:
+            raise NotFoundError(
+                resource_type="Channel",
+                identifier="UCxyz123456789",
+            )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 404
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "NOT_FOUND"
+        assert "Channel" in data["error"]["message"]
+        assert "UCxyz123456789" in data["error"]["message"]
+        assert data["error"]["details"]["resource_type"] == "Channel"
+        assert data["error"]["details"]["identifier"] == "UCxyz123456789"
+
+    async def test_not_found_error_with_hint(self) -> None:
+        """Test NotFoundError includes hint in message."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_not_found() -> None:
+            raise NotFoundError(
+                resource_type="Channel",
+                identifier="UCxyz123456789",
+                hint="Verify the channel ID or run a sync.",
+            )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 404
+        data = response.json()
+        assert "Verify the channel ID" in data["error"]["message"]
+
+
+class TestBadRequestError:
+    """Tests for BadRequestError exception handling."""
+
+    async def test_bad_request_error_returns_400(self) -> None:
+        """Test BadRequestError returns 400 with correct format."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_bad_request() -> None:
+            raise BadRequestError(
+                message="Invalid parameter value",
+                details={"field": "limit", "reason": "Must be positive"},
+            )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "BAD_REQUEST"
+        assert data["error"]["message"] == "Invalid parameter value"
+        assert data["error"]["details"]["field"] == "limit"
+
+    async def test_mutually_exclusive_error_returns_400(self) -> None:
+        """Test BadRequestError with mutually_exclusive flag uses correct code."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_mutually_exclusive() -> None:
+            raise BadRequestError(
+                message="Cannot specify both linked=true and unlinked=true",
+                details={"field": "linked,unlinked", "constraint": "mutually_exclusive"},
+                mutually_exclusive=True,
+            )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["error"]["code"] == "MUTUALLY_EXCLUSIVE"
+
+
+class TestAPIValidationError:
+    """Tests for APIValidationError exception handling."""
+
+    async def test_api_validation_error_returns_422(self) -> None:
+        """Test APIValidationError returns 422 with correct format."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_validation_error() -> None:
+            raise APIValidationError(
+                message="Request validation failed",
+                details={"errors": [{"loc": ["body", "title"], "msg": "field required"}]},
+            )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "VALIDATION_ERROR"
+
+
+class TestConflictError:
+    """Tests for ConflictError exception handling."""
+
+    async def test_conflict_error_returns_409(self) -> None:
+        """Test ConflictError returns 409 with correct format."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_conflict() -> None:
+            raise ConflictError(
+                message="Resource already exists",
+                details={"channel_id": "UCxyz123456789"},
+            )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 409
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "CONFLICT"
+        assert data["error"]["message"] == "Resource already exists"
+
+
+class TestAuthenticationError:
+    """Tests for AuthenticationError exception handling."""
+
+    async def test_auth_error_returns_401(self) -> None:
+        """Test AuthenticationError returns 401 with correct format."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_auth_error() -> None:
+            raise AuthenticationError(message="Invalid or expired token")
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 401
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "NOT_AUTHENTICATED"
+        assert data["error"]["message"] == "Invalid or expired token"
+
+
+class TestRepositoryError:
+    """Tests for RepositoryError exception handling."""
+
+    async def test_repository_error_returns_500(self) -> None:
+        """Test RepositoryError returns 500 without exposing internal details."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_repo_error() -> None:
+            raise RepositoryError(
+                message="Database connection failed",
+                operation="insert",
+                entity_type="Video",
+                original_error=ValueError("sensitive error details"),
+            )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 500
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "DATABASE_ERROR"
+        # Should not expose internal details
+        assert "Database connection failed" not in data["error"]["message"]
+        assert "sensitive error details" not in data["error"]["message"]
+        assert "An internal database error" in data["error"]["message"]
+
+
+class TestPydanticValidationError:
+    """Tests for Pydantic RequestValidationError handling."""
+
+    async def test_pydantic_validation_error_returns_422(self) -> None:
+        """Test Pydantic validation errors return 422 with field details."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        class RequestBody(BaseModel):
+            title: str = Field(..., min_length=1)
+            count: int = Field(..., ge=0)
+
+        @app.post("/test")
+        async def validate_body(body: RequestBody) -> dict[str, str]:
+            return {"status": "ok"}
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Send invalid data
+            response = await client.post("/test", json={"title": "", "count": -1})
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "VALIDATION_ERROR"
+        assert "errors" in data["error"]["details"]
+        assert len(data["error"]["details"]["errors"]) > 0
+
+
+class TestGenericExceptionHandler:
+    """Tests for generic exception handling."""
+
+    async def test_generic_error_returns_500(self) -> None:
+        """Test generic exceptions return 500 without exposing details."""
+        # Debug must be False for exception handlers to catch generic exceptions
+        app = FastAPI(debug=False)
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_generic_error() -> None:
+            raise RuntimeError("Internal implementation detail")
+
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 500
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "INTERNAL_ERROR"
+        # Should not expose internal details
+        assert "Internal implementation detail" not in data["error"]["message"]
+        assert "unexpected error occurred" in data["error"]["message"]
+
+
+class TestAPIErrorBase:
+    """Tests for APIError base class."""
+
+    async def test_api_error_returns_500_by_default(self) -> None:
+        """Test base APIError returns 500 by default."""
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        @app.get("/test")
+        async def raise_api_error() -> None:
+            raise APIError(message="Something went wrong")
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/test")
+
+        assert response.status_code == 500
+        data = response.json()
+        assert data["error"]["code"] == "INTERNAL_ERROR"
+        assert data["error"]["message"] == "Something went wrong"
+
+
+class TestErrorResponseFormat:
+    """Tests for consistent error response format across all handlers."""
+
+    async def test_all_errors_have_error_wrapper(self) -> None:
+        """Test all error responses are wrapped in 'error' key."""
+        # Debug must be False for exception handlers to catch generic exceptions
+        app = FastAPI(debug=False)
+        register_exception_handlers(app)
+
+        @app.get("/not-found")
+        async def raise_not_found() -> None:
+            raise NotFoundError("Video", "xyz123")
+
+        @app.get("/bad-request")
+        async def raise_bad_request() -> None:
+            raise BadRequestError("Bad input")
+
+        @app.get("/auth-error")
+        async def raise_auth() -> None:
+            raise AuthenticationError("Not authenticated")
+
+        @app.get("/generic")
+        async def raise_generic() -> None:
+            raise ValueError("oops")
+
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            for endpoint in ["/not-found", "/bad-request", "/auth-error", "/generic"]:
+                response = await client.get(endpoint)
+                data = response.json()
+                # All responses should have "error" key at top level
+                assert "error" in data, f"{endpoint} response missing 'error' key"
+                # All errors should have code and message
+                assert "code" in data["error"], f"{endpoint} error missing 'code'"
+                assert "message" in data["error"], f"{endpoint} error missing 'message'"
+
+
+class TestErrorCodeEnum:
+    """Tests for ErrorCode enum values."""
+
+    def test_error_code_values(self) -> None:
+        """Test ErrorCode enum has expected values."""
+        # 4xx errors
+        assert ErrorCode.NOT_FOUND.value == "NOT_FOUND"
+        assert ErrorCode.BAD_REQUEST.value == "BAD_REQUEST"
+        assert ErrorCode.VALIDATION_ERROR.value == "VALIDATION_ERROR"
+        assert ErrorCode.NOT_AUTHENTICATED.value == "NOT_AUTHENTICATED"
+        assert ErrorCode.FORBIDDEN.value == "FORBIDDEN"
+        assert ErrorCode.CONFLICT.value == "CONFLICT"
+        assert ErrorCode.MUTUALLY_EXCLUSIVE.value == "MUTUALLY_EXCLUSIVE"
+
+        # 5xx errors
+        assert ErrorCode.INTERNAL_ERROR.value == "INTERNAL_ERROR"
+        assert ErrorCode.DATABASE_ERROR.value == "DATABASE_ERROR"
+        assert ErrorCode.SERVICE_UNAVAILABLE.value == "SERVICE_UNAVAILABLE"
+
+
+class TestExceptionToApiErrorConversion:
+    """Tests for exception to_api_error method."""
+
+    def test_not_found_error_to_api_error(self) -> None:
+        """Test NotFoundError converts to ApiError correctly."""
+        exc = NotFoundError(
+            resource_type="Channel",
+            identifier="UCxyz123456789",
+            hint="Try syncing first.",
+        )
+
+        api_error = exc.to_api_error()
+
+        assert api_error.code == "NOT_FOUND"
+        assert "Channel" in api_error.message
+        assert "UCxyz123456789" in api_error.message
+        assert "Try syncing first" in api_error.message
+        assert api_error.details is not None
+        assert api_error.details["resource_type"] == "Channel"
+        assert api_error.details["identifier"] == "UCxyz123456789"
+
+    def test_bad_request_error_to_api_error(self) -> None:
+        """Test BadRequestError converts to ApiError correctly."""
+        exc = BadRequestError(
+            message="Invalid limit value",
+            details={"field": "limit", "max": 100},
+        )
+
+        api_error = exc.to_api_error()
+
+        assert api_error.code == "BAD_REQUEST"
+        assert api_error.message == "Invalid limit value"
+        assert api_error.details is not None
+        assert api_error.details["field"] == "limit"
+
+    def test_api_error_error_code_property(self) -> None:
+        """Test APIError error_code property returns correct enum."""
+        exc = NotFoundError("Video", "xyz")
+        assert exc.error_code == ErrorCode.NOT_FOUND
+
+        exc2 = BadRequestError("bad", mutually_exclusive=True)
+        assert exc2.error_code == ErrorCode.MUTUALLY_EXCLUSIVE

--- a/tests/unit/services/enrichment/test_logging.py
+++ b/tests/unit/services/enrichment/test_logging.py
@@ -15,7 +15,6 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/unit/services/enrichment/test_report_generation.py
+++ b/tests/unit/services/enrichment/test_report_generation.py
@@ -16,7 +16,6 @@ import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 


### PR DESCRIPTION
## Summary

This PR adds REST API endpoints for the remaining core entities (channels, playlists, topics) and establishes standardized error handling across all 20 API endpoints.

### New Endpoints (9 total)

**Channels**
- `GET /api/v1/channels` - List channels with pagination
- `GET /api/v1/channels/{channel_id}` - Get channel details
- `GET /api/v1/channels/{channel_id}/videos` - Get videos by channel

**Playlists**
- `GET /api/v1/playlists` - List playlists with linked/unlinked filters
- `GET /api/v1/playlists/{playlist_id}` - Get playlist details
- `GET /api/v1/playlists/{playlist_id}/videos` - Get videos in playlist

**Topics**
- `GET /api/v1/topics` - List topics with video/channel counts
- `GET /api/v1/topics/{topic_id}` - Get topic details (supports slash IDs)
- `GET /api/v1/topics/{topic_id}/videos` - Get videos by topic

### Error Handling Standardization

- Added `ErrorCode` enum with 10 standardized codes
- Created centralized exception handlers in `exception_handlers.py`
- Retrofitted all F010 endpoints to use typed exceptions
- Consistent `{"error": {"code": "...", "message": "...", "details": {...}}}` format

### Additional Changes

- Fixed topic IDs with slashes (e.g., `/m/098wr`) using `:path` converter
- Cleaned up orphaned YouTube category IDs from `topic_categories` table
- Updated REST API documentation with all new endpoints
- Bumped version to 0.14.0

## Test Plan

- [x] All 306 tests passing
- [x] mypy --strict passes with 0 errors
- [x] Manual endpoint testing verified all 20 endpoints
- [x] Response times under 500ms (max observed: 141ms)
- [x] Error responses return correct format and codes