### PR TITLE
fix(api): display corrected transcript text and make corrections searchable

### DIFF
--- a/src/chronovista/api/routers/transcripts.py
+++ b/src/chronovista/api/routers/transcripts.py
@@ -294,7 +294,7 @@ async def get_transcript_segments(
     items = [
         TranscriptSegment(
             id=seg.id,
-            text=seg.text,
+            text=seg.corrected_text if seg.has_correction and seg.corrected_text else seg.text,
             start_time=seg.start_time,
             end_time=seg.end_time,
             duration=seg.duration,


### PR DESCRIPTION
## Summary

- Transcript segment endpoints now serve `corrected_text` when `has_correction` is true, instead of always returning the original ASR text
- Search ILIKE queries now check both `text` and `corrected_text` columns (OR), so corrected terms are findable
- Context snippets (before/after) and match counts also use corrected text when available
- Added `_display_text()` helper in search router to keep correction logic DRY

Implements ADR-005 Increment 0 (correction display) and partial Increment 6 (search both columns).

## Files Changed

| File | Change |
|------|--------|
| `api/routers/transcripts.py` | Serve corrected text in segment list response |
| `api/routers/search.py` | `_display_text()` helper, OR search on both columns, corrected context/match count |

## Test plan

- [x] All 85 existing backend API tests pass (transcript + search endpoints)
- [x] Manual verification: corrected segment 28707 ("Chsky" → "Chomsky") displays correctly in transcript panel
- [x] Manual verification: searching "chomsky" on search page finds the corrected segment
- [x] Uncorrected segments continue to display original text unchanged