### PR TITLE
feat(frontend): Video Detail Page with Transcript Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [0.19.0] - 2026-02-06
+
+### Added
+
+#### Feature 016: Video Detail Page with Transcript Display
+
+A dedicated video detail page with comprehensive metadata display and multi-language transcript support.
+
+**Video Detail Features:**
+
+- **Browser Tab Title**: Shows "Channel Name - Video Title" for easy tab identification
+- **Absolute Date Display**: Upload dates shown as "Jan 15, 2024" instead of relative "1 week ago"
+- **Full Language Codes**: Transcript language selector shows full BCP-47 codes (e.g., "EN-gb" vs "EN") to distinguish variants
+- **Video Metadata**: Title, channel, upload date, duration, view count, like count, description, tags
+- **Watch on YouTube**: External link button with proper `target="_blank"` and `rel="noopener noreferrer"`
+- **Back Navigation**: Consistent "Back to Videos" links
+
+**Transcript Panel Features:**
+
+- **Collapsible Panel**: Expand/collapse with CSS-only 200ms animation
+- **Language Selector**: WAI-ARIA tabs pattern with keyboard navigation (Arrow keys, Home/End)
+- **Quality Indicators**: Checkmark (✓) badge for manual/CC transcripts
+- **View Mode Toggle**: Switch between Segments and Full Text views
+- **Infinite Scroll**: Virtualized segments with 50 initial + 25 subsequent batch loading
+- **Debounced Language Switch**: 150ms debounce with request cancellation
+
+**Accessibility (WCAG 2.1 AA):**
+
+- `prefers-reduced-motion` support for expand/collapse animation
+- `aria-expanded`, `aria-controls` on toggle button
+- `role="tablist"` and `role="tab"` for language selector
+- `aria-live="polite"` announcements for language changes
+- Visible focus indicators on all interactive elements
+
+**New Components:**
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `VideoDetailPage` | `pages/VideoDetailPage.tsx` | Main detail page |
+| `TranscriptPanel` | `components/transcript/TranscriptPanel.tsx` | Collapsible transcript container |
+| `LanguageSelector` | `components/transcript/LanguageSelector.tsx` | Language tab selector |
+| `ViewModeToggle` | `components/transcript/ViewModeToggle.tsx` | Segments/Full Text toggle |
+| `TranscriptSegments` | `components/transcript/TranscriptSegments.tsx` | Virtualized segment list |
+| `TranscriptFullText` | `components/transcript/TranscriptFullText.tsx` | Continuous prose view |
+
+**New Hooks:**
+
+| Hook | Purpose |
+|------|---------|
+| `useVideoDetail` | Fetch video metadata |
+| `useTranscriptLanguages` | Fetch available transcript languages |
+| `useTranscript` | Fetch full transcript text |
+| `useTranscriptSegments` | Infinite scroll for transcript segments |
+| `usePrefersReducedMotion` | Detect reduced motion preference |
+
+**New Route:**
+
+- `/videos/:videoId` - Video detail page with transcript panel
+
+**Technical Details:**
+
+- React Router v6 dynamic route with `useParams`
+- TanStack Query v5 with `useInfiniteQuery` for segments
+- `@tanstack/react-virtual` v3.10+ for windowed virtualization
+- Design tokens extracted to `frontend/src/styles/tokens.ts`
+- 255 passing tests (24 new tests for this feature)
+
 ## [0.18.0] - 2026-02-06
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive user guide and API reference
 - Architecture documentation
 
+## [0.19.0] - 2026-02-06
+
+### Added
+- **Feature 016: Video Detail Page with Transcript Display**
+  - Dedicated video detail page at `/videos/:videoId` route
+  - Browser tab title shows "Channel Name - Video Title"
+  - Absolute date display (e.g., "Jan 15, 2024") instead of relative time
+  - Full BCP-47 language codes in transcript selector (e.g., "EN-gb" vs "EN")
+  - Collapsible transcript panel with expand/collapse animation
+  - WAI-ARIA tabs pattern for language selection with keyboard navigation
+  - Quality indicators (checkmarks) for manual/CC transcripts
+  - View mode toggle between Segments and Full Text views
+  - Infinite scroll with virtualized segments (50 initial + 25 subsequent batches)
+  - 150ms debounced language switching with request cancellation
+  - `prefers-reduced-motion` support for animations
+
+### Components
+- `VideoDetailPage` - Main detail page with video metadata
+- `TranscriptPanel` - Collapsible transcript container
+- `LanguageSelector` - Language tab selector with ARIA attributes
+- `ViewModeToggle` - Segments/Full Text toggle
+- `TranscriptSegments` - Virtualized segment list with infinite scroll
+- `TranscriptFullText` - Continuous prose view
+
+### Hooks
+- `useVideoDetail` - Fetch video metadata
+- `useTranscriptLanguages` - Fetch available transcript languages
+- `useTranscript` - Fetch full transcript text
+- `useTranscriptSegments` - Infinite scroll for transcript segments
+- `usePrefersReducedMotion` - Detect reduced motion preference
+
+### Accessibility
+- WCAG 2.1 AA compliant focus indicators
+- `aria-expanded`, `aria-controls` on toggle buttons
+- `role="tablist"` and `role="tab"` for language selector
+- `aria-live="polite"` announcements for language changes
+- Keyboard navigation (Arrow keys, Home/End, Tab)
+
+### Technical
+- React Router v6 dynamic route with `useParams`
+- TanStack Query v5 with `useInfiniteQuery`
+- `@tanstack/react-virtual` v3.10+ for windowed virtualization
+- Design tokens in `frontend/src/styles/tokens.ts`
+- 255 passing frontend tests
+
 ## [0.18.0] - 2026-02-06
 
 ### Added

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,20 +9,40 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.64.0",
+        "@tanstack/react-virtual": "^3.13.18",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.18",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "@vitest/ui": "^4.0.18",
+        "happy-dom": "^20.5.0",
+        "jsdom": "^28.0.0",
         "orval": "^7.4.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "14.0.1",
@@ -71,6 +91,56 @@
       "peerDependencies": {
         "openapi-types": ">=7"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
+      "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true
     },
     "node_modules/@asyncapi/specs": {
       "version": "6.11.1",
@@ -299,6 +369,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -351,6 +430,132 @@
       "dev": true,
       "peerDependencies": {
         "commander": "~14.0.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
+      "integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ]
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -769,6 +974,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
+      "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@exodus/schemasafe": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
@@ -1058,6 +1280,12 @@
         "lodash.uniq": "^4.5.0",
         "openapi3-ts": "4.5.0"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
@@ -1440,6 +1668,12 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
     },
     "node_modules/@stoplight/better-ajv-errors": {
@@ -2040,6 +2274,123 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.18.tgz",
+      "integrity": "sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.18.tgz",
+      "integrity": "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2080,6 +2431,22 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/es-aggregate-error": {
       "version": "1.0.6",
@@ -2150,6 +2517,21 @@
       "integrity": "sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg==",
       "dev": true
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2168,6 +2550,131 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.18.tgz",
+      "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.18"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abort-controller": {
@@ -2192,6 +2699,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2289,6 +2805,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -2333,6 +2858,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -2381,6 +2915,15 @@
       "dev": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2510,6 +3053,15 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2614,11 +3166,111 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2688,6 +3340,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -2731,6 +3389,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2751,6 +3418,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2924,6 +3598,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3024,6 +3704,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3063,6 +3752,15 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3124,6 +3822,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3151,6 +3855,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3392,6 +4102,23 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/happy-dom": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.5.0.tgz",
+      "integrity": "sha512-VQe+Q5CYiGOgcCERXhcfNsbnrN92FDEKciMH/x6LppU9dd0j4aTjCTlqONFOIMcAm/5JxS3+utowbXV1OoFr+g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^4.5.0",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3479,11 +4206,49 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http2-client": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
       "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
       "dev": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3511,6 +4276,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflected": {
@@ -3758,6 +4532,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3943,6 +4723,89 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
+      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "dev": true,
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^5.3.7",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.20.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsep": {
@@ -4396,6 +5259,16 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4430,6 +5303,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -4474,6 +5353,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
@@ -4487,6 +5375,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -4729,6 +5626,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ]
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -4849,6 +5756,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4875,6 +5806,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4940,6 +5877,43 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -4987,6 +5961,13 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5038,6 +6019,19 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5243,6 +6237,18 @@
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
       "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==",
       "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -5451,6 +6457,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -5467,6 +6479,20 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/slash": {
@@ -5486,6 +6512,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5600,6 +6638,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5648,6 +6698,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -5665,6 +6721,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -5712,6 +6783,33 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
+      "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^7.0.22"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+      "dev": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5722,6 +6820,27 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -5929,6 +7048,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
+      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -6101,11 +7229,121 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -6217,6 +7455,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -6233,6 +7487,42 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,22 +8,33 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "generate-api": "orval"
+    "generate-api": "orval",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.64.0",
+    "@tanstack/react-virtual": "^3.13.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^6.30.3"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "@vitest/ui": "^4.0.18",
+    "happy-dom": "^20.5.0",
+    "jsdom": "^28.0.0",
     "orval": "^7.4.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -2,6 +2,9 @@
  * VideoCard component displays a single video item in the list.
  */
 
+import { Link } from "react-router-dom";
+
+import { cardPatterns, colorTokens } from "../styles";
 import type { VideoListItem } from "../types/video";
 
 interface VideoCardProps {
@@ -103,24 +106,27 @@ export function VideoCard({ video }: VideoCardProps) {
   } = video;
 
   return (
-    <article
-      className="bg-white rounded-xl shadow-md border border-gray-100 p-5 hover:shadow-xl hover:border-gray-200 transition-all duration-200 focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2"
-      tabIndex={0}
-      role="article"
-      aria-label={`Video: ${title}`}
+    <Link
+      to={`/videos/${video.video_id}`}
+      className="block no-underline text-inherit focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-xl"
     >
+      <article
+        className={`${cardPatterns.base} ${cardPatterns.hover} ${cardPatterns.transition} p-5`}
+        role="article"
+        aria-label={`Video: ${title}`}
+      >
       {/* Video Title */}
-      <h3 className="text-lg font-semibold text-gray-900 line-clamp-2 mb-2">
+      <h3 className={`text-lg font-semibold text-${colorTokens.text.primary} line-clamp-2 mb-2`}>
         {title}
       </h3>
 
       {/* Channel Name */}
-      <p className="text-sm text-gray-600 mb-3">
+      <p className={`text-sm text-${colorTokens.text.secondary} mb-3`}>
         {channel_title ?? "Unknown Channel"}
       </p>
 
       {/* Video Metadata Row */}
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500">
+      <div className={`flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-${colorTokens.text.tertiary}`}>
         {/* Duration Badge */}
         <span className="inline-flex items-center bg-gray-100 px-2 py-0.5 rounded font-mono text-xs">
           {formatDuration(duration)}
@@ -137,18 +143,18 @@ export function VideoCard({ video }: VideoCardProps) {
 
       {/* Transcript Info */}
       {transcript_summary.count > 0 && (
-        <div className="mt-3 pt-3 border-t border-gray-100">
+        <div className={`mt-3 pt-3 border-t border-${colorTokens.border}`}>
           <div className="flex items-center gap-2 text-sm">
             <span
               className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
                 transcript_summary.has_manual
-                  ? "bg-green-100 text-green-800"
-                  : "bg-blue-100 text-blue-800"
+                  ? `bg-${colorTokens.status.success.bg} text-${colorTokens.status.success.text}`
+                  : `bg-${colorTokens.status.info.bg} text-${colorTokens.status.info.text}`
               }`}
             >
               {transcript_summary.has_manual ? "Manual CC" : "Auto CC"}
             </span>
-            <span className="text-gray-500">
+            <span className={`text-${colorTokens.text.tertiary}`}>
               {transcript_summary.count} transcript
               {transcript_summary.count !== 1 ? "s" : ""}
               {transcript_summary.languages.length > 0 && (
@@ -161,6 +167,7 @@ export function VideoCard({ video }: VideoCardProps) {
           </div>
         </div>
       )}
-    </article>
+      </article>
+    </Link>
   );
 }

--- a/frontend/src/components/transcript/LanguageSelector.tsx
+++ b/frontend/src/components/transcript/LanguageSelector.tsx
@@ -1,0 +1,269 @@
+/**
+ * LanguageSelector component for transcript language selection.
+ *
+ * Implements WAI-ARIA tabs pattern (NFR-A03) with keyboard navigation
+ * and quality indicators for transcript types.
+ *
+ * @module components/transcript/LanguageSelector
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { DEBOUNCE_CONFIG } from "../../styles/tokens";
+import type { TranscriptLanguage, TranscriptType } from "../../types/transcript";
+
+/**
+ * Props for the LanguageSelector component.
+ */
+export interface LanguageSelectorProps {
+  /** Array of available transcript languages */
+  languages: TranscriptLanguage[];
+  /** Currently selected language code */
+  selectedLanguage: string;
+  /** Callback when language selection changes */
+  onLanguageChange: (code: string) => void;
+  /** Optional ID for aria-controls reference */
+  contentId?: string;
+}
+
+/**
+ * Determines if a transcript type is high quality (manual or auto_synced).
+ *
+ * @param transcriptType - The transcript type to check
+ * @returns true if the transcript is manual/CC quality (FR-011)
+ */
+function isHighQuality(transcriptType: TranscriptType): boolean {
+  return transcriptType === "manual" || transcriptType === "auto_synced";
+}
+
+/**
+ * Gets the display label for a language code.
+ *
+ * Shows full BCP-47 code to distinguish variants (e.g., "en-GB" vs "en").
+ * Displays with the variant in lowercase for readability (e.g., "EN-gb").
+ *
+ * @param languageCode - BCP-47 language code (e.g., "en", "en-GB", "pt-BR")
+ * @returns Formatted language code with primary language uppercase
+ */
+function getLanguageLabel(languageCode: string): string {
+  const parts = languageCode.split("-");
+  const primaryLanguage = (parts[0] ?? languageCode).toUpperCase();
+
+  // If there's a variant (region/script), include it
+  if (parts.length > 1) {
+    const variant = parts.slice(1).join("-").toLowerCase();
+    return `${primaryLanguage}-${variant}`;
+  }
+
+  return primaryLanguage;
+}
+
+/**
+ * LanguageSelector component displays pill tabs for transcript language selection.
+ *
+ * Features:
+ * - WAI-ARIA tabs pattern with proper roles and attributes (NFR-A03)
+ * - Arrow key navigation: Left/Right to move, Home/End for first/last
+ * - Quality indicator (checkmark) for manual/CC transcripts
+ * - Debounced language switch (NFR-P05)
+ * - Aria-live announcements for language changes (NFR-A04)
+ *
+ * @example
+ * ```tsx
+ * <LanguageSelector
+ *   languages={languages}
+ *   selectedLanguage="en"
+ *   onLanguageChange={(code) => setSelectedLanguage(code)}
+ * />
+ * ```
+ */
+export function LanguageSelector({
+  languages,
+  selectedLanguage,
+  onLanguageChange,
+  contentId = "transcript-content",
+}: LanguageSelectorProps) {
+  // Ref for debounce timeout
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Ref for tab elements for focus management
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // State for aria-live announcement
+  const [announcement, setAnnouncement] = useState<string>("");
+
+  // Track the focused tab index for keyboard navigation
+  const [focusedIndex, setFocusedIndex] = useState<number>(() => {
+    const index = languages.findIndex(
+      (lang) => lang.language_code === selectedLanguage
+    );
+    return index >= 0 ? index : 0;
+  });
+
+  // Update focusedIndex when selectedLanguage changes externally
+  useEffect(() => {
+    const index = languages.findIndex(
+      (lang) => lang.language_code === selectedLanguage
+    );
+    if (index >= 0) {
+      setFocusedIndex(index);
+    }
+  }, [selectedLanguage, languages]);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  /**
+   * Handles language selection with debouncing (NFR-P05).
+   */
+  const handleLanguageSelect = useCallback(
+    (languageCode: string, languageName: string) => {
+      if (languageCode === selectedLanguage) {
+        return;
+      }
+
+      // Clear any pending debounce
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+
+      // Debounce the language change (NFR-P05)
+      debounceRef.current = setTimeout(() => {
+        onLanguageChange(languageCode);
+
+        // Announce the language change for screen readers (NFR-A04)
+        setAnnouncement(`Transcript language changed to ${languageName}`);
+
+        // Clear announcement after it's been read
+        setTimeout(() => setAnnouncement(""), 1000);
+      }, DEBOUNCE_CONFIG.languageSwitch);
+    },
+    [selectedLanguage, onLanguageChange]
+  );
+
+  /**
+   * Handles keyboard navigation for tabs (NFR-A03).
+   * - Left/Right arrows: Navigate between tabs
+   * - Home/End: Jump to first/last tab
+   * - Enter/Space: Select the focused tab
+   */
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const tabCount = languages.length;
+      let newIndex = index;
+      let shouldPreventDefault = true;
+
+      switch (event.key) {
+        case "ArrowLeft":
+          newIndex = index > 0 ? index - 1 : tabCount - 1;
+          break;
+        case "ArrowRight":
+          newIndex = index < tabCount - 1 ? index + 1 : 0;
+          break;
+        case "Home":
+          newIndex = 0;
+          break;
+        case "End":
+          newIndex = tabCount - 1;
+          break;
+        default:
+          shouldPreventDefault = false;
+      }
+
+      if (shouldPreventDefault) {
+        event.preventDefault();
+        setFocusedIndex(newIndex);
+        tabRefs.current[newIndex]?.focus();
+
+        // Select the tab when navigating with arrow keys
+        const language = languages[newIndex];
+        if (language) {
+          handleLanguageSelect(language.language_code, language.language_name);
+        }
+      }
+    },
+    [languages, handleLanguageSelect]
+  );
+
+  if (languages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="relative">
+      {/* Tab list container with horizontal scroll for many languages (NFR-R05) */}
+      <div
+        role="tablist"
+        aria-label="Transcript languages"
+        className="flex gap-2 overflow-x-auto pb-1"
+      >
+        {languages.map((language, index) => {
+          const isSelected = language.language_code === selectedLanguage;
+          const highQuality = isHighQuality(language.transcript_type);
+
+          return (
+            <button
+              key={language.language_code}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              role="tab"
+              id={`tab-${language.language_code}`}
+              aria-selected={isSelected}
+              aria-controls={contentId}
+              tabIndex={index === focusedIndex ? 0 : -1}
+              onClick={() =>
+                handleLanguageSelect(
+                  language.language_code,
+                  language.language_name
+                )
+              }
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              className={`
+                inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium
+                whitespace-nowrap transition-colors duration-150
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2
+                ${
+                  isSelected
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }
+              `}
+              title={`${language.language_name} (${highQuality ? "Manual/CC" : "Auto-generated"})`}
+            >
+              {getLanguageLabel(language.language_code)}
+              {highQuality && (
+                <span
+                  aria-hidden="true"
+                  className={isSelected ? "text-white" : "text-green-600"}
+                >
+                  &#10003;
+                </span>
+              )}
+              <span className="sr-only">
+                {language.language_name}
+                {highQuality ? ", high quality transcript" : ""}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Aria-live region for language change announcements (NFR-A04) */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {announcement}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/transcript/TranscriptFullText.tsx
+++ b/frontend/src/components/transcript/TranscriptFullText.tsx
@@ -1,0 +1,213 @@
+/**
+ * TranscriptFullText component displays transcript as continuous prose.
+ *
+ * Shows the complete transcript text without timestamps, optimized for
+ * reading and searching through content.
+ *
+ * Implements:
+ * - FR-019: Full text view as continuous prose
+ * - Loading state with skeleton placeholder
+ * - Error state with retry option
+ *
+ * @module components/transcript/TranscriptFullText
+ */
+
+import { useCallback } from "react";
+
+import { useTranscript } from "../../hooks/useTranscript";
+
+/**
+ * Props for the TranscriptFullText component.
+ */
+export interface TranscriptFullTextProps {
+  /** The YouTube video ID to fetch transcript for */
+  videoId: string;
+  /** The BCP-47 language code for the transcript */
+  languageCode: string;
+}
+
+/**
+ * Skeleton component for loading state.
+ * Displays animated placeholder lines mimicking transcript text.
+ */
+function TranscriptSkeleton() {
+  return (
+    <div
+      className="space-y-3 animate-pulse"
+      role="status"
+      aria-label="Loading transcript"
+    >
+      {/* Multiple lines of varying widths to simulate text */}
+      <div className="h-4 bg-gray-200 rounded w-full" />
+      <div className="h-4 bg-gray-200 rounded w-11/12" />
+      <div className="h-4 bg-gray-200 rounded w-full" />
+      <div className="h-4 bg-gray-200 rounded w-10/12" />
+      <div className="h-4 bg-gray-200 rounded w-full" />
+      <div className="h-4 bg-gray-200 rounded w-9/12" />
+      <div className="h-4 bg-gray-200 rounded w-full" />
+      <div className="h-4 bg-gray-200 rounded w-11/12" />
+      <span className="sr-only">Loading transcript content...</span>
+    </div>
+  );
+}
+
+/**
+ * Error display component with retry button.
+ */
+interface ErrorDisplayProps {
+  /** Error message to display */
+  message: string;
+  /** Callback to retry the fetch */
+  onRetry: () => void;
+}
+
+function ErrorDisplay({ message, onRetry }: ErrorDisplayProps) {
+  return (
+    <div
+      className="rounded-lg border border-red-200 bg-red-50 p-4"
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="flex flex-col items-start gap-3">
+        <div className="flex items-start gap-2">
+          {/* Error icon */}
+          <svg
+            className="h-5 w-5 text-red-600 flex-shrink-0 mt-0.5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <div>
+            <h3 className="text-sm font-medium text-red-800">
+              Failed to load transcript
+            </h3>
+            <p className="text-sm text-red-700 mt-1">{message}</p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={onRetry}
+          className="
+            inline-flex items-center gap-2 px-3 py-1.5
+            text-sm font-medium text-red-700
+            bg-white border border-red-300 rounded-md
+            hover:bg-red-50 hover:border-red-400
+            focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2
+            transition-colors duration-150
+          "
+        >
+          {/* Retry icon */}
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * TranscriptFullText displays transcript as continuous prose text.
+ *
+ * Features:
+ * - Displays full transcript text without timestamps (FR-019)
+ * - Loading state with skeleton placeholder
+ * - Error state with retry option
+ * - Proper text formatting and line height for readability
+ * - WCAG AA compliant text contrast (NFR-A18)
+ *
+ * @example
+ * ```tsx
+ * <TranscriptFullText
+ *   videoId="dQw4w9WgXcQ"
+ *   languageCode="en"
+ * />
+ * ```
+ */
+export function TranscriptFullText({
+  videoId,
+  languageCode,
+}: TranscriptFullTextProps) {
+  const { data: transcript, isLoading, isError, error, refetch } = useTranscript(
+    videoId,
+    languageCode
+  );
+
+  /**
+   * Handles retry button click.
+   */
+  const handleRetry = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  // Loading state
+  if (isLoading) {
+    return <TranscriptSkeleton />;
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <ErrorDisplay
+        message={error?.message ?? "An unexpected error occurred"}
+        onRetry={handleRetry}
+      />
+    );
+  }
+
+  // No transcript data
+  if (!transcript) {
+    return (
+      <div className="text-sm text-gray-500" role="status">
+        No transcript available for this language.
+      </div>
+    );
+  }
+
+  // Empty transcript
+  if (!transcript.full_text || transcript.full_text.trim().length === 0) {
+    return (
+      <div className="text-sm text-gray-500" role="status">
+        Transcript is empty.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="prose prose-sm max-w-none"
+      role="region"
+      aria-label="Full transcript text"
+    >
+      {/*
+        Render full text as paragraphs, preserving line breaks.
+        Using text-gray-900 for WCAG AA compliance (NFR-A18).
+        Line height of 1.75 for readability.
+      */}
+      <p className="text-sm text-gray-900 leading-7 whitespace-pre-wrap">
+        {transcript.full_text}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/transcript/TranscriptPanel.tsx
+++ b/frontend/src/components/transcript/TranscriptPanel.tsx
@@ -1,0 +1,450 @@
+/**
+ * TranscriptPanel component displays transcript availability information.
+ *
+ * Shows a collapsible panel with available transcript languages, quality indicators,
+ * and language selection functionality.
+ *
+ * Implements:
+ * - FR-009 through FR-015: Transcript panel requirements
+ * - FR-012a-c: Expand/collapse with animation and reduced motion support
+ * - FR-014: Session-scoped language persistence
+ * - NFR-A01-A02: Focus management
+ * - NFR-A04-A10: Accessibility requirements
+ *
+ * @module components/transcript/TranscriptPanel
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { usePrefersReducedMotion } from "../../hooks/usePrefersReducedMotion";
+import { useTranscriptLanguages } from "../../hooks/useTranscriptLanguages";
+import type { TranscriptLanguage, TranscriptType } from "../../types/transcript";
+import { LanguageSelector } from "./LanguageSelector";
+import { TranscriptFullText } from "./TranscriptFullText";
+import { TranscriptSegments } from "./TranscriptSegments";
+import { ViewModeToggle, type ViewMode } from "./ViewModeToggle";
+
+/**
+ * Props for the TranscriptPanel component.
+ */
+interface TranscriptPanelProps {
+  /** The YouTube video ID to fetch transcript languages for */
+  videoId: string;
+}
+
+/**
+ * Unique ID for the transcript content region.
+ */
+const TRANSCRIPT_CONTENT_ID = "transcript-content";
+
+/**
+ * Gets the language badge display text with full BCP-47 code.
+ *
+ * Shows full variant codes to distinguish similar languages (e.g., "EN-gb" vs "EN").
+ *
+ * @param languageCode - BCP-47 language code (e.g., "en-GB", "es")
+ * @returns Formatted language code with primary language uppercase
+ */
+function getLanguageBadgeText(languageCode: string): string {
+  const parts = languageCode.split("-");
+  const primaryLanguage = (parts[0] ?? languageCode).toUpperCase();
+
+  // If there's a variant (region/script), include it
+  if (parts.length > 1) {
+    const variant = parts.slice(1).join("-").toLowerCase();
+    return `${primaryLanguage}-${variant}`;
+  }
+
+  return primaryLanguage;
+}
+
+/**
+ * Determines if a transcript type is high quality (manual or auto_synced).
+ *
+ * @param transcriptType - The transcript type to check
+ * @returns true if the transcript is manual/CC quality (FR-011)
+ */
+function isHighQuality(transcriptType: TranscriptType): boolean {
+  return transcriptType === "manual" || transcriptType === "auto_synced";
+}
+
+/**
+ * LanguageBadge component displays a single language with quality indicator.
+ *
+ * Shows a checkmark for manual/CC transcripts per FR-011.
+ */
+function LanguageBadge({ language }: { language: TranscriptLanguage }) {
+  const highQuality = isHighQuality(language.transcript_type);
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium ${
+        highQuality
+          ? "bg-green-100 text-green-800"
+          : "bg-blue-100 text-blue-800"
+      }`}
+      title={`${language.language_name} (${highQuality ? "Manual/CC" : "Auto-generated"})`}
+    >
+      {getLanguageBadgeText(language.language_code)}
+      {highQuality && (
+        <span aria-label="High quality transcript">&#10003;</span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * ChevronIcon component for the expand/collapse button.
+ *
+ * Renders as decorative (aria-hidden="true") per NFR-A09.
+ */
+function ChevronIcon({ isExpanded }: { isExpanded: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={`w-5 h-5 text-gray-500 transform transition-transform duration-200 ${
+        isExpanded ? "rotate-180" : ""
+      }`}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M19 9l-7 7-7-7"
+      />
+    </svg>
+  );
+}
+
+/**
+ * TranscriptPanel displays transcript availability and language options.
+ *
+ * Features:
+ * - Collapsed by default with 48px min-height (FR-010a)
+ * - Shows "Transcript Available" text when collapsed
+ * - Displays language badges with quality indicators (FR-011)
+ * - Expand/collapse toggle with 200ms ease-out animation (FR-012b)
+ * - Max-height 60vh when expanded (FR-012a)
+ * - Respects prefers-reduced-motion (FR-012c)
+ * - Focus management on expand/collapse (NFR-A01, NFR-A02)
+ * - Session-scoped language persistence (FR-014)
+ * - Shows "No transcript available" when no transcripts exist (FR-015)
+ * - Includes aria-live region for accessibility (NFR-A04)
+ *
+ * @example
+ * ```tsx
+ * <TranscriptPanel videoId="dQw4w9WgXcQ" />
+ * ```
+ */
+export function TranscriptPanel({ videoId }: TranscriptPanelProps) {
+  const {
+    data: languages,
+    isLoading,
+    isError,
+    error,
+  } = useTranscriptLanguages(videoId);
+
+  // Expand/collapse state
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Session-scoped language persistence (FR-014)
+  const [selectedLanguage, setSelectedLanguage] = useState<string>("");
+
+  // View mode state for segments vs full text display (FR-016a-c)
+  const [viewMode, setViewMode] = useState<ViewMode>("segments");
+
+  // Refs for focus management (NFR-A01, NFR-A02)
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
+  const languageSelectorRef = useRef<HTMLDivElement>(null);
+  const transcriptContentRef = useRef<HTMLDivElement>(null);
+
+  // Check for reduced motion preference (FR-012c)
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  // State for aria-live announcements
+  const [announcement, setAnnouncement] = useState<string>("");
+
+  // Initialize selected language when languages load
+  useEffect(() => {
+    if (languages && languages.length > 0 && !selectedLanguage) {
+      // Default to first language
+      const firstLanguage = languages[0];
+      if (firstLanguage) {
+        setSelectedLanguage(firstLanguage.language_code);
+      }
+    }
+  }, [languages, selectedLanguage]);
+
+  /**
+   * Handles expand/collapse toggle.
+   * Manages focus per NFR-A01 (focus first tab on expand) and NFR-A02 (focus toggle on collapse).
+   */
+  const handleToggle = useCallback(() => {
+    setIsExpanded((prev) => {
+      const newState = !prev;
+
+      // Announce state change (NFR-A04)
+      setAnnouncement(
+        newState ? "Transcript panel expanded" : "Transcript panel collapsed"
+      );
+
+      // Clear announcement after it's been read
+      setTimeout(() => setAnnouncement(""), 1000);
+
+      // Focus management
+      if (newState) {
+        // NFR-A01: Focus first language tab on expand
+        // Use setTimeout to wait for the panel to be visible
+        setTimeout(() => {
+          const firstTab = languageSelectorRef.current?.querySelector(
+            'button[role="tab"]'
+          ) as HTMLButtonElement | null;
+          firstTab?.focus();
+        }, prefersReducedMotion ? 0 : 200);
+      } else {
+        // NFR-A02: Return focus to toggle on collapse
+        setTimeout(() => {
+          toggleButtonRef.current?.focus();
+        }, prefersReducedMotion ? 0 : 200);
+      }
+
+      return newState;
+    });
+  }, [prefersReducedMotion]);
+
+  /**
+   * Handles language selection change.
+   */
+  const handleLanguageChange = useCallback((code: string) => {
+    setSelectedLanguage(code);
+  }, []);
+
+  /**
+   * Handles view mode change (FR-016a-c).
+   * Resets scroll position to top when switching between segments and full text views.
+   */
+  const handleViewModeChange = useCallback((mode: ViewMode) => {
+    setViewMode(mode);
+
+    // Reset scroll position to top when view mode changes (FR-016a-c)
+    if (transcriptContentRef.current) {
+      transcriptContentRef.current.scrollTop = 0;
+    }
+  }, []);
+
+  /**
+   * Handles scroll position reset callback from TranscriptSegments.
+   * Called when segments reset their internal scroll position.
+   */
+  const handleScrollReset = useCallback(() => {
+    // Additional scroll reset handling if needed
+    if (transcriptContentRef.current) {
+      transcriptContentRef.current.scrollTop = 0;
+    }
+  }, []);
+
+  // Handle loading state
+  if (isLoading) {
+    return (
+      <div
+        className="bg-white rounded-lg border border-gray-100 min-h-[48px] px-4 py-3 animate-pulse"
+        role="status"
+        aria-label="Loading transcript information"
+      >
+        <div className="flex items-center gap-3">
+          <div className="h-4 bg-gray-200 rounded w-32" />
+          <div className="flex gap-2">
+            <div className="h-6 bg-gray-200 rounded-full w-10" />
+            <div className="h-6 bg-gray-200 rounded-full w-10" />
+          </div>
+        </div>
+        <span className="sr-only">Loading transcript information...</span>
+      </div>
+    );
+  }
+
+  // Handle error state
+  if (isError) {
+    return (
+      <div
+        className="bg-white rounded-lg border border-red-200 min-h-[48px] px-4 py-3"
+        role="alert"
+        aria-live="polite"
+      >
+        <p className="text-sm text-red-800">
+          Could not load transcript information.
+          {error?.message && (
+            <span className="block text-red-600 text-xs mt-1">
+              {error.message}
+            </span>
+          )}
+        </p>
+      </div>
+    );
+  }
+
+  // Handle no transcripts available (FR-015)
+  if (!languages || languages.length === 0) {
+    return (
+      <div
+        className="bg-white rounded-lg border border-gray-100 min-h-[48px] px-4 py-3"
+        role="region"
+        aria-label="Transcript information"
+        aria-live="polite"
+      >
+        <p className="text-sm text-gray-500">
+          No transcript available for this video
+        </p>
+      </div>
+    );
+  }
+
+  // Animation classes based on reduced motion preference (FR-012c)
+  const animationClasses = prefersReducedMotion
+    ? ""
+    : "transition-all duration-200 ease-out";
+
+  // Button text based on state (NFR-A08)
+  const buttonText = isExpanded ? "Hide transcript" : "Show transcript";
+
+  return (
+    <div
+      className="bg-white rounded-lg border border-gray-100 overflow-hidden"
+      role="region"
+      aria-label="Transcript information"
+    >
+      {/* Expand/collapse toggle button (NFR-A06, NFR-A07) */}
+      <button
+        ref={toggleButtonRef}
+        type="button"
+        onClick={handleToggle}
+        aria-expanded={isExpanded}
+        aria-controls={TRANSCRIPT_CONTENT_ID}
+        className={`
+          w-full min-h-[48px] px-4 py-3
+          flex items-center justify-between
+          text-left
+          hover:bg-gray-50
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500
+          ${animationClasses}
+        `}
+      >
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Transcript Available text */}
+          <span className="text-sm font-medium text-gray-900">
+            Transcript Available
+          </span>
+
+          {/* Language badges (shown in collapsed state) */}
+          {!isExpanded && (
+            <div
+              className="flex flex-wrap gap-2"
+              role="list"
+              aria-label="Available languages"
+            >
+              {languages.map((language) => (
+                <div key={language.language_code} role="listitem">
+                  <LanguageBadge language={language} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Toggle indicator with button text and chevron */}
+        <div className="flex items-center gap-2 ml-4 flex-shrink-0">
+          <span className="text-sm text-gray-600">{buttonText}</span>
+          <ChevronIcon isExpanded={isExpanded} />
+        </div>
+      </button>
+
+      {/* Expandable content area */}
+      <div
+        id={TRANSCRIPT_CONTENT_ID}
+        role="tabpanel"
+        aria-hidden={!isExpanded}
+        className={`
+          overflow-hidden
+          ${animationClasses}
+          ${
+            isExpanded
+              ? "max-h-[60vh] sm:max-h-[50vh] lg:max-h-[60vh] opacity-100"
+              : "max-h-0 opacity-0"
+          }
+        `}
+        style={{
+          // Ensure smooth height transition (NFR-P08)
+          visibility: isExpanded ? "visible" : "hidden",
+        }}
+      >
+        <div className="px-4 pb-4 border-t border-gray-100">
+          {/* Language selector tabs */}
+          <div ref={languageSelectorRef} className="pt-3 pb-3">
+            <LanguageSelector
+              languages={languages}
+              selectedLanguage={selectedLanguage}
+              onLanguageChange={handleLanguageChange}
+              contentId={TRANSCRIPT_CONTENT_ID}
+            />
+          </div>
+
+          {/* Transcript content with view mode toggle */}
+          {selectedLanguage && (
+            <>
+              {/* View Mode Toggle (FR-016a-c) */}
+              <div className="pb-3">
+                <ViewModeToggle
+                  mode={viewMode}
+                  onModeChange={handleViewModeChange}
+                />
+              </div>
+
+              {/* Transcript Content */}
+              <div
+                ref={transcriptContentRef}
+                className="overflow-y-auto max-h-[calc(60vh-150px)] sm:max-h-[calc(50vh-150px)] lg:max-h-[calc(60vh-150px)]"
+                role="region"
+                aria-label="Transcript content"
+              >
+                {viewMode === "segments" ? (
+                  <TranscriptSegments
+                    videoId={videoId}
+                    languageCode={selectedLanguage}
+                    onScrollPositionReset={handleScrollReset}
+                  />
+                ) : (
+                  <TranscriptFullText
+                    videoId={videoId}
+                    languageCode={selectedLanguage}
+                  />
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Screen reader announcement for state changes (NFR-A04) */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {announcement}
+      </div>
+
+      {/* Screen reader summary when collapsed */}
+      {!isExpanded && (
+        <div className="sr-only" aria-live="polite">
+          {languages.length} transcript{languages.length !== 1 ? "s" : ""}{" "}
+          available in {languages.map((l) => l.language_name).join(", ")}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/transcript/TranscriptSegments.tsx
+++ b/frontend/src/components/transcript/TranscriptSegments.tsx
@@ -1,0 +1,467 @@
+/**
+ * TranscriptSegments component for displaying transcript segments with infinite scroll.
+ *
+ * Implements:
+ * - FR-018: Timestamped segments with timestamp on left, text on right
+ * - FR-020c-f: Infinite scroll with trigger 200px from bottom
+ * - FR-020d: 3 skeleton segments during loading
+ * - FR-020e: "End of transcript" indicator
+ * - FR-020f: User can scroll during loading
+ * - FR-025a-d: Error handling with retry and segment preservation
+ * - NFR-A11-A15: Keyboard scrolling and accessibility
+ * - NFR-P12-P16: Virtualization for 500+ segments
+ * - NFR-R06: Responsive text sizing
+ *
+ * @module components/transcript/TranscriptSegments
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+import { useTranscriptSegments } from "../../hooks/useTranscriptSegments";
+import { formatTimestamp } from "../../utils/formatTimestamp";
+import {
+  INFINITE_SCROLL_CONFIG,
+  VIRTUALIZATION_CONFIG,
+  RESPONSIVE_CONFIG,
+  CONTRAST_SAFE_COLORS,
+} from "../../styles/tokens";
+import type { TranscriptSegment } from "../../types/transcript";
+
+/**
+ * Props for the TranscriptSegments component.
+ */
+export interface TranscriptSegmentsProps {
+  /** The YouTube video ID */
+  videoId: string;
+  /** BCP-47 language code for the transcript */
+  languageCode: string;
+  /** Callback when scroll position resets (e.g., on view mode change) */
+  onScrollPositionReset?: () => void;
+}
+
+/**
+ * SegmentItem component renders a single transcript segment.
+ */
+function SegmentItem({
+  segment,
+  isVirtualized,
+}: {
+  segment: TranscriptSegment;
+  isVirtualized: boolean;
+}) {
+  return (
+    <div
+      className={`flex gap-4 py-2 ${isVirtualized ? "px-2" : ""}`}
+      data-segment-id={segment.id}
+    >
+      {/* Timestamp - left side (NFR-A17, NFR-A18: text-gray-600 for 7.0:1 contrast) */}
+      <span
+        className={`flex-shrink-0 w-16 ${CONTRAST_SAFE_COLORS.timestamp} font-mono ${RESPONSIVE_CONFIG.segmentTextSize.mobile} lg:${RESPONSIVE_CONFIG.segmentTextSize.desktop}`}
+      >
+        {formatTimestamp(segment.start_time)}
+      </span>
+
+      {/* Segment text - right side (NFR-A16, NFR-A18: text-gray-900 for 16.6:1 contrast) */}
+      <p
+        className={`flex-1 ${CONTRAST_SAFE_COLORS.bodyText} ${RESPONSIVE_CONFIG.segmentTextSize.mobile} lg:${RESPONSIVE_CONFIG.segmentTextSize.desktop}`}
+      >
+        {segment.text}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * SkeletonSegment component renders a loading placeholder segment.
+ */
+function SkeletonSegment() {
+  return (
+    <div className="flex gap-4 py-2 animate-pulse" aria-hidden="true">
+      {/* Skeleton timestamp */}
+      <div className="flex-shrink-0 w-16 h-5 bg-gray-200 rounded" />
+      {/* Skeleton text (random width for visual variety) */}
+      <div className="flex-1 h-5 bg-gray-200 rounded" style={{ width: "85%" }} />
+    </div>
+  );
+}
+
+/**
+ * EndOfTranscript indicator shown when all segments are loaded.
+ */
+function EndOfTranscript() {
+  return (
+    <div
+      className="flex justify-center py-4 text-sm text-gray-500"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="flex items-center gap-2">
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+        End of transcript
+      </span>
+    </div>
+  );
+}
+
+/**
+ * ErrorRetry component for displaying inline retry option on partial failure.
+ */
+function ErrorRetry({
+  onRetry,
+  hasLoadedSegments,
+}: {
+  onRetry: () => void;
+  hasLoadedSegments: boolean;
+}) {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 py-4 px-4 bg-red-50 border border-red-200 rounded-lg mx-2"
+      role="alert"
+      aria-live="polite"
+    >
+      <p className="text-sm text-red-800">
+        {hasLoadedSegments
+          ? "Could not load more segments."
+          : "Could not load transcript segments."}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="px-4 py-2 text-sm font-medium text-red-800 bg-white border border-red-300 rounded-md hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+/**
+ * VirtualizedSegmentList component for rendering 500+ segments efficiently.
+ *
+ * Uses @tanstack/react-virtual for windowed rendering (NFR-P12-P16).
+ */
+function VirtualizedSegmentList({
+  segments,
+  containerRef,
+  onScroll,
+}: {
+  segments: TranscriptSegment[];
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  onScroll: () => void;
+}) {
+  const virtualizer = useVirtualizer({
+    count: segments.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => VIRTUALIZATION_CONFIG.estimatedHeight, // NFR-P15: 48px
+    overscan: VIRTUALIZATION_CONFIG.overscan, // NFR-P14: 5 segments
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  return (
+    <div
+      style={{
+        height: `${virtualizer.getTotalSize()}px`,
+        width: "100%",
+        position: "relative",
+      }}
+      onScroll={onScroll}
+    >
+      {virtualItems.map((virtualItem) => {
+        const segment = segments[virtualItem.index];
+        if (!segment) return null;
+
+        return (
+          <div
+            key={virtualItem.key}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              height: `${virtualItem.size}px`,
+              transform: `translateY(${virtualItem.start}px)`,
+            }}
+          >
+            <SegmentItem segment={segment} isVirtualized={true} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * StandardSegmentList component for rendering segments without virtualization.
+ */
+function StandardSegmentList({ segments }: { segments: TranscriptSegment[] }) {
+  return (
+    <>
+      {segments.map((segment) => (
+        <SegmentItem key={segment.id} segment={segment} isVirtualized={false} />
+      ))}
+    </>
+  );
+}
+
+/**
+ * TranscriptSegments displays transcript segments with infinite scroll and virtualization.
+ *
+ * Features:
+ * - Timestamped display with timestamp on left, text on right (FR-018)
+ * - Infinite scroll triggered 200px from bottom (FR-020c)
+ * - 3 skeleton segments during loading (FR-020d)
+ * - "End of transcript" indicator when all loaded (FR-020e)
+ * - User can scroll during loading (FR-020f)
+ * - Virtualization for 500+ segments using @tanstack/react-virtual (NFR-P12-P16)
+ * - Keyboard scrolling: Arrow Up/Down, Page Up/Down, Home/End (NFR-A11-A14)
+ * - Accessible container with tabindex, role, aria-label (NFR-A15)
+ * - Responsive text sizing: text-sm mobile, text-base desktop (NFR-R06)
+ * - Error handling with retry button and segment preservation (FR-025a-d)
+ *
+ * @example
+ * ```tsx
+ * <TranscriptSegments
+ *   videoId="dQw4w9WgXcQ"
+ *   languageCode="en"
+ *   onScrollPositionReset={() => console.log('Scroll reset')}
+ * />
+ * ```
+ */
+export function TranscriptSegments({
+  videoId,
+  languageCode,
+  onScrollPositionReset,
+}: TranscriptSegmentsProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const loadMoreRef = useRef<HTMLDivElement>(null);
+  const previousLanguageRef = useRef<string>(languageCode);
+
+  const {
+    segments,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    isError,
+    // error is available but not displayed; we use isError for conditional rendering
+    fetchNextPage,
+    retry,
+  } = useTranscriptSegments(videoId, languageCode);
+
+  // Determine if virtualization should be used (NFR-P12)
+  const useVirtualization = segments.length > VIRTUALIZATION_CONFIG.threshold;
+
+  // Reset scroll position when language changes (FR-016a-c)
+  useEffect(() => {
+    if (previousLanguageRef.current !== languageCode) {
+      if (containerRef.current) {
+        containerRef.current.scrollTop = 0;
+      }
+      onScrollPositionReset?.();
+      previousLanguageRef.current = languageCode;
+    }
+  }, [languageCode, onScrollPositionReset]);
+
+  // Intersection Observer for infinite scroll (FR-020c)
+  useEffect(() => {
+    const loadMoreElement = loadMoreRef.current;
+    if (!loadMoreElement || !hasNextPage || isFetchingNextPage) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry?.isIntersecting) {
+          fetchNextPage();
+        }
+      },
+      {
+        root: containerRef.current,
+        // FR-020c: Trigger 200px from bottom
+        rootMargin: `0px 0px ${INFINITE_SCROLL_CONFIG.triggerDistance}px 0px`,
+        threshold: 0,
+      }
+    );
+
+    observer.observe(loadMoreElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // Keyboard navigation handler (NFR-A11-A14)
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const segmentHeight = VIRTUALIZATION_CONFIG.estimatedHeight; // ~48px
+      const viewportHeight = container.clientHeight;
+
+      switch (event.key) {
+        case "ArrowUp":
+          // NFR-A12: Scroll up by one segment
+          event.preventDefault();
+          container.scrollBy({ top: -segmentHeight, behavior: "smooth" });
+          break;
+
+        case "ArrowDown":
+          // NFR-A12: Scroll down by one segment
+          event.preventDefault();
+          container.scrollBy({ top: segmentHeight, behavior: "smooth" });
+          break;
+
+        case "PageUp":
+          // NFR-A13: Scroll up by viewport height
+          event.preventDefault();
+          container.scrollBy({ top: -viewportHeight, behavior: "smooth" });
+          break;
+
+        case "PageDown":
+          // NFR-A13: Scroll down by viewport height
+          event.preventDefault();
+          container.scrollBy({ top: viewportHeight, behavior: "smooth" });
+          break;
+
+        case "Home":
+          // NFR-A14: Scroll to beginning
+          event.preventDefault();
+          container.scrollTo({ top: 0, behavior: "smooth" });
+          break;
+
+        case "End":
+          // NFR-A14: Scroll to end
+          event.preventDefault();
+          container.scrollTo({
+            top: container.scrollHeight,
+            behavior: "smooth",
+          });
+          break;
+      }
+    },
+    []
+  );
+
+  // Handle scroll for manual infinite scroll trigger (fallback)
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || !hasNextPage || isFetchingNextPage) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+
+    // FR-020c: Trigger 200px from bottom
+    if (distanceFromBottom < INFINITE_SCROLL_CONFIG.triggerDistance) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // Initial loading state
+  if (isLoading && segments.length === 0) {
+    return (
+      <div
+        className="p-2"
+        role="status"
+        aria-label="Loading transcript segments"
+      >
+        {/* FR-020d: Show 3 skeleton segments */}
+        {Array.from({ length: INFINITE_SCROLL_CONFIG.skeletonCount }).map(
+          (_, index) => (
+            <SkeletonSegment key={index} />
+          )
+        )}
+        <span className="sr-only">Loading transcript segments...</span>
+      </div>
+    );
+  }
+
+  // Error state with no segments loaded (FR-025a)
+  if (isError && segments.length === 0) {
+    return (
+      <ErrorRetry onRetry={retry} hasLoadedSegments={false} />
+    );
+  }
+
+  // No segments available
+  if (segments.length === 0 && !isLoading) {
+    return (
+      <div className="p-4 text-center text-sm text-gray-500" role="status">
+        No transcript segments available for this language.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      // NFR-A11: Focusable container
+      tabIndex={0}
+      // NFR-A15: Accessible region
+      role="region"
+      aria-label="Transcript segments"
+      onKeyDown={handleKeyDown}
+      onScroll={handleScroll}
+      className={`
+        overflow-y-auto
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500
+        max-h-[calc(40vh-100px)] sm:max-h-[calc(50vh-100px)] lg:max-h-[calc(60vh-100px)]
+      `}
+    >
+      {/* Segment list - virtualized or standard based on count */}
+      {useVirtualization ? (
+        <VirtualizedSegmentList
+          segments={segments}
+          containerRef={containerRef}
+          onScroll={handleScroll}
+        />
+      ) : (
+        <StandardSegmentList segments={segments} />
+      )}
+
+      {/* Loading indicator for infinite scroll (FR-020d) */}
+      {isFetchingNextPage && (
+        <div role="status" aria-label="Loading more segments">
+          {Array.from({ length: INFINITE_SCROLL_CONFIG.skeletonCount }).map(
+            (_, index) => (
+              <SkeletonSegment key={`loading-${index}`} />
+            )
+          )}
+          <span className="sr-only">Loading more segments...</span>
+        </div>
+      )}
+
+      {/* Error state with loaded segments (FR-025b, FR-025d) */}
+      {isError && segments.length > 0 && (
+        <ErrorRetry onRetry={retry} hasLoadedSegments={true} />
+      )}
+
+      {/* End of transcript indicator (FR-020e) */}
+      {!hasNextPage && !isLoading && !isError && segments.length > 0 && (
+        <EndOfTranscript />
+      )}
+
+      {/* Intersection observer target for infinite scroll */}
+      {hasNextPage && !isFetchingNextPage && (
+        <div
+          ref={loadMoreRef}
+          className="h-1"
+          aria-hidden="true"
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/transcript/ViewModeToggle.tsx
+++ b/frontend/src/components/transcript/ViewModeToggle.tsx
@@ -1,0 +1,136 @@
+/**
+ * ViewModeToggle component for switching between transcript view modes.
+ *
+ * Provides a toggle between "Segments" (timestamped) and "Full Text" (continuous prose)
+ * views for transcript display.
+ *
+ * Implements accessibility requirements:
+ * - NFR-A06: Keyboard-accessible toggle
+ * - aria-pressed states for toggle buttons
+ * - aria-live announcements for view changes
+ *
+ * @module components/transcript/ViewModeToggle
+ */
+
+import { useCallback, useState } from "react";
+
+/**
+ * View mode options for transcript display.
+ * - "segments": Timestamped segments with individual entries
+ * - "fulltext": Continuous prose view without timestamps
+ */
+export type ViewMode = "segments" | "fulltext";
+
+/**
+ * Props for the ViewModeToggle component.
+ */
+export interface ViewModeToggleProps {
+  /** Currently active view mode */
+  mode: ViewMode;
+  /** Callback when view mode changes */
+  onModeChange: (mode: ViewMode) => void;
+}
+
+/**
+ * ViewModeToggle provides a toggle button group for switching transcript view modes.
+ *
+ * Features:
+ * - Two toggle options: "Segments" and "Full Text"
+ * - Visual styling similar to tabs/segmented control
+ * - Keyboard accessible with Enter/Space activation
+ * - aria-pressed states for screen readers
+ * - aria-live announcement when view changes
+ *
+ * @example
+ * ```tsx
+ * const [viewMode, setViewMode] = useState<ViewMode>('segments');
+ *
+ * <ViewModeToggle
+ *   mode={viewMode}
+ *   onModeChange={setViewMode}
+ * />
+ * ```
+ */
+export function ViewModeToggle({ mode, onModeChange }: ViewModeToggleProps) {
+  // State for aria-live announcement
+  const [announcement, setAnnouncement] = useState<string>("");
+
+  /**
+   * Handles view mode change with accessibility announcement.
+   */
+  const handleModeChange = useCallback(
+    (newMode: ViewMode) => {
+      if (newMode === mode) {
+        return;
+      }
+
+      onModeChange(newMode);
+
+      // Announce the view change for screen readers
+      const modeLabel = newMode === "segments" ? "Segments" : "Full Text";
+      setAnnouncement(`View changed to ${modeLabel}`);
+
+      // Clear announcement after it's been read
+      setTimeout(() => setAnnouncement(""), 1000);
+    },
+    [mode, onModeChange]
+  );
+
+  /**
+   * Gets the button classes based on whether it's active.
+   */
+  const getButtonClasses = (isActive: boolean): string => {
+    const baseClasses = `
+      px-4 py-2 text-sm font-medium
+      transition-colors duration-150
+      focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1
+    `;
+
+    if (isActive) {
+      return `${baseClasses} bg-blue-600 text-white`;
+    }
+
+    return `${baseClasses} bg-gray-100 text-gray-700 hover:bg-gray-200`;
+  };
+
+  return (
+    <div className="relative">
+      {/* Toggle button group */}
+      <div
+        role="group"
+        aria-label="Transcript view mode"
+        className="inline-flex rounded-lg overflow-hidden border border-gray-200"
+      >
+        {/* Segments button */}
+        <button
+          type="button"
+          onClick={() => handleModeChange("segments")}
+          aria-pressed={mode === "segments"}
+          className={getButtonClasses(mode === "segments")}
+        >
+          Segments
+        </button>
+
+        {/* Full Text button */}
+        <button
+          type="button"
+          onClick={() => handleModeChange("fulltext")}
+          aria-pressed={mode === "fulltext"}
+          className={getButtonClasses(mode === "fulltext")}
+        >
+          Full Text
+        </button>
+      </div>
+
+      {/* Aria-live region for view change announcements */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {announcement}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/transcript/index.ts
+++ b/frontend/src/components/transcript/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Transcript component exports.
+ */
+
+export { LanguageSelector } from "./LanguageSelector";
+export type { LanguageSelectorProps } from "./LanguageSelector";
+export { TranscriptFullText } from "./TranscriptFullText";
+export type { TranscriptFullTextProps } from "./TranscriptFullText";
+export { TranscriptPanel } from "./TranscriptPanel";
+export { TranscriptSegments } from "./TranscriptSegments";
+export type { TranscriptSegmentsProps } from "./TranscriptSegments";
+export { ViewModeToggle } from "./ViewModeToggle";
+export type { ViewMode, ViewModeToggleProps } from "./ViewModeToggle";

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -2,4 +2,13 @@
  * Hook exports for Chronovista frontend.
  */
 
+export { usePrefersReducedMotion } from "./usePrefersReducedMotion";
+export { useTranscript } from "./useTranscript";
+export { useTranscriptLanguages } from "./useTranscriptLanguages";
+export {
+  useTranscriptSegments,
+  segmentsQueryKey,
+} from "./useTranscriptSegments";
+export type { UseTranscriptSegmentsResult } from "./useTranscriptSegments";
+export { useVideoDetail } from "./useVideoDetail";
 export { useVideos } from "./useVideos";

--- a/frontend/src/hooks/usePrefersReducedMotion.ts
+++ b/frontend/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,106 @@
+/**
+ * usePrefersReducedMotion hook for accessibility support.
+ *
+ * Detects if the user has requested reduced motion via their operating system
+ * preferences. This hook enables components to disable or reduce animations
+ * for users who may experience discomfort from motion.
+ *
+ * Implements FR-012c accessibility requirement.
+ *
+ * @example
+ * ```tsx
+ * import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+ *
+ * function AnimatedComponent() {
+ *   const prefersReducedMotion = usePrefersReducedMotion();
+ *
+ *   return (
+ *     <div
+ *       className={prefersReducedMotion ? 'static' : 'animate-bounce'}
+ *     >
+ *       Content
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+
+import { useEffect, useState } from "react";
+
+/**
+ * Media query for detecting reduced motion preference.
+ */
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * Hook that detects if the user prefers reduced motion.
+ *
+ * Returns true if the user has enabled reduced motion in their operating
+ * system settings. The hook listens for changes to the preference and
+ * updates automatically if the user changes their setting while the
+ * application is running.
+ *
+ * @returns True if the user prefers reduced motion, false otherwise.
+ *
+ * @example
+ * ```tsx
+ * const prefersReducedMotion = usePrefersReducedMotion();
+ *
+ * // Conditionally apply animation classes
+ * const animationClass = prefersReducedMotion
+ *   ? ''
+ *   : 'transition-transform duration-300';
+ *
+ * // Or use for imperative animations
+ * useEffect(() => {
+ *   if (!prefersReducedMotion) {
+ *     startAnimation();
+ *   }
+ * }, [prefersReducedMotion]);
+ * ```
+ */
+export function usePrefersReducedMotion(): boolean {
+  // Default to false for SSR safety (assume animations are okay until we can check)
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    // Check if matchMedia is available (browser environment)
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+
+    // Set initial value
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    /**
+     * Handler for media query changes.
+     * Updates state when user changes their reduced motion preference.
+     */
+    const handleChange = (event: MediaQueryListEvent): void => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    // Modern browsers support addEventListener on MediaQueryList
+    // Older browsers only support addListener (deprecated)
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", handleChange);
+    } else {
+      // Fallback for older browsers
+      mediaQuery.addListener(handleChange);
+    }
+
+    // Cleanup listener on unmount
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener("change", handleChange);
+      } else {
+        // Fallback for older browsers
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/frontend/src/hooks/useTranscript.ts
+++ b/frontend/src/hooks/useTranscript.ts
@@ -1,0 +1,63 @@
+/**
+ * useTranscript hook for fetching full transcript text.
+ *
+ * Fetches the complete transcript for a video in a specific language.
+ * Used by the full-text view mode in the transcript panel.
+ *
+ * @module hooks/useTranscript
+ */
+
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+
+import { apiFetch } from "../api/config";
+import type { ApiError } from "../types/video";
+import type { Transcript, TranscriptResponse } from "../types/transcript";
+
+/**
+ * Fetches the full transcript for a video in a specific language.
+ *
+ * @param videoId - The YouTube video ID
+ * @param languageCode - The BCP-47 language code
+ * @returns Transcript data
+ */
+async function fetchTranscript(
+  videoId: string,
+  languageCode: string
+): Promise<Transcript> {
+  const response = await apiFetch<TranscriptResponse>(
+    `/videos/${videoId}/transcript?language=${encodeURIComponent(languageCode)}`
+  );
+  return response.data;
+}
+
+/**
+ * Hook for fetching the full transcript text for a video.
+ *
+ * Uses TanStack Query's useQuery for data fetching and caching.
+ * Configured with a 10 second timeout per NFR-P01 requirements.
+ *
+ * @param videoId - The YouTube video ID to fetch transcript for
+ * @param languageCode - The BCP-47 language code for the transcript
+ * @returns UseQueryResult with Transcript data or ApiError
+ *
+ * @example
+ * ```tsx
+ * const { data: transcript, isLoading, error } = useTranscript('dQw4w9WgXcQ', 'en');
+ *
+ * if (isLoading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage error={error} />;
+ *
+ * return <TranscriptFullText transcript={transcript} />;
+ * ```
+ */
+export function useTranscript(
+  videoId: string,
+  languageCode: string
+): UseQueryResult<Transcript, ApiError> {
+  return useQuery<Transcript, ApiError>({
+    queryKey: ["transcript", videoId, languageCode],
+    queryFn: () => fetchTranscript(videoId, languageCode),
+    staleTime: 10 * 1000, // 10 seconds (NFR-P01)
+    enabled: !!videoId && !!languageCode, // Only run if both parameters are truthy
+  });
+}

--- a/frontend/src/hooks/useTranscriptLanguages.ts
+++ b/frontend/src/hooks/useTranscriptLanguages.ts
@@ -1,0 +1,63 @@
+/**
+ * useTranscriptLanguages hook for fetching available transcript languages for a video.
+ */
+
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+
+import { apiFetch } from "../api/config";
+import type { ApiError } from "../types/video";
+import type {
+  TranscriptLanguage,
+  TranscriptLanguagesResponse,
+} from "../types/transcript";
+
+/**
+ * Fetches available transcript languages for a video from the API.
+ *
+ * @param videoId - The YouTube video ID to fetch languages for
+ * @returns Array of TranscriptLanguage data
+ */
+async function fetchTranscriptLanguages(
+  videoId: string
+): Promise<TranscriptLanguage[]> {
+  const response = await apiFetch<TranscriptLanguagesResponse>(
+    `/videos/${videoId}/transcript/languages`
+  );
+  return response.data;
+}
+
+/**
+ * Hook for fetching available transcript languages for a video.
+ *
+ * Uses TanStack Query's useQuery for data fetching and caching.
+ * Configured with a 5 minute staleTime for efficient caching.
+ *
+ * @param videoId - The YouTube video ID to fetch languages for
+ * @returns UseQueryResult with TranscriptLanguage array or ApiError
+ *
+ * @example
+ * ```tsx
+ * const { data: languages, isLoading, error } = useTranscriptLanguages('dQw4w9WgXcQ');
+ *
+ * if (isLoading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage error={error} />;
+ *
+ * return (
+ *   <div>
+ *     {languages.map(lang => (
+ *       <span key={lang.language_code}>{lang.language_name}</span>
+ *     ))}
+ *   </div>
+ * );
+ * ```
+ */
+export function useTranscriptLanguages(
+  videoId: string
+): UseQueryResult<TranscriptLanguage[], ApiError> {
+  return useQuery<TranscriptLanguage[], ApiError>({
+    queryKey: ["transcriptLanguages", videoId],
+    queryFn: () => fetchTranscriptLanguages(videoId),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    enabled: !!videoId, // Only run if videoId is truthy
+  });
+}

--- a/frontend/src/hooks/useTranscriptSegments.ts
+++ b/frontend/src/hooks/useTranscriptSegments.ts
@@ -1,0 +1,250 @@
+/**
+ * useTranscriptSegments hook for fetching transcript segments with infinite scroll.
+ *
+ * Implements:
+ * - FR-020a: Initial batch of 50 segments
+ * - FR-020b: Subsequent batches of 25 segments
+ * - NFR-P02: 5 second timeout for segment batch loads
+ * - NFR-P04-P06: Request cancellation on language change
+ *
+ * @module hooks/useTranscriptSegments
+ */
+
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  UseInfiniteQueryResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useCallback, useEffect, useRef } from "react";
+
+import { apiFetch } from "../api/config";
+import { INFINITE_SCROLL_CONFIG, DEBOUNCE_CONFIG } from "../styles/tokens";
+import type { ApiError } from "../types/video";
+import type { TranscriptSegment, SegmentListResponse } from "../types/transcript";
+
+/**
+ * Query key factory for transcript segments.
+ */
+export const segmentsQueryKey = (videoId: string, languageCode: string) =>
+  ["transcriptSegments", videoId, languageCode] as const;
+
+/**
+ * Page parameter structure for infinite query.
+ */
+interface PageParam {
+  offset: number;
+  limit: number;
+}
+
+/**
+ * Return type for the useTranscriptSegments hook.
+ * Extends the base infinite query result with helper properties.
+ */
+export interface UseTranscriptSegmentsResult {
+  /** All loaded segments flattened into a single array */
+  segments: TranscriptSegment[];
+  /** Total number of segments available */
+  totalCount: number;
+  /** Whether the initial load is in progress */
+  isLoading: boolean;
+  /** Whether fetching the next page */
+  isFetchingNextPage: boolean;
+  /** Whether there are more segments to load */
+  hasNextPage: boolean;
+  /** Whether an error occurred */
+  isError: boolean;
+  /** Error object if an error occurred */
+  error: ApiError | null;
+  /** Function to fetch the next page of segments */
+  fetchNextPage: () => void;
+  /** Function to retry after an error */
+  retry: () => void;
+  /** Function to cancel in-flight requests (for language switching) */
+  cancelRequests: () => void;
+}
+
+/**
+ * Fetches a page of transcript segments from the API.
+ *
+ * @param videoId - The YouTube video ID
+ * @param languageCode - BCP-47 language code
+ * @param pageParam - Pagination parameters (offset and limit)
+ * @param signal - AbortSignal for request cancellation
+ * @returns SegmentListResponse with segments and pagination info
+ */
+async function fetchSegments(
+  videoId: string,
+  languageCode: string,
+  pageParam: PageParam,
+  signal?: AbortSignal
+): Promise<SegmentListResponse> {
+  const params = new URLSearchParams({
+    language_code: languageCode,
+    offset: pageParam.offset.toString(),
+    limit: pageParam.limit.toString(),
+  });
+
+  const endpoint = `/videos/${videoId}/transcript/segments?${params.toString()}`;
+
+  // Create a timeout-specific AbortController for 5s timeout (NFR-P02)
+  const timeoutController = new AbortController();
+  const timeoutId = setTimeout(() => timeoutController.abort(), 5000);
+
+  // Combine signals if we have an external abort signal
+  const combinedSignal = signal
+    ? combineAbortSignals(signal, timeoutController.signal)
+    : timeoutController.signal;
+
+  try {
+    const response = await apiFetch<SegmentListResponse>(endpoint, {
+      signal: combinedSignal,
+    });
+    clearTimeout(timeoutId);
+    return response;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    throw error;
+  }
+}
+
+/**
+ * Combines multiple AbortSignals into one.
+ */
+function combineAbortSignals(...signals: AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort();
+      break;
+    }
+    signal.addEventListener("abort", () => controller.abort(), { once: true });
+  }
+
+  return controller.signal;
+}
+
+/**
+ * Hook for fetching transcript segments with infinite scroll support.
+ *
+ * Features:
+ * - Initial batch of 50 segments (FR-020a)
+ * - Subsequent batches of 25 segments (FR-020b)
+ * - Automatic request cancellation on language change (NFR-P04-P06)
+ * - Debounced language switching (NFR-P05)
+ * - Error handling with retry capability
+ *
+ * @param videoId - The YouTube video ID
+ * @param languageCode - BCP-47 language code for the transcript
+ * @param enabled - Whether to enable the query (default: true)
+ * @returns UseTranscriptSegmentsResult with segments and control functions
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   segments,
+ *   isLoading,
+ *   hasNextPage,
+ *   fetchNextPage,
+ *   isFetchingNextPage,
+ * } = useTranscriptSegments(videoId, selectedLanguage);
+ *
+ * // Use Intersection Observer to trigger fetchNextPage
+ * ```
+ */
+export function useTranscriptSegments(
+  videoId: string,
+  languageCode: string,
+  enabled: boolean = true
+): UseTranscriptSegmentsResult {
+  const queryClient = useQueryClient();
+  const previousLanguageRef = useRef<string>(languageCode);
+  const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cancel previous requests when language changes (NFR-P04)
+  useEffect(() => {
+    if (previousLanguageRef.current !== languageCode) {
+      // Cancel in-flight requests for the previous language
+      queryClient.cancelQueries({
+        queryKey: segmentsQueryKey(videoId, previousLanguageRef.current),
+      });
+
+      previousLanguageRef.current = languageCode;
+    }
+  }, [videoId, languageCode, queryClient]);
+
+  // Cleanup debounce timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const query: UseInfiniteQueryResult<InfiniteData<SegmentListResponse, PageParam>, ApiError> =
+    useInfiniteQuery<SegmentListResponse, ApiError, InfiniteData<SegmentListResponse, PageParam>, readonly [string, string, string], PageParam>({
+      queryKey: segmentsQueryKey(videoId, languageCode),
+      queryFn: async ({ pageParam, signal }) => {
+        // Apply debounce for language switching (NFR-P05)
+        if (pageParam.offset === 0 && debounceTimeoutRef.current === null) {
+          await new Promise<void>((resolve) => {
+            debounceTimeoutRef.current = setTimeout(() => {
+              debounceTimeoutRef.current = null;
+              resolve();
+            }, DEBOUNCE_CONFIG.languageSwitch);
+          });
+        }
+
+        return fetchSegments(videoId, languageCode, pageParam, signal);
+      },
+      initialPageParam: {
+        offset: 0,
+        limit: INFINITE_SCROLL_CONFIG.initialBatchSize,
+      },
+      getNextPageParam: (lastPage) => {
+        if (!lastPage.pagination.has_more) {
+          return undefined;
+        }
+        return {
+          offset: lastPage.pagination.offset + lastPage.pagination.limit,
+          limit: INFINITE_SCROLL_CONFIG.subsequentBatchSize,
+        };
+      },
+      enabled: enabled && !!videoId && !!languageCode,
+      staleTime: 5 * 60 * 1000, // 5 minutes
+    });
+
+  // Flatten all pages into a single array of segments
+  const segments: TranscriptSegment[] =
+    query.data?.pages.flatMap((page) => page.data) ?? [];
+
+  // Get total count from the first page's pagination
+  const totalCount = query.data?.pages[0]?.pagination.total ?? 0;
+
+  // Cancel requests function for external use (e.g., language selector)
+  const cancelRequests = useCallback(() => {
+    queryClient.cancelQueries({
+      queryKey: segmentsQueryKey(videoId, languageCode),
+    });
+  }, [queryClient, videoId, languageCode]);
+
+  // Retry function for error recovery
+  const retry = useCallback(() => {
+    query.refetch();
+  }, [query]);
+
+  return {
+    segments,
+    totalCount,
+    isLoading: query.isLoading,
+    isFetchingNextPage: query.isFetchingNextPage,
+    hasNextPage: query.hasNextPage ?? false,
+    isError: query.isError,
+    error: query.error ?? null,
+    fetchNextPage: query.fetchNextPage,
+    retry,
+    cancelRequests,
+  };
+}

--- a/frontend/src/hooks/useVideoDetail.ts
+++ b/frontend/src/hooks/useVideoDetail.ts
@@ -1,0 +1,47 @@
+/**
+ * useVideoDetail hook for fetching a single video's details.
+ */
+
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+
+import { apiFetch } from "../api/config";
+import type { ApiError, VideoDetail, VideoDetailResponse } from "../types/video";
+
+/**
+ * Fetches video details from the API.
+ *
+ * @param videoId - The YouTube video ID to fetch
+ * @returns VideoDetail data
+ */
+async function fetchVideoDetail(videoId: string): Promise<VideoDetail> {
+  const response = await apiFetch<VideoDetailResponse>(`/videos/${videoId}`);
+  return response.data;
+}
+
+/**
+ * Hook for fetching a single video's detailed information.
+ *
+ * Uses TanStack Query's useQuery for data fetching and caching.
+ * Configured with a 10 second staleTime per NFR-P01 requirements.
+ *
+ * @param videoId - The YouTube video ID to fetch
+ * @returns UseQueryResult with VideoDetail data or ApiError
+ *
+ * @example
+ * ```tsx
+ * const { data: video, isLoading, error } = useVideoDetail('dQw4w9WgXcQ');
+ *
+ * if (isLoading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage error={error} />;
+ *
+ * return <VideoDetailView video={video} />;
+ * ```
+ */
+export function useVideoDetail(videoId: string): UseQueryResult<VideoDetail, ApiError> {
+  return useQuery<VideoDetail, ApiError>({
+    queryKey: ["video", videoId],
+    queryFn: () => fetchVideoDetail(videoId),
+    staleTime: 10 * 1000, // 10 seconds (NFR-P01)
+    enabled: !!videoId, // Only run if videoId is truthy
+  });
+}

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -1,0 +1,504 @@
+/**
+ * VideoDetailPage component displays comprehensive video information.
+ *
+ * Features:
+ * - Video metadata display (title, channel, upload date, duration, views, likes)
+ * - Full description with fallback for missing content
+ * - Tags displayed as badges (hidden if no tags per edge case)
+ * - Back to Videos navigation link (FR-004)
+ * - Watch on YouTube external link (FR-006, FR-007, FR-008)
+ * - Loading, error, and 404 states
+ * - Cascading failure handling (FR-026 through FR-030):
+ *   - When video API fails, TranscriptPanel is NOT rendered
+ *   - Unified error message with Retry and Back to Videos options
+ *   - Consistent error styling using CONTRAST_SAFE_COLORS
+ */
+
+import { useEffect } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { LoadingState } from "../components/LoadingState";
+import { TranscriptPanel } from "../components/transcript";
+import { useVideoDetail } from "../hooks/useVideoDetail";
+import { CONTRAST_SAFE_COLORS } from "../styles/tokens";
+
+/** Default page title when no video is loaded */
+const DEFAULT_PAGE_TITLE = "Chronovista";
+
+/**
+ * Formats a duration in seconds to MM:SS or HH:MM:SS format.
+ */
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+  }
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Formats a date string to a readable absolute date (e.g., "Jan 15, 2024").
+ *
+ * @param dateString - ISO 8601 date string
+ * @returns Formatted date string in "MMM D, YYYY" format
+ */
+function formatAbsoluteDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/**
+ * Formats view count with K/M suffixes for readability.
+ */
+function formatViewCount(count: number | null): string {
+  if (count === null) {
+    return "-- views";
+  }
+
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1)}M views`;
+  }
+
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K views`;
+  }
+
+  return `${count} views`;
+}
+
+/**
+ * Formats like count with K/M suffixes for readability.
+ */
+function formatLikeCount(count: number | null): string {
+  if (count === null) {
+    return "-- likes";
+  }
+
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1)}M likes`;
+  }
+
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K likes`;
+  }
+
+  return `${count} likes`;
+}
+
+/**
+ * Arrow left icon for back navigation.
+ */
+function ArrowLeftIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+      />
+    </svg>
+  );
+}
+
+/**
+ * External link icon for YouTube link.
+ */
+function ExternalLinkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Warning icon for not found state.
+ */
+function WarningIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Exclamation triangle icon for error state.
+ */
+function ExclamationTriangleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Refresh/retry icon for retry button.
+ */
+function RefreshIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
+      />
+    </svg>
+  );
+}
+
+/**
+ * VideoDetailPage displays comprehensive video metadata.
+ *
+ * Route: /videos/:videoId
+ *
+ * Implements:
+ * - FR-001: Dedicated video detail page at /videos/{video_id}
+ * - FR-002: Display video title, channel, upload date, view count, duration, description
+ * - FR-003: Display video tags as badges (if exist)
+ * - FR-004: Back to Videos navigation link
+ * - FR-006/FR-007/FR-008: Watch on YouTube external link
+ * - FR-024: Video not found handling
+ */
+export function VideoDetailPage() {
+  const { videoId } = useParams<{ videoId: string }>();
+  // Note: error is destructured but not displayed directly per FR-027 (unified error message)
+  const { data: video, isLoading, isError, error: _error, refetch } = useVideoDetail(
+    videoId ?? ""
+  );
+
+  // Set browser tab title to "Channel - Video Title" when video loads
+  useEffect(() => {
+    if (video) {
+      const channelName = video.channel_title ?? "Unknown Channel";
+      document.title = `${channelName} - ${video.title}`;
+    }
+
+    // Reset title on unmount
+    return () => {
+      document.title = DEFAULT_PAGE_TITLE;
+    };
+  }, [video]);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="p-6 lg:p-8">
+        <LoadingState count={1} />
+      </div>
+    );
+  }
+
+  // Error state with unified error message (FR-026, FR-027, FR-029, FR-030)
+  // When video API fails, TranscriptPanel is NOT rendered (FR-026)
+  // Single unified error message prevents multiple error messages (FR-029)
+  if (isError) {
+    return (
+      <div className="p-6 lg:p-8">
+        {/* Unified error display with Retry and Back to Videos (FR-027) */}
+        <div
+          className="bg-gradient-to-br from-red-50 to-amber-50 border border-red-200 rounded-xl shadow-lg p-8 text-center max-w-lg mx-auto"
+          role="alert"
+          aria-live="polite"
+        >
+          {/* Error Icon */}
+          <div className="mx-auto w-16 h-16 mb-5 text-red-500 bg-red-100 rounded-full p-3">
+            <ExclamationTriangleIcon className="w-full h-full" />
+          </div>
+
+          {/* Error Message with CONTRAST_SAFE_COLORS (FR-030, NFR-A18) */}
+          {/* Using text-gray-900 (16.6:1 contrast ratio) for error title */}
+          <p className={`text-xl font-semibold ${CONTRAST_SAFE_COLORS.bodyText} mb-4`}>
+            Could not load video.
+          </p>
+
+          {/* Action buttons: Retry and Back to Videos */}
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            {/* Retry Button */}
+            <button
+              type="button"
+              onClick={() => void refetch()}
+              className="inline-flex items-center px-6 py-3 bg-red-600 text-white font-semibold rounded-lg shadow-md hover:bg-red-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-all duration-200"
+            >
+              <RefreshIcon className="w-5 h-5 mr-2" />
+              Retry
+            </button>
+
+            {/* Back to Videos Link */}
+            <Link
+              to="/videos"
+              className="inline-flex items-center px-6 py-3 bg-slate-600 text-white font-semibold rounded-lg shadow-md hover:bg-slate-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 transition-all duration-200"
+            >
+              <ArrowLeftIcon className="w-5 h-5 mr-2" />
+              Back to Videos
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 404 state when video not found (FR-024)
+  if (!video) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-4rem)] p-8">
+        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-12 text-center max-w-md">
+          {/* Warning Icon */}
+          <div className="mx-auto w-16 h-16 mb-6 text-slate-400 bg-slate-100 rounded-full p-4">
+            <WarningIcon className="w-full h-full" />
+          </div>
+
+          {/* Heading */}
+          <h2 className="text-2xl font-bold text-slate-900 mb-3">
+            Video Not Found
+          </h2>
+
+          {/* Description */}
+          <p className="text-slate-600">
+            The video you're looking for doesn't exist or has been removed.
+          </p>
+
+          {/* Navigation Link */}
+          <Link
+            to="/videos"
+            className="inline-flex items-center mt-6 px-6 py-3 bg-slate-900 text-white font-semibold rounded-lg hover:bg-slate-800 transition-colors focus:outline-none focus:ring-2 focus:ring-slate-900 focus:ring-offset-2"
+          >
+            <ArrowLeftIcon className="w-5 h-5 mr-2" />
+            Back to Videos
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const {
+    video_id,
+    title,
+    description,
+    channel_title,
+    upload_date,
+    duration,
+    view_count,
+    like_count,
+    tags,
+  } = video;
+
+  const youtubeUrl = `https://www.youtube.com/watch?v=${video_id}`;
+
+  return (
+    <div className="p-6 lg:p-8">
+      {/* Navigation Header */}
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
+        {/* Back to Videos Link (FR-004) */}
+        <Link
+          to="/videos"
+          className="inline-flex items-center text-slate-600 hover:text-slate-900 transition-colors"
+        >
+          <ArrowLeftIcon className="w-5 h-5 mr-2" />
+          Back to Videos
+        </Link>
+
+        {/* Watch on YouTube Link (FR-006, FR-007, FR-008) */}
+        <a
+          href={youtubeUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center px-4 py-2 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+        >
+          <ExternalLinkIcon className="w-5 h-5 mr-2" />
+          Watch on YouTube
+          <span className="sr-only">(opens in new tab)</span>
+        </a>
+      </div>
+
+      {/* Video Content Card */}
+      <article className="bg-white rounded-xl shadow-md border border-gray-100 p-6 lg:p-8">
+        {/* Video Title (FR-002) */}
+        <h1 className="text-2xl lg:text-3xl font-bold text-gray-900 mb-4">
+          {title}
+        </h1>
+
+        {/* Channel Name (FR-002) */}
+        <p className="text-lg text-gray-600 mb-4">
+          {channel_title ?? "Unknown Channel"}
+        </p>
+
+        {/* Video Metadata Row (FR-002) */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-500 mb-6">
+          {/* Upload Date - shows absolute date (e.g., "Jan 15, 2024") */}
+          <span className="inline-flex items-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-4 h-4 mr-1"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+              />
+            </svg>
+            {formatAbsoluteDate(upload_date)}
+          </span>
+
+          {/* Duration Badge */}
+          <span className="inline-flex items-center bg-gray-100 px-2 py-0.5 rounded font-mono text-xs">
+            {formatDuration(duration)}
+          </span>
+
+          {/* View Count */}
+          <span className="inline-flex items-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-4 h-4 mr-1"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+              />
+            </svg>
+            {formatViewCount(view_count)}
+          </span>
+
+          {/* Like Count */}
+          <span className="inline-flex items-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-4 h-4 mr-1"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6.633 10.25c.806 0 1.533-.446 2.031-1.08a9.041 9.041 0 0 1 2.861-2.4c.723-.384 1.35-.956 1.653-1.715a4.498 4.498 0 0 0 .322-1.672V2.75a.75.75 0 0 1 .75-.75 2.25 2.25 0 0 1 2.25 2.25c0 1.152-.26 2.243-.723 3.218-.266.558.107 1.282.725 1.282m0 0h3.126c1.026 0 1.945.694 2.054 1.715.045.422.068.85.068 1.285a11.95 11.95 0 0 1-2.649 7.521c-.388.482-.987.729-1.605.729H13.48c-.483 0-.964-.078-1.423-.23l-3.114-1.04a4.501 4.501 0 0 0-1.423-.23H5.904m10.598-9.75H14.25M5.904 18.5c.083.205.173.405.27.602.197.4-.078.898-.523.898h-.908c-.889 0-1.713-.518-1.972-1.368a12 12 0 0 1-.521-3.507c0-1.553.295-3.036.831-4.398C3.387 9.953 4.167 9.5 5 9.5h1.053c.472 0 .745.556.5.96a8.958 8.958 0 0 0-1.302 4.665c0 1.194.232 2.333.654 3.375Z"
+              />
+            </svg>
+            {formatLikeCount(like_count)}
+          </span>
+        </div>
+
+        {/* Tags Section (FR-003) - Hide if no tags per edge case */}
+        {tags.length > 0 && (
+          <div className="mb-6">
+            <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider mb-2">
+              Tags
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Description Section (FR-002) */}
+        <div className="border-t border-gray-100 pt-6">
+          <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider mb-3">
+            Description
+          </h2>
+          <div className="prose prose-sm max-w-none text-gray-600 whitespace-pre-wrap">
+            {description || "No description available"}
+          </div>
+        </div>
+      </article>
+
+      {/* Transcript Panel */}
+      <TranscriptPanel videoId={video_id} />
+
+      {/* Back to Videos Link */}
+      <div className="mt-6">
+        <Link
+          to="/videos"
+          className="inline-flex items-center text-slate-600 hover:text-slate-900 transition-colors"
+        >
+          <ArrowLeftIcon className="w-5 h-5 mr-2" />
+          Back to Videos
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -9,6 +9,7 @@ import { ChannelsPage } from "../pages/ChannelsPage";
 import { HomePage } from "../pages/HomePage";
 import { NotFoundPage } from "../pages/NotFoundPage";
 import { SearchPage } from "../pages/SearchPage";
+import { VideoDetailPage } from "../pages/VideoDetailPage";
 
 /**
  * Router configuration with AppShell as the root layout.
@@ -16,6 +17,7 @@ import { SearchPage } from "../pages/SearchPage";
  * Routes:
  * - / redirects to /videos
  * - /videos displays the HomePage (video list)
+ * - /videos/:videoId displays the VideoDetailPage (FR-001)
  * - /search displays the SearchPage placeholder
  * - /channels displays the ChannelsPage placeholder
  * - * catches all other routes and shows NotFoundPage
@@ -32,6 +34,10 @@ export const router = createBrowserRouter([
       {
         path: "videos",
         element: <HomePage />,
+      },
+      {
+        path: "videos/:videoId",
+        element: <VideoDetailPage />,
       },
       {
         path: "search",

--- a/frontend/src/styles/card.ts
+++ b/frontend/src/styles/card.ts
@@ -1,0 +1,78 @@
+/**
+ * Card styling utilities for Chronovista design system.
+ *
+ * Provides consistent patterns for card components including base styles,
+ * interactive states, and accessibility-focused focus indicators.
+ *
+ * @example
+ * ```tsx
+ * import { cardClasses, cardPatterns } from '../styles/card';
+ *
+ * // Use the complete card class string
+ * <div className={cardClasses}>Card content</div>
+ *
+ * // Or compose individual patterns
+ * <div className={`${cardPatterns.base} ${cardPatterns.hover}`}>Card content</div>
+ * ```
+ */
+
+/**
+ * Individual card styling patterns that can be composed together.
+ *
+ * @property base - Core card appearance (background, corners, shadow, border)
+ * @property hover - Hover state enhancements for interactive cards
+ * @property focus - Focus state for keyboard navigation accessibility
+ * @property transition - Animation timing for smooth state changes
+ */
+export const cardPatterns = {
+  /** Base card appearance with white background, rounded corners, shadow, and subtle border */
+  base: "bg-white rounded-xl shadow-md border border-gray-100",
+
+  /** Hover state with enhanced shadow and slightly darker border */
+  hover: "hover:shadow-xl hover:border-gray-200",
+
+  /** Focus state for accessibility with visible focus ring */
+  focus: "focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2",
+
+  /** Smooth transition for all state changes */
+  transition: "transition-all duration-200",
+} as const;
+
+/**
+ * Type representing valid card pattern keys.
+ */
+export type CardPatternKey = keyof typeof cardPatterns;
+
+/**
+ * Pre-composed card class string combining all patterns.
+ *
+ * Use this for standard interactive cards that need all styling applied.
+ *
+ * @example
+ * ```tsx
+ * <article className={cardClasses}>
+ *   <h2>Card Title</h2>
+ *   <p>Card content goes here</p>
+ * </article>
+ * ```
+ */
+export const cardClasses = `${cardPatterns.base} ${cardPatterns.hover} ${cardPatterns.focus} ${cardPatterns.transition}`;
+
+/**
+ * Card variant classes for different use cases.
+ */
+export const cardVariants = {
+  /** Default interactive card with all states */
+  default: cardClasses,
+
+  /** Static card without hover effects (for non-interactive content) */
+  static: `${cardPatterns.base} ${cardPatterns.transition}`,
+
+  /** Focusable card without hover effects (for keyboard-only interaction) */
+  focusable: `${cardPatterns.base} ${cardPatterns.focus} ${cardPatterns.transition}`,
+} as const;
+
+/**
+ * Type representing valid card variant keys.
+ */
+export type CardVariantKey = keyof typeof cardVariants;

--- a/frontend/src/styles/index.ts
+++ b/frontend/src/styles/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Design System Barrel Export
+ *
+ * Re-exports all design tokens and styling utilities for convenient importing.
+ *
+ * @example
+ * ```tsx
+ * import { colorTokens, cardClasses, INFINITE_SCROLL_CONFIG } from '../styles';
+ * ```
+ *
+ * @module styles
+ */
+
+// Token exports
+export {
+  colorTokens,
+  spacingTokens,
+  INFINITE_SCROLL_CONFIG,
+  VIRTUALIZATION_CONFIG,
+  DEBOUNCE_CONFIG,
+  RESPONSIVE_CONFIG,
+  CONTRAST_SAFE_COLORS,
+} from "./tokens";
+
+// Token type exports
+export type {
+  ColorTokens,
+  SpacingTokens,
+  InfiniteScrollConfig,
+  VirtualizationConfig,
+  DebounceConfig,
+  ResponsiveConfig,
+  ContrastSafeColors,
+} from "./tokens";
+
+// Card pattern exports
+export {
+  cardPatterns,
+  cardClasses,
+  cardVariants,
+} from "./card";
+
+// Card type exports
+export type { CardPatternKey, CardVariantKey } from "./card";

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -1,0 +1,271 @@
+/**
+ * Design System Tokens for Chronovista Frontend
+ *
+ * This file defines the design system tokens including colors, spacing,
+ * and configuration constants for the video detail page and transcript display.
+ *
+ * @module styles/tokens
+ */
+
+// =============================================================================
+// Color Tokens
+// =============================================================================
+
+/**
+ * Color token structure for the design system.
+ * Uses Tailwind CSS color class names as values.
+ */
+export interface ColorTokens {
+  /** Primary brand colors */
+  primary: {
+    /** Darkest primary shade - slate-900 */
+    darkest: string;
+    /** Dark primary shade - slate-800 */
+    dark: string;
+    /** Base primary color - slate-700 */
+    base: string;
+    /** Light primary shade - slate-50 */
+    light: string;
+  };
+  /** Background colors for different surfaces */
+  background: {
+    /** Page background - slate-50 */
+    page: string;
+    /** Card/panel background - white */
+    card: string;
+    /** Hover state background - slate-100 */
+    hover: string;
+  };
+  /** Text colors with semantic hierarchy */
+  text: {
+    /** Primary text color - gray-900 */
+    primary: string;
+    /** Secondary text color - gray-600 */
+    secondary: string;
+    /** Tertiary/muted text color - gray-500 */
+    tertiary: string;
+  };
+  /** Status colors for feedback states */
+  status: {
+    /** Success state colors */
+    success: { bg: string; text: string; border: string };
+    /** Error state colors */
+    error: { bg: string; text: string; border: string };
+    /** Info state colors */
+    info: { bg: string; text: string; border: string };
+  };
+  /** Default border color - gray-100 */
+  border: string;
+}
+
+/**
+ * Color tokens constant object with Tailwind CSS class values.
+ */
+export const colorTokens: ColorTokens = {
+  primary: {
+    darkest: "slate-900",
+    dark: "slate-800",
+    base: "slate-700",
+    light: "slate-50",
+  },
+  background: {
+    page: "slate-50",
+    card: "white",
+    hover: "slate-100",
+  },
+  text: {
+    primary: "gray-900",
+    secondary: "gray-600",
+    tertiary: "gray-500",
+  },
+  status: {
+    success: {
+      bg: "green-100",
+      text: "green-800",
+      border: "green-200",
+    },
+    error: {
+      bg: "red-100",
+      text: "red-800",
+      border: "red-200",
+    },
+    info: {
+      bg: "blue-100",
+      text: "blue-800",
+      border: "blue-200",
+    },
+  },
+  border: "gray-100",
+} as const;
+
+// =============================================================================
+// Spacing Tokens
+// =============================================================================
+
+/**
+ * Spacing token structure for consistent spacing across the design system.
+ * Uses Tailwind CSS spacing values as string references.
+ */
+export interface SpacingTokens {
+  /** Extra small spacing - 2px */
+  xs: string;
+  /** Small spacing - 4px */
+  sm: string;
+  /** Medium spacing - 6px */
+  md: string;
+  /** Large spacing - 8px */
+  lg: string;
+  /** Extra large spacing - 12px */
+  xl: string;
+  /** Card padding - 20px (p-5) */
+  cardPadding: string;
+  /** Page padding - 24px (p-6) */
+  pagePadding: string;
+  /** Grid gap - 24px (gap-6) */
+  gapGrid: string;
+}
+
+/**
+ * Spacing tokens constant object with Tailwind CSS spacing values.
+ */
+export const spacingTokens: SpacingTokens = {
+  xs: "0.5", // 2px
+  sm: "1", // 4px
+  md: "1.5", // 6px
+  lg: "2", // 8px
+  xl: "3", // 12px
+  cardPadding: "5", // 20px (p-5)
+  pagePadding: "6", // 24px (p-6)
+  gapGrid: "6", // 24px (gap-6)
+} as const;
+
+// =============================================================================
+// Configuration Objects
+// =============================================================================
+
+/**
+ * Infinite scroll configuration for transcript segment loading.
+ *
+ * @remarks
+ * - FR-020a: Initial segment load of 50 items
+ * - FR-020b: Subsequent loads of 25 items
+ * - FR-020c: Trigger distance of 200px from bottom
+ * - FR-020d: Display 3 skeleton items during loading
+ */
+export const INFINITE_SCROLL_CONFIG = {
+  /** FR-020a: Initial segment load count */
+  initialBatchSize: 50,
+  /** FR-020b: Subsequent load count */
+  subsequentBatchSize: 25,
+  /** FR-020c: Pixels from bottom to trigger next load */
+  triggerDistance: 200,
+  /** FR-020d: Number of skeleton items to show during loading */
+  skeletonCount: 3,
+} as const;
+
+/**
+ * Virtualization configuration for large transcript segment lists.
+ *
+ * @remarks
+ * - NFR-P12: Enable virtualization above 500 segments
+ * - NFR-P14: Render 5 segments above/below viewport
+ * - NFR-P15: Estimated segment height of 48px
+ * - NFR-P16: Target maximum memory usage of 50MB
+ */
+export const VIRTUALIZATION_CONFIG = {
+  /** NFR-P12: Segment count threshold to enable virtualization */
+  threshold: 500,
+  /** NFR-P14: Number of segments to render above/below viewport */
+  overscan: 5,
+  /** NFR-P15: Estimated segment height in pixels */
+  estimatedHeight: 48,
+  /** NFR-P16: Maximum memory usage target in MB */
+  maxMemoryMB: 50,
+} as const;
+
+/**
+ * Debounce configuration for various user interactions.
+ *
+ * @remarks
+ * - NFR-P05: Language switch delay of 150ms minimum
+ * - Standard search input debounce of 300ms
+ */
+export const DEBOUNCE_CONFIG = {
+  /** NFR-P05: Minimum delay for language switch in milliseconds */
+  languageSwitch: 150,
+  /** Standard search debounce in milliseconds */
+  searchInput: 300,
+} as const;
+
+/**
+ * Responsive breakpoint configuration.
+ *
+ * @remarks
+ * - NFR-R01: Defines small (640px), medium (768px), and large (1024px) breakpoints
+ * - NFR-R02-R04: Transcript max heights per breakpoint
+ * - NFR-R06: Text sizes per breakpoint
+ */
+export const RESPONSIVE_CONFIG = {
+  /** NFR-R01: Responsive breakpoint widths in pixels */
+  breakpoints: {
+    /** Small breakpoint */
+    sm: 640,
+    /** Medium breakpoint */
+    md: 768,
+    /** Large breakpoint */
+    lg: 1024,
+  },
+  /** NFR-R02-R04: Transcript panel max heights per device type */
+  transcriptMaxHeight: {
+    /** NFR-R02: Mobile max height (< 640px) */
+    mobile: "40vh",
+    /** NFR-R03: Tablet max height (640px - 1023px) */
+    tablet: "50vh",
+    /** NFR-R04: Desktop max height (>= 1024px) */
+    desktop: "60vh",
+  },
+  /** NFR-R06: Segment text sizes per device type */
+  segmentTextSize: {
+    /** 14px on mobile */
+    mobile: "text-sm",
+    /** 16px on desktop */
+    desktop: "text-base",
+  },
+} as const;
+
+/**
+ * WCAG AA compliant color combinations for text.
+ *
+ * @remarks
+ * - NFR-A18: All approved combinations have 4.5:1+ contrast ratio on white
+ * - NFR-A19: Forbidden colors fail AA compliance and must never be used for informational text
+ */
+export const CONTRAST_SAFE_COLORS = {
+  /** NFR-A18: Body text color - #111827 with 16.6:1 contrast ratio */
+  bodyText: "text-gray-900",
+  /** NFR-A18: Timestamp color - #4B5563 with 7.0:1 contrast ratio */
+  timestamp: "text-gray-600",
+  /** NFR-A18: Alternative timestamp color - #6B7280 with 5.0:1 contrast ratio */
+  timestampAlt: "text-gray-500",
+  /** NFR-A19: NEVER use for informational text - #9CA3AF with 3.0:1 ratio (FAILS AA) */
+  forbidden: "text-gray-400",
+} as const;
+
+// =============================================================================
+// Type Exports
+// =============================================================================
+
+/** Type for infinite scroll configuration */
+export type InfiniteScrollConfig = typeof INFINITE_SCROLL_CONFIG;
+
+/** Type for virtualization configuration */
+export type VirtualizationConfig = typeof VIRTUALIZATION_CONFIG;
+
+/** Type for debounce configuration */
+export type DebounceConfig = typeof DEBOUNCE_CONFIG;
+
+/** Type for responsive configuration */
+export type ResponsiveConfig = typeof RESPONSIVE_CONFIG;
+
+/** Type for contrast-safe colors configuration */
+export type ContrastSafeColors = typeof CONTRAST_SAFE_COLORS;

--- a/frontend/src/tests/components/transcript/LanguageSelector.test.tsx
+++ b/frontend/src/tests/components/transcript/LanguageSelector.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for LanguageSelector component.
+ *
+ * Tests language code display, WAI-ARIA tabs pattern, and quality indicators.
+ *
+ * @module tests/components/transcript/LanguageSelector
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LanguageSelector } from "../../../components/transcript/LanguageSelector";
+import type { TranscriptLanguage } from "../../../types/transcript";
+
+describe("LanguageSelector", () => {
+  const mockOnLanguageChange = vi.fn();
+
+  const mockLanguages: TranscriptLanguage[] = [
+    {
+      language_code: "en",
+      language_name: "English",
+      transcript_type: "manual",
+    },
+    {
+      language_code: "en-GB",
+      language_name: "English (UK)",
+      transcript_type: "manual",
+    },
+    {
+      language_code: "pt-BR",
+      language_name: "Portuguese (Brazil)",
+      transcript_type: "auto_generated",
+    },
+    {
+      language_code: "es",
+      language_name: "Spanish",
+      transcript_type: "auto_generated",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("language code display", () => {
+    it("displays full BCP-47 code for language variants (e.g., EN-gb)", () => {
+      render(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tabs = screen.getAllByRole("tab");
+
+      // First tab (en) should show "EN"
+      expect(tabs[0]).toHaveTextContent("EN");
+      expect(tabs[0]).not.toHaveTextContent("EN-");
+
+      // Second tab (en-GB) should show "EN-gb" (primary uppercase, variant lowercase)
+      expect(tabs[1]).toHaveTextContent("EN-gb");
+
+      // Third tab (pt-BR) should show "PT-br"
+      expect(tabs[2]).toHaveTextContent("PT-br");
+
+      // Fourth tab (es) should show "ES"
+      expect(tabs[3]).toHaveTextContent("ES");
+      expect(tabs[3]).not.toHaveTextContent("ES-");
+    });
+
+    it("distinguishes between en and en-GB with different labels", () => {
+      const twoEnglishVariants: TranscriptLanguage[] = [
+        { language_code: "en", language_name: "English", transcript_type: "manual" },
+        { language_code: "en-GB", language_name: "English (UK)", transcript_type: "manual" },
+      ];
+
+      render(
+        <LanguageSelector
+          languages={twoEnglishVariants}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tabs = screen.getAllByRole("tab");
+
+      // First tab should contain "EN" but NOT "EN-"
+      expect(tabs[0]).toHaveTextContent("EN");
+      // Second tab should contain "EN-gb"
+      expect(tabs[1]).toHaveTextContent("EN-gb");
+
+      // The visible text (before the sr-only span) should be different
+      // Check using the id attribute to verify they're distinct
+      expect(tabs[0]).toHaveAttribute("id", "tab-en");
+      expect(tabs[1]).toHaveAttribute("id", "tab-en-GB");
+    });
+  });
+
+  describe("quality indicators", () => {
+    it("shows checkmark for manual/CC transcripts", () => {
+      render(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tabs = screen.getAllByRole("tab");
+
+      // Manual transcripts (en, en-GB) should have checkmark (✓ = &#10003;)
+      expect(tabs[0].textContent).toContain("✓"); // en
+      expect(tabs[1].textContent).toContain("✓"); // en-GB
+    });
+
+    it("does not show checkmark for auto-generated transcripts", () => {
+      render(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tabs = screen.getAllByRole("tab");
+
+      // Auto-generated transcripts (pt-BR, es) should NOT have checkmark
+      expect(tabs[2].textContent).not.toContain("✓"); // pt-BR
+      expect(tabs[3].textContent).not.toContain("✓"); // es
+    });
+  });
+
+  describe("selection behavior", () => {
+    it("marks selected language tab as aria-selected", () => {
+      render(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en-GB"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tabs = screen.getAllByRole("tab");
+
+      // en-GB (index 1) should be selected
+      expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+      // en (index 0) should not be selected
+      expect(tabs[0]).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("calls onLanguageChange when tab is clicked", async () => {
+      vi.useFakeTimers();
+
+      render(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tabs = screen.getAllByRole("tab");
+      fireEvent.click(tabs[1]); // Click en-GB tab
+
+      // Fast-forward through debounce
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(mockOnLanguageChange).toHaveBeenCalledWith("en-GB");
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has correct ARIA tablist role", () => {
+      render(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      expect(screen.getByRole("tablist")).toBeInTheDocument();
+    });
+
+    it("includes language name in screen reader text", () => {
+      render(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tabs = screen.getAllByRole("tab");
+
+      // The accessible name should contain the full language name
+      expect(tabs[1]).toHaveAccessibleName(/english \(uk\)/i);
+    });
+
+    it("indicates high quality transcript in screen reader text", () => {
+      render(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tabs = screen.getAllByRole("tab");
+
+      // Manual transcripts should have "high quality" in accessible name
+      expect(tabs[0]).toHaveAccessibleName(/high quality/i);
+      expect(tabs[1]).toHaveAccessibleName(/high quality/i);
+
+      // Auto-generated should NOT have "high quality"
+      expect(tabs[2]).not.toHaveAccessibleName(/high quality/i);
+    });
+  });
+
+  describe("empty state", () => {
+    it("renders nothing when languages array is empty", () => {
+      const { container } = render(
+        <LanguageSelector
+          languages={[]}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/frontend/src/tests/hooks/usePrefersReducedMotion.test.ts
+++ b/frontend/src/tests/hooks/usePrefersReducedMotion.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for usePrefersReducedMotion hook.
+ *
+ * Tests the FR-012c accessibility requirement: Detect user's reduced motion preference.
+ *
+ * @module tests/hooks/usePrefersReducedMotion
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { usePrefersReducedMotion } from "../../hooks/usePrefersReducedMotion";
+
+describe("usePrefersReducedMotion", () => {
+  beforeEach(() => {
+    // Reset matchMedia mock before each test
+    vi.clearAllMocks();
+  });
+
+  it("returns false by default when user has not enabled reduced motion", () => {
+    // Mock matchMedia to return matches: false
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when user has enabled reduced motion", () => {
+    // Mock matchMedia to return matches: true
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it("queries the correct media query string", () => {
+    const matchMediaSpy = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    window.matchMedia = matchMediaSpy;
+
+    renderHook(() => usePrefersReducedMotion());
+
+    expect(matchMediaSpy).toHaveBeenCalledWith("(prefers-reduced-motion: reduce)");
+  });
+
+  it("registers event listener for media query changes (modern browsers)", () => {
+    const addEventListenerSpy = vi.fn();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: addEventListenerSpy,
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    renderHook(() => usePrefersReducedMotion());
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith("change", expect.any(Function));
+  });
+
+  it("falls back to addListener for older browsers", () => {
+    const addListenerSpy = vi.fn();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: addListenerSpy,
+      removeListener: vi.fn(),
+      // No addEventListener method (older browser)
+      dispatchEvent: vi.fn(),
+    }));
+
+    renderHook(() => usePrefersReducedMotion());
+
+    expect(addListenerSpy).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it("cleans up event listener on unmount (modern browsers)", () => {
+    const removeEventListenerSpy = vi.fn();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: removeEventListenerSpy,
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { unmount } = renderHook(() => usePrefersReducedMotion());
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("change", expect.any(Function));
+  });
+
+  it("cleans up listener on unmount (older browsers)", () => {
+    const removeListenerSpy = vi.fn();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: removeListenerSpy,
+      // No removeEventListener method (older browser)
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { unmount } = renderHook(() => usePrefersReducedMotion());
+    unmount();
+
+    expect(removeListenerSpy).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it("updates when media query changes", () => {
+    let changeHandler: ((event: MediaQueryListEvent) => void) | null = null;
+
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn((event: string, handler: (event: MediaQueryListEvent) => void) => {
+        if (event === "change") {
+          changeHandler = handler;
+        }
+      }),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { result, rerender } = renderHook(() => usePrefersReducedMotion());
+
+    // Initially false
+    expect(result.current).toBe(false);
+
+    // Simulate media query change event
+    if (changeHandler) {
+      changeHandler({ matches: true } as MediaQueryListEvent);
+    }
+
+    rerender();
+
+    // Should now be true
+    expect(result.current).toBe(true);
+  });
+
+  it("handles missing matchMedia gracefully (SSR scenario)", () => {
+    // Save original matchMedia
+    const originalMatchMedia = window.matchMedia;
+
+    // Remove matchMedia to simulate SSR
+    // @ts-expect-error - Testing SSR scenario
+    delete window.matchMedia;
+
+    const { result } = renderHook(() => usePrefersReducedMotion());
+
+    // Should default to false
+    expect(result.current).toBe(false);
+
+    // Restore matchMedia
+    window.matchMedia = originalMatchMedia;
+  });
+});

--- a/frontend/src/tests/hooks/useTranscript.test.tsx
+++ b/frontend/src/tests/hooks/useTranscript.test.tsx
@@ -1,0 +1,470 @@
+/**
+ * Unit tests for useTranscript hook.
+ *
+ * Tests TanStack Query integration for fetching full transcript text.
+ *
+ * @module tests/hooks/useTranscript
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useTranscript } from "../../hooks/useTranscript";
+import type { Transcript } from "../../types/transcript";
+import * as apiConfig from "../../api/config";
+
+// Mock the API fetch
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: "http://localhost:8765/api/v1",
+  API_TIMEOUT: 10000,
+}));
+
+describe("useTranscript", () => {
+  let queryClient: QueryClient;
+
+  const mockTranscript: Transcript = {
+    video_id: "dQw4w9WgXcQ",
+    language_code: "en",
+    transcript_type: "manual",
+    full_text: "This is the full transcript text. It contains multiple sentences and paragraphs.",
+    segment_count: 25,
+    downloaded_at: "2024-01-15T10:00:00Z",
+  };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    vi.clearAllMocks();
+  });
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  describe("successful data fetching", () => {
+    it("fetches and returns full transcript text", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockTranscript,
+      });
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(mockTranscript);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("calls apiFetch with correct endpoint and language parameter", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockTranscript,
+      });
+
+      renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript?language=en");
+      });
+    });
+
+    it("properly encodes language code with special characters", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: { ...mockTranscript, language_code: "zh-Hans" },
+      });
+
+      renderHook(() => useTranscript("dQw4w9WgXcQ", "zh-Hans"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript?language=zh-Hans");
+      });
+    });
+
+    it("uses correct query key for caching", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockTranscript,
+      });
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      const cachedData = queryClient.getQueryData(["transcript", "dQw4w9WgXcQ", "en"]);
+      expect(cachedData).toEqual(mockTranscript);
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading state initially", () => {
+      vi.mocked(apiConfig.apiFetch).mockImplementationOnce(
+        () => new Promise(() => {}) // Never resolves
+      );
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.error).toBeNull();
+    });
+
+    it("transitions from loading to success", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockTranscript,
+      });
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isSuccess).toBe(true);
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles 404 not found error", async () => {
+      const notFoundError = {
+        type: "server" as const,
+        message: "Transcript not found",
+        status: 404,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(notFoundError);
+
+      const { result } = renderHook(() => useTranscript("invalidVideo", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(notFoundError);
+      expect(result.current.data).toBeUndefined();
+    });
+
+    it("handles network error", async () => {
+      const networkError = {
+        type: "network" as const,
+        message: "Cannot reach the API server. Make sure the backend is running on port 8765.",
+        status: undefined,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(networkError);
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(networkError);
+    });
+
+    it("handles timeout error per NFR-P01 requirement", async () => {
+      const timeoutError = {
+        type: "timeout" as const,
+        message: "The server took too long to respond.",
+        status: undefined,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(timeoutError);
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(timeoutError);
+    });
+
+    it("handles server error (500)", async () => {
+      const serverError = {
+        type: "server" as const,
+        message: "Something went wrong on the server.",
+        status: 500,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(serverError);
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(serverError);
+    });
+  });
+
+  describe("query enabled/disabled", () => {
+    it("does not fetch when videoId is empty", () => {
+      const { result } = renderHook(() => useTranscript("", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when languageCode is empty", () => {
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", ""), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when both parameters are empty", () => {
+      const { result } = renderHook(() => useTranscript("", ""), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+
+    it("fetches when both parameters are provided after being empty", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockTranscript,
+      });
+
+      let videoId = "";
+      let languageCode = "";
+
+      const { result, rerender } = renderHook(
+        () => useTranscript(videoId, languageCode),
+        {
+          wrapper: createWrapper(),
+        }
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+
+      videoId = "dQw4w9WgXcQ";
+      languageCode = "en";
+      rerender();
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript?language=en");
+    });
+  });
+
+  describe("staleTime configuration", () => {
+    it("uses 10 second staleTime per NFR-P01 requirement", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockTranscript,
+      });
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      const queryState = queryClient.getQueryState(["transcript", "dQw4w9WgXcQ", "en"]);
+      expect(queryState).toBeDefined();
+    });
+  });
+
+  describe("caching behavior", () => {
+    it("uses cached data for subsequent renders with same parameters", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockTranscript,
+      });
+
+      const { result: result1 } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result1.current.isSuccess).toBe(true);
+      });
+
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1);
+
+      const { result: result2 } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result2.current.data).toEqual(mockTranscript);
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("fetches different data for different language codes", async () => {
+      const mockTranscriptES: Transcript = {
+        ...mockTranscript,
+        language_code: "es",
+        full_text: "Este es el texto completo de la transcripción.",
+      };
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce({ data: mockTranscript })
+        .mockResolvedValueOnce({ data: mockTranscriptES });
+
+      const { result: result1 } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result1.current.isSuccess).toBe(true);
+      });
+
+      const { result: result2 } = renderHook(() => useTranscript("dQw4w9WgXcQ", "es"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result2.current.isSuccess).toBe(true);
+      });
+
+      expect(result1.current.data?.language_code).toBe("en");
+      expect(result2.current.data?.language_code).toBe("es");
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("fetches different data for different video IDs", async () => {
+      const mockTranscript2: Transcript = {
+        ...mockTranscript,
+        video_id: "different123",
+        full_text: "Different video transcript content.",
+      };
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce({ data: mockTranscript })
+        .mockResolvedValueOnce({ data: mockTranscript2 });
+
+      const { result: result1 } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result1.current.isSuccess).toBe(true);
+      });
+
+      const { result: result2 } = renderHook(() => useTranscript("different123", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result2.current.isSuccess).toBe(true);
+      });
+
+      expect(result1.current.data?.video_id).toBe("dQw4w9WgXcQ");
+      expect(result2.current.data?.video_id).toBe("different123");
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("multiple transcript types", () => {
+    it("fetches manual transcript", async () => {
+      const manualTranscript: Transcript = {
+        ...mockTranscript,
+        transcript_type: "manual",
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: manualTranscript,
+      });
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.transcript_type).toBe("manual");
+    });
+
+    it("fetches auto-generated transcript", async () => {
+      const autoTranscript: Transcript = {
+        ...mockTranscript,
+        transcript_type: "auto_generated",
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: autoTranscript,
+      });
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.transcript_type).toBe("auto_generated");
+    });
+
+    it("fetches auto-synced transcript", async () => {
+      const autoSyncedTranscript: Transcript = {
+        ...mockTranscript,
+        transcript_type: "auto_synced",
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: autoSyncedTranscript,
+      });
+
+      const { result } = renderHook(() => useTranscript("dQw4w9WgXcQ", "en"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.transcript_type).toBe("auto_synced");
+    });
+  });
+});

--- a/frontend/src/tests/hooks/useTranscriptLanguages.test.tsx
+++ b/frontend/src/tests/hooks/useTranscriptLanguages.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * Unit tests for useTranscriptLanguages hook.
+ *
+ * Tests TanStack Query integration for fetching available transcript languages.
+ *
+ * @module tests/hooks/useTranscriptLanguages
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useTranscriptLanguages } from "../../hooks/useTranscriptLanguages";
+import type { TranscriptLanguage } from "../../types/transcript";
+import * as apiConfig from "../../api/config";
+
+// Mock the API fetch
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: "http://localhost:8765/api/v1",
+  API_TIMEOUT: 10000,
+}));
+
+describe("useTranscriptLanguages", () => {
+  let queryClient: QueryClient;
+
+  const mockLanguages: TranscriptLanguage[] = [
+    {
+      language_code: "en",
+      language_name: "English",
+      transcript_type: "manual",
+      is_translatable: true,
+      downloaded_at: "2024-01-15T10:00:00Z",
+    },
+    {
+      language_code: "es",
+      language_name: "Spanish",
+      transcript_type: "auto_generated",
+      is_translatable: false,
+      downloaded_at: "2024-01-15T10:05:00Z",
+    },
+  ];
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    vi.clearAllMocks();
+  });
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  describe("successful data fetching", () => {
+    it("fetches and returns transcript languages array", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockLanguages,
+      });
+
+      const { result } = renderHook(() => useTranscriptLanguages("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(mockLanguages);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("calls apiFetch with correct endpoint", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockLanguages,
+      });
+
+      renderHook(() => useTranscriptLanguages("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages");
+      });
+    });
+
+    it("uses correct query key for caching", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockLanguages,
+      });
+
+      const { result } = renderHook(() => useTranscriptLanguages("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      const cachedData = queryClient.getQueryData(["transcriptLanguages", "dQw4w9WgXcQ"]);
+      expect(cachedData).toEqual(mockLanguages);
+    });
+  });
+
+  describe("empty languages array", () => {
+    it("handles empty array when no transcripts available", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: [],
+      });
+
+      const { result } = renderHook(() => useTranscriptLanguages("noTranscriptVideo"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual([]);
+      expect(Array.isArray(result.current.data)).toBe(true);
+      expect(result.current.data).toHaveLength(0);
+    });
+  });
+
+  describe("single language", () => {
+    it("handles single language correctly", async () => {
+      const singleLanguage: TranscriptLanguage[] = [
+        {
+          language_code: "en",
+          language_name: "English",
+          transcript_type: "manual",
+          is_translatable: true,
+          downloaded_at: "2024-01-15T10:00:00Z",
+        },
+      ];
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: singleLanguage,
+      });
+
+      const { result } = renderHook(() => useTranscriptLanguages("singleLangVideo"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(singleLanguage);
+      expect(result.current.data).toHaveLength(1);
+    });
+  });
+
+  describe("multiple languages", () => {
+    it("handles multiple languages with different transcript types", async () => {
+      const multipleLanguages: TranscriptLanguage[] = [
+        {
+          language_code: "en",
+          language_name: "English",
+          transcript_type: "manual",
+          is_translatable: true,
+          downloaded_at: "2024-01-15T10:00:00Z",
+        },
+        {
+          language_code: "es",
+          language_name: "Spanish",
+          transcript_type: "auto_synced",
+          is_translatable: false,
+          downloaded_at: "2024-01-15T10:05:00Z",
+        },
+        {
+          language_code: "fr",
+          language_name: "French",
+          transcript_type: "auto_generated",
+          is_translatable: true,
+          downloaded_at: "2024-01-15T10:10:00Z",
+        },
+      ];
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: multipleLanguages,
+      });
+
+      const { result } = renderHook(() => useTranscriptLanguages("multiLangVideo"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(multipleLanguages);
+      expect(result.current.data).toHaveLength(3);
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles 404 not found error", async () => {
+      const notFoundError = {
+        type: "server" as const,
+        message: "Video not found",
+        status: 404,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(notFoundError);
+
+      const { result } = renderHook(() => useTranscriptLanguages("invalidVideo"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(notFoundError);
+      expect(result.current.data).toBeUndefined();
+    });
+
+    it("handles network error", async () => {
+      const networkError = {
+        type: "network" as const,
+        message: "Cannot reach the API server. Make sure the backend is running on port 8765.",
+        status: undefined,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(networkError);
+
+      const { result } = renderHook(() => useTranscriptLanguages("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(networkError);
+    });
+  });
+
+  describe("query enabled/disabled", () => {
+    it("does not fetch when videoId is empty", () => {
+      const { result } = renderHook(() => useTranscriptLanguages(""), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+
+    it("fetches when videoId is provided after being empty", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockLanguages,
+      });
+
+      let videoId = "";
+      const { result, rerender } = renderHook(() => useTranscriptLanguages(videoId), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+
+      videoId = "dQw4w9WgXcQ";
+      rerender();
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages");
+    });
+  });
+
+  describe("staleTime configuration", () => {
+    it("uses 5 minute staleTime for efficient caching", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockLanguages,
+      });
+
+      const { result } = renderHook(() => useTranscriptLanguages("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      const queryState = queryClient.getQueryState(["transcriptLanguages", "dQw4w9WgXcQ"]);
+      expect(queryState).toBeDefined();
+    });
+  });
+
+  describe("caching behavior", () => {
+    it("uses cached data for subsequent renders", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockLanguages,
+      });
+
+      const { result: result1 } = renderHook(() => useTranscriptLanguages("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result1.current.isSuccess).toBe(true);
+      });
+
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1);
+
+      const { result: result2 } = renderHook(() => useTranscriptLanguages("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result2.current.data).toEqual(mockLanguages);
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("fetches different data for different video IDs", async () => {
+      const mockLanguages2: TranscriptLanguage[] = [
+        {
+          language_code: "de",
+          language_name: "German",
+          transcript_type: "manual",
+          is_translatable: true,
+          downloaded_at: "2024-01-15T11:00:00Z",
+        },
+      ];
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce({ data: mockLanguages })
+        .mockResolvedValueOnce({ data: mockLanguages2 });
+
+      const { result: result1 } = renderHook(() => useTranscriptLanguages("video1"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result1.current.isSuccess).toBe(true);
+      });
+
+      const { result: result2 } = renderHook(() => useTranscriptLanguages("video2"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result2.current.isSuccess).toBe(true);
+      });
+
+      expect(result1.current.data).toHaveLength(2);
+      expect(result2.current.data).toHaveLength(1);
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/tests/hooks/useTranscriptSegments.test.tsx
+++ b/frontend/src/tests/hooks/useTranscriptSegments.test.tsx
@@ -1,0 +1,594 @@
+/**
+ * Unit tests for useTranscriptSegments hook.
+ *
+ * Tests TanStack Query infinite scroll integration for fetching transcript segments.
+ * Implements FR-020a, FR-020b, NFR-P02, NFR-P04-P06.
+ *
+ * @module tests/hooks/useTranscriptSegments
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useTranscriptSegments } from "../../hooks/useTranscriptSegments";
+import type { TranscriptSegment, SegmentListResponse } from "../../types/transcript";
+import * as apiConfig from "../../api/config";
+
+// Mock the API fetch
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: "http://localhost:8765/api/v1",
+  API_TIMEOUT: 10000,
+}));
+
+describe("useTranscriptSegments", () => {
+  let queryClient: QueryClient;
+
+  const createMockSegments = (start: number, count: number): TranscriptSegment[] => {
+    return Array.from({ length: count }, (_, i) => ({
+      id: start + i,
+      text: `Segment ${start + i} text content`,
+      start_time: (start + i) * 5,
+      end_time: (start + i) * 5 + 4.5,
+      duration: 4.5,
+    }));
+  };
+
+  const createMockResponse = (
+    offset: number,
+    limit: number,
+    total: number
+  ): SegmentListResponse => {
+    const segments = createMockSegments(offset + 1, Math.min(limit, total - offset));
+    return {
+      data: segments,
+      pagination: {
+        total,
+        limit,
+        offset,
+        has_more: offset + limit < total,
+      },
+    };
+  };
+
+  // Counter to ensure unique video IDs across all tests
+  let testCounter = 0;
+  const getUniqueVideoId = () => `video-${Date.now()}-${++testCounter}`;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0, // Disable garbage collection caching
+          staleTime: 0, // Always consider data stale
+        },
+      },
+    });
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    // Clear all queries and ensure cleanup
+    queryClient.clear();
+    queryClient.removeQueries();
+    await queryClient.cancelQueries();
+    vi.resetAllMocks();
+  });
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  describe("initial batch loading (FR-020a)", () => {
+    it("loads initial batch of 50 segments", async () => {
+      const mockResponse = createMockResponse(0, 50, 150);
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("dQw4w9WgXcQ", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(50);
+        },
+        { timeout: 10000 }
+      );
+
+      expect(result.current.totalCount).toBe(150);
+      expect(result.current.hasNextPage).toBe(true);
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+        "/videos/dQw4w9WgXcQ/transcript/segments?language_code=en&offset=0&limit=50",
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+
+    it("sets hasNextPage to false when all segments loaded initially", async () => {
+      const mockResponse = createMockResponse(0, 50, 30);
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-1", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(30);
+        },
+        { timeout: 10000 }
+      );
+
+      expect(result.current.hasNextPage).toBe(false);
+    });
+  });
+
+  describe("pagination with subsequent batches (FR-020b)", () => {
+    it("loads subsequent batches of 25 segments", async () => {
+      const mockResponse1 = createMockResponse(0, 50, 100);
+      const mockResponse2 = createMockResponse(50, 25, 100);
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce(mockResponse1)
+        .mockResolvedValueOnce(mockResponse2);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-2", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(50);
+        },
+        { timeout: 10000 }
+      );
+
+      // Fetch next page
+      await act(async () => {
+        result.current.fetchNextPage();
+      });
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(75);
+        },
+        { timeout: 10000 }
+      );
+
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+        "/videos/test-2/transcript/segments?language_code=en&offset=50&limit=25",
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+
+    it("loads multiple subsequent pages correctly", async () => {
+      const mockResponse1 = createMockResponse(0, 50, 150);
+      const mockResponse2 = createMockResponse(50, 25, 150);
+      const mockResponse3 = createMockResponse(75, 25, 150);
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce(mockResponse1)
+        .mockResolvedValueOnce(mockResponse2)
+        .mockResolvedValueOnce(mockResponse3);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-3", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(50);
+        },
+        { timeout: 10000 }
+      );
+
+      await act(async () => {
+        result.current.fetchNextPage();
+      });
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(75);
+        },
+        { timeout: 10000 }
+      );
+
+      await act(async () => {
+        result.current.fetchNextPage();
+      });
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(100);
+        },
+        { timeout: 10000 }
+      );
+
+      expect(result.current.hasNextPage).toBe(true);
+    });
+  });
+
+  describe("getNextPageParam logic", () => {
+    it("returns undefined when has_more is false", async () => {
+      const mockResponse = createMockResponse(0, 50, 50);
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-4", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.hasNextPage).toBe(false);
+        },
+        { timeout: 10000 }
+      );
+    });
+
+    it("returns correct offset and limit for next page", { timeout: 15000 }, async () => {
+      const mockResponse1 = createMockResponse(0, 50, 150);
+      const mockResponse2 = createMockResponse(50, 25, 150);
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce(mockResponse1)
+        .mockResolvedValueOnce(mockResponse2);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-video-1", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.hasNextPage).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      await act(async () => {
+        result.current.fetchNextPage();
+      });
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(75);
+        },
+        { timeout: 10000 }
+      );
+    });
+  });
+
+  describe("loading states", () => {
+    it("shows initial loading state", async () => {
+      vi.mocked(apiConfig.apiFetch).mockImplementationOnce(
+        () => new Promise(() => {}) // Never resolves
+      );
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-5", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      // Wait for the query to start processing (after debounce)
+      await waitFor(
+        () => {
+          expect(result.current.isLoading).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      expect(result.current.isFetchingNextPage).toBe(false);
+      expect(result.current.segments).toHaveLength(0);
+    });
+
+    it("shows fetchingNextPage state when loading more segments", { timeout: 15000 }, async () => {
+      const mockResponse1 = createMockResponse(0, 50, 100);
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce(mockResponse1)
+        .mockImplementationOnce(() => new Promise(() => {})); // Never resolves
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-video-2", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(50);
+        },
+        { timeout: 10000 }
+      );
+
+      await act(async () => {
+        result.current.fetchNextPage();
+      });
+
+      // Wait for fetchNextPage to start
+      await waitFor(
+        () => {
+          expect(result.current.isFetchingNextPage).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles API errors", { timeout: 15000 }, async () => {
+      const apiError = {
+        type: "server" as const,
+        message: "Failed to fetch segments",
+        status: 500,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(apiError);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-video-3", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.isError).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      expect(result.current.error).toEqual(apiError);
+      expect(result.current.segments).toHaveLength(0);
+    });
+
+    it("provides retry function for error recovery", { timeout: 15000 }, async () => {
+      const apiError = {
+        type: "timeout" as const,
+        message: "Request timeout",
+        status: undefined,
+      };
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockRejectedValueOnce(apiError)
+        .mockResolvedValueOnce(createMockResponse(0, 50, 100));
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-video-4", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.isError).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      // Retry after error
+      await act(async () => {
+        result.current.retry();
+      });
+
+      await waitFor(
+        () => {
+          expect(result.current.isError).toBe(false);
+          expect(result.current.segments).toHaveLength(50);
+        },
+        { timeout: 10000 }
+      );
+    });
+  });
+
+  describe("query enabled/disabled", () => {
+    it("does not fetch when enabled is false", () => {
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-6", "en", false),
+        { wrapper: createWrapper() }
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when videoId is empty", () => {
+      const { result } = renderHook(
+        () => useTranscriptSegments("", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when languageCode is empty", () => {
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-7", ""),
+        { wrapper: createWrapper() }
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("language switching and cancellation (NFR-P04-P06)", () => {
+    it("cancels previous requests when language changes", { timeout: 15000 }, async () => {
+      const mockResponse1 = createMockResponse(0, 50, 100);
+      const mockResponse2 = createMockResponse(0, 50, 100);
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce(mockResponse1)
+        .mockResolvedValueOnce(mockResponse2);
+
+      let language = "en";
+      const { result, rerender } = renderHook(
+        () => useTranscriptSegments("test-video-5", language),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(50);
+        },
+        { timeout: 10000 }
+      );
+
+      // Change language
+      language = "es";
+      rerender();
+
+      await waitFor(
+        () => {
+          expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+            "/videos/test-video-5/transcript/segments?language_code=es&offset=0&limit=50",
+            expect.objectContaining({ signal: expect.any(AbortSignal) })
+          );
+        },
+        { timeout: 10000 }
+      );
+    });
+
+    it("provides cancelRequests function", async () => {
+      const mockResponse = createMockResponse(0, 50, 100);
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments("test-8", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      expect(typeof result.current.cancelRequests).toBe("function");
+
+      // Should not throw when called
+      await act(async () => {
+        result.current.cancelRequests();
+      });
+    });
+  });
+
+  describe("debounce for language switching (NFR-P05)", () => {
+    it("applies 150ms debounce delay on initial load", async () => {
+      const mockResponse = createMockResponse(0, 50, 100);
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockResponse);
+
+      renderHook(
+        () => useTranscriptSegments("test-9", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      // Should not call API immediately (debounced)
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+
+      // Wait for debounce delay and API call
+      await waitFor(
+        () => {
+          expect(apiConfig.apiFetch).toHaveBeenCalled();
+        },
+        { timeout: 10000 }
+      );
+    });
+  });
+
+  describe("timeout handling (NFR-P02)", () => {
+    it("applies 5 second timeout to segment batch loads", async () => {
+      const mockResponse = createMockResponse(0, 50, 100);
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockResponse);
+
+      renderHook(
+        () => useTranscriptSegments("test-10", "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ signal: expect.any(AbortSignal) })
+          );
+        },
+        { timeout: 10000 }
+      );
+    });
+  });
+
+  describe("helper properties", () => {
+    it("provides totalCount from pagination", { timeout: 15000 }, async () => {
+      const videoId = getUniqueVideoId();
+      const mockResponse = createMockResponse(0, 50, 150);
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments(videoId, "en"),
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(50);
+        },
+        { timeout: 10000 }
+      );
+
+      expect(result.current.totalCount).toBe(150);
+    });
+
+    it("flattens all pages into single segments array", { timeout: 15000 }, async () => {
+      const videoId = getUniqueVideoId();
+      // Create responses where second batch has 25 segments (50+25=75 total)
+      const mockResponse1 = createMockResponse(0, 50, 75);
+      const mockResponse2 = createMockResponse(50, 25, 75);
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce(mockResponse1)
+        .mockResolvedValueOnce(mockResponse2);
+
+      const { result } = renderHook(
+        () => useTranscriptSegments(videoId, "en"),
+        { wrapper: createWrapper() }
+      );
+
+      // Wait for initial load
+      await waitFor(
+        () => {
+          expect(result.current.segments).toHaveLength(50);
+          expect(result.current.hasNextPage).toBe(true);
+        },
+        { timeout: 10000 }
+      );
+
+      // Verify only 1 call so far
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1);
+
+      // Fetch next page
+      await act(async () => {
+        result.current.fetchNextPage();
+      });
+
+      // Wait for second page
+      await waitFor(
+        () => {
+          expect(apiConfig.apiFetch).toHaveBeenCalledTimes(2);
+          expect(result.current.segments).toHaveLength(75);
+        },
+        { timeout: 10000 }
+      );
+
+      // Segments should be a flat array, not nested pages
+      expect(Array.isArray(result.current.segments)).toBe(true);
+      expect(result.current.segments[0]).toHaveProperty("text");
+      expect(result.current.segments[50]).toHaveProperty("text");
+      // No more pages after this
+      expect(result.current.hasNextPage).toBe(false);
+    });
+  });
+});

--- a/frontend/src/tests/hooks/useVideoDetail.test.tsx
+++ b/frontend/src/tests/hooks/useVideoDetail.test.tsx
@@ -1,0 +1,362 @@
+/**
+ * Unit tests for useVideoDetail hook.
+ *
+ * Tests TanStack Query integration for fetching video details.
+ *
+ * @module tests/hooks/useVideoDetail
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useVideoDetail } from "../../hooks/useVideoDetail";
+import type { VideoDetail } from "../../types/video";
+import * as apiConfig from "../../api/config";
+
+// Mock the API fetch
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: "http://localhost:8765/api/v1",
+  API_TIMEOUT: 10000,
+}));
+
+describe("useVideoDetail", () => {
+  let queryClient: QueryClient;
+
+  const mockVideoDetail: VideoDetail = {
+    video_id: "dQw4w9WgXcQ",
+    title: "Test Video Title",
+    description: "Test video description with detailed content.",
+    channel_id: "UC123456789",
+    channel_title: "Test Channel",
+    upload_date: "2024-01-15T10:30:00Z",
+    duration: 240,
+    view_count: 1000000,
+    like_count: 50000,
+    comment_count: 1500,
+    tags: ["music", "test", "video"],
+    category_id: "10",
+    default_language: "en",
+    made_for_kids: false,
+    transcript_summary: {
+      count: 2,
+      languages: ["en", "es"],
+      has_manual: true,
+    },
+  };
+
+  beforeEach(() => {
+    // Create a fresh QueryClient for each test
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false, // Disable retries for testing
+        },
+      },
+    });
+
+    // Clear all mocks
+    vi.clearAllMocks();
+  });
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  describe("successful data fetching", () => {
+    it("fetches and returns video detail data", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      const { result } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      // Initially loading
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+
+      // Wait for data to load
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(mockVideoDetail);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("calls apiFetch with correct endpoint", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ");
+      });
+    });
+
+    it("uses correct query key for caching", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      const { result } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      // Check that the query is cached with the correct key
+      const cachedData = queryClient.getQueryData(["video", "dQw4w9WgXcQ"]);
+      expect(cachedData).toEqual(mockVideoDetail);
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading state initially", () => {
+      vi.mocked(apiConfig.apiFetch).mockImplementationOnce(
+        () => new Promise(() => {}) // Never resolves
+      );
+
+      const { result } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.error).toBeNull();
+    });
+
+    it("transitions from loading to success", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      const { result } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isSuccess).toBe(true);
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles 404 not found error", async () => {
+      const notFoundError = {
+        type: "server" as const,
+        message: "Video not found",
+        status: 404,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(notFoundError);
+
+      const { result } = renderHook(() => useVideoDetail("invalidVideo"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(notFoundError);
+      expect(result.current.data).toBeUndefined();
+    });
+
+    it("handles network error", async () => {
+      const networkError = {
+        type: "network" as const,
+        message: "Cannot reach the API server. Make sure the backend is running on port 8765.",
+        status: undefined,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(networkError);
+
+      const { result } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(networkError);
+    });
+
+    it("handles timeout error", async () => {
+      const timeoutError = {
+        type: "timeout" as const,
+        message: "The server took too long to respond.",
+        status: undefined,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(timeoutError);
+
+      const { result } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(timeoutError);
+    });
+
+    it("handles server error (500)", async () => {
+      const serverError = {
+        type: "server" as const,
+        message: "Something went wrong on the server.",
+        status: 500,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(serverError);
+
+      const { result } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(serverError);
+    });
+  });
+
+  describe("query enabled/disabled", () => {
+    it("does not fetch when videoId is empty string", () => {
+      const { result } = renderHook(() => useVideoDetail(""), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+
+    it("fetches when videoId is provided after being empty", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      let videoId = "";
+      const { result, rerender } = renderHook(() => useVideoDetail(videoId), {
+        wrapper: createWrapper(),
+      });
+
+      // Initially disabled
+      expect(result.current.isLoading).toBe(false);
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+
+      // Update videoId
+      videoId = "dQw4w9WgXcQ";
+      rerender();
+
+      // Should now fetch
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ");
+    });
+  });
+
+  describe("staleTime configuration", () => {
+    it("uses 10 second staleTime per NFR-P01", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      const { result } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      // Check query state includes staleTime
+      const queryState = queryClient.getQueryState(["video", "dQw4w9WgXcQ"]);
+      expect(queryState).toBeDefined();
+    });
+  });
+
+  describe("caching behavior", () => {
+    it("uses cached data for subsequent renders", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      // First render
+      const { result: result1 } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result1.current.isSuccess).toBe(true);
+      });
+
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1);
+
+      // Second render with same queryClient
+      const { result: result2 } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      // Should immediately have data from cache
+      expect(result2.current.data).toEqual(mockVideoDetail);
+      // Should not trigger another fetch
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("fetches different data for different video IDs", async () => {
+      const mockVideoDetail2: VideoDetail = {
+        ...mockVideoDetail,
+        video_id: "different123",
+        title: "Different Video",
+      };
+
+      vi.mocked(apiConfig.apiFetch)
+        .mockResolvedValueOnce({ data: mockVideoDetail })
+        .mockResolvedValueOnce({ data: mockVideoDetail2 });
+
+      // First video
+      const { result: result1 } = renderHook(() => useVideoDetail("dQw4w9WgXcQ"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result1.current.isSuccess).toBe(true);
+      });
+
+      // Second video
+      const { result: result2 } = renderHook(() => useVideoDetail("different123"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result2.current.isSuccess).toBe(true);
+      });
+
+      expect(result1.current.data?.video_id).toBe("dQw4w9WgXcQ");
+      expect(result2.current.data?.video_id).toBe("different123");
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/tests/pages/VideoDetailPage.test.tsx
+++ b/frontend/src/tests/pages/VideoDetailPage.test.tsx
@@ -1,0 +1,288 @@
+/**
+ * Unit tests for VideoDetailPage component.
+ *
+ * Tests browser tab title, absolute date display, and video metadata rendering.
+ *
+ * @module tests/pages/VideoDetailPage
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import React from "react";
+import { VideoDetailPage } from "../../pages/VideoDetailPage";
+import * as apiConfig from "../../api/config";
+import type { VideoDetail } from "../../types/video";
+
+// Mock the API fetch
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: "http://localhost:8765/api/v1",
+  API_TIMEOUT: 10000,
+}));
+
+describe("VideoDetailPage", () => {
+  let queryClient: QueryClient;
+  const originalTitle = document.title;
+
+  const mockVideoDetail: VideoDetail = {
+    video_id: "test123",
+    title: "Amazing Test Video About Coding",
+    description: "This is a comprehensive test video.",
+    channel_id: "channel456",
+    channel_title: "TestChannel",
+    upload_date: "2024-01-15T10:30:00Z",
+    duration: 3600,
+    view_count: 1500000,
+    like_count: 75000,
+    comment_count: 2500,
+    tags: ["coding", "tutorial"],
+    category_id: "28",
+    default_language: "en",
+    made_for_kids: false,
+    transcript_summary: {
+      count: 1,
+      languages: ["en"],
+      has_manual: true,
+    },
+  };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+          staleTime: 0,
+        },
+      },
+    });
+    vi.clearAllMocks();
+    document.title = "Chronovista";
+  });
+
+  afterEach(() => {
+    document.title = originalTitle;
+    queryClient.clear();
+  });
+
+  const renderWithProviders = (videoId: string) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/videos/${videoId}`]}>
+          <Routes>
+            <Route path="/videos/:videoId" element={<VideoDetailPage />} />
+            <Route path="/videos" element={<div>Videos List</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+
+  describe("browser tab title", () => {
+    it("sets document.title to 'Channel - Video Title' when video loads", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(document.title).toBe("TestChannel - Amazing Test Video About Coding");
+      });
+    });
+
+    it("uses 'Unknown Channel' when channel_title is null", async () => {
+      const videoWithNoChannel: VideoDetail = {
+        ...mockVideoDetail,
+        channel_title: null,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: videoWithNoChannel,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(document.title).toBe("Unknown Channel - Amazing Test Video About Coding");
+      });
+    });
+
+    it("resets document.title to default on unmount", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      const { unmount } = renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(document.title).toBe("TestChannel - Amazing Test Video About Coding");
+      });
+
+      unmount();
+
+      expect(document.title).toBe("Chronovista");
+    });
+  });
+
+  describe("absolute date display", () => {
+    it("displays upload date in absolute format (e.g., 'Jan 15, 2024')", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(screen.getByText("Amazing Test Video About Coding")).toBeInTheDocument();
+      });
+
+      // Should show "Jan 15, 2024" instead of relative time like "2 weeks ago"
+      expect(screen.getByText("Jan 15, 2024")).toBeInTheDocument();
+    });
+
+    it("does not show relative time like 'ago'", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(screen.getByText("Amazing Test Video About Coding")).toBeInTheDocument();
+      });
+
+      // Should NOT contain relative time indicators
+      expect(screen.queryByText(/ago/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/yesterday/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/just now/i)).not.toBeInTheDocument();
+    });
+
+    it("formats different dates correctly", async () => {
+      const videoFromDec: VideoDetail = {
+        ...mockVideoDetail,
+        upload_date: "2023-12-25T08:00:00Z",
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: videoFromDec,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(screen.getByText("Dec 25, 2023")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("video metadata display", () => {
+    it("displays channel name", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(screen.getByText("TestChannel")).toBeInTheDocument();
+      });
+    });
+
+    it("displays video title", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+          "Amazing Test Video About Coding"
+        );
+      });
+    });
+
+    it("displays formatted view count", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(screen.getByText("1.5M views")).toBeInTheDocument();
+      });
+    });
+
+    it("displays formatted like count", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(screen.getByText("75.0K likes")).toBeInTheDocument();
+      });
+    });
+
+    it("displays formatted duration", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce({
+        data: mockVideoDetail,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        // 3600 seconds = 1:00:00
+        expect(screen.getByText("1:00:00")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading state initially", () => {
+      vi.mocked(apiConfig.apiFetch).mockImplementationOnce(
+        () => new Promise(() => {}) // Never resolves
+      );
+
+      renderWithProviders("test123");
+
+      // LoadingState component should be rendered
+      expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("error state", () => {
+    it("shows error message when API fails", async () => {
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce({
+        type: "server",
+        message: "Server error",
+        status: 500,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(screen.getByText("Could not load video.")).toBeInTheDocument();
+      });
+    });
+
+    it("shows retry button in error state", async () => {
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce({
+        type: "server",
+        message: "Server error",
+        status: 500,
+      });
+
+      renderWithProviders("test123");
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,0 +1,56 @@
+/**
+ * Test setup file for vitest.
+ *
+ * This file is run before each test file and provides:
+ * - Testing library matchers from @testing-library/jest-dom
+ * - Global test utilities and mocks
+ * - Environment configuration for happy-dom
+ */
+
+import '@testing-library/jest-dom';
+import { afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Cleanup after each test case (e.g. clearing jsdom)
+afterEach(() => {
+  cleanup();
+});
+
+// Mock IntersectionObserver (used by infinite scroll)
+global.IntersectionObserver = class IntersectionObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = vi.fn(() => []);
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+
+  constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {}
+} as any;
+
+// Mock ResizeObserver (used by some components)
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock matchMedia (used by responsive components)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock scrollTo and scrollBy (used by keyboard navigation)
+Element.prototype.scrollTo = vi.fn();
+Element.prototype.scrollBy = vi.fn();

--- a/frontend/src/tests/utils/formatTimestamp.test.ts
+++ b/frontend/src/tests/utils/formatTimestamp.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for formatTimestamp utility function.
+ *
+ * Tests the FR-018 requirement: Format timestamps as MM:SS or H:MM:SS based on duration.
+ *
+ * @module tests/utils/formatTimestamp
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatTimestamp } from "../../utils/formatTimestamp";
+
+describe("formatTimestamp", () => {
+  describe("MM:SS format (times under 1 hour)", () => {
+    it("formats 0 seconds as 0:00", () => {
+      expect(formatTimestamp(0)).toBe("0:00");
+    });
+
+    it("formats seconds without minutes as M:SS", () => {
+      expect(formatTimestamp(5)).toBe("0:05");
+      expect(formatTimestamp(45)).toBe("0:45");
+    });
+
+    it("formats minutes and seconds as MM:SS", () => {
+      expect(formatTimestamp(65)).toBe("1:05");
+      expect(formatTimestamp(125)).toBe("2:05");
+      expect(formatTimestamp(725)).toBe("12:05");
+    });
+
+    it("pads seconds to 2 digits", () => {
+      expect(formatTimestamp(60)).toBe("1:00");
+      expect(formatTimestamp(61)).toBe("1:01");
+      expect(formatTimestamp(609)).toBe("10:09");
+    });
+
+    it("formats maximum time under 1 hour (59:59)", () => {
+      expect(formatTimestamp(3599)).toBe("59:59");
+    });
+
+    it("does not pad minutes for times under 1 hour", () => {
+      expect(formatTimestamp(180)).toBe("3:00");
+      expect(formatTimestamp(540)).toBe("9:00");
+    });
+  });
+
+  describe("H:MM:SS format (times 1 hour or longer)", () => {
+    it("formats exactly 1 hour as 1:00:00", () => {
+      expect(formatTimestamp(3600)).toBe("1:00:00");
+    });
+
+    it("formats hours with minutes and seconds as H:MM:SS", () => {
+      expect(formatTimestamp(3661)).toBe("1:01:01");
+      expect(formatTimestamp(3725)).toBe("1:02:05");
+      expect(formatTimestamp(4500)).toBe("1:15:00");
+    });
+
+    it("pads minutes to 2 digits for times >= 1 hour", () => {
+      expect(formatTimestamp(3660)).toBe("1:01:00");
+      expect(formatTimestamp(3780)).toBe("1:03:00");
+      expect(formatTimestamp(7380)).toBe("2:03:00");
+    });
+
+    it("pads seconds to 2 digits for times >= 1 hour", () => {
+      expect(formatTimestamp(3601)).toBe("1:00:01");
+      expect(formatTimestamp(3609)).toBe("1:00:09");
+    });
+
+    it("formats multiple hours", () => {
+      expect(formatTimestamp(7200)).toBe("2:00:00");
+      expect(formatTimestamp(10800)).toBe("3:00:00");
+      expect(formatTimestamp(36000)).toBe("10:00:00");
+    });
+
+    it("formats very long durations (>10 hours)", () => {
+      expect(formatTimestamp(43199)).toBe("11:59:59");
+      expect(formatTimestamp(86399)).toBe("23:59:59");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles negative numbers (treats as 0)", () => {
+      expect(formatTimestamp(-1)).toBe("0:00");
+      expect(formatTimestamp(-100)).toBe("0:00");
+    });
+
+    it("truncates decimal values", () => {
+      expect(formatTimestamp(65.7)).toBe("1:05");
+      expect(formatTimestamp(125.999)).toBe("2:05");
+      expect(formatTimestamp(3661.5)).toBe("1:01:01");
+    });
+
+    it("handles floating point precision issues", () => {
+      expect(formatTimestamp(0.1)).toBe("0:00");
+      expect(formatTimestamp(0.9)).toBe("0:00");
+      expect(formatTimestamp(59.99)).toBe("0:59");
+    });
+
+    it("handles very large numbers", () => {
+      expect(formatTimestamp(999999)).toBe("277:46:39");
+    });
+  });
+
+  describe("common video duration scenarios", () => {
+    it("formats typical short video durations", () => {
+      expect(formatTimestamp(30)).toBe("0:30");
+      expect(formatTimestamp(90)).toBe("1:30");
+      expect(formatTimestamp(300)).toBe("5:00");
+      expect(formatTimestamp(600)).toBe("10:00");
+    });
+
+    it("formats typical medium video durations", () => {
+      expect(formatTimestamp(1200)).toBe("20:00");
+      expect(formatTimestamp(1800)).toBe("30:00");
+      expect(formatTimestamp(2700)).toBe("45:00");
+    });
+
+    it("formats typical long video durations", () => {
+      expect(formatTimestamp(3600)).toBe("1:00:00");
+      expect(formatTimestamp(5400)).toBe("1:30:00");
+      expect(formatTimestamp(7200)).toBe("2:00:00");
+    });
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,6 +7,17 @@ export type {
   ApiErrorType,
   PaginationInfo,
   TranscriptSummary,
+  VideoDetail,
   VideoListItem,
   VideoListResponse,
 } from "./video";
+
+export type {
+  SegmentListResponse,
+  Transcript,
+  TranscriptLanguage,
+  TranscriptLanguagesResponse,
+  TranscriptResponse,
+  TranscriptSegment,
+  TranscriptType,
+} from "./transcript";

--- a/frontend/src/types/transcript.ts
+++ b/frontend/src/types/transcript.ts
@@ -1,0 +1,94 @@
+/**
+ * Transcript data types for the Chronovista frontend.
+ * These types match the backend API response schemas for transcript functionality.
+ */
+
+import type { PaginationInfo } from "./video";
+
+/**
+ * Quality indicator for transcript source.
+ * - "manual": Human-created captions (highest quality)
+ * - "auto_synced": Auto-synced from uploaded transcript
+ * - "auto_generated": YouTube's automatic speech recognition
+ */
+export type TranscriptType = "manual" | "auto_synced" | "auto_generated";
+
+/**
+ * Available transcript language with quality indicator.
+ * Represents a single transcript option for a video.
+ */
+export interface TranscriptLanguage {
+  /** BCP-47 language code (e.g., "en-US", "es") */
+  language_code: string;
+  /** Human-readable display name (e.g., "English (US)") */
+  language_name: string;
+  /** Quality indicator for the transcript source */
+  transcript_type: TranscriptType;
+  /** Whether this transcript can be auto-translated to other languages */
+  is_translatable: boolean;
+  /** ISO 8601 datetime when the transcript was downloaded */
+  downloaded_at: string;
+}
+
+/**
+ * Full transcript text for a video in a specific language.
+ * Contains the complete transcript content and metadata.
+ */
+export interface Transcript {
+  /** 11-character YouTube video ID */
+  video_id: string;
+  /** BCP-47 language code */
+  language_code: string;
+  /** Quality indicator for the transcript source */
+  transcript_type: TranscriptType;
+  /** Complete transcript text content */
+  full_text: string;
+  /** Number of segments in this transcript */
+  segment_count: number;
+  /** ISO 8601 datetime when the transcript was downloaded */
+  downloaded_at: string;
+}
+
+/**
+ * Individual transcript segment with timestamp.
+ * Represents a single timed text segment within a transcript.
+ */
+export interface TranscriptSegment {
+  /** Unique segment identifier */
+  id: number;
+  /** Segment text content */
+  text: string;
+  /** Start time in seconds */
+  start_time: number;
+  /** End time in seconds */
+  end_time: number;
+  /** Duration in seconds (end_time - start_time) */
+  duration: number;
+}
+
+/**
+ * API response wrapper for available transcript languages.
+ */
+export interface TranscriptLanguagesResponse {
+  /** Array of available transcript languages */
+  data: TranscriptLanguage[];
+}
+
+/**
+ * API response wrapper for a full transcript.
+ */
+export interface TranscriptResponse {
+  /** Full transcript data */
+  data: Transcript;
+}
+
+/**
+ * API response wrapper for transcript segments with pagination.
+ * Used for infinite scroll loading of transcript segments.
+ */
+export interface SegmentListResponse {
+  /** Array of transcript segments */
+  data: TranscriptSegment[];
+  /** Pagination metadata for infinite scroll */
+  pagination: PaginationInfo;
+}

--- a/frontend/src/types/video.ts
+++ b/frontend/src/types/video.ts
@@ -38,6 +38,42 @@ export interface VideoListItem {
 }
 
 /**
+ * Extended video information for the detail page.
+ */
+export interface VideoDetail {
+  /** 11-character YouTube video ID */
+  video_id: string;
+  /** Video title */
+  title: string;
+  /** Full description text */
+  description: string;
+  /** YouTube channel ID (24 chars, may be null for deleted channels) */
+  channel_id: string | null;
+  /** Channel display name (may be null for deleted channels) */
+  channel_title: string | null;
+  /** ISO 8601 datetime string of upload date */
+  upload_date: string;
+  /** Video duration in seconds */
+  duration: number;
+  /** View count (may be null if hidden) */
+  view_count: number | null;
+  /** Like count (may be null if hidden) */
+  like_count: number | null;
+  /** Comment count (may be null if disabled) */
+  comment_count: number | null;
+  /** Video tags */
+  tags: string[];
+  /** YouTube category ID */
+  category_id: string | null;
+  /** BCP-47 language code for default language */
+  default_language: string | null;
+  /** COPPA compliance flag */
+  made_for_kids: boolean;
+  /** Transcript availability summary */
+  transcript_summary: TranscriptSummary;
+}
+
+/**
  * Pagination metadata for list responses.
  */
 export interface PaginationInfo {
@@ -59,6 +95,14 @@ export interface VideoListResponse {
   data: VideoListItem[];
   /** Pagination metadata (null if pagination not supported) */
   pagination: PaginationInfo | null;
+}
+
+/**
+ * Response from the video detail API endpoint.
+ */
+export interface VideoDetailResponse {
+  /** Video detail data */
+  data: VideoDetail;
 }
 
 /**

--- a/frontend/src/utils/formatTimestamp.ts
+++ b/frontend/src/utils/formatTimestamp.ts
@@ -1,0 +1,46 @@
+/**
+ * Timestamp formatting utilities for transcript display.
+ *
+ * Implements FR-018: Format timestamps as MM:SS or H:MM:SS based on duration.
+ *
+ * @module utils/formatTimestamp
+ */
+
+/**
+ * Formats a timestamp in seconds to a human-readable string.
+ *
+ * For times under 1 hour: MM:SS format (e.g., "3:45", "12:08")
+ * For times >= 1 hour: H:MM:SS format (e.g., "1:23:45", "2:00:00")
+ *
+ * @param seconds - Time in seconds (can be decimal)
+ * @returns Formatted timestamp string
+ *
+ * @example
+ * ```ts
+ * formatTimestamp(0);      // "0:00"
+ * formatTimestamp(65);     // "1:05"
+ * formatTimestamp(3661);   // "1:01:01"
+ * formatTimestamp(3600);   // "1:00:00"
+ * formatTimestamp(125.5);  // "2:05" (decimal truncated)
+ * ```
+ */
+export function formatTimestamp(seconds: number): string {
+  // Handle negative numbers (shouldn't happen, but be safe)
+  const totalSeconds = Math.max(0, Math.floor(seconds));
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+
+  // Pad seconds to always be 2 digits
+  const paddedSeconds = secs.toString().padStart(2, "0");
+
+  if (hours > 0) {
+    // H:MM:SS format for times >= 1 hour
+    const paddedMinutes = minutes.toString().padStart(2, "0");
+    return `${hours}:${paddedMinutes}:${paddedSeconds}`;
+  }
+
+  // MM:SS format for times < 1 hour (minutes not padded)
+  return `${minutes}:${paddedSeconds}`;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Utility function exports for Chronovista frontend.
+ */
+
+export { formatTimestamp } from "./formatTimestamp";

--- a/frontend/tests/components/transcript/LanguageSelector.test.tsx
+++ b/frontend/tests/components/transcript/LanguageSelector.test.tsx
@@ -1,0 +1,496 @@
+/**
+ * Tests for LanguageSelector component.
+ *
+ * Covers:
+ * - Tab selection
+ * - Keyboard navigation (Left/Right arrows, Home/End)
+ * - ARIA attributes (tablist, tab, aria-selected, aria-controls)
+ * - Quality indicators (checkmarks for manual transcripts)
+ * - Language change callback
+ * - Accessibility announcements
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { renderWithProviders } from '../../test-utils';
+import { LanguageSelector } from '../../../src/components/transcript/LanguageSelector';
+import type { TranscriptLanguage } from '../../../src/types/transcript';
+
+describe('LanguageSelector', () => {
+  const mockLanguages: TranscriptLanguage[] = [
+    {
+      language_code: 'en',
+      language_name: 'English',
+      transcript_type: 'manual',
+      is_translatable: true,
+      downloaded_at: '2024-01-15T10:00:00Z',
+    },
+    {
+      language_code: 'es',
+      language_name: 'Spanish',
+      transcript_type: 'auto_synced',
+      is_translatable: true,
+      downloaded_at: '2024-01-15T10:05:00Z',
+    },
+    {
+      language_code: 'fr',
+      language_name: 'French',
+      transcript_type: 'auto_generated',
+      is_translatable: false,
+      downloaded_at: '2024-01-15T10:10:00Z',
+    },
+  ];
+
+  const mockOnLanguageChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render tablist with proper ARIA attributes', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tablist = screen.getByRole('tablist', { name: 'Transcript languages' });
+      expect(tablist).toBeInTheDocument();
+    });
+
+    it('should render all language tabs', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs).toHaveLength(3);
+    });
+
+    it('should render language labels as uppercase 2-letter codes', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      expect(screen.getByRole('tab', { name: /english/i })).toHaveTextContent('EN');
+      expect(screen.getByRole('tab', { name: /spanish/i })).toHaveTextContent('ES');
+      expect(screen.getByRole('tab', { name: /french/i })).toHaveTextContent('FR');
+    });
+
+    it('should render nothing when languages array is empty', () => {
+      const { container } = renderWithProviders(
+        <LanguageSelector
+          languages={[]}
+          selectedLanguage=""
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('Tab Selection', () => {
+    it('should mark selected tab with aria-selected="true"', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="es"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const spanishTab = screen.getByRole('tab', { name: /spanish/i });
+      expect(spanishTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('should mark non-selected tabs with aria-selected="false"', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="es"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      const frenchTab = screen.getByRole('tab', { name: /french/i });
+      expect(englishTab).toHaveAttribute('aria-selected', 'false');
+      expect(frenchTab).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('should call onLanguageChange when tab is clicked', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const spanishTab = screen.getByRole('tab', { name: /spanish/i });
+      await user.click(spanishTab);
+
+      await waitFor(() => {
+        expect(mockOnLanguageChange).toHaveBeenCalledWith('es');
+      });
+    });
+
+    it('should NOT call onLanguageChange when already selected tab is clicked', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      await user.click(englishTab);
+
+      await waitFor(() => {
+        expect(mockOnLanguageChange).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Quality Indicators', () => {
+    it('should show checkmark for manual transcripts', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      expect(englishTab).toHaveTextContent('✓');
+    });
+
+    it('should show checkmark for auto_synced transcripts', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="es"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const spanishTab = screen.getByRole('tab', { name: /spanish/i });
+      expect(spanishTab).toHaveTextContent('✓');
+    });
+
+    it('should NOT show checkmark for auto_generated transcripts', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="fr"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const frenchTab = screen.getByRole('tab', { name: /french/i });
+      expect(frenchTab).not.toHaveTextContent('✓');
+    });
+
+    it('should include quality indicator in screen reader text', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english.*high quality/i });
+      expect(englishTab).toBeInTheDocument();
+    });
+  });
+
+  describe('Keyboard Navigation (NFR-A03)', () => {
+    it('should move focus to next tab with ArrowRight', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      englishTab.focus();
+
+      await user.keyboard('{ArrowRight}');
+
+      await waitFor(() => {
+        const spanishTab = screen.getByRole('tab', { name: /spanish/i });
+        expect(spanishTab).toHaveFocus();
+      });
+    });
+
+    it('should move focus to previous tab with ArrowLeft', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="es"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const spanishTab = screen.getByRole('tab', { name: /spanish/i });
+      spanishTab.focus();
+
+      await user.keyboard('{ArrowLeft}');
+
+      await waitFor(() => {
+        const englishTab = screen.getByRole('tab', { name: /english/i });
+        expect(englishTab).toHaveFocus();
+      });
+    });
+
+    it('should wrap to first tab when ArrowRight on last tab', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="fr"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const frenchTab = screen.getByRole('tab', { name: /french/i });
+      frenchTab.focus();
+
+      await user.keyboard('{ArrowRight}');
+
+      await waitFor(() => {
+        const englishTab = screen.getByRole('tab', { name: /english/i });
+        expect(englishTab).toHaveFocus();
+      });
+    });
+
+    it('should wrap to last tab when ArrowLeft on first tab', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      englishTab.focus();
+
+      await user.keyboard('{ArrowLeft}');
+
+      await waitFor(() => {
+        const frenchTab = screen.getByRole('tab', { name: /french/i });
+        expect(frenchTab).toHaveFocus();
+      });
+    });
+
+    it('should move to first tab with Home key', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="fr"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const frenchTab = screen.getByRole('tab', { name: /french/i });
+      frenchTab.focus();
+
+      await user.keyboard('{Home}');
+
+      await waitFor(() => {
+        const englishTab = screen.getByRole('tab', { name: /english/i });
+        expect(englishTab).toHaveFocus();
+      });
+    });
+
+    it('should move to last tab with End key', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      englishTab.focus();
+
+      await user.keyboard('{End}');
+
+      await waitFor(() => {
+        const frenchTab = screen.getByRole('tab', { name: /french/i });
+        expect(frenchTab).toHaveFocus();
+      });
+    });
+
+    it('should select tab when navigating with arrow keys', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      englishTab.focus();
+
+      await user.keyboard('{ArrowRight}');
+
+      await waitFor(() => {
+        expect(mockOnLanguageChange).toHaveBeenCalledWith('es');
+      });
+    });
+  });
+
+  describe('ARIA Attributes', () => {
+    it('should have proper aria-controls attribute', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+          contentId="test-content"
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      expect(englishTab).toHaveAttribute('aria-controls', 'test-content');
+    });
+
+    it('should use default content ID when not provided', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      expect(englishTab).toHaveAttribute('aria-controls', 'transcript-content');
+    });
+
+    it('should have proper tabindex for roving tabindex pattern', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="es"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      const spanishTab = screen.getByRole('tab', { name: /spanish/i });
+      const frenchTab = screen.getByRole('tab', { name: /french/i });
+
+      // Selected tab should have tabindex="0"
+      expect(spanishTab).toHaveAttribute('tabindex', '0');
+      // Other tabs should have tabindex="-1"
+      expect(englishTab).toHaveAttribute('tabindex', '-1');
+      expect(frenchTab).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('should have id attribute for each tab', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      expect(englishTab).toHaveAttribute('id', 'tab-en');
+    });
+  });
+
+  describe('Accessibility Announcements (NFR-A04)', () => {
+    it('should announce language change to screen readers', async () => {
+      const { user } = renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="en"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const spanishTab = screen.getByRole('tab', { name: /spanish/i });
+      await user.click(spanishTab);
+
+      await waitFor(() => {
+        const announcement = screen.getByRole('status');
+        expect(announcement).toHaveTextContent('Transcript language changed to Spanish');
+      });
+    });
+
+    it('should clear announcement after it has been read', async () => {
+      vi.useFakeTimers();
+
+      try {
+        renderWithProviders(
+          <LanguageSelector
+            languages={mockLanguages}
+            selectedLanguage="en"
+            onLanguageChange={mockOnLanguageChange}
+          />
+        );
+
+        const spanishTab = screen.getByRole('tab', { name: /spanish/i });
+
+        // Click in act()
+        act(() => {
+          spanishTab.click();
+        });
+
+        // Fast-forward past debounce and announcement clear
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2000);
+        });
+
+        const announcement = screen.getByRole('status');
+        expect(announcement).toHaveTextContent('');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('Visual Styling', () => {
+    it('should have different styling for selected tab', () => {
+      renderWithProviders(
+        <LanguageSelector
+          languages={mockLanguages}
+          selectedLanguage="es"
+          onLanguageChange={mockOnLanguageChange}
+        />
+      );
+
+      const englishTab = screen.getByRole('tab', { name: /english/i });
+      const spanishTab = screen.getByRole('tab', { name: /spanish/i });
+
+      // Selected tab should have blue background
+      expect(spanishTab).toHaveClass('bg-blue-600');
+      // Non-selected tab should have gray background
+      expect(englishTab).toHaveClass('bg-gray-100');
+    });
+  });
+});

--- a/frontend/tests/components/transcript/TranscriptFullText.test.tsx
+++ b/frontend/tests/components/transcript/TranscriptFullText.test.tsx
@@ -1,0 +1,475 @@
+/**
+ * Tests for TranscriptFullText component.
+ *
+ * Covers:
+ * - Rendering continuous prose text
+ * - Loading state with skeleton placeholder
+ * - Error state with retry functionality
+ * - Empty transcript handling
+ * - Proper text formatting and accessibility
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils';
+import { TranscriptFullText } from '../../../src/components/transcript/TranscriptFullText';
+import type { Transcript } from '../../../src/types/transcript';
+
+// Mock hooks
+vi.mock('../../../src/hooks/useTranscript');
+
+import { useTranscript } from '../../../src/hooks/useTranscript';
+
+const mockUseTranscript = vi.mocked(useTranscript);
+
+describe('TranscriptFullText', () => {
+  const mockTranscript: Transcript = {
+    video_id: 'test-video',
+    language_code: 'en',
+    transcript_type: 'manual',
+    full_text: 'Welcome to this video tutorial. Today we will learn about React testing. Let us start with the basics.',
+    segment_count: 3,
+    downloaded_at: '2024-01-15T10:00:00Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Loading State', () => {
+    it('should render skeleton placeholder during load', () => {
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('status', { name: 'Loading transcript' })).toBeInTheDocument();
+      expect(screen.getByText('Loading transcript content...')).toBeInTheDocument();
+    });
+
+    it('should render animated pulse skeleton', () => {
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      const { container } = renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const skeleton = container.querySelector('.animate-pulse');
+      expect(skeleton).toBeInTheDocument();
+    });
+  });
+
+  describe('Transcript Rendering (FR-019)', () => {
+    beforeEach(() => {
+      mockUseTranscript.mockReturnValue({
+        data: mockTranscript,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+    });
+
+    it('should render full transcript text as continuous prose', () => {
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByText(mockTranscript.full_text)).toBeInTheDocument();
+    });
+
+    it('should have region role with proper label', () => {
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('region', { name: 'Full transcript text' })).toBeInTheDocument();
+    });
+
+    it('should preserve whitespace with pre-wrap', () => {
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const textElement = screen.getByText(mockTranscript.full_text);
+      expect(textElement).toHaveClass('whitespace-pre-wrap');
+    });
+
+    it('should have proper text contrast for accessibility (NFR-A18)', () => {
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const textElement = screen.getByText(mockTranscript.full_text);
+      expect(textElement).toHaveClass('text-gray-900');
+    });
+
+    it('should have proper line height for readability', () => {
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const textElement = screen.getByText(mockTranscript.full_text);
+      expect(textElement).toHaveClass('leading-7');
+    });
+  });
+
+  describe('Error State', () => {
+    it('should render error message when fetch fails', () => {
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('Failed to load transcript')).toBeInTheDocument();
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+
+    it('should render retry button in error state', () => {
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    });
+
+    it('should call refetch when retry button is clicked', async () => {
+      const mockRefetch = vi.fn();
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: mockRefetch,
+      } as any);
+
+      const { user } = renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const retryButton = screen.getByRole('button', { name: /try again/i });
+      await user.click(retryButton);
+
+      await waitFor(() => {
+        expect(mockRefetch).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should display default error message when error has no message', () => {
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByText('An unexpected error occurred')).toBeInTheDocument();
+    });
+  });
+
+  describe('Empty States', () => {
+    it('should show message when transcript data is null', () => {
+      mockUseTranscript.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByText('No transcript available for this language.')).toBeInTheDocument();
+    });
+
+    it('should show message when full_text is empty string', () => {
+      mockUseTranscript.mockReturnValue({
+        data: { ...mockTranscript, full_text: '' },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByText('Transcript is empty.')).toBeInTheDocument();
+    });
+
+    it('should show message when full_text is only whitespace', () => {
+      mockUseTranscript.mockReturnValue({
+        data: { ...mockTranscript, full_text: '   \n  \t  ' },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByText('Transcript is empty.')).toBeInTheDocument();
+    });
+  });
+
+  describe('Text Formatting', () => {
+    it('should preserve line breaks in transcript text', () => {
+      const multilineTranscript: Transcript = {
+        ...mockTranscript,
+        full_text: 'Line one.\n\nLine two.\nLine three.',
+      };
+
+      mockUseTranscript.mockReturnValue({
+        data: multilineTranscript,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      const { container } = renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      // Query for the paragraph element with whitespace-pre-wrap class
+      const textElement = container.querySelector('.whitespace-pre-wrap');
+      expect(textElement).toBeInTheDocument();
+      // Check that the text content (with newlines collapsed) matches
+      expect(textElement).toHaveTextContent(/Line one.*Line two.*Line three/);
+      // The key assertion: whitespace-pre-wrap class preserves line breaks
+      expect(textElement).toHaveClass('whitespace-pre-wrap');
+    });
+
+    it('should use prose styling for readability', () => {
+      mockUseTranscript.mockReturnValue({
+        data: mockTranscript,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      const { container } = renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const proseContainer = container.querySelector('.prose');
+      expect(proseContainer).toBeInTheDocument();
+      expect(proseContainer).toHaveClass('prose-sm');
+      expect(proseContainer).toHaveClass('max-w-none');
+    });
+  });
+
+  describe('Accessibility', () => {
+    beforeEach(() => {
+      mockUseTranscript.mockReturnValue({
+        data: mockTranscript,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+    });
+
+    it('should have proper semantic HTML structure', () => {
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const region = screen.getByRole('region', { name: 'Full transcript text' });
+      expect(region).toBeInTheDocument();
+    });
+
+    it('should have sufficient color contrast (NFR-A18)', () => {
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const textElement = screen.getByText(mockTranscript.full_text);
+      // text-gray-900 ensures WCAG AA compliance with high contrast ratio
+      expect(textElement).toHaveClass('text-gray-900');
+    });
+
+    it('should have role="status" for loading state', () => {
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('should have role="alert" for error state', () => {
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  describe('Retry Functionality', () => {
+    it('should have keyboard accessible retry button', async () => {
+      const mockRefetch = vi.fn();
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: mockRefetch,
+      } as any);
+
+      const { user } = renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const retryButton = screen.getByRole('button', { name: /try again/i });
+      retryButton.focus();
+      expect(retryButton).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        expect(mockRefetch).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should have visible focus indicator on retry button', () => {
+      mockUseTranscript.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(
+        <TranscriptFullText
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const retryButton = screen.getByRole('button', { name: /try again/i });
+      expect(retryButton).toHaveClass('focus-visible:ring-2');
+      expect(retryButton).toHaveClass('focus-visible:ring-red-500');
+    });
+  });
+});

--- a/frontend/tests/components/transcript/TranscriptPanel.test.tsx
+++ b/frontend/tests/components/transcript/TranscriptPanel.test.tsx
@@ -1,0 +1,465 @@
+/**
+ * Tests for TranscriptPanel component.
+ *
+ * Covers:
+ * - Collapsed state (default)
+ * - Expanded state
+ * - No transcripts message
+ * - Expand/collapse button semantics (NFR-A06-A10)
+ * - Loading and error states
+ * - Language badges display
+ * - Focus management
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils';
+import { TranscriptPanel } from '../../../src/components/transcript/TranscriptPanel';
+import type { TranscriptLanguage } from '../../../src/types/transcript';
+
+// Mock hooks
+vi.mock('../../../src/hooks/useTranscriptLanguages');
+vi.mock('../../../src/hooks/usePrefersReducedMotion');
+
+// Mock child components
+vi.mock('../../../src/components/transcript/LanguageSelector', () => ({
+  LanguageSelector: ({ selectedLanguage, onLanguageChange }: any) => (
+    <div data-testid="language-selector">
+      <button onClick={() => onLanguageChange('en')}>EN</button>
+      <button onClick={() => onLanguageChange('es')}>ES</button>
+      <div>Selected: {selectedLanguage}</div>
+    </div>
+  ),
+}));
+
+vi.mock('../../../src/components/transcript/ViewModeToggle', () => ({
+  ViewModeToggle: ({ mode, onModeChange }: any) => (
+    <div data-testid="view-mode-toggle">
+      <button onClick={() => onModeChange('segments')}>Segments</button>
+      <button onClick={() => onModeChange('fulltext')}>Full Text</button>
+      <div>Mode: {mode}</div>
+    </div>
+  ),
+}));
+
+vi.mock('../../../src/components/transcript/TranscriptSegments', () => ({
+  TranscriptSegments: ({ videoId, languageCode }: any) => (
+    <div data-testid="transcript-segments">
+      Segments: {videoId} - {languageCode}
+    </div>
+  ),
+}));
+
+vi.mock('../../../src/components/transcript/TranscriptFullText', () => ({
+  TranscriptFullText: ({ videoId, languageCode }: any) => (
+    <div data-testid="transcript-fulltext">
+      FullText: {videoId} - {languageCode}
+    </div>
+  ),
+}));
+
+import { useTranscriptLanguages } from '../../../src/hooks/useTranscriptLanguages';
+import { usePrefersReducedMotion } from '../../../src/hooks/usePrefersReducedMotion';
+
+const mockUseTranscriptLanguages = vi.mocked(useTranscriptLanguages);
+const mockUsePrefersReducedMotion = vi.mocked(usePrefersReducedMotion);
+
+describe('TranscriptPanel', () => {
+  const mockLanguages: TranscriptLanguage[] = [
+    {
+      language_code: 'en',
+      language_name: 'English',
+      transcript_type: 'manual',
+      is_translatable: true,
+      downloaded_at: '2024-01-15T10:00:00Z',
+    },
+    {
+      language_code: 'es',
+      language_name: 'Spanish',
+      transcript_type: 'auto_generated',
+      is_translatable: true,
+      downloaded_at: '2024-01-15T10:05:00Z',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsePrefersReducedMotion.mockReturnValue(false);
+  });
+
+  describe('Loading State', () => {
+    it('should render loading skeleton', () => {
+      mockUseTranscriptLanguages.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        error: null,
+      } as any);
+
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      expect(screen.getByRole('status', { name: 'Loading transcript information' })).toBeInTheDocument();
+      expect(screen.getByText('Loading transcript information...')).toBeInTheDocument();
+    });
+  });
+
+  describe('Error State', () => {
+    it('should render error message', () => {
+      mockUseTranscriptLanguages.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Failed to fetch' },
+      } as any);
+
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('Could not load transcript information.')).toBeInTheDocument();
+      expect(screen.getByText('Failed to fetch')).toBeInTheDocument();
+    });
+  });
+
+  describe('No Transcripts Available', () => {
+    it('should render no transcript message when languages array is empty', () => {
+      mockUseTranscriptLanguages.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any);
+
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      expect(screen.getByText('No transcript available for this video')).toBeInTheDocument();
+    });
+  });
+
+  describe('Collapsed State (Default)', () => {
+    beforeEach(() => {
+      mockUseTranscriptLanguages.mockReturnValue({
+        data: mockLanguages,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any);
+    });
+
+    it('should render in collapsed state by default', () => {
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should show "Transcript Available" text when collapsed', () => {
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      expect(screen.getByText('Transcript Available')).toBeInTheDocument();
+    });
+
+    it('should show language badges when collapsed', () => {
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      // Query within the language badge list to avoid confusion with mocked LanguageSelector buttons
+      const badgeList = screen.getByRole('list', { name: 'Available languages' });
+      const badges = badgeList.querySelectorAll('[role="listitem"]');
+
+      // Should show language badges for en and es
+      expect(badges).toHaveLength(2);
+      expect(badges[0]).toHaveTextContent('EN');
+      expect(badges[1]).toHaveTextContent('ES');
+    });
+
+    it('should show high quality checkmark for manual transcripts', () => {
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const badges = screen.getAllByRole('listitem');
+      // First badge (EN) should have checkmark for manual transcript
+      expect(badges[0]).toHaveTextContent('EN✓');
+      // Second badge (ES) should not have checkmark (auto-generated)
+      expect(badges[1]).toHaveTextContent('ES');
+      expect(badges[1]).not.toHaveTextContent('✓');
+    });
+
+    it('should have expandable content hidden when collapsed', () => {
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      const contentId = toggleButton.getAttribute('aria-controls');
+      const expandableContent = document.getElementById(contentId!);
+
+      expect(expandableContent).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  describe('Expanded State', () => {
+    beforeEach(() => {
+      mockUseTranscriptLanguages.mockReturnValue({
+        data: mockLanguages,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any);
+    });
+
+    it('should expand when toggle button is clicked', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+        const contentId = toggleButton.getAttribute('aria-controls');
+        const expandableContent = document.getElementById(contentId!);
+        expect(expandableContent).toHaveAttribute('aria-hidden', 'false');
+      });
+    });
+
+    it('should show "Hide transcript" text when expanded', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Hide transcript')).toBeInTheDocument();
+      });
+    });
+
+    it('should show language selector when expanded', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('language-selector')).toBeInTheDocument();
+      });
+    });
+
+    it('should show view mode toggle when expanded', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('view-mode-toggle')).toBeInTheDocument();
+      });
+    });
+
+    it('should show transcript segments by default', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('transcript-segments')).toBeInTheDocument();
+      });
+    });
+
+    it('should NOT show language badges when expanded', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+
+      // Verify badges are visible when collapsed
+      expect(screen.getByRole('list', { name: 'Available languages' })).toBeInTheDocument();
+
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        // After expansion, the badges should be hidden (not rendered in collapsed state)
+        // The implementation renders badges conditionally with !isExpanded
+        expect(screen.queryByRole('list', { name: 'Available languages' })).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Expand/Collapse Button Semantics (NFR-A06-A10)', () => {
+    beforeEach(() => {
+      mockUseTranscriptLanguages.mockReturnValue({
+        data: mockLanguages,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any);
+    });
+
+    it('should have proper aria-expanded attribute', () => {
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should have proper aria-controls attribute', () => {
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      expect(toggleButton).toHaveAttribute('aria-controls', 'transcript-content');
+    });
+
+    it('should be keyboard accessible', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      toggleButton.focus();
+
+      expect(toggleButton).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+      });
+    });
+
+    it('should announce state changes to screen readers', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        const announcement = screen.getByRole('status');
+        expect(announcement).toHaveTextContent('Transcript panel expanded');
+      });
+    });
+  });
+
+  describe('View Mode Switching', () => {
+    beforeEach(() => {
+      mockUseTranscriptLanguages.mockReturnValue({
+        data: mockLanguages,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any);
+    });
+
+    it('should show segments view by default', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('transcript-segments')).toBeInTheDocument();
+        expect(screen.queryByTestId('transcript-fulltext')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should switch to full text view when view mode toggle is clicked', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      // Expand panel first
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('view-mode-toggle')).toBeInTheDocument();
+      });
+
+      // Click Full Text button in view mode toggle
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+      await user.click(fullTextButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('transcript-fulltext')).toBeInTheDocument();
+        expect(screen.queryByTestId('transcript-segments')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Language Selection', () => {
+    beforeEach(() => {
+      mockUseTranscriptLanguages.mockReturnValue({
+        data: mockLanguages,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any);
+    });
+
+    it('should initialize with first language selected', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Selected: en')).toBeInTheDocument();
+      });
+    });
+
+    it('should pass selected language to transcript components', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('transcript-segments')).toHaveTextContent('Segments: test-video - en');
+      });
+    });
+
+    it('should update transcript when language is changed', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('language-selector')).toBeInTheDocument();
+      });
+
+      const spanishButton = screen.getByRole('button', { name: 'ES' });
+      await user.click(spanishButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('transcript-segments')).toHaveTextContent('Segments: test-video - es');
+      });
+    });
+  });
+
+  describe('Accessibility', () => {
+    beforeEach(() => {
+      mockUseTranscriptLanguages.mockReturnValue({
+        data: mockLanguages,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as any);
+    });
+
+    it('should have proper region role and label', () => {
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      expect(screen.getByRole('region', { name: 'Transcript information' })).toBeInTheDocument();
+    });
+
+    it('should provide screen reader summary when collapsed', () => {
+      renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      expect(screen.getByText(/2 transcripts available in English, Spanish/i)).toBeInTheDocument();
+    });
+
+    it('should have tabpanel role for expanded content', async () => {
+      const { user } = renderWithProviders(<TranscriptPanel videoId="test-video" />);
+
+      const toggleButton = screen.getByRole('button', { name: /show transcript/i });
+      const contentId = toggleButton.getAttribute('aria-controls');
+
+      await user.click(toggleButton);
+
+      await waitFor(() => {
+        const expandableContent = document.getElementById(contentId!);
+        expect(expandableContent).toHaveAttribute('role', 'tabpanel');
+      });
+    });
+  });
+});

--- a/frontend/tests/components/transcript/TranscriptSegments.test.tsx
+++ b/frontend/tests/components/transcript/TranscriptSegments.test.tsx
@@ -1,0 +1,585 @@
+/**
+ * Tests for TranscriptSegments component.
+ *
+ * Covers:
+ * - Rendering with segments
+ * - Infinite scroll trigger
+ * - Loading states (initial and pagination)
+ * - Error states with retry
+ * - End of transcript indicator
+ * - Keyboard navigation (Arrow keys, Page Up/Down, Home/End)
+ * - Virtualization for 500+ segments
+ * - Accessibility attributes
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils';
+import { TranscriptSegments } from '../../../src/components/transcript/TranscriptSegments';
+import type { TranscriptSegment } from '../../../src/types/transcript';
+
+// Mock hooks
+vi.mock('../../../src/hooks/useTranscriptSegments');
+
+// Mock @tanstack/react-virtual for virtualization tests
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: vi.fn(() => ({
+    getVirtualItems: () => [],
+    getTotalSize: () => 0,
+  })),
+}));
+
+import { useTranscriptSegments } from '../../../src/hooks/useTranscriptSegments';
+
+const mockUseTranscriptSegments = vi.mocked(useTranscriptSegments);
+
+describe('TranscriptSegments', () => {
+  const mockSegments: TranscriptSegment[] = [
+    {
+      id: 1,
+      text: 'Welcome to this video tutorial.',
+      start_time: 0.5,
+      end_time: 3.2,
+      duration: 2.7,
+    },
+    {
+      id: 2,
+      text: 'Today we will learn about React testing.',
+      start_time: 3.5,
+      end_time: 7.1,
+      duration: 3.6,
+    },
+    {
+      id: 3,
+      text: 'Let us start with the basics.',
+      start_time: 7.5,
+      end_time: 10.0,
+      duration: 2.5,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Loading States', () => {
+    it('should render skeleton segments during initial load', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: [],
+        totalCount: 0,
+        isLoading: true,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('status', { name: 'Loading transcript segments' })).toBeInTheDocument();
+      expect(screen.getByText('Loading transcript segments...')).toBeInTheDocument();
+    });
+
+    it('should render 3 skeleton segments during loading (FR-020d)', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: [],
+        totalCount: 0,
+        isLoading: true,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      const { container } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      // Count skeleton elements (animated pulse divs)
+      const skeletons = container.querySelectorAll('.animate-pulse');
+      expect(skeletons.length).toBe(3);
+    });
+
+    it('should show loading indicator when fetching next page', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: mockSegments,
+        totalCount: 100,
+        isLoading: false,
+        isFetchingNextPage: true,
+        hasNextPage: true,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('status', { name: 'Loading more segments' })).toBeInTheDocument();
+      expect(screen.getByText('Loading more segments...')).toBeInTheDocument();
+    });
+  });
+
+  describe('Segments Rendering', () => {
+    beforeEach(() => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: mockSegments,
+        totalCount: 3,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+    });
+
+    it('should render all segments with timestamps and text', () => {
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByText('Welcome to this video tutorial.')).toBeInTheDocument();
+      expect(screen.getByText('Today we will learn about React testing.')).toBeInTheDocument();
+      expect(screen.getByText('Let us start with the basics.')).toBeInTheDocument();
+    });
+
+    it('should render timestamps in MM:SS format (FR-018)', () => {
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByText('0:00')).toBeInTheDocument(); // 0.5s rounded down
+      expect(screen.getByText('0:03')).toBeInTheDocument(); // 3.5s
+      expect(screen.getByText('0:07')).toBeInTheDocument(); // 7.5s
+    });
+
+    it('should render timestamp on left and text on right (FR-018)', () => {
+      const { container } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const segmentContainers = container.querySelectorAll('[data-segment-id]');
+      expect(segmentContainers.length).toBe(3);
+
+      // Check first segment structure
+      const firstSegment = segmentContainers[0];
+      expect(firstSegment).toHaveClass('flex');
+      expect(firstSegment).toHaveClass('gap-4');
+    });
+  });
+
+  describe('Error States', () => {
+    it('should render error message when fetch fails with no segments', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: [],
+        totalCount: 0,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('Could not load transcript segments.')).toBeInTheDocument();
+    });
+
+    it('should render retry button in error state', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: [],
+        totalCount: 0,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+
+    it('should call retry when retry button is clicked', async () => {
+      const mockRetry = vi.fn();
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: [],
+        totalCount: 0,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        fetchNextPage: vi.fn(),
+        retry: mockRetry,
+        cancelRequests: vi.fn(),
+      });
+
+      const { user } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const retryButton = screen.getByRole('button', { name: /retry/i });
+      await user.click(retryButton);
+
+      await waitFor(() => {
+        expect(mockRetry).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should preserve loaded segments when error occurs during pagination (FR-025b)', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: mockSegments,
+        totalCount: 100,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: true,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      // Segments should still be visible
+      expect(screen.getByText('Welcome to this video tutorial.')).toBeInTheDocument();
+      expect(screen.getByText('Today we will learn about React testing.')).toBeInTheDocument();
+
+      // Error message should be shown inline
+      expect(screen.getByText('Could not load more segments.')).toBeInTheDocument();
+    });
+  });
+
+  describe('End of Transcript', () => {
+    it('should show "End of transcript" when all segments loaded (FR-020e)', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: mockSegments,
+        totalCount: 3,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByText('End of transcript')).toBeInTheDocument();
+    });
+
+    it('should NOT show "End of transcript" when more segments available', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: mockSegments,
+        totalCount: 100,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: true,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.queryByText('End of transcript')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Empty State', () => {
+    it('should show message when no segments available', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: [],
+        totalCount: 0,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByText('No transcript segments available for this language.')).toBeInTheDocument();
+    });
+  });
+
+  describe('Keyboard Navigation (NFR-A11-A14)', () => {
+    beforeEach(() => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: mockSegments,
+        totalCount: 3,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+    });
+
+    it('should be focusable with tabindex="0" (NFR-A11)', () => {
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const container = screen.getByRole('region', { name: 'Transcript segments' });
+      expect(container).toHaveAttribute('tabindex', '0');
+    });
+
+    it('should scroll down when ArrowDown is pressed (NFR-A12)', async () => {
+      const { user } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const container = screen.getByRole('region', { name: 'Transcript segments' });
+      container.focus();
+
+      await user.keyboard('{ArrowDown}');
+
+      // scrollBy should be called on the container
+      expect(container.scrollBy).toHaveBeenCalled();
+    });
+
+    it('should scroll up when ArrowUp is pressed (NFR-A12)', async () => {
+      const { user } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const container = screen.getByRole('region', { name: 'Transcript segments' });
+      container.focus();
+
+      await user.keyboard('{ArrowUp}');
+
+      expect(container.scrollBy).toHaveBeenCalled();
+    });
+
+    it('should scroll by viewport height with PageDown (NFR-A13)', async () => {
+      const { user } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const container = screen.getByRole('region', { name: 'Transcript segments' });
+      container.focus();
+
+      await user.keyboard('{PageDown}');
+
+      expect(container.scrollBy).toHaveBeenCalled();
+    });
+
+    it('should scroll by viewport height with PageUp (NFR-A13)', async () => {
+      const { user } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const container = screen.getByRole('region', { name: 'Transcript segments' });
+      container.focus();
+
+      await user.keyboard('{PageUp}');
+
+      expect(container.scrollBy).toHaveBeenCalled();
+    });
+
+    it('should scroll to beginning with Home key (NFR-A14)', async () => {
+      const { user } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const container = screen.getByRole('region', { name: 'Transcript segments' });
+      container.focus();
+
+      await user.keyboard('{Home}');
+
+      expect(container.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 0 })
+      );
+    });
+
+    it('should scroll to end with End key (NFR-A14)', async () => {
+      const { user } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const container = screen.getByRole('region', { name: 'Transcript segments' });
+      container.focus();
+
+      await user.keyboard('{End}');
+
+      expect(container.scrollTo).toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility Attributes (NFR-A15)', () => {
+    beforeEach(() => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: mockSegments,
+        totalCount: 3,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+    });
+
+    it('should have region role with proper label', () => {
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      expect(screen.getByRole('region', { name: 'Transcript segments' })).toBeInTheDocument();
+    });
+
+    it('should have visible focus indicator', () => {
+      renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      const container = screen.getByRole('region', { name: 'Transcript segments' });
+      expect(container).toHaveClass('focus-visible:ring-2');
+      expect(container).toHaveClass('focus-visible:ring-blue-500');
+    });
+  });
+
+  describe('Virtualization (NFR-P12-P16)', () => {
+    it('should use standard rendering for < 500 segments', () => {
+      mockUseTranscriptSegments.mockReturnValue({
+        segments: mockSegments,
+        totalCount: 3,
+        isLoading: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        retry: vi.fn(),
+        cancelRequests: vi.fn(),
+      });
+
+      const { container } = renderWithProviders(
+        <TranscriptSegments
+          videoId="test-video"
+          languageCode="en"
+        />
+      );
+
+      // Standard rendering should show all segment elements directly
+      const segmentElements = container.querySelectorAll('[data-segment-id]');
+      expect(segmentElements.length).toBe(3);
+    });
+  });
+});

--- a/frontend/tests/components/transcript/ViewModeToggle.test.tsx
+++ b/frontend/tests/components/transcript/ViewModeToggle.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * Tests for ViewModeToggle component.
+ *
+ * Covers:
+ * - Segments/Full Text toggle rendering
+ * - Mode change callback
+ * - ARIA pressed states
+ * - Keyboard accessibility
+ * - Accessibility announcements
+ * - Visual styling for active/inactive states
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
+import { renderWithProviders } from '../../test-utils';
+import { ViewModeToggle } from '../../../src/components/transcript/ViewModeToggle';
+import type { ViewMode } from '../../../src/components/transcript/ViewModeToggle';
+
+describe('ViewModeToggle', () => {
+  const mockOnModeChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render toggle button group with proper role', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      expect(screen.getByRole('group', { name: 'Transcript view mode' })).toBeInTheDocument();
+    });
+
+    it('should render both Segments and Full Text buttons', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      expect(screen.getByRole('button', { name: 'Segments' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Full Text' })).toBeInTheDocument();
+    });
+  });
+
+  describe('Mode Change Callback', () => {
+    it('should call onModeChange when Segments button is clicked', async () => {
+      const { user } = renderWithProviders(
+        <ViewModeToggle mode="fulltext" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      await user.click(segmentsButton);
+
+      await waitFor(() => {
+        expect(mockOnModeChange).toHaveBeenCalledWith('segments');
+      });
+    });
+
+    it('should call onModeChange when Full Text button is clicked', async () => {
+      const { user } = renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+      await user.click(fullTextButton);
+
+      await waitFor(() => {
+        expect(mockOnModeChange).toHaveBeenCalledWith('fulltext');
+      });
+    });
+
+    it('should NOT call onModeChange when already active button is clicked', async () => {
+      const { user } = renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      await user.click(segmentsButton);
+
+      await waitFor(() => {
+        expect(mockOnModeChange).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('ARIA Pressed States', () => {
+    it('should set aria-pressed="true" for active Segments mode', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      expect(segmentsButton).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('should set aria-pressed="false" for inactive Segments mode', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="fulltext" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      expect(segmentsButton).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('should set aria-pressed="true" for active Full Text mode', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="fulltext" onModeChange={mockOnModeChange} />
+      );
+
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+      expect(fullTextButton).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('should set aria-pressed="false" for inactive Full Text mode', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+      expect(fullTextButton).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+
+  describe('Keyboard Accessibility (NFR-A06)', () => {
+    it('should be keyboard accessible via Tab navigation', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+
+      segmentsButton.focus();
+      expect(segmentsButton).toHaveFocus();
+
+      fullTextButton.focus();
+      expect(fullTextButton).toHaveFocus();
+    });
+
+    it('should activate button via Enter key', async () => {
+      const { user } = renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+      fullTextButton.focus();
+
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        expect(mockOnModeChange).toHaveBeenCalledWith('fulltext');
+      });
+    });
+
+    it('should activate button via Space key', async () => {
+      const { user } = renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+      fullTextButton.focus();
+
+      await user.keyboard(' ');
+
+      await waitFor(() => {
+        expect(mockOnModeChange).toHaveBeenCalledWith('fulltext');
+      });
+    });
+  });
+
+  describe('Accessibility Announcements (NFR-A04)', () => {
+    it('should announce view change when switching to Segments', async () => {
+      const { user } = renderWithProviders(
+        <ViewModeToggle mode="fulltext" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      await user.click(segmentsButton);
+
+      await waitFor(() => {
+        const announcement = screen.getByRole('status');
+        expect(announcement).toHaveTextContent('View changed to Segments');
+      });
+    });
+
+    it('should announce view change when switching to Full Text', async () => {
+      const { user } = renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+      await user.click(fullTextButton);
+
+      await waitFor(() => {
+        const announcement = screen.getByRole('status');
+        expect(announcement).toHaveTextContent('View changed to Full Text');
+      });
+    });
+
+    it('should clear announcement after it has been read', async () => {
+      vi.useFakeTimers();
+
+      try {
+        renderWithProviders(
+          <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+        );
+
+        const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+
+        // Click and advance timers in act()
+        act(() => {
+          fullTextButton.click();
+        });
+
+        let announcement = screen.getByRole('status');
+        expect(announcement).toHaveTextContent('View changed to Full Text');
+
+        // Fast-forward past announcement clear
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1500);
+        });
+
+        announcement = screen.getByRole('status');
+        expect(announcement).toHaveTextContent('');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('Visual Styling', () => {
+    it('should have active styling for Segments mode when selected', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      expect(segmentsButton).toHaveClass('bg-blue-600');
+      expect(segmentsButton).toHaveClass('text-white');
+    });
+
+    it('should have inactive styling for Segments mode when not selected', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="fulltext" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      expect(segmentsButton).toHaveClass('bg-gray-100');
+      expect(segmentsButton).toHaveClass('text-gray-700');
+    });
+
+    it('should have active styling for Full Text mode when selected', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="fulltext" onModeChange={mockOnModeChange} />
+      );
+
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+      expect(fullTextButton).toHaveClass('bg-blue-600');
+      expect(fullTextButton).toHaveClass('text-white');
+    });
+
+    it('should have inactive styling for Full Text mode when not selected', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+      expect(fullTextButton).toHaveClass('bg-gray-100');
+      expect(fullTextButton).toHaveClass('text-gray-700');
+    });
+  });
+
+  describe('Focus Management', () => {
+    it('should have visible focus indicator on buttons', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      expect(segmentsButton).toHaveClass('focus-visible:ring-2');
+      expect(segmentsButton).toHaveClass('focus-visible:ring-blue-500');
+    });
+  });
+
+  describe('Button Type', () => {
+    it('should have type="button" to prevent form submission', () => {
+      renderWithProviders(
+        <ViewModeToggle mode="segments" onModeChange={mockOnModeChange} />
+      );
+
+      const segmentsButton = screen.getByRole('button', { name: 'Segments' });
+      const fullTextButton = screen.getByRole('button', { name: 'Full Text' });
+
+      expect(segmentsButton).toHaveAttribute('type', 'button');
+      expect(fullTextButton).toHaveAttribute('type', 'button');
+    });
+  });
+});

--- a/frontend/tests/pages/VideoDetailPage.test.tsx
+++ b/frontend/tests/pages/VideoDetailPage.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * Tests for VideoDetailPage component.
+ *
+ * Covers:
+ * - Loading state rendering
+ * - Video data display with all metadata
+ * - 404 error display when video not found
+ * - Error state with retry functionality
+ * - Back to Videos navigation link
+ * - Watch on YouTube external link
+ * - Tag display (hidden when no tags)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import { VideoDetailPage } from '../../src/pages/VideoDetailPage';
+import type { VideoDetail } from '../../src/types/video';
+
+// Mock hooks
+vi.mock('../../src/hooks/useVideoDetail');
+vi.mock('../../src/components/transcript', () => ({
+  TranscriptPanel: ({ videoId }: { videoId: string }) => (
+    <div data-testid="transcript-panel">TranscriptPanel: {videoId}</div>
+  ),
+}));
+
+import { useVideoDetail } from '../../src/hooks/useVideoDetail';
+
+const mockUseVideoDetail = vi.mocked(useVideoDetail);
+
+describe('VideoDetailPage', () => {
+  const mockVideoData: VideoDetail = {
+    video_id: 'dQw4w9WgXcQ',
+    title: 'Test Video Title',
+    description: 'This is a test video description.',
+    channel_id: 'UC123456',
+    channel_title: 'Test Channel',
+    upload_date: '2024-01-15T10:30:00Z',
+    duration: 245, // 4:05
+    view_count: 1234567,
+    like_count: 98765,
+    comment_count: 4321,
+    tags: ['test', 'video', 'example'],
+    category_id: '22',
+    default_language: 'en',
+    made_for_kids: false,
+    transcript_summary: {
+      count: 2,
+      languages: ['en', 'es'],
+      has_manual: true,
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Loading State', () => {
+    it('should render loading state when data is being fetched', () => {
+      mockUseVideoDetail.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      // LoadingState component should be rendered
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+  });
+
+  describe('Video Data Display', () => {
+    beforeEach(() => {
+      mockUseVideoDetail.mockReturnValue({
+        data: mockVideoData,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+    });
+
+    it('should render video title', () => {
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByRole('heading', { name: 'Test Video Title' })).toBeInTheDocument();
+    });
+
+    it('should render channel name', () => {
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByText('Test Channel')).toBeInTheDocument();
+    });
+
+    it('should render formatted view count', () => {
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByText('1.2M views')).toBeInTheDocument();
+    });
+
+    it('should render formatted like count', () => {
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByText('98.8K likes')).toBeInTheDocument();
+    });
+
+    it('should render formatted duration', () => {
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByText('4:05')).toBeInTheDocument();
+    });
+
+    it('should render description', () => {
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByText('This is a test video description.')).toBeInTheDocument();
+    });
+
+    it('should render tags as badges', () => {
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByText('test')).toBeInTheDocument();
+      expect(screen.getByText('video')).toBeInTheDocument();
+      expect(screen.getByText('example')).toBeInTheDocument();
+    });
+
+    it('should hide tags section when no tags present', () => {
+      mockUseVideoDetail.mockReturnValue({
+        data: { ...mockVideoData, tags: [] },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.queryByText('Tags')).not.toBeInTheDocument();
+    });
+
+    it('should render TranscriptPanel with correct videoId', () => {
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByTestId('transcript-panel')).toHaveTextContent('TranscriptPanel: dQw4w9WgXcQ');
+    });
+  });
+
+  describe('404 Error Display', () => {
+    it('should render 404 state when video is null', () => {
+      mockUseVideoDetail.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/invalid-id'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByRole('heading', { name: 'Video Not Found' })).toBeInTheDocument();
+      expect(screen.getByText(/doesn't exist or has been removed/i)).toBeInTheDocument();
+    });
+
+    it('should render Back to Videos link in 404 state', () => {
+      mockUseVideoDetail.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/invalid-id'],
+        path: '/videos/:videoId',
+      });
+
+      const backLink = screen.getAllByRole('link', { name: /back to videos/i })[0];
+      expect(backLink).toBeInTheDocument();
+      expect(backLink).toHaveAttribute('href', '/videos');
+    });
+  });
+
+  describe('Error State', () => {
+    it('should render error state when fetch fails', () => {
+      mockUseVideoDetail.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('Could not load video.')).toBeInTheDocument();
+    });
+
+    it('should render Retry button in error state', () => {
+      const mockRefetch = vi.fn();
+      mockUseVideoDetail.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: mockRefetch,
+      } as any);
+
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      const retryButton = screen.getByRole('button', { name: /retry/i });
+      expect(retryButton).toBeInTheDocument();
+    });
+
+    it('should call refetch when Retry button is clicked', async () => {
+      const mockRefetch = vi.fn();
+      mockUseVideoDetail.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: mockRefetch,
+      } as any);
+
+      const { user } = renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      const retryButton = screen.getByRole('button', { name: /retry/i });
+      await user.click(retryButton);
+
+      await waitFor(() => {
+        expect(mockRefetch).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should NOT render TranscriptPanel in error state', () => {
+      mockUseVideoDetail.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: { type: 'network', message: 'Network error' },
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      expect(screen.queryByTestId('transcript-panel')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Back to Videos Link', () => {
+    it('should render Back to Videos link in header', () => {
+      mockUseVideoDetail.mockReturnValue({
+        data: mockVideoData,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      const backLinks = screen.getAllByRole('link', { name: /back to videos/i });
+      expect(backLinks.length).toBeGreaterThan(0);
+      expect(backLinks[0]).toHaveAttribute('href', '/videos');
+    });
+  });
+
+  describe('Watch on YouTube Link', () => {
+    it('should render Watch on YouTube link', () => {
+      mockUseVideoDetail.mockReturnValue({
+        data: mockVideoData,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as any);
+
+      renderWithProviders(<VideoDetailPage />, {
+        initialEntries: ['/videos/dQw4w9WgXcQ'],
+        path: '/videos/:videoId',
+      });
+
+      const youtubeLink = screen.getByRole('link', { name: /watch on youtube/i });
+      expect(youtubeLink).toBeInTheDocument();
+      expect(youtubeLink).toHaveAttribute('href', 'https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+      expect(youtubeLink).toHaveAttribute('target', '_blank');
+      expect(youtubeLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
+});

--- a/frontend/tests/test-utils.tsx
+++ b/frontend/tests/test-utils.tsx
@@ -1,0 +1,121 @@
+/**
+ * Test utilities for setting up React Query and React Router.
+ *
+ * Provides wrapper components and helper functions for testing components
+ * that use TanStack Query, React Router, and other context providers.
+ */
+
+import { ReactElement, ReactNode } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+/**
+ * Creates a new QueryClient for testing with disabled retries and cache.
+ */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+        staleTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  });
+}
+
+/**
+ * Props for AllProviders wrapper component.
+ */
+interface AllProvidersProps {
+  children: ReactNode;
+  queryClient?: QueryClient;
+  initialEntries?: string[];
+  path?: string;
+}
+
+/**
+ * Wrapper component that provides all necessary context providers for testing.
+ */
+function AllProviders({
+  children,
+  queryClient = createTestQueryClient(),
+  initialEntries = ['/'],
+  path = '*',
+}: AllProvidersProps) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path={path} element={<>{children}</>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+/**
+ * Custom render options extending RTL's RenderOptions.
+ */
+export interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
+  queryClient?: QueryClient;
+  initialEntries?: string[];
+  path?: string;
+}
+
+/**
+ * Custom render function that wraps components with all providers.
+ *
+ * @param ui - The component to render
+ * @param options - Render options including query client and router config
+ * @returns Render result with query client and rerender helper
+ */
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    queryClient,
+    initialEntries,
+    path,
+    ...renderOptions
+  }: CustomRenderOptions = {}
+) {
+  const testQueryClient = queryClient ?? createTestQueryClient();
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <AllProviders
+        queryClient={testQueryClient}
+        initialEntries={initialEntries}
+        path={path}
+      >
+        {children}
+      </AllProviders>
+    );
+  }
+
+  const result = render(ui, { wrapper: Wrapper, ...renderOptions });
+
+  return {
+    ...result,
+    queryClient: testQueryClient,
+    user: userEvent.setup(),
+  };
+}
+
+/**
+ * Re-export everything from React Testing Library.
+ */
+export * from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+// Export userEvent separately for backwards compatibility
+export { userEvent };

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'happy-dom',
+    setupFiles: ['./src/tests/setup.ts'],
+    css: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'tests/',
+        '*.config.ts',
+        'src/main.tsx',
+      ],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.18.0"
+version = "0.19.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary

Feature 016: Video Detail Page with comprehensive metadata display and multi-language transcript support.

### Video Detail Enhancements
- **Browser Tab Title**: Shows "Channel Name - Video Title" for easy tab identification
- **Absolute Date Display**: Upload dates shown as "Jan 15, 2024" instead of relative "1 week ago"
- **Full Language Codes**: Transcript selector shows full BCP-47 codes (e.g., "EN-gb" vs "EN") to distinguish variants

### Transcript Panel Features
- Collapsible panel with CSS-only 200ms animation
- WAI-ARIA tabs pattern for language selection with keyboard navigation
- Quality indicators (✓) for manual/CC transcripts
- View mode toggle between Segments and Full Text
- Infinite scroll with virtualized segments (50 initial + 25 subsequent batches)
- 150ms debounced language switching with request cancellation
- `prefers-reduced-motion` support

### New Components
| Component | Purpose |
|-----------|---------|
| `VideoDetailPage` | Main detail page with video metadata |
| `TranscriptPanel` | Collapsible transcript container |
| `LanguageSelector` | Language tab selector with ARIA |
| `ViewModeToggle` | Segments/Full Text toggle |
| `TranscriptSegments` | Virtualized segment list |
| `TranscriptFullText` | Continuous prose view |

### New Hooks
- `useVideoDetail`, `useTranscriptLanguages`, `useTranscript`, `useTranscriptSegments`, `usePrefersReducedMotion`

### Test Coverage
- 24 new tests for components and pages
- Fixed 5 pre-existing test failures
- **All 255 frontend tests pass**

### Version
- Bumped to **0.19.0**

## Test plan
- [x] All 255 frontend tests pass
- [x] Manual test: Navigate to video detail page from video list
- [x] Manual test: Verify browser tab shows "Channel - Title"
- [x] Manual test: Verify upload date shows absolute format
- [x] Manual test: Verify language codes show full BCP-47 (e.g., EN-gb)
- [x] Manual test: Expand/collapse transcript panel
- [x] Manual test: Switch between languages
- [x] Manual test: Switch between Segments and Full Text views
- [x] Manual test: Scroll through segments (infinite scroll)