### PR TITLE
fix(transcripts): disable mock transcript fallback by default

### DIFF
--- a/src/chronovista/services/transcript_service.py
+++ b/src/chronovista/services/transcript_service.py
@@ -58,19 +58,21 @@ class TranscriptServiceUnavailableError(TranscriptServiceError):
 class TranscriptService(TranscriptServiceInterface):
     """Service for downloading and processing YouTube transcripts."""
 
-    def __init__(self, enable_mock_fallback: bool = True):
+    def __init__(self, enable_mock_fallback: bool = False):
         """
         Initialize the transcript service.
 
         Args:
-            enable_mock_fallback: Whether to use mock data when API is unavailable
+            enable_mock_fallback: Whether to use mock data when API is unavailable.
+                Defaults to False so failed downloads don't create placeholder
+                records. Set to True only in tests.
         """
         self.enable_mock_fallback = enable_mock_fallback
         self._api_available = TRANSCRIPT_API_AVAILABLE
 
         if not self._api_available:
             logger.warning(
-                "youtube-transcript-api not available - using mock fallback only"
+                "youtube-transcript-api not available - transcript downloads will fail"
             )
 
     async def get_transcript(

--- a/tests/unit/services/test_transcript_service.py
+++ b/tests/unit/services/test_transcript_service.py
@@ -63,7 +63,7 @@ class TestTranscriptServiceInitialization:
             "chronovista.services.transcript_service.TRANSCRIPT_API_AVAILABLE", True
         ):
             service = TranscriptService()
-            assert service.enable_mock_fallback is True
+            assert service.enable_mock_fallback is False
             assert service._api_available is True
 
     def test_init_with_api_unavailable(self):
@@ -73,10 +73,10 @@ class TestTranscriptServiceInitialization:
         ):
             with patch("chronovista.services.transcript_service.logger") as mock_logger:
                 service = TranscriptService()
-                assert service.enable_mock_fallback is True
+                assert service.enable_mock_fallback is False
                 assert service._api_available is False
                 mock_logger.warning.assert_called_once_with(
-                    "youtube-transcript-api not available - using mock fallback only"
+                    "youtube-transcript-api not available - transcript downloads will fail"
                 )
 
     def test_init_with_mock_fallback_disabled(self):


### PR DESCRIPTION
## Summary

- Changed `enable_mock_fallback` default from `True` to `False` in `TranscriptService`
- Failed transcript downloads (e.g., YouTube IP blocks) no longer create phantom records with placeholder text like "This is a mock transcript"
- The mock fallback remains available for tests via `TranscriptService(enable_mock_fallback=True)`

## Files Changed

| File | Change |
|------|--------|
| `services/transcript_service.py` | Default `enable_mock_fallback=False`, updated warning message |
| `tests/.../test_transcript_service.py` | Updated 3 assertions to match new default and warning text |

## Test plan

- [x] All 58 transcript service unit tests pass
- [x] Tests that explicitly set `enable_mock_fallback=True` continue to work