### PR TITLE
feat(recovery): add Wayback Machine video recovery system (Feature 024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/license-AGPL--3.0-green.svg" alt="License: AGPL-3.0">
-  <img src="https://img.shields.io/badge/tests-5,473+-brightgreen.svg" alt="Tests: 5,473+">
+  <img src="https://img.shields.io/badge/tests-6,000+-brightgreen.svg" alt="Tests: 6,000+">
   <img src="https://img.shields.io/badge/coverage-72%25-brightgreen.svg" alt="Coverage: 72%">
   <img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style: black">
 </p>
@@ -54,6 +54,7 @@ chronovista sync all
 | **Write Operations** | Create playlists, like videos, subscribe to channels |
 | **REST API** | FastAPI server with 20+ endpoints for programmatic access |
 | **Video Filtering** | Filter by tags, topics, categories with fuzzy search suggestions |
+| **Deleted Video Recovery** | Recover metadata for deleted/unavailable videos via the Wayback Machine |
 
 ## Installation
 
@@ -187,6 +188,37 @@ chronovista sync all  # Enriches with current API data
 ```
 </details>
 
+### Recover Deleted Videos
+
+Recover metadata for deleted or unavailable videos from the [Wayback Machine](https://web.archive.org/):
+
+```bash
+chronovista recover video --video-id VIDEO_ID                # Single video
+chronovista recover video --all --limit 50                   # Batch recover
+chronovista recover video --all --dry-run                    # Preview changes
+chronovista recover video --video-id VIDEO_ID --start-year 2018  # Anchor to era
+```
+
+<details>
+<summary>Recovery Details</summary>
+
+**What gets recovered:**
+- Title, description, upload date, channel info
+- Tags, category, thumbnail URL
+- View count, like count
+
+**How it works:**
+- Queries the Wayback Machine CDX API for archived YouTube video pages
+- Extracts metadata from JSON or HTML meta tags
+- Three-tier overwrite policy protects existing data
+- Results cached locally for 24 hours
+
+**Options:**
+- `--start-year` / `--end-year` — Focus search on a specific archive era
+- `--delay` — Rate limiting between videos in batch mode (default: 1s)
+- `--dry-run` — Preview without making database changes
+</details>
+
 ### REST API
 
 Start the REST API server for programmatic access:
@@ -306,13 +338,14 @@ poetry install
 
 ```
 chronovista/
-├── api/          # FastAPI REST API (routers, schemas, deps)
-├── cli/          # Typer CLI commands
-├── services/     # Business logic (rate-limited API, retry logic)
-├── repositories/ # Async data access with composite keys
-├── models/       # Pydantic models with validation
-├── db/           # SQLAlchemy + Alembic migrations
-└── auth/         # OAuth 2.0 with progressive scopes
+├── api/              # FastAPI REST API (routers, schemas, deps)
+├── cli/              # Typer CLI commands
+├── services/         # Business logic (rate-limited API, retry logic)
+│   └── recovery/     # Wayback Machine video recovery (CDX client, page parser, orchestrator)
+├── repositories/     # Async data access with composite keys
+├── models/           # Pydantic models with validation
+├── db/               # SQLAlchemy + Alembic migrations
+└── auth/             # OAuth 2.0 with progressive scopes
 ```
 
 **Key design decisions:**
@@ -332,6 +365,8 @@ See [System Architecture](src/chronovista/docs/architecture/system-architecture.
 - [x] REST API (20+ endpoints)
 - [x] Web frontend (React + Vite)
 - [x] Video search and filtering UI
+- [x] Deleted content visibility and status tracking
+- [x] Wayback Machine video recovery
 - [ ] ML-powered insights
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,8 @@ make install-docs
 - [Exporting Data](user-guide/exporting.md) - CSV/JSON export with filtering
 - [REST API](user-guide/rest-api.md) - FastAPI endpoints and usage examples
 
+Recovery commands are documented in the [CLI Overview](user-guide/cli-overview.md#recover-commands) under the Recover Commands section.
+
 ### Architecture
 
 - [Overview](architecture/overview.md) - High-level system architecture

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -81,6 +81,7 @@ CREATE TABLE channels (
     default_language VARCHAR(10),
     country VARCHAR(2),
     thumbnail_url VARCHAR(500),
+    availability_status VARCHAR(20) DEFAULT 'available',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -106,11 +107,24 @@ CREATE TABLE videos (
     like_count INTEGER,
     view_count BIGINT,
     comment_count INTEGER,
-    deleted_flag BOOLEAN DEFAULT FALSE,
+    deleted_flag BOOLEAN DEFAULT FALSE,  -- Legacy; prefer availability_status
+    availability_status VARCHAR(20) DEFAULT 'available',
+    alternative_url VARCHAR(500),
+    recovered_at TIMESTAMP WITH TIME ZONE,
+    recovery_source VARCHAR(255),  -- e.g. "wayback:20220106075526"
+    unavailability_first_detected TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ```
+
+**Availability Status Values:** `available`, `deleted`, `private`, `unavailable`, `region_restricted`
+
+**Recovery Columns:**
+- `recovered_at` — When metadata was last recovered from an external source
+- `recovery_source` — Provenance identifier (e.g., `wayback:20220106075526`)
+- `alternative_url` — Alternate URL if the video is available elsewhere
+- `unavailability_first_detected` — When the video was first detected as unavailable
 
 ### user_language_preferences
 

--- a/docs/architecture/frontend-architecture.md
+++ b/docs/architecture/frontend-architecture.md
@@ -127,6 +127,9 @@ The project uses a hybrid approach:
 - **Orval** generates typed hooks from the OpenAPI spec for stable endpoints
 - **`apiFetch`** utility for direct API calls where generated hooks aren't available
 
+### Deleted Content Visibility
+Videos with `availability_status` other than `available` display status badges (e.g., "Deleted", "Private", "Unavailable") throughout the UI. Recovered videos show a "Recovered" indicator with the recovery source timestamp. Filters on the video list page allow toggling deleted content visibility via the `?include_deleted=true` query parameter.
+
 ### Light Theme Only
 The app uses a light-only theme (`bg-slate-50` main content). Dark mode variants are not used.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive user guide and API reference
 - Architecture documentation
 
+## [0.27.0] - 2026-02-15
+
+### Added
+- **Feature 024: Wayback Video Recovery**
+  - CDX API client with caching, retry logic, and `--start-year`/`--end-year` temporal anchor filtering
+  - Page parser extracting metadata from `ytInitialPlayerResponse`/`ytInitialData` JSON with BeautifulSoup fallback
+  - Recovery orchestrator with three-tier overwrite policy and stub channel creation for FK safety
+  - `chronovista recover video` CLI command with single/batch modes, dry-run, and Rich output
+  - Recovered titles displayed in frontend instead of generic "Unavailable Video" text
+  - Unavailable videos visible by default across video list, channel, and playlist views
+
+### Fixed
+- Foreign key violation when recovered `channel_id` references a missing channel
+- CDX client and page parser retry on transient connection errors
+
 ## [0.26.0] - 2026-02-13
 
 ### Added

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -45,6 +45,26 @@ Project-specific terminology used throughout chronovista documentation and code.
 **Auto-generated Transcript**
 :   Transcripts created by YouTube's speech recognition. Available for most videos but may contain errors.
 
+## Recovery Concepts
+
+**Wayback Machine**
+:   The Internet Archive's web archive ([web.archive.org](https://web.archive.org/)). chronovista queries archived YouTube video pages to recover metadata for deleted or unavailable videos.
+
+**CDX API**
+:   The Wayback Machine's index API (`web.archive.org/cdx/search/cdx`). Returns a list of archived snapshots for a given URL, filtered by status code, MIME type, and date range. chronovista uses this to discover which YouTube video pages have been archived.
+
+**Snapshot**
+:   A single archived copy of a web page stored by the Wayback Machine, identified by a 14-digit timestamp (e.g., `20220106075526`). Each snapshot may contain different metadata depending on when it was captured.
+
+**Availability Status**
+:   A video or channel's current accessibility state. Values: `available` (normal), `deleted`, `private`, `unavailable` (generic), `region_restricted`. Replaces the legacy `deleted_flag` boolean with richer status tracking.
+
+**Recovery**
+:   The process of extracting metadata (title, description, channel, tags, etc.) from a Wayback Machine snapshot of a deleted YouTube video page and updating the local database. Uses a three-tier overwrite policy: immutable fields (fill-if-NULL only), mutable fields (overwrite-if-newer), and NULL protection (never blank existing values).
+
+**Stub Channel**
+:   A minimal channel record created automatically during recovery when the recovered `channel_id` doesn't exist in the database. Satisfies foreign key constraints and is marked with `availability_status = unavailable`.
+
 ## Technical Concepts
 
 **Development Mode**

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,19 +55,26 @@ chronovista is a CLI application that enables users to access, store, and explor
 
     ---
 
-    FastAPI-powered REST API with 11 endpoints for programmatic access to videos, transcripts, and search
+    FastAPI-powered REST API with 20+ endpoints for programmatic access to videos, transcripts, and search
+
+-   :material-delete-restore:{ .lg .middle } **Deleted Video Recovery**
+
+    ---
+
+    Recover metadata for deleted/unavailable videos from the Wayback Machine with configurable date ranges and batch processing
 
 </div>
 
 ## Project Status
 
 !!! success "Current Status"
-    - **3,650+ tests** with **90%+ coverage** across all modules
+    - **5,500+ tests** (4,500+ backend, 1,500+ frontend) with **90%+ coverage**
     - **Comprehensive Pydantic models** with advanced validation and type safety
     - **Real API integration testing** with YouTube API data validation
     - **Advanced repository pattern** with async support and composite keys
     - **Rate-limited API service** with intelligent error handling and retry logic
-    - **Transcript timestamp preservation** with full JSONB storage (v0.10.0)
+    - **Wayback Machine recovery** for deleted/unavailable video metadata (v0.27.0)
+    - **React frontend** with video browsing, transcript search, and deep link navigation (v0.6.0)
 
 ## Quick Example
 
@@ -122,6 +129,22 @@ chronovista is a CLI application that enables users to access, store, and explor
 
     # Interactive API docs
     open http://localhost:8765/docs
+    ```
+
+=== "Recover Deleted Videos"
+
+    ```bash
+    # Recover a specific deleted video
+    chronovista recover video --video-id dQw4w9WgXcQ
+
+    # Batch recover all unavailable videos
+    chronovista recover video --all --limit 50
+
+    # Focus on a specific archive era
+    chronovista recover video --all --start-year 2018 --end-year 2020
+
+    # Preview without making changes
+    chronovista recover video --all --dry-run
     ```
 
 ## Architecture Highlights

--- a/docs/user-guide/cli-overview.md
+++ b/docs/user-guide/cli-overview.md
@@ -165,6 +165,18 @@ chronovista export [COMMAND]
 | `channels` | Export channel data |
 | `watch-history` | Export watch history |
 
+### Recover Commands
+
+```bash
+chronovista recover [COMMAND]
+```
+
+| Command | Description |
+|---------|-------------|
+| `video` | Recover metadata for deleted videos via Wayback Machine |
+
+**Note:** Requires `beautifulsoup4` (included in default install). Optional `selenium` enables pre-2017 page fallback.
+
 ### API Commands
 
 ```bash
@@ -618,6 +630,56 @@ Enriches channel metadata from the YouTube Data API.
 - `--limit <n>` - Maximum channels to enrich
 - `--dry-run` - Preview without making changes
 
+### Video Recovery
+
+#### Recover Video
+
+```bash
+chronovista recover video [OPTIONS]
+```
+
+Recovers metadata for deleted YouTube videos from the Internet Archive's Wayback Machine. Supports single-video and batch recovery modes.
+
+**Options:**
+
+- `--video-id, -v <id>` - Recover a single video by ID
+- `--all, -a` - Recover all unavailable videos (batch mode)
+- `--limit, -l <n>` - Maximum videos to recover (batch mode only)
+- `--dry-run` - Preview recovery without making changes
+- `--delay, -d <seconds>` - Delay between videos in batch mode (default: 1.0)
+- `--start-year <year>` - Only search Wayback snapshots from this year onward (2005-2026)
+- `--end-year <year>` - Only search Wayback snapshots up to this year (2005-2026)
+
+**Note:** `--video-id` and `--all` are mutually exclusive. One must be specified.
+
+**Examples:**
+
+```bash
+# Recover a specific video
+chronovista recover video --video-id dQw4w9WgXcQ
+
+# Recover all unavailable videos
+chronovista recover video --all --limit 50
+
+# Preview what would be recovered
+chronovista recover video --all --dry-run --limit 10
+
+# Focus on archives from a specific era
+chronovista recover video --video-id VIDEO_ID --start-year 2018 --end-year 2020
+
+# Batch recovery with slower rate limiting
+chronovista recover video --all --delay 2.0
+```
+
+**Recovery Details:**
+
+- Queries the Wayback Machine CDX API for archived YouTube video pages
+- Extracts metadata from JSON (`ytInitialPlayerResponse`) or HTML meta tags
+- Recovers: title, description, channel, tags, upload date, view/like counts, category, thumbnail
+- Three-tier overwrite policy: immutable fields fill-if-NULL only, mutable fields overwrite-if-newer, NULL protection
+- Results are cached locally for 24 hours to avoid redundant API calls
+- Creates stub channel records when recovered `channel_id` has no existing DB entry
+
 ### Google Takeout
 
 #### Seed Database
@@ -781,6 +843,25 @@ chronovista tags by-video --id "dQw4w9WgXcQ"
 chronovista tags by-video --id "-2kc5xfeQEs"  # Video ID starting with -
 ```
 
+### Deleted Video Recovery
+
+```bash
+# Recover a specific deleted video
+chronovista recover video --video-id dQw4w9WgXcQ
+
+# Recover all unavailable videos (batch mode)
+chronovista recover video --all --limit 50
+
+# Preview recovery without making changes
+chronovista recover video --all --dry-run
+
+# Focus search on a specific era (faster for older videos)
+chronovista recover video --video-id VIDEO_ID --start-year 2018
+
+# Batch recovery with custom rate limiting
+chronovista recover video --all --limit 20 --delay 2.0
+```
+
 ### REST API Workflow
 
 ```bash
@@ -815,4 +896,5 @@ open http://localhost:8765/docs
 - [Data Synchronization](data-sync.md)
 - [Topic Analytics](topic-analytics.md)
 - [Google Takeout](google-takeout.md)
+- [Data Population](data-population.md) - Recommended data population order (including recovery)
 - [REST API](rest-api.md)

--- a/docs/user-guide/data-population.md
+++ b/docs/user-guide/data-population.md
@@ -77,7 +77,28 @@ chronovista sync transcripts
 !!! warning "IP Throttling"
     YouTube may temporarily block your IP after ~40 rapid transcript requests. If this happens, wait 24 hours and retry. Consider using smaller batches with pauses between them.
 
-### Step 6: Verify
+### Step 6: Recover Deleted Content (Optional)
+
+If your database contains deleted or unavailable videos (common with Takeout imports), recover their metadata from the Wayback Machine:
+
+```bash
+# Preview what would be recovered
+chronovista recover video --all --dry-run --limit 10
+
+# Recover all unavailable videos (with rate limiting)
+chronovista recover video --all --limit 50 --delay 1.0
+
+# Recover a specific video
+chronovista recover video --video-id VIDEO_ID
+
+# Focus on a specific time range (e.g., archives from 2018-2020)
+chronovista recover video --all --start-year 2018 --end-year 2020
+```
+
+!!! tip "Anchor Year"
+    If you know roughly when a video was available, use `--start-year` to start searching from that era. Without it, recovery tries the newest archives first, which may exhaust the search limit before reaching older (often better) snapshots.
+
+### Step 7: Verify
 
 ```bash
 # Check what's in your database
@@ -109,10 +130,11 @@ chronovista takeout seed /path/to/new-takeout --incremental
 | 3. Takeout | `chronovista takeout seed ...` | 5-30 min | Depends on history size |
 | 4. Sync all | `chronovista sync all` | 10-60 min | Depends on library size, API quota |
 | 5. Transcripts | `chronovista sync transcripts` | 30+ min | Rate-limited by YouTube |
+| 6. Recovery | `chronovista recover video --all` | 5-60 min | Rate-limited by Wayback Machine |
 
 ## See Also
 
 - [Data Sync](data-sync.md) - Detailed sync command reference
 - [Google Takeout](google-takeout.md) - Full Takeout guide
 - [Transcripts](transcripts.md) - Transcript management
-- [CLI Overview](cli-overview.md) - All commands
+- [CLI Overview](cli-overview.md) - All commands (including recover)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/PlaylistVideoCard.tsx
+++ b/frontend/src/components/PlaylistVideoCard.tsx
@@ -54,16 +54,16 @@ export function PlaylistVideoCard({ video }: PlaylistVideoCardProps) {
 
   // Derive unavailable state from availability_status
   const isUnavailable = isVideoUnavailable(availability_status);
-
-  // Apply unavailable state styling
-  const cardOpacity = isUnavailable ? "opacity-50" : "";
-  const titleDecoration = isUnavailable ? "line-through" : "";
+  // Only apply heavy dimming when there's no recovered title
+  const hasRecoveredData = isUnavailable && !!title;
+  const cardOpacity = isUnavailable && !hasRecoveredData ? "opacity-50" : "";
+  const titleDecoration = isUnavailable && !hasRecoveredData ? "line-through" : "";
 
   return (
     <Link
       to={`/videos/${video_id}`}
       className="block no-underline text-inherit focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-lg"
-      aria-label={isUnavailable ? `Unavailable video (was at position ${displayPosition})` : `Video: ${title} at position ${displayPosition}`}
+      aria-label={isUnavailable && !title ? `Unavailable video (was at position ${displayPosition})` : `Video: ${title} at position ${displayPosition}`}
     >
       <article
         className={`${cardPatterns.base} ${cardPatterns.hover} ${cardPatterns.transition} p-4 ${cardOpacity}`}
@@ -84,9 +84,9 @@ export function PlaylistVideoCard({ video }: PlaylistVideoCardProps) {
             <div className="flex items-start justify-between gap-2 mb-1">
               <h3
                 className={`text-base font-semibold text-${colorTokens.text.primary} line-clamp-2 flex-1 ${titleDecoration}`}
-                title={isUnavailable ? "This video is no longer available on YouTube" : title}
+                title={isUnavailable && !title ? "This video is no longer available on YouTube" : title}
               >
-                {isUnavailable ? "Unavailable Video" : title}
+                {title || (isUnavailable ? "Unavailable Video" : "")}
               </h3>
               <AvailabilityBadge status={availability_status} className="flex-shrink-0" />
             </div>

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -111,8 +111,10 @@ export function VideoCard({ video }: VideoCardProps) {
 
   // Determine if video is unavailable
   const isUnavailable = isVideoUnavailable(availability_status);
-  const cardOpacity = isUnavailable ? "opacity-50" : "";
-  const titleDecoration = isUnavailable ? "line-through" : "";
+  // Only apply heavy dimming when there's no recovered title
+  const hasRecoveredData = isUnavailable && !!title;
+  const cardOpacity = isUnavailable && !hasRecoveredData ? "opacity-50" : "";
+  const titleDecoration = isUnavailable && !hasRecoveredData ? "line-through" : "";
 
   return (
     <Link
@@ -122,12 +124,12 @@ export function VideoCard({ video }: VideoCardProps) {
       <article
         className={`${cardPatterns.base} ${cardPatterns.hover} ${cardPatterns.transition} p-5 ${cardOpacity}`}
         role="article"
-        aria-label={isUnavailable ? `Unavailable video` : `Video: ${title}`}
+        aria-label={isUnavailable && !title ? `Unavailable video` : `Video: ${title}`}
       >
       {/* Video Title with Availability Badge */}
       <div className="flex items-start justify-between gap-2 mb-2">
         <h3 className={`text-lg font-semibold text-${colorTokens.text.primary} line-clamp-2 flex-1 ${titleDecoration}`}>
-          {isUnavailable ? "Unavailable Video" : title}
+          {title || (isUnavailable ? "Unavailable Video" : "")}
         </h3>
         <AvailabilityBadge status={availability_status} className="flex-shrink-0" />
       </div>

--- a/frontend/src/components/VideoList.tsx
+++ b/frontend/src/components/VideoList.tsx
@@ -112,7 +112,7 @@ interface VideoListProps {
  * VideoList displays videos with loading, error, and empty states.
  * Includes infinite scroll with Intersection Observer and fallback Load More button.
  */
-export function VideoList({ tags = [], category = null, topicIds = [], includeUnavailable = false }: VideoListProps = {}) {
+export function VideoList({ tags = [], category = null, topicIds = [], includeUnavailable = true }: VideoListProps = {}) {
   const {
     videos,
     total,

--- a/frontend/src/components/VideoSearchResult.tsx
+++ b/frontend/src/components/VideoSearchResult.tsx
@@ -32,8 +32,9 @@ function formatDate(isoDate: string): string {
 
 export function VideoSearchResult({ result, queryTerms }: VideoSearchResultProps) {
   const isUnavailable = isVideoUnavailable(result.availability_status);
-  const cardOpacity = isUnavailable ? "opacity-50" : "";
-  const titleDecoration = isUnavailable ? "line-through" : "";
+  const hasRecoveredData = isUnavailable && !!result.title;
+  const cardOpacity = isUnavailable && !hasRecoveredData ? "opacity-50" : "";
+  const titleDecoration = isUnavailable && !hasRecoveredData ? "line-through" : "";
 
   return (
     <article className={`rounded-lg border border-gray-200 bg-white p-4 hover:shadow-md transition-shadow ${cardOpacity}`}>
@@ -44,7 +45,7 @@ export function VideoSearchResult({ result, queryTerms }: VideoSearchResultProps
             to={`/videos/${result.video_id}`}
             className="text-blue-700 hover:underline"
           >
-            {isUnavailable ? (
+            {!result.title && isUnavailable ? (
               "Unavailable Video"
             ) : (
               <HighlightedText text={result.title} queryTerms={queryTerms} />

--- a/frontend/src/hooks/useChannelVideos.ts
+++ b/frontend/src/hooks/useChannelVideos.ts
@@ -24,11 +24,13 @@ const INTERSECTION_THRESHOLD = 0.8;
 async function fetchChannelVideos(
   channelId: string,
   offset: number,
-  limit: number
+  limit: number,
+  includeUnavailable: boolean
 ): Promise<VideoListResponse> {
   const params = new URLSearchParams({
     offset: offset.toString(),
     limit: limit.toString(),
+    include_unavailable: includeUnavailable.toString(),
   });
 
   return apiFetch<VideoListResponse>(
@@ -41,6 +43,8 @@ interface UseChannelVideosOptions {
   limit?: number;
   /** Whether to enable the query (default: true) */
   enabled?: boolean;
+  /** Whether to include unavailable videos (default: true) */
+  includeUnavailable?: boolean;
 }
 
 interface UseChannelVideosReturn {
@@ -90,7 +94,7 @@ export function useChannelVideos(
   channelId: string | undefined,
   options: UseChannelVideosOptions = {}
 ): UseChannelVideosReturn {
-  const { limit = DEFAULT_LIMIT, enabled = true } = options;
+  const { limit = DEFAULT_LIMIT, enabled = true, includeUnavailable = true } = options;
 
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
@@ -104,12 +108,12 @@ export function useChannelVideos(
     fetchNextPage,
     refetch,
   } = useInfiniteQuery({
-    queryKey: ["channel-videos", channelId, limit],
+    queryKey: ["channel-videos", channelId, limit, includeUnavailable],
     queryFn: async ({ pageParam }) => {
       if (!channelId) {
         throw new Error("Channel ID is required");
       }
-      return fetchChannelVideos(channelId, pageParam, limit);
+      return fetchChannelVideos(channelId, pageParam, limit, includeUnavailable);
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {

--- a/frontend/src/hooks/usePlaylistVideos.ts
+++ b/frontend/src/hooks/usePlaylistVideos.ts
@@ -27,11 +27,13 @@ const INTERSECTION_THRESHOLD = 0.8;
 async function fetchPlaylistVideos(
   playlistId: string,
   offset: number,
-  limit: number
+  limit: number,
+  includeUnavailable: boolean
 ): Promise<PlaylistVideoListResponse> {
   const params = new URLSearchParams({
     offset: offset.toString(),
     limit: limit.toString(),
+    include_unavailable: includeUnavailable.toString(),
   });
 
   return apiFetch<PlaylistVideoListResponse>(
@@ -44,6 +46,8 @@ interface UsePlaylistVideosOptions {
   limit?: number;
   /** Whether to enable the query (default: true) */
   enabled?: boolean;
+  /** Whether to include unavailable videos (default: true) */
+  includeUnavailable?: boolean;
 }
 
 interface UsePlaylistVideosReturn {
@@ -94,7 +98,7 @@ export function usePlaylistVideos(
   playlistId: string,
   options: UsePlaylistVideosOptions = {}
 ): UsePlaylistVideosReturn {
-  const { limit = DEFAULT_LIMIT, enabled = true } = options;
+  const { limit = DEFAULT_LIMIT, enabled = true, includeUnavailable = true } = options;
 
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
@@ -108,9 +112,9 @@ export function usePlaylistVideos(
     fetchNextPage,
     refetch,
   } = useInfiniteQuery({
-    queryKey: ["playlistVideos", playlistId, limit],
+    queryKey: ["playlistVideos", playlistId, limit, includeUnavailable],
     queryFn: async ({ pageParam }) => {
-      return fetchPlaylistVideos(playlistId, pageParam, limit);
+      return fetchPlaylistVideos(playlistId, pageParam, limit, includeUnavailable);
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -83,7 +83,7 @@ export function useVideos(options: UseVideosOptions = {}): UseVideosReturn {
     tags = [],
     category = null,
     topicIds = [],
-    includeUnavailable = false
+    includeUnavailable = true
   } = options;
 
   const loadMoreRef = useRef<HTMLDivElement | null>(null);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -21,8 +21,8 @@ export function HomePage() {
   const tags = searchParams.getAll('tag');
   const category = searchParams.get('category');
   const topicIds = searchParams.getAll('topic_id');
-  // T031: Read include_unavailable state from URL (FR-021)
-  const includeUnavailable = searchParams.get('include_unavailable') === 'true';
+  // Include unavailable/recovered videos by default (Feature 024)
+  const includeUnavailable = searchParams.get('include_unavailable') !== 'false';
 
   // Get total count for filters display (using the same hook with filters)
   const { total } = useVideos({ tags, category, topicIds, includeUnavailable });

--- a/frontend/src/tests/hooks/useChannelVideos.test.tsx
+++ b/frontend/src/tests/hooks/useChannelVideos.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for useChannelVideos hook.
+ *
+ * Tests TanStack Query integration for fetching channel videos with infinite scroll.
+ * Includes tests for the include_unavailable parameter.
+ *
+ * @module tests/hooks/useChannelVideos
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useChannelVideos } from "../../hooks/useChannelVideos";
+import type { VideoListResponse } from "../../types/video";
+import * as apiConfig from "../../api/config";
+
+// Mock the API fetch
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: "http://localhost:8765/api/v1",
+  API_TIMEOUT: 10000,
+}));
+
+describe("useChannelVideos", () => {
+  let queryClient: QueryClient;
+
+  const mockChannelId = "UC1234567890123456789012";
+
+  const mockVideoListResponse: VideoListResponse = {
+    data: [
+      {
+        video_id: "dQw4w9WgXcQ",
+        title: "Test Video 1",
+        channel_id: mockChannelId,
+        channel_title: "Test Channel",
+        upload_date: "2024-01-15T10:30:00Z",
+        duration: 240,
+        view_count: 1000,
+        transcript_summary: {
+          count: 1,
+          languages: ["en"],
+          has_manual: false,
+        },
+        tags: [],
+        category_id: "10",
+        category_name: "Music",
+        topics: [],
+        availability_status: "available",
+      },
+      {
+        video_id: "unavail123",
+        title: "Unavailable Video",
+        channel_id: mockChannelId,
+        channel_title: "Test Channel",
+        upload_date: "2024-01-10T10:30:00Z",
+        duration: 180,
+        view_count: null,
+        transcript_summary: {
+          count: 0,
+          languages: [],
+          has_manual: false,
+        },
+        tags: [],
+        category_id: null,
+        category_name: null,
+        topics: [],
+        availability_status: "deleted",
+      },
+    ],
+    pagination: {
+      total: 2,
+      limit: 25,
+      offset: 0,
+      has_more: false,
+    },
+  };
+
+  beforeEach(() => {
+    // Create a fresh QueryClient for each test
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false, // Disable retries for testing
+        },
+      },
+    });
+
+    // Clear all mocks
+    vi.clearAllMocks();
+  });
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  describe("successful data fetching", () => {
+    it("fetches and returns channel videos", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockVideoListResponse);
+
+      const { result } = renderHook(() => useChannelVideos(mockChannelId), {
+        wrapper: createWrapper(),
+      });
+
+      // Initially loading
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.videos).toEqual([]);
+
+      // Wait for data to load
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.videos).toHaveLength(2);
+      expect(result.current.videos[0]?.video_id).toBe("dQw4w9WgXcQ");
+      expect(result.current.videos[1]?.video_id).toBe("unavail123");
+      expect(result.current.total).toBe(2);
+      expect(result.current.isError).toBe(false);
+    });
+
+    it("includes unavailable videos by default", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockVideoListResponse);
+
+      const { result } = renderHook(() => useChannelVideos(mockChannelId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Verify API was called with include_unavailable=true
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+        `/channels/${mockChannelId}/videos?offset=0&limit=25&include_unavailable=true`
+      );
+
+      // Verify both available and unavailable videos are included
+      expect(result.current.videos).toHaveLength(2);
+      const unavailableVideo = result.current.videos.find(
+        (v) => v.availability_status === "deleted"
+      );
+      expect(unavailableVideo).toBeDefined();
+      expect(unavailableVideo?.video_id).toBe("unavail123");
+    });
+
+    it("excludes unavailable videos when includeUnavailable is false", async () => {
+      const availableOnlyResponse: VideoListResponse = {
+        data: [mockVideoListResponse.data[0]!],
+        pagination: {
+          total: 1,
+          limit: 25,
+          offset: 0,
+          has_more: false,
+        },
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(availableOnlyResponse);
+
+      const { result } = renderHook(
+        () => useChannelVideos(mockChannelId, { includeUnavailable: false }),
+        {
+          wrapper: createWrapper(),
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Verify API was called with include_unavailable=false
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+        `/channels/${mockChannelId}/videos?offset=0&limit=25&include_unavailable=false`
+      );
+
+      // Verify only available videos are included
+      expect(result.current.videos).toHaveLength(1);
+      expect(result.current.videos[0]?.availability_status).toBe("available");
+    });
+
+    it("respects custom limit parameter", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockVideoListResponse);
+
+      const { result } = renderHook(
+        () => useChannelVideos(mockChannelId, { limit: 50 }),
+        {
+          wrapper: createWrapper(),
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Verify API was called with custom limit
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+        `/channels/${mockChannelId}/videos?offset=0&limit=50&include_unavailable=true`
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles API errors correctly", async () => {
+      const mockError = {
+        type: "server",
+        message: "Failed to fetch videos",
+        status: 500,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useChannelVideos(mockChannelId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(mockError);
+      expect(result.current.videos).toEqual([]);
+    });
+
+    it("handles undefined channelId", async () => {
+      const { result } = renderHook(() => useChannelVideos(undefined), {
+        wrapper: createWrapper(),
+      });
+
+      // Should not make API call
+      expect(result.current.isLoading).toBe(false);
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("pagination", () => {
+    it("indicates when more pages are available", async () => {
+      const responseWithMore: VideoListResponse = {
+        ...mockVideoListResponse,
+        pagination: {
+          total: 100,
+          limit: 25,
+          offset: 0,
+          has_more: true,
+        },
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(responseWithMore);
+
+      const { result } = renderHook(() => useChannelVideos(mockChannelId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasNextPage).toBe(true);
+      expect(result.current.total).toBe(100);
+    });
+
+    it("indicates when all pages are loaded", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockVideoListResponse);
+
+      const { result } = renderHook(() => useChannelVideos(mockChannelId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasNextPage).toBe(false);
+      expect(result.current.total).toBe(2);
+      expect(result.current.loadedCount).toBe(2);
+    });
+  });
+
+  describe("enabled option", () => {
+    it("does not fetch when enabled is false", async () => {
+      const { result } = renderHook(
+        () => useChannelVideos(mockChannelId, { enabled: false }),
+        {
+          wrapper: createWrapper(),
+        }
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/tests/hooks/usePlaylistVideos.test.tsx
+++ b/frontend/src/tests/hooks/usePlaylistVideos.test.tsx
@@ -1,0 +1,384 @@
+/**
+ * Unit tests for usePlaylistVideos hook.
+ *
+ * Tests TanStack Query integration for fetching playlist videos with infinite scroll.
+ * Includes tests for the include_unavailable parameter.
+ *
+ * @module tests/hooks/usePlaylistVideos
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { usePlaylistVideos } from "../../hooks/usePlaylistVideos";
+import type { PlaylistVideoListResponse } from "../../types/playlist";
+import * as apiConfig from "../../api/config";
+
+// Mock the API fetch
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: "http://localhost:8765/api/v1",
+  API_TIMEOUT: 10000,
+}));
+
+describe("usePlaylistVideos", () => {
+  let queryClient: QueryClient;
+
+  const mockPlaylistId = "PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf";
+
+  const mockPlaylistVideoResponse: PlaylistVideoListResponse = {
+    data: [
+      {
+        video_id: "dQw4w9WgXcQ",
+        title: "Test Video 1",
+        channel_id: "UC1234567890123456789012",
+        channel_title: "Test Channel",
+        upload_date: "2024-01-15T10:30:00Z",
+        duration: 240,
+        view_count: 1000,
+        transcript_summary: {
+          count: 1,
+          languages: ["en"],
+          has_manual: false,
+        },
+        position: 0,
+        availability_status: "available",
+      },
+      {
+        video_id: "unavail123",
+        title: "Recovered Video Title",
+        channel_id: "UC1234567890123456789012",
+        channel_title: "Recovered Channel Name",
+        upload_date: "2024-01-10T10:30:00Z",
+        duration: 180,
+        view_count: null,
+        transcript_summary: {
+          count: 0,
+          languages: [],
+          has_manual: false,
+        },
+        position: 1,
+        availability_status: "deleted",
+      },
+      {
+        video_id: "private456",
+        title: "Private Video Title",
+        channel_id: null,
+        channel_title: null,
+        upload_date: "2024-01-05T10:30:00Z",
+        duration: 300,
+        view_count: null,
+        transcript_summary: {
+          count: 0,
+          languages: [],
+          has_manual: false,
+        },
+        position: 2,
+        availability_status: "private",
+      },
+    ],
+    pagination: {
+      total: 3,
+      limit: 25,
+      offset: 0,
+      has_more: false,
+    },
+  };
+
+  beforeEach(() => {
+    // Create a fresh QueryClient for each test
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false, // Disable retries for testing
+        },
+      },
+    });
+
+    // Clear all mocks
+    vi.clearAllMocks();
+  });
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  describe("successful data fetching", () => {
+    it("fetches and returns playlist videos", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockPlaylistVideoResponse);
+
+      const { result } = renderHook(() => usePlaylistVideos(mockPlaylistId), {
+        wrapper: createWrapper(),
+      });
+
+      // Initially loading
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.videos).toEqual([]);
+
+      // Wait for data to load
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.videos).toHaveLength(3);
+      expect(result.current.videos[0]?.video_id).toBe("dQw4w9WgXcQ");
+      expect(result.current.videos[1]?.video_id).toBe("unavail123");
+      expect(result.current.videos[2]?.video_id).toBe("private456");
+      expect(result.current.total).toBe(3);
+      expect(result.current.isError).toBe(false);
+    });
+
+    it("includes unavailable videos by default", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockPlaylistVideoResponse);
+
+      const { result } = renderHook(() => usePlaylistVideos(mockPlaylistId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Verify API was called with include_unavailable=true
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+        `/playlists/${mockPlaylistId}/videos?offset=0&limit=25&include_unavailable=true`
+      );
+
+      // Verify all videos (including unavailable) are included
+      expect(result.current.videos).toHaveLength(3);
+
+      const deletedVideo = result.current.videos.find(
+        (v) => v.availability_status === "deleted"
+      );
+      expect(deletedVideo).toBeDefined();
+      expect(deletedVideo?.video_id).toBe("unavail123");
+      expect(deletedVideo?.title).toBe("Recovered Video Title");
+      expect(deletedVideo?.channel_title).toBe("Recovered Channel Name");
+
+      const privateVideo = result.current.videos.find(
+        (v) => v.availability_status === "private"
+      );
+      expect(privateVideo).toBeDefined();
+      expect(privateVideo?.video_id).toBe("private456");
+      expect(privateVideo?.title).toBe("Private Video Title");
+    });
+
+    it("excludes unavailable videos when includeUnavailable is false", async () => {
+      const availableOnlyResponse: PlaylistVideoListResponse = {
+        data: [mockPlaylistVideoResponse.data[0]!],
+        pagination: {
+          total: 1,
+          limit: 25,
+          offset: 0,
+          has_more: false,
+        },
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(availableOnlyResponse);
+
+      const { result } = renderHook(
+        () => usePlaylistVideos(mockPlaylistId, { includeUnavailable: false }),
+        {
+          wrapper: createWrapper(),
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Verify API was called with include_unavailable=false
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+        `/playlists/${mockPlaylistId}/videos?offset=0&limit=25&include_unavailable=false`
+      );
+
+      // Verify only available videos are included
+      expect(result.current.videos).toHaveLength(1);
+      expect(result.current.videos[0]?.availability_status).toBe("available");
+    });
+
+    it("respects custom limit parameter", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockPlaylistVideoResponse);
+
+      const { result } = renderHook(
+        () => usePlaylistVideos(mockPlaylistId, { limit: 50 }),
+        {
+          wrapper: createWrapper(),
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Verify API was called with custom limit
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith(
+        `/playlists/${mockPlaylistId}/videos?offset=0&limit=50&include_unavailable=true`
+      );
+    });
+
+    it("preserves video position order", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockPlaylistVideoResponse);
+
+      const { result } = renderHook(() => usePlaylistVideos(mockPlaylistId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Verify videos are in position order
+      expect(result.current.videos[0]?.position).toBe(0);
+      expect(result.current.videos[1]?.position).toBe(1);
+      expect(result.current.videos[2]?.position).toBe(2);
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles API errors correctly", async () => {
+      const mockError = {
+        type: "server",
+        message: "Failed to fetch playlist videos",
+        status: 500,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => usePlaylistVideos(mockPlaylistId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(mockError);
+      expect(result.current.videos).toEqual([]);
+    });
+
+    it("handles 404 playlist not found", async () => {
+      const mockError = {
+        type: "server",
+        message: "Playlist not found",
+        status: 404,
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => usePlaylistVideos("invalid-id"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toEqual(mockError);
+    });
+  });
+
+  describe("pagination", () => {
+    it("indicates when more pages are available", async () => {
+      const responseWithMore: PlaylistVideoListResponse = {
+        ...mockPlaylistVideoResponse,
+        pagination: {
+          total: 100,
+          limit: 25,
+          offset: 0,
+          has_more: true,
+        },
+      };
+
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(responseWithMore);
+
+      const { result } = renderHook(() => usePlaylistVideos(mockPlaylistId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasNextPage).toBe(true);
+      expect(result.current.total).toBe(100);
+    });
+
+    it("indicates when all pages are loaded", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockPlaylistVideoResponse);
+
+      const { result } = renderHook(() => usePlaylistVideos(mockPlaylistId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hasNextPage).toBe(false);
+      expect(result.current.total).toBe(3);
+      expect(result.current.loadedCount).toBe(3);
+    });
+  });
+
+  describe("enabled option", () => {
+    it("does not fetch when enabled is false", async () => {
+      const { result } = renderHook(
+        () => usePlaylistVideos(mockPlaylistId, { enabled: false }),
+        {
+          wrapper: createWrapper(),
+        }
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(apiConfig.apiFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unavailable video metadata", () => {
+    it("returns recovered metadata for deleted videos", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockPlaylistVideoResponse);
+
+      const { result } = renderHook(() => usePlaylistVideos(mockPlaylistId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const deletedVideo = result.current.videos.find(
+        (v) => v.availability_status === "deleted"
+      );
+
+      // Verify recovered metadata is present
+      expect(deletedVideo?.title).toBe("Recovered Video Title");
+      expect(deletedVideo?.channel_title).toBe("Recovered Channel Name");
+      expect(deletedVideo?.channel_id).toBe("UC1234567890123456789012");
+    });
+
+    it("handles null channel metadata for private videos", async () => {
+      vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(mockPlaylistVideoResponse);
+
+      const { result } = renderHook(() => usePlaylistVideos(mockPlaylistId), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const privateVideo = result.current.videos.find(
+        (v) => v.availability_status === "private"
+      );
+
+      // Verify null channel fields are preserved
+      expect(privateVideo?.channel_id).toBeNull();
+      expect(privateVideo?.channel_title).toBeNull();
+      expect(privateVideo?.title).toBe("Private Video Title");
+    });
+  });
+});

--- a/poetry.lock
+++ b/poetry.lock
@@ -143,7 +143,7 @@ version = "25.3.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["dev", "recovery"]
 files = [
     {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
     {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
@@ -191,6 +191,29 @@ files = [
 
 [package.extras]
 extras = ["regex"]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.7.0"
+groups = ["main"]
+files = [
+    {file = "beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb"},
+    {file = "beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86"},
+]
+
+[package.dependencies]
+soupsieve = ">=1.6.1"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
 
 [[package]]
 name = "black"
@@ -317,11 +340,109 @@ version = "2025.7.14"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "docs", "nlp"]
+groups = ["main", "docs", "nlp", "recovery"]
 files = [
     {file = "certifi-2025.7.14-py3-none-any.whl", hash = "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2"},
     {file = "certifi-2025.7.14.tar.gz", hash = "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995"},
 ]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.9"
+groups = ["recovery"]
+markers = "os_name == \"nt\" and implementation_name != \"pypy\""
+files = [
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "cfgv"
@@ -341,7 +462,7 @@ version = "3.4.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "docs", "nlp"]
+groups = ["main", "docs", "nlp", "recovery"]
 files = [
     {file = "charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941"},
     {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd"},
@@ -997,7 +1118,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "recovery"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -1234,7 +1355,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "docs", "nlp"]
+groups = ["main", "docs", "nlp", "recovery"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -2435,12 +2556,27 @@ signals = ["blinker (>=1.4.0)"]
 signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
+name = "outcome"
+version = "1.3.0.post0"
+description = "Capture the outcome of Python function calls."
+optional = false
+python-versions = ">=3.7"
+groups = ["recovery"]
+files = [
+    {file = "outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b"},
+    {file = "outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8"},
+]
+
+[package.dependencies]
+attrs = ">=19.2.0"
+
+[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs", "nlp"]
+groups = ["dev", "docs", "nlp", "recovery"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -2844,6 +2980,19 @@ files = [
 pyasn1 = ">=0.6.1,<0.7.0"
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["recovery"]
+markers = "os_name == \"nt\" and implementation_name != \"pypy\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 description = "Data validation using Python type hints"
@@ -3067,6 +3216,19 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+groups = ["recovery"]
+files = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
+]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
@@ -3146,7 +3308,7 @@ version = "1.1.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "recovery"]
 files = [
     {file = "python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc"},
     {file = "python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"},
@@ -3343,7 +3505,7 @@ version = "2.32.4"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "docs", "nlp"]
+groups = ["main", "docs", "nlp", "recovery"]
 files = [
     {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
     {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
@@ -3599,6 +3761,26 @@ files = [
 regex = "*"
 
 [[package]]
+name = "selenium"
+version = "4.36.0"
+description = "Official Python bindings for Selenium WebDriver"
+optional = false
+python-versions = ">=3.9"
+groups = ["recovery"]
+files = [
+    {file = "selenium-4.36.0-py3-none-any.whl", hash = "sha256:525fdfe96b99c27d9a2c773c75aa7413f4c24bdb7b9749c1950aa3b5f79ed915"},
+    {file = "selenium-4.36.0.tar.gz", hash = "sha256:0eced83038736c3a013b824116df0b6dbb83e93721545f51b680451013416723"},
+]
+
+[package.dependencies]
+certifi = ">=2025.6.15"
+trio = ">=0.30.0,<1.0"
+trio-websocket = ">=0.12.2,<1.0"
+typing_extensions = ">=4.14.0,<5.0"
+urllib3 = {version = ">=2.5.0,<3.0", extras = ["socks"]}
+websocket-client = ">=1.8.0,<2.0"
+
+[[package]]
 name = "sentence-transformers"
 version = "5.0.0"
 description = "Embeddings, Retrieval, and Reranking"
@@ -3704,7 +3886,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "recovery"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -3716,10 +3898,22 @@ version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["dev", "recovery"]
 files = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95"},
+    {file = "soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349"},
 ]
 
 [[package]]
@@ -4325,6 +4519,43 @@ video = ["av"]
 vision = ["Pillow (>=10.0.1,<=15.0)"]
 
 [[package]]
+name = "trio"
+version = "0.33.0"
+description = "A friendly Python library for async concurrency and I/O"
+optional = false
+python-versions = ">=3.10"
+groups = ["recovery"]
+files = [
+    {file = "trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b"},
+    {file = "trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970"},
+]
+
+[package.dependencies]
+attrs = ">=23.2.0"
+cffi = {version = ">=1.14", markers = "os_name == \"nt\" and implementation_name != \"pypy\""}
+idna = "*"
+outcome = "*"
+sniffio = ">=1.3.0"
+sortedcontainers = "*"
+
+[[package]]
+name = "trio-websocket"
+version = "0.12.2"
+description = "WebSocket library for Trio"
+optional = false
+python-versions = ">=3.8"
+groups = ["recovery"]
+files = [
+    {file = "trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6"},
+    {file = "trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae"},
+]
+
+[package.dependencies]
+outcome = ">=1.2.0"
+trio = ">=0.11"
+wsproto = ">=0.14"
+
+[[package]]
 name = "triton"
 version = "3.3.1"
 description = "A language and compiler for custom Deep Learning operations"
@@ -4385,7 +4616,7 @@ version = "4.14.1"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "nlp"]
+groups = ["main", "dev", "nlp", "recovery"]
 files = [
     {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
     {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
@@ -4436,11 +4667,14 @@ version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "docs", "nlp"]
+groups = ["main", "docs", "nlp", "recovery"]
 files = [
     {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
     {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
 ]
+
+[package.dependencies]
+pysocks = {version = ">=1.5.6,<1.5.7 || >1.5.7,<2.0", optional = true, markers = "extra == \"socks\""}
 
 [package.extras]
 brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
@@ -4779,6 +5013,40 @@ typer = ">=0.3.0,<1.0.0"
 wasabi = ">=0.9.1,<1.2.0"
 
 [[package]]
+name = "webdriver-manager"
+version = "4.0.2"
+description = "Library provides the way to automatically manage drivers for different browsers"
+optional = false
+python-versions = ">=3.7"
+groups = ["recovery"]
+files = [
+    {file = "webdriver_manager-4.0.2-py2.py3-none-any.whl", hash = "sha256:75908d92ecc45ff2b9953614459c633db8f9aa1ff30181cefe8696e312908129"},
+    {file = "webdriver_manager-4.0.2.tar.gz", hash = "sha256:efedf428f92fd6d5c924a0d054e6d1322dd77aab790e834ee767af392b35590f"},
+]
+
+[package.dependencies]
+packaging = "*"
+python-dotenv = "*"
+requests = "*"
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+description = "WebSocket client for Python with low level API options"
+optional = false
+python-versions = ">=3.9"
+groups = ["recovery"]
+files = [
+    {file = "websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef"},
+    {file = "websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=6.0)", "myst-parser (>=2.0.0)", "sphinx_rtd_theme (>=1.1.0)"]
+optional = ["python-socks", "wsaccel"]
+test = ["pytest", "websockets"]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
@@ -4939,6 +5207,21 @@ files = [
 ]
 
 [[package]]
+name = "wsproto"
+version = "1.3.2"
+description = "Pure-Python WebSocket protocol implementation"
+optional = false
+python-versions = ">=3.10"
+groups = ["recovery"]
+files = [
+    {file = "wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584"},
+    {file = "wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294"},
+]
+
+[package.dependencies]
+h11 = ">=0.16.0,<1"
+
+[[package]]
 name = "yake"
 version = "0.4.8"
 description = "Keyword extraction Python package"
@@ -4997,4 +5280,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "48ddd8c7b1bba35bcd9f7165a2e9a4ac4dd8f2b35c22904fb21edb1946a098a7"
+content-hash = "f3a5a78ed5af87a1fb1dbf7f1bbd1a9dc05e6b2b104e5687acc21964122d6d5c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.26.0"
+version = "0.27.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]
@@ -46,6 +46,14 @@ greenlet = "^3.0.0"
 youtube-transcript-api = "^1.2.2"
 fastapi = "^0.109.0"
 uvicorn = {extras = ["standard"], version = "^0.27.0"}
+beautifulsoup4 = "^4.12.0"
+
+[tool.poetry.group.recovery]
+optional = true
+
+[tool.poetry.group.recovery.dependencies]
+selenium = "^4.25.0"
+webdriver-manager = "^4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"
@@ -161,7 +169,10 @@ module = [
     "yake.*",
     "spacy.*",
     "youtube_transcript_api.*",
-    "factory_boy.*"
+    "factory_boy.*",
+    "selenium.*",
+    "webdriver_manager.*",
+    "bs4.*"
 ]
 ignore_missing_imports = true
 

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/cli/commands/recover.py
+++ b/src/chronovista/cli/commands/recover.py
@@ -1,0 +1,550 @@
+"""
+CLI commands for recovering deleted video metadata via Wayback Machine.
+
+This module provides the `chronovista recover video` command for recovering
+metadata from deleted YouTube videos using the Internet Archive's Wayback Machine.
+
+Supports single-video recovery, batch recovery with configurable limits and delays,
+dry-run mode for preview, and detailed summary reports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.table import Table
+
+from chronovista.config.database import db_manager
+from chronovista.config.settings import settings
+from chronovista.exceptions import (
+    CDXError,
+    EXIT_CODE_NETWORK_ERROR,
+    PageParseError,
+    RecoveryDependencyError,
+)
+from chronovista.models.enums import AvailabilityStatus
+from chronovista.repositories.video_repository import VideoRepository
+from chronovista.services.recovery import SELENIUM_AVAILABLE
+from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
+from chronovista.services.recovery.models import RecoveryResult
+from chronovista.services.recovery.orchestrator import recover_video
+from chronovista.services.recovery.page_parser import PageParser
+
+# Check for required dependencies
+try:
+    import bs4  # noqa: F401
+
+    BEAUTIFULSOUP_AVAILABLE = True
+except ImportError:
+    BEAUTIFULSOUP_AVAILABLE = False
+
+console = Console()
+
+# Create the recover Typer app
+recover_app = typer.Typer(
+    name="recover",
+    help="Recover metadata for deleted videos",
+    no_args_is_help=True,
+)
+
+
+@recover_app.command(name="video")
+def recover_video_command(
+    video_id: Optional[str] = typer.Option(
+        None,
+        "--video-id",
+        "-v",
+        help="Recover a single video by ID",
+    ),
+    all_videos: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="Recover all unavailable videos",
+    ),
+    limit: Optional[int] = typer.Option(
+        None,
+        "--limit",
+        "-l",
+        help="Maximum number of videos to recover (batch mode only)",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview recovery without making changes",
+    ),
+    delay: float = typer.Option(
+        1.0,
+        "--delay",
+        "-d",
+        help="Delay in seconds between videos (batch mode only)",
+        min=0.0,
+    ),
+    start_year: Optional[int] = typer.Option(
+        None,
+        "--start-year",
+        help="Only search Wayback snapshots from this year onward (e.g., 2018).",
+        min=2005,
+        max=2026,
+    ),
+    end_year: Optional[int] = typer.Option(
+        None,
+        "--end-year",
+        help="Only search Wayback snapshots up to this year (e.g., 2020).",
+        min=2005,
+        max=2026,
+    ),
+) -> None:
+    """
+    Recover metadata for deleted YouTube videos via Wayback Machine.
+
+    Recovers video metadata (title, description, tags, etc.) from archived
+    YouTube pages in the Internet Archive. Supports both single-video and
+    batch recovery modes with configurable rate limiting.
+
+    Examples:
+        chronovista recover video --video-id dQw4w9WgXcQ
+        chronovista recover video --all --limit 10
+        chronovista recover video --all --dry-run
+        chronovista recover video --all --delay 2.0
+    """
+    # T050: Validate arguments
+    if video_id and all_videos:
+        console.print(
+            "[red]Error: --video-id and --all are mutually exclusive[/red]"
+        )
+        raise typer.Exit(code=2)
+
+    if not video_id and not all_videos:
+        console.print(
+            "[yellow]Error: Must specify either --video-id or --all[/yellow]"
+        )
+        console.print("Use 'chronovista recover video --help' for usage information.")
+        raise typer.Exit(code=2)
+
+    if start_year is not None and end_year is not None and start_year > end_year:
+        console.print(
+            "[red]Error: --start-year cannot be greater than --end-year[/red]"
+        )
+        raise typer.Exit(code=2)
+
+    # T056: Check dependencies
+    if not BEAUTIFULSOUP_AVAILABLE:
+        console.print(
+            Panel(
+                "[red]Error: beautifulsoup4 is required for video recovery[/red]\n\n"
+                "Install with: pip install beautifulsoup4",
+                title="Missing Dependency",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(code=1)
+
+    if not SELENIUM_AVAILABLE:
+        console.print(
+            "[yellow]Warning: selenium is not installed. Pre-2017 page fallback disabled.[/yellow]"
+        )
+
+    # Run async recovery
+    try:
+        asyncio.run(_recover_async(video_id, all_videos, limit, dry_run, delay, start_year, end_year))
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Recovery interrupted by user[/yellow]")
+        raise typer.Exit(code=130)
+
+
+async def _recover_async(
+    video_id: Optional[str],
+    all_videos: bool,
+    limit: Optional[int],
+    dry_run: bool,
+    delay: float,
+    start_year: Optional[int] = None,
+    end_year: Optional[int] = None,
+) -> None:
+    """
+    Async implementation of video recovery.
+
+    Parameters
+    ----------
+    video_id : str | None
+        Single video ID to recover, or None for batch mode.
+    all_videos : bool
+        Whether to recover all unavailable videos (batch mode).
+    limit : int | None
+        Maximum number of videos to recover in batch mode.
+    dry_run : bool
+        If True, preview recovery without making changes.
+    delay : float
+        Delay in seconds between videos in batch mode.
+    start_year : int | None, optional
+        Only search Wayback snapshots from this year onward (default: None).
+    end_year : int | None, optional
+        Only search Wayback snapshots up to this year (default: None).
+    """
+    # T050: Initialize services
+    cache_dir = settings.cache_dir
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    cdx_client = CDXClient(cache_dir=cache_dir)
+    rate_limiter = RateLimiter(rate=40.0)
+    page_parser = PageParser(rate_limiter=rate_limiter)
+
+    if video_id:
+        # T052: Single-video recovery
+        await _recover_single_video(
+            video_id=video_id,
+            cdx_client=cdx_client,
+            page_parser=page_parser,
+            rate_limiter=rate_limiter,
+            dry_run=dry_run,
+            start_year=start_year,
+            end_year=end_year,
+        )
+    else:
+        # T053: Batch recovery
+        await _recover_batch(
+            cdx_client=cdx_client,
+            page_parser=page_parser,
+            rate_limiter=rate_limiter,
+            limit=limit,
+            dry_run=dry_run,
+            delay=delay,
+            start_year=start_year,
+            end_year=end_year,
+        )
+
+
+async def _recover_single_video(
+    video_id: str,
+    cdx_client: CDXClient,
+    page_parser: PageParser,
+    rate_limiter: RateLimiter,
+    dry_run: bool,
+    start_year: Optional[int] = None,
+    end_year: Optional[int] = None,
+) -> None:
+    """
+    Recover a single video by ID.
+
+    Parameters
+    ----------
+    video_id : str
+        YouTube video ID to recover.
+    cdx_client : CDXClient
+        CDX API client for fetching snapshots.
+    page_parser : PageParser
+        Page parser for extracting metadata.
+    rate_limiter : RateLimiter
+        Rate limiter for throttling requests.
+    dry_run : bool
+        If True, preview recovery without making changes.
+    start_year : int | None, optional
+        Only search Wayback snapshots from this year onward (default: None).
+    end_year : int | None, optional
+        Only search Wayback snapshots up to this year (default: None).
+    """
+    # T052: Show progress spinner
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        console=console,
+    ) as progress:
+        task = progress.add_task(
+            f"[cyan]Recovering video {video_id}...",
+            total=None,
+        )
+
+        exit_code = 1
+        try:
+            async for session in db_manager.get_session(echo=False):
+                result = await recover_video(
+                    session=session,
+                    video_id=video_id,
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=dry_run,
+                    from_year=start_year,
+                    to_year=end_year,
+                )
+
+                progress.update(task, completed=True)
+
+                # T052: Display result
+                _display_single_result(result, dry_run)
+
+                # T052: Exit codes
+                exit_code = 0 if result.success else 1
+
+        except CDXError as e:
+            console.print(f"[red]CDX API error: {e.message}[/red]")
+            raise typer.Exit(code=EXIT_CODE_NETWORK_ERROR)
+        except PageParseError as e:
+            console.print(f"[red]Page parsing error: {e.message}[/red]")
+            raise typer.Exit(code=1)
+
+    raise typer.Exit(code=exit_code)
+
+
+async def _recover_batch(
+    cdx_client: CDXClient,
+    page_parser: PageParser,
+    rate_limiter: RateLimiter,
+    limit: Optional[int],
+    dry_run: bool,
+    delay: float,
+    start_year: Optional[int] = None,
+    end_year: Optional[int] = None,
+) -> None:
+    """
+    Recover all unavailable videos in batch mode.
+
+    Parameters
+    ----------
+    cdx_client : CDXClient
+        CDX API client for fetching snapshots.
+    page_parser : PageParser
+        Page parser for extracting metadata.
+    rate_limiter : RateLimiter
+        Rate limiter for throttling requests.
+    limit : int | None
+        Maximum number of videos to recover.
+    dry_run : bool
+        If True, preview recovery without making changes.
+    delay : float
+        Delay in seconds between videos.
+    start_year : int | None, optional
+        Only search Wayback snapshots from this year onward (default: None).
+    end_year : int | None, optional
+        Only search Wayback snapshots up to this year (default: None).
+    """
+    # T053: Query unavailable videos
+    video_repo = VideoRepository()
+
+    exit_code = 1
+    async for session in db_manager.get_session(echo=False):
+        # Query unavailable videos (ordered by unavailability_first_detected ASC NULLS LAST, then created_at ASC)
+        from sqlalchemy import asc, select
+        from chronovista.db.models import Video as VideoDB
+
+        stmt = (
+            select(VideoDB)
+            .where(VideoDB.availability_status != AvailabilityStatus.AVAILABLE.value)
+            .order_by(
+                asc(VideoDB.unavailability_first_detected.is_(None)),
+                asc(VideoDB.unavailability_first_detected),
+                asc(VideoDB.created_at),
+            )
+        )
+
+        if limit:
+            stmt = stmt.limit(limit)
+
+        result = await session.execute(stmt)
+        videos = list(result.scalars().all())
+
+        # T053: Handle zero videos
+        if not videos:
+            console.print(
+                Panel(
+                    "[yellow]No unavailable videos found in the database.[/yellow]",
+                    title="Batch Recovery",
+                    border_style="yellow",
+                )
+            )
+            exit_code = 0
+            break
+
+        console.print(
+            Panel(
+                f"[cyan]Found {len(videos)} unavailable video(s) to recover[/cyan]",
+                title="Batch Recovery",
+                border_style="cyan",
+            )
+        )
+
+        # T053: Process videos with delay
+        results: list[RecoveryResult] = []
+
+        for i, video in enumerate(videos):
+            try:
+                recovery_result = await recover_video(
+                    session=session,
+                    video_id=video.video_id,
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=dry_run,
+                    from_year=start_year,
+                    to_year=end_year,
+                )
+                results.append(recovery_result)
+
+                # Show progress
+                console.print(
+                    f"[dim]Progress: {i + 1}/{len(videos)} - "
+                    f"{'✓' if recovery_result.success else '✗'} {video.video_id}[/dim]"
+                )
+
+                # T053: Apply delay between videos (except after last video)
+                if i < len(videos) - 1 and delay > 0:
+                    await asyncio.sleep(delay)
+
+            except CDXError as e:
+                console.print(
+                    f"[red]CDX error for {video.video_id}: {e.message}[/red]"
+                )
+                # T053: Continue past failures
+                results.append(
+                    RecoveryResult(
+                        video_id=video.video_id,
+                        success=False,
+                        failure_reason="cdx_error",
+                        duration_seconds=0.0,
+                    )
+                )
+                continue
+            except Exception as e:
+                console.print(
+                    f"[red]Unexpected error for {video.video_id}: {e}[/red]"
+                )
+                results.append(
+                    RecoveryResult(
+                        video_id=video.video_id,
+                        success=False,
+                        failure_reason="unexpected_error",
+                        duration_seconds=0.0,
+                    )
+                )
+                continue
+
+        # T055: Display summary report
+        _display_batch_summary(results, dry_run)
+
+        # Exit based on results
+        success_count = sum(1 for r in results if r.success)
+        exit_code = 0 if success_count > 0 else 1
+
+    raise typer.Exit(code=exit_code)
+
+
+def _display_single_result(result: RecoveryResult, dry_run: bool) -> None:
+    """
+    Display single-video recovery result.
+
+    Parameters
+    ----------
+    result : RecoveryResult
+        Recovery result for a single video.
+    dry_run : bool
+        Whether this was a dry-run recovery.
+    """
+    # T052: Create result table
+    table = Table(title=f"Recovery Result: {result.video_id}")
+
+    table.add_column("Field", style="cyan")
+    table.add_column("Value", style="green" if result.success else "red")
+
+    table.add_row("Status", "✓ Success" if result.success else "✗ Failed")
+
+    if result.success:
+        table.add_row("Snapshot Used", result.snapshot_used or "N/A")
+        table.add_row(
+            "Fields Recovered",
+            f"{len(result.fields_recovered)} ({', '.join(result.fields_recovered)})"
+            if result.fields_recovered
+            else "0",
+        )
+        if result.fields_skipped:
+            table.add_row(
+                "Fields Skipped",
+                f"{len(result.fields_skipped)} ({', '.join(result.fields_skipped[:5])})",
+            )
+        table.add_row("Snapshots Available", str(result.snapshots_available))
+        table.add_row("Snapshots Tried", str(result.snapshots_tried))
+    else:
+        table.add_row("Failure Reason", result.failure_reason or "Unknown")
+        if result.snapshots_available > 0:
+            table.add_row("Snapshots Available", str(result.snapshots_available))
+            table.add_row("Snapshots Tried", str(result.snapshots_tried))
+
+    table.add_row("Duration", f"{result.duration_seconds:.2f}s")
+
+    if dry_run:
+        table.add_row("Mode", "[yellow]DRY RUN - No changes made[/yellow]")
+
+    console.print(table)
+
+
+def _display_batch_summary(results: list[RecoveryResult], dry_run: bool) -> None:
+    """
+    Display batch recovery summary report.
+
+    Parameters
+    ----------
+    results : list[RecoveryResult]
+        List of recovery results for all processed videos.
+    dry_run : bool
+        Whether this was a dry-run recovery.
+    """
+    # T055: Calculate summary statistics
+    total = len(results)
+    succeeded = sum(1 for r in results if r.success)
+    failed = total - succeeded
+    no_archive = sum(
+        1 for r in results if not r.success and r.failure_reason == "no_snapshots_found"
+    )
+
+    # T055: Summary panel
+    summary_text = (
+        f"[cyan]Attempted:[/cyan] {total}\n"
+        f"[green]Succeeded:[/green] {succeeded}\n"
+        f"[red]Failed:[/red] {failed}\n"
+        f"[yellow]No Archive Found:[/yellow] {no_archive}"
+    )
+
+    if dry_run:
+        summary_text += "\n\n[yellow]DRY RUN - No changes were made[/yellow]"
+
+    console.print(
+        Panel(
+            summary_text,
+            title="Batch Recovery Summary",
+            border_style="cyan",
+        )
+    )
+
+    # T055: Per-video results table
+    table = Table(title="Per-Video Results")
+
+    table.add_column("Video ID", style="cyan")
+    table.add_column("Status", style="bold")
+    table.add_column("Fields Recovered", style="green")
+    table.add_column("Snapshot Used", style="dim")
+
+    for result in results:
+        status = "✓ Success" if result.success else "✗ Failed"
+        status_style = "[green]" if result.success else "[red]"
+
+        fields_count = (
+            str(len(result.fields_recovered)) if result.success else "-"
+        )
+
+        snapshot = result.snapshot_used if result.success else "-"
+
+        table.add_row(
+            result.video_id,
+            f"{status_style}{status}[/]",
+            fields_count,
+            snapshot,
+        )
+
+    console.print(table)

--- a/src/chronovista/cli/main.py
+++ b/src/chronovista/cli/main.py
@@ -14,6 +14,7 @@ from chronovista.cli.category_commands import category_app
 from chronovista.cli.commands.api import api_app
 from chronovista.cli.commands.enrich import app as enrich_app
 from chronovista.cli.commands.playlist import playlist_app
+from chronovista.cli.commands.recover import recover_app
 from chronovista.cli.commands.seed import seed_app
 from chronovista.cli.commands.takeout import takeout_app
 from chronovista.cli.language_commands import language_app
@@ -40,6 +41,7 @@ app.add_typer(
 app.add_typer(enrich_app, name="enrich", help="🔄 Enrich video metadata from YouTube API")
 app.add_typer(language_app, name="languages", help="🌐 Manage language preferences for transcripts")
 app.add_typer(playlist_app, name="playlist", help="📋 Playlist management commands")
+app.add_typer(recover_app, name="recover", help="🔄 Recover metadata for deleted videos")
 app.add_typer(sync_app, name="sync", help="Data synchronization commands")
 app.add_typer(seed_app, name="seed", help="🌱 Seed reference data into the database")
 app.add_typer(tag_app, name="tags", help="🏷️ Video tag exploration and analytics")

--- a/src/chronovista/config/settings.py
+++ b/src/chronovista/config/settings.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     data_dir: Path = Field(default=Path("./data"))
     cache_dir: Path = Field(default=Path("./cache"))
     logs_dir: Path = Field(default=Path("./logs"))
+    cdx_cache_ttl_hours: int = Field(default=24, description="CDX cache TTL in hours")
 
     # NLP
     nlp_model: str = Field(default="en_core_web_sm")

--- a/src/chronovista/models/video.py
+++ b/src/chronovista/models/video.py
@@ -165,6 +165,8 @@ class VideoUpdate(BaseModel):
     available_languages: Optional[Dict[str, Any]] = None
     region_restriction: Optional[Dict[str, Any]] = None
     content_rating: Optional[Dict[str, Any]] = None
+    upload_date: Optional[datetime] = None
+    thumbnail_url: Optional[str] = None
     category_id: Optional[str] = Field(default=None, max_length=10)
     like_count: Optional[int] = Field(default=None, ge=0)
     view_count: Optional[int] = Field(default=None, ge=0)

--- a/src/chronovista/services/recovery/__init__.py
+++ b/src/chronovista/services/recovery/__init__.py
@@ -1,0 +1,57 @@
+"""
+Wayback Machine video recovery services.
+
+This package provides functionality to recover metadata for deleted YouTube videos
+using the Internet Archive's Wayback Machine CDX API and archived page snapshots.
+
+The recovery process includes:
+- CDX API integration with rate limiting
+- HTML parsing for video metadata extraction
+- Optional Selenium fallback for pre-2017 archived pages
+- Result caching and deduplication
+
+Modules
+-------
+cdx_client
+    CDX API client with rate limiting and caching
+page_parser
+    HTML/JSON parsing for video metadata extraction
+recovery_service
+    Main recovery orchestration service
+
+Selenium Support
+---------------
+Selenium WebDriver is an optional dependency used only as a fallback for
+pre-2017 archived pages that require JavaScript rendering. If selenium
+is not installed, the recovery service will skip JavaScript rendering
+and rely on static HTML parsing only.
+"""
+
+# Try to import selenium to check availability
+try:
+    import selenium.webdriver  # type: ignore[import-not-found]  # noqa: F401
+    SELENIUM_AVAILABLE = True
+except ImportError:
+    SELENIUM_AVAILABLE = False
+
+from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
+from chronovista.services.recovery.models import (
+    CdxCacheEntry,
+    CdxSnapshot,
+    RecoveredVideoData,
+    RecoveryResult,
+)
+from chronovista.services.recovery.orchestrator import recover_video
+from chronovista.services.recovery.page_parser import PageParser
+
+__all__ = [
+    "SELENIUM_AVAILABLE",
+    "CdxSnapshot",
+    "RecoveredVideoData",
+    "RecoveryResult",
+    "CdxCacheEntry",
+    "CDXClient",
+    "RateLimiter",
+    "PageParser",
+    "recover_video",
+]

--- a/src/chronovista/services/recovery/cdx_client.py
+++ b/src/chronovista/services/recovery/cdx_client.py
@@ -1,0 +1,552 @@
+"""
+CDX API client for the Wayback Machine video recovery service.
+
+Provides rate-limited, cached access to the Internet Archive CDX API
+for discovering archived YouTube video snapshots. Includes exponential
+backoff retry logic for transient failures and file-based caching
+with configurable TTL.
+
+Classes
+-------
+RateLimiter
+    Token-bucket rate limiter for controlling request throughput.
+CDXClient
+    Async client for the Wayback Machine CDX API with caching and retry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import json
+import logging
+from pathlib import Path
+from typing import cast
+
+import httpx
+
+from chronovista import __version__
+from chronovista.exceptions import CDXError
+from chronovista.services.recovery.models import CdxCacheEntry, CdxSnapshot
+
+logger = logging.getLogger(__name__)
+
+_CDX_BASE_URL = "https://web.archive.org/cdx/search/cdx"
+_MAX_RETRIES = 3
+_BACKOFF_BASE_SECONDS = 2.0
+_RATE_LIMIT_PAUSE_SECONDS = 60.0
+_REQUEST_TIMEOUT_SECONDS = 30.0
+_CACHE_TTL_HOURS = 24
+_CDX_RESULT_LIMIT = 100
+_MIN_RESPONSE_LENGTH = 5000
+
+
+class RateLimiter:
+    """
+    Token-bucket rate limiter for controlling async request throughput.
+
+    Starts with a full bucket of tokens equal to the configured rate,
+    allowing an initial burst. Once tokens are exhausted, subsequent
+    calls to ``acquire()`` will sleep to maintain the target rate.
+
+    Parameters
+    ----------
+    rate : float
+        Maximum requests per second (e.g., 40.0 means 40 req/s).
+
+    Examples
+    --------
+    >>> limiter = RateLimiter(rate=40.0)
+    >>> await limiter.acquire()  # First 40 calls proceed immediately
+    """
+
+    def __init__(self, rate: float) -> None:
+        """
+        Initialize the RateLimiter.
+
+        Parameters
+        ----------
+        rate : float
+            Maximum requests per second. The bucket starts full with
+            ``rate`` tokens, allowing an initial burst up to that count.
+        """
+        self._rate = rate
+        self._tokens = rate
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        """
+        Acquire a single token, sleeping if the bucket is empty.
+
+        If tokens are available, one is consumed immediately. If the
+        bucket is empty, sleeps for ``1/rate`` seconds to replenish
+        one token before proceeding.
+
+        This method is safe for concurrent async callers via an
+        internal ``asyncio.Lock``.
+        """
+        async with self._lock:
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return
+
+            # Need to wait for a token to become available
+            wait_time = 1.0 / self._rate
+            await asyncio.sleep(wait_time)
+            # After sleeping, we have effectively earned one token
+            # and immediately consume it, so tokens stays the same
+
+
+class CDXClient:
+    """
+    Async client for the Wayback Machine CDX API.
+
+    Fetches archived YouTube video snapshots from the CDX API with
+    built-in file-based caching, rate limiting, and retry logic for
+    transient HTTP errors.
+
+    Parameters
+    ----------
+    cache_dir : Path
+        Root directory for CDX response cache files. Cache entries
+        are stored under ``{cache_dir}/cdx/{video_id}.json``.
+
+    Attributes
+    ----------
+    cache_dir : Path
+        The configured cache directory root.
+
+    Examples
+    --------
+    >>> client = CDXClient(cache_dir=Path("/tmp/cdx_cache"))
+    >>> snapshots = await client.fetch_snapshots("dQw4w9WgXcQ")
+    >>> for snap in snapshots:
+    ...     print(snap.timestamp, snap.wayback_url)
+    """
+
+    def __init__(self, cache_dir: Path) -> None:
+        """
+        Initialize the CDXClient.
+
+        Parameters
+        ----------
+        cache_dir : Path
+            Root directory for CDX response cache files.
+        """
+        self.cache_dir = cache_dir
+
+    async def fetch_snapshots(
+        self,
+        video_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> list[CdxSnapshot]:
+        """
+        Fetch CDX snapshots for a YouTube video, using cache when available.
+
+        Checks the file-based cache first. If a fresh cache entry exists
+        (less than 24 hours old), returns the cached snapshots without
+        making an HTTP request. Otherwise, queries the CDX API, filters
+        and sorts the results, caches them, and returns the snapshots.
+
+        Parameters
+        ----------
+        video_id : str
+            YouTube video ID (e.g., "dQw4w9WgXcQ").
+        from_year : int | None, optional
+            Only return snapshots from this year onward (default: None).
+        to_year : int | None, optional
+            Only return snapshots up to this year (default: None).
+
+        Returns
+        -------
+        list[CdxSnapshot]
+            List of CDX snapshots. Sorted newest-first by default, or
+            oldest-first when ``from_year`` is specified (so iteration
+            starts near the anchor year). May be empty.
+
+        Raises
+        ------
+        CDXError
+            If the CDX API request fails after all retries are exhausted.
+        """
+        # Check cache first
+        cached = self._read_cache(video_id, from_year=from_year, to_year=to_year)
+        if cached is not None:
+            snapshots = cached
+        else:
+            # Fetch from CDX API with retries
+            raw_rows = await self._fetch_with_retries(
+                video_id, from_year=from_year, to_year=to_year
+            )
+
+            # Parse and filter
+            snapshots = self._parse_cdx_response(raw_rows)
+
+            # Cache the results
+            self._write_cache(
+                video_id, snapshots, raw_count=len(raw_rows),
+                from_year=from_year, to_year=to_year,
+            )
+
+        # When from_year is set, return oldest-first (ascending) so the
+        # orchestrator tries snapshots closest to the anchor year first.
+        if from_year is not None:
+            snapshots = list(reversed(snapshots))
+
+        return snapshots
+
+    def _build_cdx_url(
+        self,
+        video_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> str:
+        """
+        Build the CDX API query URL for a given video ID.
+
+        Parameters
+        ----------
+        video_id : str
+            YouTube video ID.
+        from_year : int | None, optional
+            Only return snapshots from this year onward (default: None).
+        to_year : int | None, optional
+            Only return snapshots up to this year (default: None).
+
+        Returns
+        -------
+        str
+            Fully-formed CDX API URL with all required query parameters.
+        """
+        # When from_year is set, use positive limit (oldest first from anchor)
+        # so snapshots near the anchor year are returned.
+        # Without from_year, use negative limit (newest first).
+        limit = _CDX_RESULT_LIMIT if from_year is not None else -_CDX_RESULT_LIMIT
+        url = (
+            f"{_CDX_BASE_URL}"
+            f"?url=youtube.com/watch%3Fv%3D{video_id}"
+            f"&output=json"
+            f"&filter=statuscode:200"
+            f"&filter=mimetype:text/html"
+            f"&fl=timestamp,original,mimetype,statuscode,digest,length"
+            f"&limit={limit}"
+        )
+        if from_year is not None:
+            url += f"&from={from_year}0101000000"
+        if to_year is not None:
+            url += f"&to={to_year}1231235959"
+        return url
+
+    async def _fetch_with_retries(
+        self,
+        video_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> list[list[str]]:
+        """
+        Fetch CDX data with retry logic for transient HTTP errors.
+
+        Implements exponential backoff for HTTP 503 (base 2s, 3 retries)
+        and a fixed 60s pause for HTTP 429 (rate limit).
+
+        Parameters
+        ----------
+        video_id : str
+            YouTube video ID.
+        from_year : int | None, optional
+            Only return snapshots from this year onward (default: None).
+        to_year : int | None, optional
+            Only return snapshots up to this year (default: None).
+
+        Returns
+        -------
+        list[list[str]]
+            Raw CDX response rows (array of arrays, first row is headers).
+
+        Raises
+        ------
+        CDXError
+            If all retries are exhausted without a successful response.
+        """
+        url = self._build_cdx_url(video_id, from_year=from_year, to_year=to_year)
+        headers = {"User-Agent": f"chronovista/{__version__}"}
+        retries_remaining = _MAX_RETRIES
+
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            while True:
+                try:
+                    response = await client.get(
+                        url,
+                        headers=headers,
+                        timeout=_REQUEST_TIMEOUT_SECONDS,
+                    )
+                except (
+                    httpx.ConnectTimeout,
+                    httpx.ReadTimeout,
+                    httpx.ConnectError,
+                ) as e:
+                    if retries_remaining <= 0:
+                        raise CDXError(
+                            message=(
+                                f"CDX API connection failed for video "
+                                f"'{video_id}' after retries: "
+                                f"{type(e).__name__}"
+                            ),
+                            video_id=video_id,
+                            status_code=0,
+                        ) from e
+                    attempt = _MAX_RETRIES - retries_remaining
+                    delay = _BACKOFF_BASE_SECONDS * (2 ** attempt)
+                    retries_remaining -= 1
+                    logger.warning(
+                        "CDX fetch attempt %d/%d for video %s failed "
+                        "(%s), retrying in %.0fs",
+                        attempt + 1,
+                        _MAX_RETRIES,
+                        video_id,
+                        type(e).__name__,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+
+                if response.status_code == 200:
+                    return cast(list[list[str]], response.json())
+
+                if response.status_code == 429:
+                    if retries_remaining <= 0:
+                        raise CDXError(
+                            message=(
+                                f"CDX API rate limit exceeded for video "
+                                f"'{video_id}' after retries"
+                            ),
+                            video_id=video_id,
+                            status_code=429,
+                        )
+                    retries_remaining -= 1
+                    await asyncio.sleep(_RATE_LIMIT_PAUSE_SECONDS)
+                    continue
+
+                if response.status_code == 503:
+                    if retries_remaining <= 0:
+                        raise CDXError(
+                            message=(
+                                f"CDX API unavailable (503) for video "
+                                f"'{video_id}' after retries"
+                            ),
+                            video_id=video_id,
+                            status_code=503,
+                        )
+                    attempt = _MAX_RETRIES - retries_remaining
+                    delay = _BACKOFF_BASE_SECONDS * (2 ** attempt)
+                    retries_remaining -= 1
+                    await asyncio.sleep(delay)
+                    continue
+
+                # Unexpected status code — raise immediately
+                raise CDXError(
+                    message=(
+                        f"CDX API returned unexpected status "
+                        f"{response.status_code} for video '{video_id}'"
+                    ),
+                    video_id=video_id,
+                    status_code=response.status_code,
+                )
+
+    def _parse_cdx_response(
+        self, raw_rows: list[list[str]]
+    ) -> list[CdxSnapshot]:
+        """
+        Parse raw CDX JSON rows into filtered, sorted CdxSnapshot objects.
+
+        Skips the header row, filters out redirect rows (statuscode="-"),
+        non-200 status codes, non-text/html mimetypes, and responses with
+        length <= 5000. Results are sorted newest-first by timestamp.
+
+        Parameters
+        ----------
+        raw_rows : list[list[str]]
+            Raw CDX response data (array of arrays).
+
+        Returns
+        -------
+        list[CdxSnapshot]
+            Filtered and sorted list of CdxSnapshot objects.
+        """
+        if not raw_rows or len(raw_rows) <= 1:
+            return []
+
+        # First row is headers, skip it
+        data_rows = raw_rows[1:]
+
+        snapshots: list[CdxSnapshot] = []
+        for row in data_rows:
+            if len(row) < 6:
+                continue
+
+            timestamp, original, mimetype, statuscode_str, digest, length_str = (
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+            )
+
+            # Skip redirect rows with statuscode="-"
+            if statuscode_str == "-":
+                continue
+
+            # Parse numeric fields
+            try:
+                statuscode = int(statuscode_str)
+                length = int(length_str)
+            except (ValueError, TypeError):
+                continue
+
+            # Apply filters
+            if statuscode != 200:
+                continue
+            if mimetype != "text/html":
+                continue
+            if length <= _MIN_RESPONSE_LENGTH:
+                continue
+
+            snapshot = CdxSnapshot(
+                timestamp=timestamp,
+                original=original,
+                mimetype=mimetype,
+                statuscode=statuscode,
+                digest=digest,
+                length=length,
+            )
+            snapshots.append(snapshot)
+
+        # Sort newest-first (descending by timestamp)
+        snapshots.sort(key=lambda s: s.timestamp, reverse=True)
+
+        return snapshots
+
+    def _cache_path(
+        self,
+        video_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> Path:
+        """
+        Compute the cache file path for a given video ID and year range.
+
+        Parameters
+        ----------
+        video_id : str
+            YouTube video ID.
+        from_year : int | None, optional
+            Start year filter used in the CDX query (default: None).
+        to_year : int | None, optional
+            End year filter used in the CDX query (default: None).
+
+        Returns
+        -------
+        Path
+            Path to the cache file. When year filters are active the
+            filename includes suffixes, e.g.
+            ``{cache_dir}/cdx/{video_id}_from2018_to2020.json``.
+        """
+        suffix = ""
+        if from_year is not None:
+            suffix += f"_from{from_year}"
+        if to_year is not None:
+            suffix += f"_to{to_year}"
+        return self.cache_dir / "cdx" / f"{video_id}{suffix}.json"
+
+    def _read_cache(
+        self,
+        video_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> list[CdxSnapshot] | None:
+        """
+        Read and validate a cached CDX response for a video.
+
+        Returns the cached snapshots if the cache file exists, contains
+        valid JSON, and is still fresh (less than 24 hours old). Returns
+        None on cache miss, expiration, or corruption. Corrupted cache
+        files are deleted automatically.
+
+        Parameters
+        ----------
+        video_id : str
+            YouTube video ID.
+        from_year : int | None, optional
+            Start year filter used in the CDX query (default: None).
+        to_year : int | None, optional
+            End year filter used in the CDX query (default: None).
+
+        Returns
+        -------
+        list[CdxSnapshot] | None
+            Cached snapshots if valid, or None if cache miss/expired/corrupt.
+        """
+        cache_file = self._cache_path(video_id, from_year=from_year, to_year=to_year)
+        if not cache_file.exists():
+            return None
+
+        try:
+            raw_text = cache_file.read_text()
+            entry = CdxCacheEntry.model_validate_json(raw_text)
+        except Exception:
+            # Corrupted cache — delete and re-fetch
+            logger.warning(
+                "Corrupted CDX cache for video '%s', deleting: %s",
+                video_id,
+                cache_file,
+            )
+            try:
+                cache_file.unlink()
+            except OSError:
+                pass
+            return None
+
+        if not entry.is_valid(ttl_hours=_CACHE_TTL_HOURS):
+            return None
+
+        return entry.snapshots
+
+    def _write_cache(
+        self,
+        video_id: str,
+        snapshots: list[CdxSnapshot],
+        raw_count: int,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> None:
+        """
+        Write a CDX response to the file cache.
+
+        Creates the cache directory structure if it does not exist.
+
+        Parameters
+        ----------
+        video_id : str
+            YouTube video ID.
+        snapshots : list[CdxSnapshot]
+            Filtered CDX snapshots to cache.
+        raw_count : int
+            Total number of raw CDX rows before filtering.
+        from_year : int | None, optional
+            Start year filter used in the CDX query (default: None).
+        to_year : int | None, optional
+            End year filter used in the CDX query (default: None).
+        """
+        cache_file = self._cache_path(video_id, from_year=from_year, to_year=to_year)
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+
+        entry = CdxCacheEntry(
+            video_id=video_id,
+            fetched_at=_dt.datetime.now(_dt.timezone.utc),
+            snapshots=snapshots,
+            raw_count=raw_count,
+        )
+
+        cache_file.write_text(entry.model_dump_json())

--- a/src/chronovista/services/recovery/models.py
+++ b/src/chronovista/services/recovery/models.py
@@ -1,0 +1,499 @@
+"""
+Pydantic models for the Wayback Machine video recovery service.
+
+Provides validated data models for CDX API snapshots, recovered video metadata,
+recovery results, and CDX response caching.
+
+Models
+------
+CdxSnapshot
+    Represents a single archived capture from the Wayback Machine CDX API.
+RecoveredVideoData
+    Metadata extracted from an archived YouTube page.
+RecoveryResult
+    Outcome of a single video recovery attempt.
+CdxCacheEntry
+    File-based cache entry for CDX responses.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+
+from chronovista.models.youtube_types import VideoId
+
+
+class CdxSnapshot(BaseModel):
+    """
+    Represents a single archived capture from the Wayback Machine CDX API.
+
+    Each snapshot corresponds to one Wayback Machine capture, including the
+    timestamp, original URL, MIME type, HTTP status, content digest, and
+    response size. Provides computed properties for Wayback Machine URLs
+    and parsed datetime.
+
+    Attributes
+    ----------
+    timestamp : str
+        CDX timestamp, exactly 14 digits (YYYYMMDDHHmmss format).
+    original : str
+        The original URL that was archived.
+    mimetype : str
+        Content MIME type of the archived response.
+    statuscode : int
+        HTTP status code of the archived response.
+    digest : str
+        Content hash (SHA-1 digest) of the archived response body.
+    length : int
+        Response body size in bytes. Must be greater than 0.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    timestamp: str
+    original: str
+    mimetype: str
+    statuscode: int
+    digest: str
+    length: int
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp(cls, v: str) -> str:
+        """
+        Validate that timestamp is exactly 14 digits.
+
+        Parameters
+        ----------
+        v : str
+            The timestamp string to validate.
+
+        Returns
+        -------
+        str
+            The validated timestamp.
+
+        Raises
+        ------
+        ValueError
+            If timestamp is not exactly 14 digits.
+        """
+        if not re.match(r"^\d{14}$", v):
+            raise ValueError(
+                f"timestamp must be exactly 14 digits, got '{v}'"
+            )
+        return v
+
+    @field_validator("length")
+    @classmethod
+    def validate_length(cls, v: int) -> int:
+        """
+        Validate that length is positive (greater than 0).
+
+        Parameters
+        ----------
+        v : int
+            The length value to validate.
+
+        Returns
+        -------
+        int
+            The validated length.
+
+        Raises
+        ------
+        ValueError
+            If length is not greater than 0.
+        """
+        if v <= 0:
+            raise ValueError(f"length must be greater than 0, got {v}")
+        return v
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def wayback_url(self) -> str:
+        """
+        Wayback Machine raw URL (no toolbar) for this snapshot.
+
+        Returns
+        -------
+        str
+            URL in the format ``https://web.archive.org/web/{timestamp}id_/{original}``.
+        """
+        return f"https://web.archive.org/web/{self.timestamp}id_/{self.original}"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def wayback_url_rendered(self) -> str:
+        """
+        Wayback Machine rendered URL (with iframe) for this snapshot.
+
+        Returns
+        -------
+        str
+            URL in the format ``https://web.archive.org/web/{timestamp}if_/{original}``.
+        """
+        return f"https://web.archive.org/web/{self.timestamp}if_/{self.original}"
+
+    @computed_field(return_type=_dt.datetime)  # type: ignore[prop-decorator]
+    @property
+    def datetime(self) -> _dt.datetime:
+        """
+        Parse the CDX timestamp into a timezone-aware Python datetime object.
+
+        Returns
+        -------
+        datetime.datetime
+            UTC-aware datetime parsed from the 14-digit timestamp.
+        """
+        return _dt.datetime.strptime(self.timestamp, "%Y%m%d%H%M%S").replace(
+            tzinfo=_dt.timezone.utc
+        )
+
+
+class RecoveredVideoData(BaseModel):
+    """
+    Metadata extracted from an archived YouTube page.
+
+    Contains optional fields for all recoverable video metadata. Only
+    ``snapshot_timestamp`` is required. All other fields default to None
+    or empty lists.
+
+    Attributes
+    ----------
+    title : str | None
+        Video title, if recovered.
+    description : str | None
+        Video description, if recovered.
+    channel_name_hint : str | None
+        Channel display name for future resolution (source: videoDetails.author).
+    channel_id : str | None
+        YouTube channel ID (must match UC[A-Za-z0-9_-]{22} if provided).
+    view_count : int | None
+        View count at the time of archival. Must be >= 0.
+    like_count : int | None
+        Like count at the time of archival. Must be >= 0.
+    upload_date : datetime.datetime | None
+        Original upload date, if recovered.
+    thumbnail_url : str | None
+        Thumbnail URL, if recovered.
+    tags : list[str]
+        Video tags extracted from the archived page.
+    category_id : str | None
+        YouTube category ID, if recovered.
+    snapshot_timestamp : str
+        CDX timestamp of the snapshot used for extraction. Must be 14 digits.
+    """
+
+    title: str | None = None
+    description: str | None = None
+    channel_name_hint: str | None = None
+    channel_id: str | None = None
+    view_count: int | None = None
+    like_count: int | None = None
+    upload_date: _dt.datetime | None = None
+    thumbnail_url: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    category_id: str | None = None
+    snapshot_timestamp: str
+
+    @field_validator("snapshot_timestamp")
+    @classmethod
+    def validate_snapshot_timestamp(cls, v: str) -> str:
+        """
+        Validate that snapshot_timestamp is exactly 14 digits.
+
+        Parameters
+        ----------
+        v : str
+            The snapshot timestamp to validate.
+
+        Returns
+        -------
+        str
+            The validated snapshot timestamp.
+
+        Raises
+        ------
+        ValueError
+            If snapshot_timestamp is not exactly 14 digits.
+        """
+        if not re.match(r"^\d{14}$", v):
+            raise ValueError(
+                f"snapshot_timestamp must be exactly 14 digits, got '{v}'"
+            )
+        return v
+
+    @field_validator("channel_id", mode="before")
+    @classmethod
+    def validate_channel_id(cls, v: Any) -> str | None:
+        """
+        Validate channel_id matches YouTube channel ID format if provided.
+
+        Parameters
+        ----------
+        v : Any
+            The channel ID value to validate.
+
+        Returns
+        -------
+        str | None
+            The validated channel ID, or None.
+
+        Raises
+        ------
+        ValueError
+            If channel_id is provided but does not match ``UC[A-Za-z0-9_-]{22}``.
+        """
+        if v is None:
+            return v
+        if not isinstance(v, str):
+            raise ValueError(f"channel_id must be a string, got {type(v).__name__}")
+        if not re.match(r"^UC[A-Za-z0-9_-]{22}$", v):
+            raise ValueError(
+                f"channel_id must match UC[A-Za-z0-9_-]{{22}}, got '{v}'"
+            )
+        return v
+
+    @field_validator("view_count")
+    @classmethod
+    def validate_view_count(cls, v: int | None) -> int | None:
+        """
+        Validate that view_count is non-negative if provided.
+
+        Parameters
+        ----------
+        v : int | None
+            The view count to validate.
+
+        Returns
+        -------
+        int | None
+            The validated view count.
+
+        Raises
+        ------
+        ValueError
+            If view_count is negative.
+        """
+        if v is not None and v < 0:
+            raise ValueError(f"view_count must be >= 0, got {v}")
+        return v
+
+    @field_validator("like_count")
+    @classmethod
+    def validate_like_count(cls, v: int | None) -> int | None:
+        """
+        Validate that like_count is non-negative if provided.
+
+        Parameters
+        ----------
+        v : int | None
+            The like count to validate.
+
+        Returns
+        -------
+        int | None
+            The validated like count.
+
+        Raises
+        ------
+        ValueError
+            If like_count is negative.
+        """
+        if v is not None and v < 0:
+            raise ValueError(f"like_count must be >= 0, got {v}")
+        return v
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def recovery_source(self) -> str:
+        """
+        Recovery source identifier combining source type and timestamp.
+
+        Returns
+        -------
+        str
+            String in the format ``wayback:{snapshot_timestamp}``.
+        """
+        return f"wayback:{self.snapshot_timestamp}"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def recovered_fields(self) -> list[str]:
+        """
+        List of field names that have non-None values.
+
+        Excludes ``tags`` if the list is empty (no tags recovered).
+        Always includes ``snapshot_timestamp`` since it is required.
+
+        Returns
+        -------
+        list[str]
+            List of field names with recovered (non-None) values.
+        """
+        _metadata_fields = [
+            "title",
+            "description",
+            "channel_name_hint",
+            "channel_id",
+            "view_count",
+            "like_count",
+            "upload_date",
+            "thumbnail_url",
+            "category_id",
+        ]
+        fields: list[str] = ["snapshot_timestamp"]
+        for field_name in _metadata_fields:
+            if getattr(self, field_name) is not None:
+                fields.append(field_name)
+        if self.tags:
+            fields.append("tags")
+        return fields
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def has_data(self) -> bool:
+        """
+        Check if at least one metadata field has been recovered.
+
+        Metadata fields are all optional fields except ``snapshot_timestamp``
+        and ``tags`` (when empty).
+
+        Returns
+        -------
+        bool
+            True if at least one metadata field is non-None.
+        """
+        _metadata_fields = [
+            "title",
+            "description",
+            "channel_name_hint",
+            "channel_id",
+            "view_count",
+            "like_count",
+            "upload_date",
+            "thumbnail_url",
+            "category_id",
+        ]
+        return any(getattr(self, f) is not None for f in _metadata_fields)
+
+
+class RecoveryResult(BaseModel):
+    """
+    Outcome of a single video recovery attempt.
+
+    Captures the full context of a recovery operation, including whether it
+    succeeded, which fields were recovered, which snapshot was used, and
+    any failure reason.
+
+    Attributes
+    ----------
+    video_id : VideoId
+        YouTube video ID (11 characters, alphanumeric with hyphens/underscores).
+    success : bool
+        Whether the recovery attempt succeeded.
+    snapshot_used : str | None
+        CDX timestamp of the snapshot used for recovery.
+    fields_recovered : list[str]
+        Names of fields successfully recovered.
+    fields_skipped : list[str]
+        Names of fields that were skipped during recovery.
+    snapshots_available : int
+        Total number of CDX snapshots found.
+    snapshots_tried : int
+        Number of snapshots attempted before success or exhaustion.
+    failure_reason : str | None
+        Reason for failure, if ``success`` is False.
+    duration_seconds : float
+        Wall-clock time for the recovery operation.
+    channel_recovery_candidates : list[str]
+        Channel IDs discovered during recovery that may need their own recovery.
+    """
+
+    video_id: VideoId
+    success: bool
+    snapshot_used: str | None = None
+    fields_recovered: list[str] = Field(default_factory=list)
+    fields_skipped: list[str] = Field(default_factory=list)
+    snapshots_available: int = 0
+    snapshots_tried: int = 0
+    failure_reason: str | None = None
+    duration_seconds: float = 0.0
+    channel_recovery_candidates: list[str] = Field(default_factory=list)
+
+
+class CdxCacheEntry(BaseModel):
+    """
+    File-based cache entry for CDX API responses.
+
+    Stores the result of a CDX API query along with metadata for
+    cache invalidation. The ``is_valid`` method checks whether the
+    cache entry is still fresh based on a configurable TTL.
+
+    Attributes
+    ----------
+    video_id : str
+        YouTube video ID (plain string, not validated as VideoId).
+    fetched_at : datetime.datetime
+        Timestamp when the CDX response was fetched. Must be timezone-aware (UTC).
+    snapshots : list[CdxSnapshot]
+        Filtered CDX snapshots from the API response.
+    raw_count : int
+        Total number of CDX entries before filtering.
+    """
+
+    video_id: str
+    fetched_at: _dt.datetime
+    snapshots: list[CdxSnapshot]
+    raw_count: int
+
+    @field_validator("fetched_at")
+    @classmethod
+    def validate_fetched_at(cls, v: _dt.datetime) -> _dt.datetime:
+        """
+        Validate that fetched_at is timezone-aware.
+
+        Parameters
+        ----------
+        v : datetime.datetime
+            The datetime to validate.
+
+        Returns
+        -------
+        datetime.datetime
+            The validated timezone-aware datetime.
+
+        Raises
+        ------
+        ValueError
+            If fetched_at is a naive (timezone-unaware) datetime.
+        """
+        if v.tzinfo is None:
+            raise ValueError(
+                "fetched_at must be timezone-aware (has tzinfo), "
+                "got naive datetime"
+            )
+        return v
+
+    def is_valid(self, ttl_hours: int = 24) -> bool:
+        """
+        Check whether this cache entry is still valid.
+
+        Parameters
+        ----------
+        ttl_hours : int, optional
+            Time-to-live in hours (default is 24).
+
+        Returns
+        -------
+        bool
+            True if the cache entry age is less than ``ttl_hours``.
+        """
+        now = _dt.datetime.now(_dt.timezone.utc)
+        age = now - self.fetched_at
+        return age < _dt.timedelta(hours=ttl_hours)

--- a/src/chronovista/services/recovery/orchestrator.py
+++ b/src/chronovista/services/recovery/orchestrator.py
@@ -1,0 +1,445 @@
+"""
+Recovery orchestrator for deleted YouTube videos.
+
+Coordinates CDX API queries, page parsing, database updates, and tag persistence
+to recover metadata for unavailable YouTube videos using Wayback Machine snapshots.
+
+Functions
+---------
+recover_video
+    Main orchestration function for recovering a single video's metadata.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.exceptions import CDXError
+from chronovista.models.channel import ChannelCreate
+from chronovista.models.enums import AvailabilityStatus
+from chronovista.models.video import VideoUpdate
+from chronovista.repositories.channel_repository import ChannelRepository
+from chronovista.repositories.video_repository import VideoRepository
+from chronovista.repositories.video_tag_repository import VideoTagRepository
+from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
+from chronovista.services.recovery.models import RecoveredVideoData, RecoveryResult
+from chronovista.services.recovery.page_parser import PageParser
+
+logger = logging.getLogger(__name__)
+
+# Recovery configuration constants
+_MAX_SNAPSHOTS_TO_TRY = 20
+_RECOVERY_TIMEOUT_SECONDS = 600.0
+
+# Immutable fields that are only filled when NULL (never overwrite existing values)
+_IMMUTABLE_FIELDS = frozenset(["channel_id", "category_id"])
+
+# Mutable fields that can be overwritten if snapshot is newer than existing recovery_source
+_MUTABLE_FIELDS = frozenset(
+    ["title", "description", "upload_date", "view_count", "like_count", "channel_name_hint", "thumbnail_url"]
+)
+
+
+async def recover_video(
+    session: AsyncSession,
+    video_id: str,
+    cdx_client: CDXClient,
+    page_parser: PageParser,
+    rate_limiter: RateLimiter,
+    dry_run: bool = False,
+    from_year: int | None = None,
+    to_year: int | None = None,
+) -> RecoveryResult:
+    """
+    Recover metadata for a deleted YouTube video using Wayback Machine snapshots.
+
+    This function coordinates the full recovery process:
+    1. Fetch video from database and check eligibility (availability_status != AVAILABLE)
+    2. Query CDX API for archived snapshots
+    3. Iterate snapshots newest-first (max 20, 600s timeout)
+    4. Extract metadata via PageParser
+    5. Apply three-tier overwrite policy (immutable, mutable, NULL protection)
+    6. Update database and persist recovered tags
+    7. Return RecoveryResult with success/failure status
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session for querying and updating video records.
+    video_id : str
+        YouTube video ID to recover (e.g., "dQw4w9WgXcQ").
+    cdx_client : CDXClient
+        CDX API client for fetching Wayback Machine snapshots.
+    page_parser : PageParser
+        Page parser for extracting metadata from archived pages.
+    rate_limiter : RateLimiter
+        Rate limiter for throttling page fetch requests.
+    dry_run : bool, optional
+        If True, skips page fetching and DB writes but queries CDX (default: False).
+    from_year : int | None, optional
+        Only search Wayback snapshots from this year onward (default: None).
+    to_year : int | None, optional
+        Only search Wayback snapshots up to this year (default: None).
+
+    Returns
+    -------
+    RecoveryResult
+        Result object containing success status, fields recovered/skipped,
+        snapshot information, failure reason (if applicable), and duration.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
+    >>> from chronovista.services.recovery.page_parser import PageParser
+    >>> cdx_client = CDXClient(cache_dir=Path("/tmp/cdx_cache"))
+    >>> rate_limiter = RateLimiter(rate=40.0)
+    >>> page_parser = PageParser(rate_limiter=rate_limiter)
+    >>> result = await recover_video(
+    ...     session=session,
+    ...     video_id="dQw4w9WgXcQ",
+    ...     cdx_client=cdx_client,
+    ...     page_parser=page_parser,
+    ...     rate_limiter=rate_limiter,
+    ...     dry_run=False,
+    ... )
+    >>> if result.success:
+    ...     print(f"Recovered {len(result.fields_recovered)} fields")
+    """
+    start_time = datetime.now(timezone.utc)
+
+    # Initialize repositories
+    video_repo = VideoRepository()
+    tag_repo = VideoTagRepository()
+    channel_repo = ChannelRepository()
+
+    try:
+        # Fetch video from database
+        video = await video_repo.get_by_video_id(session, video_id)
+
+        # Check eligibility: video must exist
+        if video is None:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return RecoveryResult(
+                video_id=video_id,
+                success=False,
+                failure_reason="video_not_found",
+                duration_seconds=duration,
+            )
+
+        # Check eligibility: video must not be AVAILABLE
+        if video.availability_status == AvailabilityStatus.AVAILABLE.value:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return RecoveryResult(
+                video_id=video_id,
+                success=False,
+                failure_reason="video_available",
+                duration_seconds=duration,
+            )
+
+        # Query CDX API for snapshots
+        try:
+            snapshots = await asyncio.wait_for(
+                cdx_client.fetch_snapshots(
+                    video_id, from_year=from_year, to_year=to_year
+                ),
+                timeout=_RECOVERY_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return RecoveryResult(
+                video_id=video_id,
+                success=False,
+                failure_reason="cdx_query_timeout",
+                duration_seconds=duration,
+            )
+        except CDXError as e:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            logger.warning("CDX error for video %s: %s", video_id, e.message)
+            return RecoveryResult(
+                video_id=video_id,
+                success=False,
+                failure_reason="cdx_connection_error",
+                duration_seconds=duration,
+            )
+
+        snapshots_available = len(snapshots)
+
+        # No snapshots available
+        if snapshots_available == 0:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return RecoveryResult(
+                video_id=video_id,
+                success=False,
+                failure_reason="no_snapshots_found",
+                snapshots_available=0,
+                snapshots_tried=0,
+                duration_seconds=duration,
+            )
+
+        # Iterate snapshots newest-first (already sorted by CDXClient)
+        snapshots_tried = 0
+        recovered_data: RecoveredVideoData | None = None
+
+        for snapshot in snapshots[: _MAX_SNAPSHOTS_TO_TRY]:
+            snapshots_tried += 1
+
+            # Skip page fetching in dry-run mode
+            if dry_run:
+                recovered_data = RecoveredVideoData(
+                    snapshot_timestamp=snapshot.timestamp
+                )
+                break
+
+            # Extract metadata from snapshot
+            try:
+                extracted_data = await page_parser.extract_metadata(snapshot)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Timeout extracting metadata from snapshot %s for video %s",
+                    snapshot.timestamp,
+                    video_id,
+                )
+                continue
+            except Exception as e:
+                logger.warning(
+                    "Error extracting metadata from snapshot %s for video %s: %s",
+                    snapshot.timestamp,
+                    video_id,
+                    e,
+                )
+                continue
+
+            # Check if we got usable data
+            if extracted_data is None or not extracted_data.has_data:
+                # Removal notice or no data - try next snapshot
+                continue
+
+            # Found usable data - stop iteration
+            recovered_data = extracted_data
+            break
+
+        # No usable data found after trying all snapshots
+        if recovered_data is None or (not dry_run and not recovered_data.has_data):
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return RecoveryResult(
+                video_id=video_id,
+                success=False,
+                failure_reason="all_snapshots_failed",
+                snapshots_available=snapshots_available,
+                snapshots_tried=snapshots_tried,
+                duration_seconds=duration,
+            )
+
+        # Build update dictionary with overwrite policy
+        update_dict, fields_recovered, fields_skipped = _build_video_update(
+            video, recovered_data
+        )
+
+        # Add recovery metadata (always set on success)
+        update_dict["recovered_at"] = datetime.now(timezone.utc)
+        update_dict["recovery_source"] = recovered_data.recovery_source
+
+        # Skip database write in dry-run mode
+        if not dry_run:
+            # Ensure channel exists before setting channel_id (FK constraint)
+            if "channel_id" in update_dict:
+                channel_exists = await channel_repo.exists(
+                    session, update_dict["channel_id"]
+                )
+                if not channel_exists:
+                    stub_title = (
+                        recovered_data.channel_name_hint
+                        or update_dict["channel_id"]
+                    )
+                    try:
+                        stub_channel = ChannelCreate(
+                            channel_id=update_dict["channel_id"],
+                            title=stub_title,
+                            availability_status=AvailabilityStatus.UNAVAILABLE,
+                        )
+                        await channel_repo.create(session, obj_in=stub_channel)
+                        logger.info(
+                            "Created stub channel %s (%s) for video %s",
+                            update_dict["channel_id"],
+                            stub_title,
+                            video_id,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to create stub channel %s for video %s: %s",
+                            update_dict["channel_id"],
+                            video_id,
+                            e,
+                        )
+                        # Remove channel_id from update to avoid FK violation
+                        del update_dict["channel_id"]
+                        if "channel_id" in fields_recovered:
+                            fields_recovered.remove("channel_id")
+                            fields_skipped.append("channel_id")
+
+            # Update video in database
+            video_update = VideoUpdate(**update_dict)
+            await video_repo.update(session, db_obj=video, obj_in=video_update)
+
+            # Persist tags if any were recovered
+            if recovered_data.tags:
+                try:
+                    await tag_repo.bulk_create_video_tags(
+                        session=session,
+                        video_id=video_id,
+                        tags=recovered_data.tags,
+                        tag_orders=None,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to persist tags for video %s: %s", video_id, e
+                    )
+                    # Tag errors do not fail recovery
+
+            # Commit changes
+            await session.commit()
+
+        # Identify channel recovery candidates
+        channel_recovery_candidates: list[str] = []
+        if recovered_data.channel_id:
+            # Check if this channel exists and is unavailable
+            channel = await channel_repo.get(session, recovered_data.channel_id)
+            if channel is not None and channel.availability_status != AvailabilityStatus.AVAILABLE.value:
+                channel_recovery_candidates.append(recovered_data.channel_id)
+
+        # Build success result
+        duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+        return RecoveryResult(
+            video_id=video_id,
+            success=True,
+            snapshot_used=recovered_data.snapshot_timestamp,
+            fields_recovered=fields_recovered,
+            fields_skipped=fields_skipped,
+            snapshots_available=snapshots_available,
+            snapshots_tried=snapshots_tried,
+            duration_seconds=duration,
+            channel_recovery_candidates=channel_recovery_candidates,
+        )
+
+    except Exception as e:
+        # Unexpected error during recovery
+        duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+        logger.error("Unexpected error recovering video %s: %s", video_id, e)
+        return RecoveryResult(
+            video_id=video_id,
+            success=False,
+            failure_reason="unexpected_error",
+            duration_seconds=duration,
+        )
+
+
+def _build_video_update(
+    existing_video: Any, recovered_data: RecoveredVideoData
+) -> tuple[dict[str, Any], list[str], list[str]]:
+    """
+    Build video update dictionary with three-tier overwrite policy.
+
+    Applies the following policy:
+    1. **Immutable fields** (upload_date, channel_id, category_id):
+       Fill-if-NULL only. Never overwrite existing values.
+    2. **Mutable fields** (title, description, view_count, like_count, channel_name_hint):
+       - Fill-if-NULL always
+       - Overwrite existing values only if incoming snapshot is newer than
+         existing recovery_source
+    3. **NULL protection**: Never blank existing values with None/NULL from
+       recovered data.
+
+    Parameters
+    ----------
+    existing_video : Any
+        SQLAlchemy Video model instance from database.
+    recovered_data : RecoveredVideoData
+        Metadata extracted from Wayback Machine snapshot.
+
+    Returns
+    -------
+    tuple[dict[str, Any], list[str], list[str]]
+        A 3-tuple containing:
+        - update_dict: Dictionary of field updates to apply
+        - fields_recovered: List of field names successfully recovered
+        - fields_skipped: List of field names that were skipped
+    """
+    update_dict: dict[str, Any] = {}
+    fields_recovered: list[str] = []
+    fields_skipped: list[str] = []
+
+    # Extract existing recovery_source timestamp (if any)
+    existing_recovery_timestamp: str | None = None
+    if existing_video.recovery_source:
+        # Format: "wayback:20220106075526"
+        parts = existing_video.recovery_source.split(":")
+        if len(parts) == 2 and parts[0] == "wayback":
+            existing_recovery_timestamp = parts[1]
+
+    # Determine if incoming snapshot is newer than existing recovery
+    incoming_is_newer = False
+    if existing_recovery_timestamp is None:
+        # No existing recovery - incoming is considered "newer"
+        incoming_is_newer = True
+    elif recovered_data.snapshot_timestamp >= existing_recovery_timestamp:
+        # Incoming snapshot has same or later timestamp
+        incoming_is_newer = True
+
+    # Map RecoveredVideoData fields to Video model fields
+    field_mapping = {
+        "title": "title",
+        "description": "description",
+        "channel_id": "channel_id",
+        "channel_name_hint": "channel_name_hint",
+        "view_count": "view_count",
+        "like_count": "like_count",
+        "upload_date": "upload_date",
+        "thumbnail_url": "thumbnail_url",
+        "category_id": "category_id",
+    }
+
+    for recovered_field, db_field in field_mapping.items():
+        recovered_value = getattr(recovered_data, recovered_field, None)
+        existing_value = getattr(existing_video, db_field, None)
+
+        # NULL protection: never blank existing values
+        if recovered_value is None:
+            if existing_value is not None:
+                # Skip: incoming is NULL, existing has value
+                fields_skipped.append(db_field)
+            # If both are NULL, do nothing (not recovered, not skipped)
+            continue
+
+        # Immutable fields: fill-if-NULL only
+        if db_field in _IMMUTABLE_FIELDS:
+            if existing_value is None:
+                # Fill NULL immutable field
+                update_dict[db_field] = recovered_value
+                fields_recovered.append(db_field)
+            else:
+                # Skip: immutable field already has value
+                fields_skipped.append(db_field)
+            continue
+
+        # Mutable fields: fill-if-NULL always, overwrite if newer
+        if db_field in _MUTABLE_FIELDS:
+            if existing_value is None:
+                # Fill NULL mutable field
+                update_dict[db_field] = recovered_value
+                fields_recovered.append(db_field)
+            elif incoming_is_newer:
+                # Overwrite existing value with newer snapshot data
+                update_dict[db_field] = recovered_value
+                fields_recovered.append(db_field)
+            else:
+                # Skip: existing value is from newer or same snapshot
+                fields_skipped.append(db_field)
+            continue
+
+    return update_dict, fields_recovered, fields_skipped

--- a/src/chronovista/services/recovery/page_parser.py
+++ b/src/chronovista/services/recovery/page_parser.py
@@ -1,0 +1,694 @@
+"""
+Page parser for extracting video metadata from archived YouTube pages.
+
+Extracts metadata from Wayback Machine snapshots of YouTube video pages
+using three strategies in priority order:
+
+1. JSON extraction from ``ytInitialPlayerResponse`` embedded in page source
+2. HTML meta tag extraction using BeautifulSoup (Open Graph + itemprop)
+3. Optional Selenium fallback for pre-2017 pages requiring JS rendering
+
+Functions
+---------
+is_removal_notice
+    Detect whether an archived page is a removal/unavailable notice.
+
+Classes
+-------
+PageParser
+    Main coordinator for fetching and parsing archived YouTube pages.
+
+Constants
+---------
+YOUTUBE_CATEGORY_MAP
+    Mapping from YouTube category display names to numeric ID strings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from datetime import datetime, timezone
+
+import httpx
+from bs4 import BeautifulSoup
+
+from chronovista import __version__
+from chronovista.services.recovery import SELENIUM_AVAILABLE
+from chronovista.services.recovery.cdx_client import RateLimiter
+from chronovista.services.recovery.models import CdxSnapshot, RecoveredVideoData
+
+logger = logging.getLogger(__name__)
+
+YOUTUBE_CATEGORY_MAP: dict[str, str] = {
+    "Film & Animation": "1",
+    "Autos & Vehicles": "2",
+    "Music": "10",
+    "Pets & Animals": "15",
+    "Sports": "17",
+    "Short Movies": "18",
+    "Travel & Events": "19",
+    "Gaming": "20",
+    "Videoblogging": "21",
+    "People & Blogs": "22",
+    "Comedy": "23",
+    "Entertainment": "24",
+    "News & Politics": "25",
+    "Howto & Style": "26",
+    "Education": "27",
+    "Science & Technology": "28",
+    "Nonprofits & Activism": "29",
+}
+"""Mapping from YouTube category display names to numeric category ID strings."""
+
+# Regex to locate the START of ytInitialPlayerResponse/ytInitialData JSON.
+# Only matches the variable assignment prefix; JSON body is extracted via
+# brace-counting in _extract_json_object() to handle nested structures.
+# Handles: var ytInitialPlayerResponse = {...};
+#          ytInitialPlayerResponse = {...};
+#          window["ytInitialPlayerResponse"] = {...};
+_YT_INITIAL_PLAYER_RE = re.compile(
+    r'(?:var\s+|window\["|)ytInitialPlayerResponse(?:"\])?\s*=\s*',
+)
+_YT_INITIAL_DATA_RE = re.compile(
+    r'(?:var\s+|window\["|)ytInitialData(?:"\])?\s*=\s*',
+)
+
+# Regex for validating YouTube channel ID format.
+_CHANNEL_ID_RE = re.compile(r"^UC[A-Za-z0-9_-]{22}$")
+
+_REQUEST_TIMEOUT_SECONDS = 30.0
+_MAX_FETCH_RETRIES = 3
+_RETRY_BACKOFF_SECONDS = [2.0, 5.0, 10.0]
+
+# Playability status values indicating removal/unavailability.
+_REMOVAL_PLAYABILITY_STATUSES: dict[str, str] = {
+    "ERROR": "playability_status_error",
+    "UNPLAYABLE": "playability_status_unplayable",
+    "LOGIN_REQUIRED": "playability_status_login_required",
+}
+
+# Text patterns (case-insensitive) indicating a removal notice.
+_REMOVAL_TEXT_PATTERNS: list[tuple[str, str]] = [
+    ("video unavailable", "text_video_unavailable"),
+    ("removed by the uploader", "text_removed_by_uploader"),
+    ("this video is private", "text_private"),
+    ("copyright claim", "text_copyright"),
+    ("violating youtube", "text_tos_violation"),
+    ("terms of service", "text_tos_violation"),
+    ("account associated with this video has been terminated", "text_account_terminated"),
+]
+
+
+def _extract_json_object(html: str, start: int) -> str | None:
+    """
+    Extract a balanced JSON object from HTML starting at the given position.
+
+    Uses brace-counting to handle arbitrarily nested ``{...}`` structures
+    that would break a simple non-greedy regex.
+
+    Parameters
+    ----------
+    html : str
+        Raw HTML source.
+    start : int
+        Position of the opening ``{`` in the HTML string.
+
+    Returns
+    -------
+    str | None
+        The balanced JSON string, or None if no opening brace at start
+        or braces are unbalanced within the first 5MB of text.
+    """
+    if start >= len(html) or html[start] != "{":
+        return None
+
+    depth = 0
+    in_string = False
+    escape = False
+    limit = min(len(html), start + 5_000_000)
+
+    for i in range(start, limit):
+        ch = html[i]
+
+        if escape:
+            escape = False
+            continue
+
+        if ch == "\\":
+            if in_string:
+                escape = True
+            continue
+
+        if ch == '"':
+            in_string = not in_string
+            continue
+
+        if in_string:
+            continue
+
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return html[start : i + 1]
+
+    return None
+
+
+def is_removal_notice(html: str) -> tuple[bool, str | None]:
+    """
+    Detect whether an archived YouTube page is a removal/unavailable notice.
+
+    Applies several heuristics in a specific priority order to determine
+    if the page represents a removed, private, or otherwise unavailable
+    video rather than a page with recoverable metadata.
+
+    Detection order:
+
+    1. **Positive signal override**: If an ``og:video:url`` meta tag is
+       present, the page is assumed to contain valid video data regardless
+       of other removal signals.
+    2. **Title checks**: Pages with only ``<title>YouTube</title>`` or
+       ``<title> - YouTube</title>`` are generic removal stubs.
+    3. **JSON playabilityStatus**: Checks the ``ytInitialPlayerResponse``
+       JSON for ``playabilityStatus.status`` values indicating removal.
+    4. **Body text patterns**: Case-insensitive search for known removal
+       phrases in the HTML body.
+
+    Parameters
+    ----------
+    html : str
+        Raw HTML content of the archived YouTube page.
+
+    Returns
+    -------
+    tuple[bool, str | None]
+        A 2-tuple where the first element is ``True`` if the page is a
+        removal notice and ``False`` otherwise. The second element is a
+        reason string identifier (e.g., ``"title_only_youtube"``,
+        ``"playability_status_error"``) when removed, or ``None`` when not.
+    """
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+
+        # (a) Positive signal override: og:video:url meta tag present
+        og_video_url = soup.find("meta", attrs={"property": "og:video:url"})
+        if og_video_url is not None:
+            return (False, None)
+
+        # (b) Title checks
+        title_tag = soup.find("title")
+        if title_tag is not None:
+            title_text = title_tag.get_text(strip=True)
+            if title_text == "YouTube":
+                return (True, "title_only_youtube")
+            if title_text == "- YouTube":
+                return (True, "title_dash_youtube")
+
+        # (c) JSON playabilityStatus checks
+        match = _YT_INITIAL_PLAYER_RE.search(html)
+        if match:
+            try:
+                json_str = _extract_json_object(html, match.end())
+                if json_str:
+                    data = json.loads(json_str)
+                    playability = data.get("playabilityStatus", {})
+                    status = playability.get("status", "")
+                    if status in _REMOVAL_PLAYABILITY_STATUSES:
+                        return (True, _REMOVAL_PLAYABILITY_STATUSES[status])
+            except (json.JSONDecodeError, ValueError, TypeError):
+                pass
+
+        # (d) Text pattern checks (case-insensitive)
+        html_lower = html.lower()
+        for pattern, reason in _REMOVAL_TEXT_PATTERNS:
+            if pattern in html_lower:
+                return (True, reason)
+
+        return (False, None)
+
+    except Exception:
+        # Never raise — always return the tuple
+        return (False, None)
+
+
+class PageParser:
+    """
+    Main coordinator for fetching and parsing archived YouTube pages.
+
+    Fetches a Wayback Machine snapshot via HTTP, checks for removal notices,
+    then attempts to extract video metadata using JSON extraction first,
+    falling back to HTML meta tag extraction, and optionally to Selenium
+    rendering for pre-2017 pages.
+
+    Parameters
+    ----------
+    rate_limiter : RateLimiter
+        Rate limiter instance to throttle outgoing HTTP requests.
+
+    Examples
+    --------
+    >>> from chronovista.services.recovery.cdx_client import RateLimiter
+    >>> limiter = RateLimiter(rate=40.0)
+    >>> parser = PageParser(rate_limiter=limiter)
+    >>> result = await parser.extract_metadata(snapshot)
+    """
+
+    def __init__(self, rate_limiter: RateLimiter) -> None:
+        """
+        Initialize the PageParser.
+
+        Parameters
+        ----------
+        rate_limiter : RateLimiter
+            Rate limiter instance to throttle HTTP requests to the
+            Wayback Machine.
+        """
+        self._rate_limiter = rate_limiter
+
+    async def extract_metadata(
+        self, snapshot: CdxSnapshot
+    ) -> RecoveredVideoData | None:
+        """
+        Extract video metadata from a Wayback Machine snapshot.
+
+        Fetches the snapshot URL, checks for removal notices, and attempts
+        metadata extraction via JSON, meta tags, and optionally Selenium.
+
+        Parameters
+        ----------
+        snapshot : CdxSnapshot
+            The CDX snapshot to fetch and parse.
+
+        Returns
+        -------
+        RecoveredVideoData | None
+            Extracted metadata, or a minimal ``RecoveredVideoData`` with
+            ``has_data=False`` if no metadata could be recovered.
+        """
+        # Fetch the snapshot page with retry for transient failures
+        html: str | None = None
+        for attempt in range(_MAX_FETCH_RETRIES):
+            await self._rate_limiter.acquire()
+            try:
+                async with httpx.AsyncClient(
+                    follow_redirects=True,
+                ) as client:
+                    response = await client.get(
+                        snapshot.wayback_url,
+                        timeout=_REQUEST_TIMEOUT_SECONDS,
+                        headers={"User-Agent": f"chronovista/{__version__}"},
+                    )
+                html = response.text
+                break
+            except (httpx.ConnectTimeout, httpx.ReadTimeout, httpx.ConnectError) as e:
+                backoff = _RETRY_BACKOFF_SECONDS[attempt]
+                logger.warning(
+                    "Fetch attempt %d/%d for snapshot %s failed (%s), "
+                    "retrying in %.0fs",
+                    attempt + 1,
+                    _MAX_FETCH_RETRIES,
+                    snapshot.timestamp,
+                    type(e).__name__,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+            except Exception as e:
+                logger.warning(
+                    "Failed to fetch snapshot %s: %s: %s",
+                    snapshot.timestamp,
+                    type(e).__name__,
+                    e,
+                )
+                return RecoveredVideoData(snapshot_timestamp=snapshot.timestamp)
+
+        if html is None:
+            logger.warning(
+                "Failed to fetch snapshot %s after %d retries",
+                snapshot.timestamp,
+                _MAX_FETCH_RETRIES,
+            )
+            return RecoveredVideoData(snapshot_timestamp=snapshot.timestamp)
+
+        # Check for removal notice
+        is_removed, reason = is_removal_notice(html)
+        if is_removed:
+            logger.info(
+                "Snapshot %s is a removal notice: %s",
+                snapshot.timestamp,
+                reason,
+            )
+            return RecoveredVideoData(snapshot_timestamp=snapshot.timestamp)
+
+        # Try JSON extraction first
+        result = self._extract_from_json(html, snapshot.timestamp)
+        if result is not None:
+            return result
+
+        # Fall back to meta tag extraction
+        result = self._extract_from_meta_tags(html, snapshot.timestamp)
+        if result is not None:
+            return result
+
+        # If neither found data and Selenium is available, try Selenium
+        if SELENIUM_AVAILABLE:
+            try:
+                selenium_result = await self._extract_with_selenium(
+                    snapshot
+                )
+                if selenium_result is not None:
+                    return selenium_result
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Selenium timeout for snapshot %s",
+                    snapshot.timestamp,
+                )
+                return RecoveredVideoData(
+                    snapshot_timestamp=snapshot.timestamp
+                )
+
+        # No data could be recovered
+        return RecoveredVideoData(snapshot_timestamp=snapshot.timestamp)
+
+    def _extract_from_json(
+        self, html: str, snapshot_timestamp: str
+    ) -> RecoveredVideoData | None:
+        """
+        Extract metadata from ytInitialPlayerResponse JSON in page source.
+
+        Searches the HTML for the ``ytInitialPlayerResponse`` JavaScript
+        variable, parses the JSON, and extracts fields from ``videoDetails``
+        and ``microformat.playerMicroformatRenderer``.
+
+        Parameters
+        ----------
+        html : str
+            Raw HTML content of the archived YouTube page.
+        snapshot_timestamp : str
+            CDX timestamp of the snapshot (14 digits).
+
+        Returns
+        -------
+        RecoveredVideoData | None
+            Extracted metadata if JSON was found and contained video details,
+            or ``None`` if JSON was not found or was malformed.
+        """
+        match = _YT_INITIAL_PLAYER_RE.search(html)
+        if not match:
+            return None
+
+        json_str = _extract_json_object(html, match.end())
+        if not json_str:
+            return None
+
+        try:
+            data = json.loads(json_str)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning(
+                "Malformed ytInitialPlayerResponse JSON in snapshot %s",
+                snapshot_timestamp,
+            )
+            return None
+
+        video_details = data.get("videoDetails")
+        if not video_details:
+            return None
+
+        # Extract fields from videoDetails
+        title = video_details.get("title")
+        description = video_details.get("shortDescription")
+        channel_name_hint = video_details.get("author")
+        channel_id = video_details.get("channelId")
+        # Validate channel_id format; set to None if invalid
+        if channel_id and not _CHANNEL_ID_RE.match(channel_id):
+            channel_id = None
+        tags = video_details.get("keywords", [])
+
+        # Parse view count (string to int)
+        view_count: int | None = None
+        view_count_str = video_details.get("viewCount")
+        if view_count_str is not None:
+            try:
+                view_count = int(view_count_str)
+            except (ValueError, TypeError):
+                pass
+
+        # Extract from microformat
+        upload_date: datetime | None = None
+        category_id: str | None = None
+        thumbnail_url: str | None = None
+        microformat = data.get("microformat", {})
+        renderer = microformat.get("playerMicroformatRenderer", {})
+
+        publish_date_str = renderer.get("publishDate")
+        if publish_date_str:
+            try:
+                upload_date = datetime.strptime(
+                    publish_date_str, "%Y-%m-%d"
+                ).replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                pass
+
+        category_name = renderer.get("category")
+        if category_name:
+            category_id = YOUTUBE_CATEGORY_MAP.get(category_name)
+
+        # Extract thumbnail from microformat or videoDetails
+        thumbnail_data = renderer.get("thumbnail", {}).get("thumbnails", [])
+        if thumbnail_data:
+            thumbnail_url = thumbnail_data[-1].get("url")
+
+        # Extract like count from ytInitialData (separate JSON blob)
+        like_count = self._extract_like_count(html)
+
+        return RecoveredVideoData(
+            title=title,
+            description=description,
+            channel_name_hint=channel_name_hint,
+            channel_id=channel_id,
+            view_count=view_count,
+            like_count=like_count,
+            upload_date=upload_date,
+            tags=tags,
+            category_id=category_id,
+            thumbnail_url=thumbnail_url,
+            snapshot_timestamp=snapshot_timestamp,
+        )
+
+    def _extract_from_meta_tags(
+        self, html: str, snapshot_timestamp: str
+    ) -> RecoveredVideoData | None:
+        """
+        Extract metadata from HTML meta tags using BeautifulSoup.
+
+        Parses Open Graph (``og:``) meta tags and ``itemprop`` attributes
+        to recover video metadata from pre-2017 archived pages that lack
+        the ``ytInitialPlayerResponse`` JSON.
+
+        Parameters
+        ----------
+        html : str
+            Raw HTML content of the archived YouTube page.
+        snapshot_timestamp : str
+            CDX timestamp of the snapshot (14 digits).
+
+        Returns
+        -------
+        RecoveredVideoData | None
+            Extracted metadata if any usable tags were found, or ``None``
+            if no meaningful metadata could be extracted.
+        """
+        soup = BeautifulSoup(html, "html.parser")
+
+        # Extract og:title
+        title: str | None = None
+        og_title = soup.find("meta", attrs={"property": "og:title"})
+        if og_title and og_title.get("content"):
+            title = str(og_title["content"])
+
+        # Extract og:description
+        description: str | None = None
+        og_desc = soup.find("meta", attrs={"property": "og:description"})
+        if og_desc and og_desc.get("content"):
+            description = str(og_desc["content"])
+
+        # Extract og:image -> thumbnail_url
+        thumbnail_url: str | None = None
+        og_image = soup.find("meta", attrs={"property": "og:image"})
+        if og_image and og_image.get("content"):
+            thumbnail_url = str(og_image["content"])
+
+        # Extract all og:video:tag -> tags list
+        tags: list[str] = []
+        for tag_meta in soup.find_all(
+            "meta", attrs={"property": "og:video:tag"}
+        ):
+            content = tag_meta.get("content")
+            if content:
+                tags.append(str(content))
+
+        # Extract itemprop="datePublished" -> upload_date
+        upload_date: datetime | None = None
+        date_meta = soup.find(attrs={"itemprop": "datePublished"})
+        if date_meta:
+            date_str = date_meta.get("content")
+            if date_str:
+                try:
+                    upload_date = datetime.strptime(
+                        str(date_str), "%Y-%m-%d"
+                    ).replace(tzinfo=timezone.utc)
+                except (ValueError, TypeError):
+                    pass
+
+        # Extract itemprop="interactionCount" -> view_count
+        view_count: int | None = None
+        interaction_meta = soup.find(attrs={"itemprop": "interactionCount"})
+        if interaction_meta:
+            count_str = interaction_meta.get("content")
+            if count_str:
+                try:
+                    view_count = int(str(count_str))
+                except (ValueError, TypeError):
+                    pass
+
+        # Extract itemprop="genre" -> category_id (via YOUTUBE_CATEGORY_MAP)
+        category_id: str | None = None
+        genre_meta = soup.find(attrs={"itemprop": "genre"})
+        if genre_meta:
+            genre_str = genre_meta.get("content")
+            if genre_str:
+                category_id = YOUTUBE_CATEGORY_MAP.get(str(genre_str))
+
+        # Extract channel ID: try itemprop="channelId" first, then link href pattern
+        channel_id: str | None = None
+        channel_id_meta = soup.find(attrs={"itemprop": "channelId"})
+        if channel_id_meta:
+            cid = channel_id_meta.get("content", "")
+            if cid and _CHANNEL_ID_RE.match(str(cid)):
+                channel_id = str(cid)
+        if channel_id is None:
+            for link in soup.find_all("link", attrs={"itemprop": "url"}):
+                href = link.get("href", "")
+                if href:
+                    channel_match = re.search(r"(UC[A-Za-z0-9_-]{22})", str(href))
+                    if channel_match:
+                        channel_id = channel_match.group(1)
+                        break
+
+        # Extract channel name from <link itemprop="url" href=".../user/Name">
+        channel_name_hint: str | None = None
+        for link in soup.find_all("link", attrs={"itemprop": "url"}):
+            href = str(link.get("href", ""))
+            user_match = re.search(r"/user/([^/?#]+)", href)
+            if user_match:
+                channel_name_hint = user_match.group(1)
+                break
+            # Also try /channel/ display name from og or other sources
+            c_match = re.search(r"/c/([^/?#]+)", href)
+            if c_match:
+                channel_name_hint = c_match.group(1)
+                break
+
+        # Check if any usable data was found
+        has_any = any([
+            title,
+            description,
+            thumbnail_url,
+            tags,
+            upload_date,
+            view_count is not None,
+            category_id,
+            channel_id,
+            channel_name_hint,
+        ])
+
+        if not has_any:
+            return None
+
+        return RecoveredVideoData(
+            title=title,
+            description=description,
+            thumbnail_url=thumbnail_url,
+            tags=tags,
+            upload_date=upload_date,
+            view_count=view_count,
+            category_id=category_id,
+            channel_id=channel_id,
+            channel_name_hint=channel_name_hint,
+            snapshot_timestamp=snapshot_timestamp,
+        )
+
+    def _extract_like_count(self, html: str) -> int | None:
+        """
+        Extract like count from ytInitialData JSON blob.
+
+        The like count is stored in the ``toggleButtonRenderer`` within
+        ``videoPrimaryInfoRenderer`` in ytInitialData, with a label like
+        ``"1,579 likes"``.
+
+        Parameters
+        ----------
+        html : str
+            Raw HTML content of the archived YouTube page.
+
+        Returns
+        -------
+        int | None
+            The like count as an integer, or None if not found.
+        """
+        match = _YT_INITIAL_DATA_RE.search(html)
+        if not match:
+            return None
+
+        json_str = _extract_json_object(html, match.end())
+        if not json_str:
+            return None
+
+        try:
+            data = json.loads(json_str)
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+        # Navigate the nested structure to find the like count label
+        # Path: contents.twoColumnWatchNextResults.results.results.contents[]
+        #   .videoPrimaryInfoRenderer.videoActions.menuRenderer.topLevelButtons[]
+        #   .toggleButtonRenderer.defaultText.accessibility.accessibilityData.label
+        try:
+            text = json.dumps(data)
+            # Search for the "N likes" pattern in accessibility labels
+            like_match = re.search(
+                r'"label"\s*:\s*"([\d,]+)\s+likes?"', text
+            )
+            if like_match:
+                count_str = like_match.group(1).replace(",", "")
+                return int(count_str)
+        except (ValueError, TypeError):
+            pass
+
+        return None
+
+    async def _extract_with_selenium(
+        self, snapshot: CdxSnapshot
+    ) -> RecoveredVideoData | None:
+        """
+        Extract metadata using Selenium WebDriver (placeholder).
+
+        This method serves as a placeholder for optional Selenium-based
+        extraction of pre-2017 archived pages that require JavaScript
+        rendering. The actual Selenium implementation is deferred.
+
+        Parameters
+        ----------
+        snapshot : CdxSnapshot
+            The CDX snapshot to render with Selenium.
+
+        Returns
+        -------
+        RecoveredVideoData | None
+            Always returns ``None`` in this placeholder implementation.
+        """
+        return None

--- a/tests/unit/cli/test_recover_commands.py
+++ b/tests/unit/cli/test_recover_commands.py
@@ -1,0 +1,1018 @@
+"""
+Tests for CLI recover commands (Feature 024 Phase 6).
+
+This module provides comprehensive unit tests for the `chronovista recover video`
+CLI command, covering argument parsing, single-video recovery, batch recovery,
+dry-run mode, summary reports, and dependency checks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from chronovista.cli.main import app
+from chronovista.models.enums import AvailabilityStatus
+from chronovista.services.recovery.models import RecoveryResult
+
+runner = CliRunner()
+
+
+def create_async_mock_recover(result: RecoveryResult):
+    """Create an async mock for recover_video that returns the given result."""
+    async def mock_recover_async(*args, **kwargs):
+        return result
+    return mock_recover_async
+
+
+def create_async_mock_session() -> tuple[AsyncGenerator[AsyncMock, None], AsyncMock]:
+    """Create an async context manager mock for db_manager.get_session."""
+    mock_session = AsyncMock()
+
+    async def mock_session_gen() -> AsyncGenerator[AsyncMock, None]:
+        yield mock_session
+
+    return mock_session_gen(), mock_session
+
+
+def create_mock_video_db(video_id: str, availability_status: AvailabilityStatus = AvailabilityStatus.DELETED):
+    """Create a mock Video DB object."""
+    mock_video = MagicMock()
+    mock_video.video_id = video_id
+    mock_video.availability_status = availability_status.value
+    mock_video.unavailability_first_detected = None
+    mock_video.created_at = datetime.now(timezone.utc)
+    return mock_video
+
+
+def setup_batch_query_mock(mock_session: AsyncMock, videos: list[Any]) -> None:
+    """Setup mock session to return videos from SQLAlchemy query."""
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = videos
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalars
+
+    # session.execute() is async, so it returns a coroutine
+    async def mock_execute(*args: Any, **kwargs: Any) -> MagicMock:
+        return mock_result
+
+    mock_session.execute.side_effect = mock_execute
+
+
+class TestRecoverArgumentParsing:
+    """T044: CLI argument parsing tests."""
+
+    def test_video_id_and_all_are_mutually_exclusive(self) -> None:
+        """Test that --video-id and --all cannot be used together."""
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--all"],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.stdout.lower() or "cannot" in result.stdout.lower()
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_limit_ignored_with_video_id(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that --limit is ignored when using --video-id."""
+        # This test verifies the command accepts both flags but limit is ignored
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title", "description"],
+                duration_seconds=1.5,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--limit", "50"],
+        )
+
+        # Should succeed - limit is simply ignored in this case
+        assert result.exit_code == 0
+
+    def test_delay_accepts_float(self) -> None:
+        """Test that --delay accepts float values >= 0.0."""
+        # Test valid float
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all", "--limit", "1", "--delay", "1.5", "--dry-run"],
+        )
+
+        # Should not fail on argument parsing (may fail on other things)
+        assert "invalid" not in result.stdout.lower()
+
+    def test_delay_minimum_zero(self) -> None:
+        """Test that --delay must be >= 0.0."""
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all", "--delay", "-1.0"],
+        )
+
+        assert result.exit_code != 0
+
+    def test_dry_run_flag(self) -> None:
+        """Test that --dry-run flag is accepted."""
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--dry-run"],
+        )
+
+        # Should accept the flag (may fail on missing dependencies or other issues)
+        # We're just testing argument parsing here
+        assert "--dry-run" in result.stdout or result.exit_code in [0, 1]
+
+    def test_missing_both_video_id_and_all_shows_error(self) -> None:
+        """Test that missing both --video-id and --all shows an error."""
+        result = runner.invoke(
+            app,
+            ["recover", "video"],
+        )
+
+        # Should show help or error message
+        assert result.exit_code != 0 or "help" in result.stdout.lower()
+
+
+class TestSingleVideoRecovery:
+    """T045: Single-video recovery command tests."""
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_invokes_orchestrator_with_correct_video_id(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that single-video recovery invokes orchestrator correctly."""
+        # Setup mocks
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title", "description"],
+                duration_seconds=1.5,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ"],
+        )
+
+        assert result.exit_code == 0
+        mock_recover.assert_called_once()
+        # Verify video_id was passed
+        call_args = mock_recover.call_args
+        assert call_args[1]["video_id"] == "dQw4w9WgXcQ"
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_displays_rich_progress_and_result_table(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that single-video recovery displays progress and results."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title", "description"],
+                snapshots_available=10,
+                snapshots_tried=3,
+                duration_seconds=1.5,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ"],
+        )
+
+        assert result.exit_code == 0
+        # Check for result information in output
+        assert "dQw4w9WgXcQ" in result.stdout
+        assert "Success" in result.stdout or "✓" in result.stdout
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    @patch("chronovista.cli.commands.recover.CDXClient")
+    @patch("chronovista.cli.commands.recover.PageParser")
+    @patch("chronovista.cli.commands.recover.RateLimiter")
+    def test_exit_code_0_on_success(
+        self,
+        mock_rate_limiter: MagicMock,
+        mock_page_parser: MagicMock,
+        mock_cdx_client: MagicMock,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that successful recovery returns exit code 0."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ"],
+        )
+
+        assert result.exit_code == 0
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_exit_code_1_on_failure(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that failed recovery returns exit code 1."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=False,
+                failure_reason="no_snapshots_found",
+                duration_seconds=0.5,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ"],
+        )
+
+        assert result.exit_code == 1
+
+
+class TestBatchRecovery:
+    """T046: Batch recovery command tests."""
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_queries_unavailable_videos_ordered_correctly(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that batch mode queries unavailable videos with correct ordering."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        # Create mock video
+        mock_video = create_mock_video_db("dQw4w9WgXcQ", AvailabilityStatus.DELETED)
+
+        # Setup session to return video from query
+        setup_batch_query_mock(session, [mock_video])
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all", "--limit", "1"],
+        )
+
+        assert result.exit_code == 0
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_respects_limit(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that --limit parameter is respected in batch mode."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        # Create 1 mock video (limit applied at SQL level)
+        mock_video = create_mock_video_db("dQw4w9WgXcQ")
+        setup_batch_query_mock(session, [mock_video])
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all", "--limit", "1"],
+        )
+
+        # Should only call recover_video once (for 1 video)
+        assert result.exit_code == 0
+        assert mock_recover.call_count == 1
+
+    @patch("chronovista.cli.commands.recover.asyncio.sleep")
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_applies_delay_between_videos(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+        mock_sleep: AsyncMock,
+    ) -> None:
+        """Test that --delay is applied between videos in batch mode."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        # Create 2 mock videos
+        mock_videos = [
+            create_mock_video_db("dQw4w9WgXcQ"),
+            create_mock_video_db("jNQXAC9IVRw"),
+        ]
+        setup_batch_query_mock(session, mock_videos)
+
+        # Mock recover to return success for both videos
+        results = [
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            ),
+            RecoveryResult(
+                video_id="jNQXAC9IVRw",
+                success=True,
+                snapshot_used="20220106075527",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            ),
+        ]
+
+        call_count = 0
+        async def mock_recover_side_effect(*args, **kwargs):
+            nonlocal call_count
+            result = results[call_count]
+            call_count += 1
+            return result
+
+        mock_recover.side_effect = mock_recover_side_effect
+
+        # AsyncMock for sleep - no need to manually create Future
+        async def mock_sleep_async(delay):
+            pass
+
+        mock_sleep.side_effect = mock_sleep_async
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all", "--delay", "2.5"],
+        )
+
+        # Should call sleep with delay value (between videos)
+        # Called once between video 0 and video 1
+        assert result.exit_code == 0
+        assert mock_sleep.called
+        # Check that sleep was called with the correct delay
+        mock_sleep.assert_called_with(2.5)
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_continues_past_individual_failures(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that batch mode continues after individual video failures."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        # Create 3 mock videos
+        mock_videos = [
+            create_mock_video_db("dQw4w9WgXcQ"),
+            create_mock_video_db("jNQXAC9IVRw"),
+            create_mock_video_db("9bZkp7q19f0"),
+        ]
+        setup_batch_query_mock(session, mock_videos)
+
+        # First video fails, second succeeds, third fails
+        results = [
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=False,
+                failure_reason="no_snapshots_found",
+                duration_seconds=0.5,
+            ),
+            RecoveryResult(
+                video_id="jNQXAC9IVRw",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            ),
+            RecoveryResult(
+                video_id="9bZkp7q19f0",
+                success=False,
+                failure_reason="cdx_query_timeout",
+                duration_seconds=600.0,
+            ),
+        ]
+
+        call_count = 0
+        async def mock_recover_side_effect(*args, **kwargs):
+            nonlocal call_count
+            result = results[call_count]
+            call_count += 1
+            return result
+
+        mock_recover.side_effect = mock_recover_side_effect
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all"],
+        )
+
+        # Should call recover_video for all 3 videos despite failures
+        assert mock_recover.call_count == 3
+        # Should exit with 0 because at least one succeeded
+        assert result.exit_code == 0
+
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_zero_unavailable_videos_shows_message(
+        self,
+        mock_get_session: MagicMock,
+    ) -> None:
+        """Test that zero unavailable videos shows informational message."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        # Setup session to return empty list
+        setup_batch_query_mock(session, [])
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all"],
+        )
+
+        assert result.exit_code == 0
+        assert "no unavailable videos" in result.stdout.lower() or "0" in result.stdout
+
+
+class TestDryRunMode:
+    """T047: Dry-run mode tests."""
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_cdx_queries_made_in_dry_run(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that CDX queries are made in dry-run mode."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                snapshots_available=5,
+                duration_seconds=0.5,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--dry-run"],
+        )
+
+        # Verify dry_run=True was passed to recover_video
+        assert result.exit_code == 0
+        mock_recover.assert_called_once()
+        call_kwargs = mock_recover.call_args[1]
+        assert call_kwargs["dry_run"] is True
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_displays_snapshot_availability_report(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that dry-run displays snapshot availability report."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                snapshots_available=10,
+                snapshots_tried=1,
+                duration_seconds=0.5,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--dry-run"],
+        )
+
+        assert result.exit_code == 0
+        # Should mention snapshots available or dry run mode
+        assert "snapshot" in result.stdout.lower() or "dry" in result.stdout.lower() or "10" in result.stdout
+
+
+class TestSummaryReport:
+    """T048: Summary report tests."""
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_displays_summary_counts(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that summary displays attempted/succeeded/failed counts."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        # Create 3 mock videos
+        mock_videos = [
+            create_mock_video_db("dQw4w9WgXcQ"),
+            create_mock_video_db("jNQXAC9IVRw"),
+            create_mock_video_db("9bZkp7q19f0"),
+        ]
+        setup_batch_query_mock(session, mock_videos)
+
+        # Mix of success and failure
+        results = [
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            ),
+            RecoveryResult(
+                video_id="jNQXAC9IVRw",
+                success=False,
+                failure_reason="no_snapshots_found",
+                duration_seconds=0.5,
+            ),
+            RecoveryResult(
+                video_id="9bZkp7q19f0",
+                success=True,
+                snapshot_used="20220106075527",
+                fields_recovered=["title", "description"],
+                duration_seconds=1.5,
+            ),
+        ]
+
+        call_count = 0
+        async def mock_recover_side_effect(*args, **kwargs):
+            nonlocal call_count
+            result = results[call_count]
+            call_count += 1
+            return result
+
+        mock_recover.side_effect = mock_recover_side_effect
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all"],
+        )
+
+        # Check for summary information
+        assert result.exit_code == 0
+        assert "summary" in result.stdout.lower() or "succeeded" in result.stdout.lower()
+        # Should show count information (3 attempted, 2 succeeded, 1 failed)
+        assert "3" in result.stdout and "2" in result.stdout
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_includes_per_video_result_table(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that summary includes per-video result table."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_video = create_mock_video_db("dQw4w9WgXcQ")
+        setup_batch_query_mock(session, [mock_video])
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title", "description", "view_count"],
+                snapshots_available=10,
+                duration_seconds=1.5,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all"],
+        )
+
+        # Should show video ID and recovery information
+        assert result.exit_code == 0
+        assert "dQw4w9WgXcQ" in result.stdout
+        # Should show fields recovered count (3) or mention fields
+        assert "3" in result.stdout or "field" in result.stdout.lower()
+
+
+class TestDependencyChecks:
+    """T049: Dependency check tests."""
+
+    @patch("chronovista.cli.commands.recover.BEAUTIFULSOUP_AVAILABLE", False)
+    def test_missing_beautifulsoup_shows_error(self) -> None:
+        """Test that missing beautifulsoup4 shows error and halts."""
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ"],
+        )
+
+        # Should fail with error about missing dependency
+        assert result.exit_code != 0
+        assert "beautifulsoup" in result.stdout.lower() or "dependency" in result.stdout.lower()
+
+    @patch("chronovista.cli.commands.recover.SELENIUM_AVAILABLE", False)
+    @patch("chronovista.cli.commands.recover.BEAUTIFULSOUP_AVAILABLE", True)
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    @patch("chronovista.cli.commands.recover.CDXClient")
+    @patch("chronovista.cli.commands.recover.PageParser")
+    @patch("chronovista.cli.commands.recover.RateLimiter")
+    def test_missing_selenium_shows_warning_but_continues(
+        self,
+        mock_rate_limiter: MagicMock,
+        mock_page_parser: MagicMock,
+        mock_cdx_client: MagicMock,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that missing selenium shows warning but continues."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20220106075526",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ"],
+        )
+
+        # Should succeed with warning
+        assert result.exit_code == 0
+        # May show warning about selenium (optional)
+        # Command should still complete successfully
+
+
+class TestErrorHandling:
+    """Test error handling in recovery commands."""
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_cdx_error_returns_network_error_code(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that CDXError returns EXIT_CODE_NETWORK_ERROR."""
+        from chronovista.exceptions import CDXError, EXIT_CODE_NETWORK_ERROR
+
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        async def mock_recover_raises_cdx_error(*args, **kwargs):
+            raise CDXError("CDX API timeout", video_id="dQw4w9WgXcQ", status_code=504)
+
+        mock_recover.side_effect = mock_recover_raises_cdx_error
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ"],
+        )
+
+        assert result.exit_code == EXIT_CODE_NETWORK_ERROR
+        assert "cdx" in result.stdout.lower()
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_page_parse_error_returns_exit_code_1(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that PageParseError returns exit code 1."""
+        from chronovista.exceptions import PageParseError
+
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        async def mock_recover_raises_parse_error(*args, **kwargs):
+            raise PageParseError(
+                "Failed to parse ytInitialPlayerResponse",
+                video_id="dQw4w9WgXcQ",
+                snapshot_timestamp="20220106075526",
+            )
+
+        mock_recover.side_effect = mock_recover_raises_parse_error
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ"],
+        )
+
+        assert result.exit_code == 1
+        assert "pars" in result.stdout.lower() or "error" in result.stdout.lower()
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_batch_cdx_error_continues_with_other_videos(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that batch mode continues after CDXError on individual video."""
+        from chronovista.exceptions import CDXError
+
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        # Create 2 mock videos
+        mock_videos = [
+            create_mock_video_db("dQw4w9WgXcQ"),
+            create_mock_video_db("jNQXAC9IVRw"),
+        ]
+        setup_batch_query_mock(session, mock_videos)
+
+        # First video raises CDXError, second succeeds
+        async def mock_recover_first_fails(*args, **kwargs):
+            if "dQw4w9WgXcQ" in str(kwargs.get("video_id", "")):
+                raise CDXError("CDX timeout", video_id="dQw4w9WgXcQ", status_code=504)
+            else:
+                return RecoveryResult(
+                    video_id="jNQXAC9IVRw",
+                    success=True,
+                    snapshot_used="20220106075526",
+                    fields_recovered=["title"],
+                    duration_seconds=1.0,
+                )
+
+        mock_recover.side_effect = mock_recover_first_fails
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all"],
+        )
+
+        # Should continue and process second video
+        assert mock_recover.call_count == 2
+        # Should exit with 0 because second video succeeded
+        assert result.exit_code == 0
+
+
+class TestRecoverCommandHelp:
+    """Test help text for recover commands."""
+
+    def test_recover_help(self) -> None:
+        """Test that recover --help shows command information."""
+        result = runner.invoke(app, ["recover", "--help"])
+
+        assert result.exit_code == 0
+        assert "recover" in result.stdout.lower()
+
+    def test_recover_video_help(self) -> None:
+        """Test that recover video --help shows command information."""
+        result = runner.invoke(app, ["recover", "video", "--help"])
+
+        assert result.exit_code == 0
+        assert "--video-id" in result.stdout
+        assert "--all" in result.stdout
+        assert "--limit" in result.stdout
+        assert "--dry-run" in result.stdout
+        assert "--delay" in result.stdout
+
+    def test_recover_video_help_includes_year_flags(self) -> None:
+        """Test that recover video --help shows --start-year and --end-year options."""
+        result = runner.invoke(app, ["recover", "video", "--help"])
+
+        assert result.exit_code == 0
+        assert "--start-year" in result.stdout
+        assert "--end-year" in result.stdout
+
+
+class TestYearFilterValidation:
+    """Test --start-year and --end-year CLI flag validation."""
+
+    def test_start_year_greater_than_end_year_shows_error(self) -> None:
+        """Test that --start-year > --end-year prints error and exits with code 2."""
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--start-year", "2022", "--end-year", "2018"],
+        )
+
+        assert result.exit_code == 2
+        assert "start-year" in result.stdout.lower() or "greater" in result.stdout.lower()
+
+    def test_start_year_equal_to_end_year_accepted(self) -> None:
+        """Test that --start-year == --end-year is accepted (not an error)."""
+        # This should not fail on validation (may fail on other things like dependencies)
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--start-year", "2020", "--end-year", "2020"],
+        )
+
+        # Should NOT be exit code 2 (the year-range validation error)
+        # It may be 0 or 1 depending on downstream mocking, but not 2 for validation
+        assert result.exit_code != 2 or "start-year" not in result.stdout.lower()
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_start_year_passed_to_orchestrator(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that --start-year is threaded through to recover_video as from_year."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20180601120000",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--start-year", "2018"],
+        )
+
+        assert result.exit_code == 0
+        mock_recover.assert_called_once()
+        call_kwargs = mock_recover.call_args[1]
+        assert call_kwargs["from_year"] == 2018
+        assert call_kwargs.get("to_year") is None
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_end_year_passed_to_orchestrator(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that --end-year is threaded through to recover_video as to_year."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20200601120000",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--end-year", "2020"],
+        )
+
+        assert result.exit_code == 0
+        mock_recover.assert_called_once()
+        call_kwargs = mock_recover.call_args[1]
+        assert call_kwargs.get("from_year") is None
+        assert call_kwargs["to_year"] == 2020
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_both_years_passed_to_orchestrator(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that both --start-year and --end-year are threaded through."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20190601120000",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--video-id", "dQw4w9WgXcQ", "--start-year", "2018", "--end-year", "2020"],
+        )
+
+        assert result.exit_code == 0
+        mock_recover.assert_called_once()
+        call_kwargs = mock_recover.call_args[1]
+        assert call_kwargs["from_year"] == 2018
+        assert call_kwargs["to_year"] == 2020
+
+    @patch("chronovista.cli.commands.recover.recover_video")
+    @patch("chronovista.cli.commands.recover.db_manager.get_session")
+    def test_batch_mode_passes_years_to_orchestrator(
+        self,
+        mock_get_session: MagicMock,
+        mock_recover: MagicMock,
+    ) -> None:
+        """Test that year flags in batch mode are threaded to recover_video."""
+        session_gen, session = create_async_mock_session()
+        mock_get_session.return_value = session_gen
+
+        mock_video = create_mock_video_db("dQw4w9WgXcQ")
+        setup_batch_query_mock(session, [mock_video])
+
+        mock_recover.side_effect = create_async_mock_recover(
+            RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=True,
+                snapshot_used="20190601120000",
+                fields_recovered=["title"],
+                duration_seconds=1.0,
+            )
+        )
+
+        result = runner.invoke(
+            app,
+            ["recover", "video", "--all", "--limit", "1", "--start-year", "2018", "--end-year", "2020"],
+        )
+
+        assert result.exit_code == 0
+        mock_recover.assert_called_once()
+        call_kwargs = mock_recover.call_args[1]
+        assert call_kwargs["from_year"] == 2018
+        assert call_kwargs["to_year"] == 2020

--- a/tests/unit/services/recovery/__init__.py
+++ b/tests/unit/services/recovery/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for recovery services."""

--- a/tests/unit/services/recovery/conftest.py
+++ b/tests/unit/services/recovery/conftest.py
@@ -1,0 +1,342 @@
+"""
+Pytest fixtures for recovery service unit tests.
+
+This module provides shared fixtures for testing the Wayback Machine
+video recovery functionality, including:
+- Factory functions for CdxSnapshot, RecoveredVideoData, RecoveryResult, CdxCacheEntry
+- Mock CDX API responses
+- Sample archived page HTML
+- Mock Selenium WebDriver instances
+- Test data builders for recovery models
+
+These factories return dictionaries with realistic defaults that can be unpacked
+into model constructors once the models are implemented at
+chronovista.services.recovery.models.
+"""
+
+from __future__ import annotations
+
+import itertools
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+# Mark all tests in this module as async by default
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _clean_test_cache():
+    """Clean /tmp/test_cache before each test to prevent cache cross-contamination."""
+    cache_dir = Path("/tmp/test_cache")
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
+    yield
+
+
+# Counters for generating unique IDs
+_video_id_counter = itertools.count(1)
+_snapshot_counter = itertools.count(1)
+
+
+def make_cdx_snapshot(**overrides: Any) -> dict[str, Any]:
+    """
+    Create a CdxSnapshot dictionary with realistic defaults.
+
+    A CDX snapshot represents a single Wayback Machine capture point.
+    All fields match the CDX API response format after filtering for
+    valid HTML pages (mimetype=text/html, statuscode=200, length>5000).
+
+    Parameters
+    ----------
+    **overrides : Any
+        Override any default field values.
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary that can be unpacked into CdxSnapshot constructor.
+
+    Examples
+    --------
+    >>> snapshot = make_cdx_snapshot(timestamp="20220106075526")
+    >>> snapshot = make_cdx_snapshot(
+    ...     timestamp="20180101120000",
+    ...     original="https://www.youtube.com/watch?v=customId123"
+    ... )
+    """
+    # Generate unique 14-digit timestamp (format: YYYYMMDDhhmmss)
+    snapshot_num = next(_snapshot_counter)
+    # Use incremental timestamps starting from 2020-01-01
+    base_timestamp = 20200101000000
+    timestamp = str(base_timestamp + snapshot_num * 10000)  # Increment by ~1 hour
+
+    defaults = {
+        "timestamp": timestamp,
+        "original": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "mimetype": "text/html",
+        "statuscode": 200,
+        "digest": f"ABCDEFGHIJ{snapshot_num:010d}",  # Realistic hash-like string
+        "length": 50000 + snapshot_num * 1000,  # > 5000 threshold
+    }
+
+    return {**defaults, **overrides}
+
+
+def make_recovered_video_data(**overrides: Any) -> dict[str, Any]:
+    """
+    Create a RecoveredVideoData dictionary with realistic defaults.
+
+    Represents metadata extracted from an archived YouTube page.
+    All fields are optional except snapshot_timestamp.
+
+    Parameters
+    ----------
+    **overrides : Any
+        Override any default field values.
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary that can be unpacked into RecoveredVideoData constructor.
+
+    Examples
+    --------
+    >>> data = make_recovered_video_data(title="My Deleted Video")
+    >>> data = make_recovered_video_data(
+    ...     title="Concert Recording",
+    ...     channel_name_hint="MusicChannel",
+    ...     view_count=1_000_000
+    ... )
+    """
+    snapshot_num = next(_snapshot_counter)
+    timestamp = str(20220101000000 + snapshot_num * 10000)
+
+    defaults = {
+        "title": "Recovered Video Title",
+        "description": "This is a recovered video description from Wayback Machine.",
+        "channel_name_hint": "Recovered Channel",
+        "channel_id": f"UC{uuid4().hex[:22]}",  # Valid ChannelId format
+        "view_count": 10000,
+        "like_count": 500,
+        "upload_date": datetime(2021, 6, 15, 12, 0, 0, tzinfo=timezone.utc),
+        "thumbnail_url": f"https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+        "tags": ["music", "entertainment", "viral"],
+        "category_id": "10",  # Music category
+        "snapshot_timestamp": timestamp,
+    }
+
+    return {**defaults, **overrides}
+
+
+def make_recovery_result(
+    success: bool = True, **overrides: Any
+) -> dict[str, Any]:
+    """
+    Create a RecoveryResult dictionary with realistic defaults.
+
+    Represents the outcome of a video recovery attempt, including
+    success/failure status, fields recovered, and diagnostic information.
+
+    Parameters
+    ----------
+    success : bool
+        Whether the recovery succeeded. Determines which fields are populated.
+        Default is True (successful recovery).
+    **overrides : Any
+        Override any default field values.
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary that can be unpacked into RecoveryResult constructor.
+
+    Examples
+    --------
+    >>> result = make_recovery_result(success=True)
+    >>> result = make_recovery_result(
+    ...     success=False,
+    ...     failure_reason="No snapshots found in CDX API"
+    ... )
+    >>> result = make_recovery_result(
+    ...     success=True,
+    ...     fields_recovered=["title", "description", "channel_id"],
+    ...     snapshots_tried=3
+    ... )
+    """
+    video_num = next(_video_id_counter)
+    video_id = f"{uuid4().hex[:11]}"  # Valid VideoId format (11 chars)
+
+    if success:
+        # Successful recovery defaults
+        defaults = {
+            "video_id": video_id,
+            "success": True,
+            "snapshot_used": str(20220106075526 + video_num * 10000),
+            "fields_recovered": [
+                "title",
+                "description",
+                "channel_id",
+                "view_count",
+                "upload_date",
+            ],
+            "fields_skipped": ["like_count", "comment_count"],
+            "snapshots_available": 5,
+            "snapshots_tried": 2,
+            "failure_reason": None,
+            "duration_seconds": 2.5,
+            "channel_recovery_candidates": [f"UC{uuid4().hex[:22]}"],
+        }
+    else:
+        # Failed recovery defaults
+        defaults = {
+            "video_id": video_id,
+            "success": False,
+            "snapshot_used": None,
+            "fields_recovered": [],
+            "fields_skipped": [],
+            "snapshots_available": 3,
+            "snapshots_tried": 3,
+            "failure_reason": "All snapshots failed to extract metadata",
+            "duration_seconds": 5.0,
+            "channel_recovery_candidates": [],
+        }
+
+    return {**defaults, **overrides}
+
+
+def make_cdx_cache_entry(**overrides: Any) -> dict[str, Any]:
+    """
+    Create a CdxCacheEntry dictionary with realistic defaults.
+
+    Represents a cached CDX API response for a specific video ID,
+    including the raw snapshot list and fetch timestamp.
+
+    Parameters
+    ----------
+    **overrides : Any
+        Override any default field values.
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary that can be unpacked into CdxCacheEntry constructor.
+
+    Examples
+    --------
+    >>> entry = make_cdx_cache_entry(video_id="dQw4w9WgXcQ")
+    >>> entry = make_cdx_cache_entry(
+    ...     video_id="customId123",
+    ...     snapshots=[make_cdx_snapshot(), make_cdx_snapshot()],
+    ...     raw_count=50
+    ... )
+    """
+    video_id = f"{uuid4().hex[:11]}"  # Valid VideoId format
+
+    # Generate 3 sample snapshots by default
+    default_snapshots = [
+        make_cdx_snapshot(timestamp="20200106075526"),
+        make_cdx_snapshot(timestamp="20210315102030"),
+        make_cdx_snapshot(timestamp="20220620183045"),
+    ]
+
+    defaults = {
+        "video_id": video_id,
+        "fetched_at": datetime.now(timezone.utc),
+        "snapshots": default_snapshots,
+        "raw_count": 25,  # Total snapshots before filtering
+    }
+
+    return {**defaults, **overrides}
+
+
+# ============================================================================
+# Pytest Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def cdx_snapshot_factory():
+    """
+    Fixture that returns the make_cdx_snapshot factory function.
+
+    Returns
+    -------
+    Callable
+        Function that creates CdxSnapshot dictionaries.
+
+    Examples
+    --------
+    >>> def test_snapshot_creation(cdx_snapshot_factory):
+    ...     snapshot = cdx_snapshot_factory(timestamp="20220101120000")
+    ...     assert snapshot["mimetype"] == "text/html"
+    """
+    return make_cdx_snapshot
+
+
+@pytest.fixture
+def recovered_video_data_factory():
+    """
+    Fixture that returns the make_recovered_video_data factory function.
+
+    Returns
+    -------
+    Callable
+        Function that creates RecoveredVideoData dictionaries.
+
+    Examples
+    --------
+    >>> def test_recovery_data(recovered_video_data_factory):
+    ...     data = recovered_video_data_factory(title="My Video")
+    ...     assert data["title"] == "My Video"
+    """
+    return make_recovered_video_data
+
+
+@pytest.fixture
+def recovery_result_factory():
+    """
+    Fixture that returns the make_recovery_result factory function.
+
+    Returns
+    -------
+    Callable
+        Function that creates RecoveryResult dictionaries.
+
+    Examples
+    --------
+    >>> def test_success_result(recovery_result_factory):
+    ...     result = recovery_result_factory(success=True)
+    ...     assert result["success"] is True
+    ...     assert len(result["fields_recovered"]) > 0
+    >>>
+    >>> def test_failure_result(recovery_result_factory):
+    ...     result = recovery_result_factory(success=False)
+    ...     assert result["success"] is False
+    ...     assert result["failure_reason"] is not None
+    """
+    return make_recovery_result
+
+
+@pytest.fixture
+def cdx_cache_entry_factory():
+    """
+    Fixture that returns the make_cdx_cache_entry factory function.
+
+    Returns
+    -------
+    Callable
+        Function that creates CdxCacheEntry dictionaries.
+
+    Examples
+    --------
+    >>> def test_cache_entry(cdx_cache_entry_factory):
+    ...     entry = cdx_cache_entry_factory(video_id="abc123xyz45")
+    ...     assert len(entry["snapshots"]) == 3  # Default count
+    ...     assert entry["raw_count"] == 25
+    """
+    return make_cdx_cache_entry

--- a/tests/unit/services/recovery/test_cdx_client.py
+++ b/tests/unit/services/recovery/test_cdx_client.py
@@ -1,0 +1,1231 @@
+"""
+Comprehensive unit tests for the CDX client.
+
+This module provides complete test coverage for the Wayback Machine CDX API
+client, including:
+- RateLimiter token-bucket rate limiting logic
+- CDX URL construction and JSON response parsing
+- Filtering and sorting of CDX snapshots
+- File-based caching with TTL validation
+- Retry logic with exponential backoff and rate limit handling
+
+All tests use mocked httpx responses and never make real HTTP calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, mock_open, patch
+
+import httpx
+import pytest
+
+from chronovista.exceptions import CDXError
+from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
+from chronovista.services.recovery.models import CdxCacheEntry, CdxSnapshot
+
+# Mark all tests in this module as async by default
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# TestRateLimiter - Token-bucket rate limiting logic
+# =============================================================================
+
+
+class TestRateLimiter:
+    """Test the token-bucket rate limiter."""
+
+    async def test_rate_limiter_allows_burst(self) -> None:
+        """
+        Creating a RateLimiter(rate=40) should allow initial requests without delay.
+
+        The token bucket should start full, allowing up to `rate` requests
+        to proceed immediately without any asyncio.sleep calls.
+        """
+        rate_limiter = RateLimiter(rate=40.0)
+
+        # First 40 requests should complete without delay
+        with patch("asyncio.sleep") as mock_sleep:
+            for _ in range(40):
+                await rate_limiter.acquire()
+
+            # No sleep should have been called for burst capacity
+            mock_sleep.assert_not_called()
+
+    async def test_rate_limiter_enforces_rate(self) -> None:
+        """
+        After burst capacity is consumed, acquire() should introduce a delay.
+
+        Once the token bucket is empty, subsequent requests should sleep
+        to maintain the configured rate limit.
+        """
+        # Use a small rate for faster test execution
+        rate_limiter = RateLimiter(rate=10.0)  # 10 requests per second
+
+        with patch("asyncio.sleep") as mock_sleep:
+            # Consume burst capacity (10 tokens)
+            for _ in range(10):
+                await rate_limiter.acquire()
+
+            # No sleep yet
+            mock_sleep.assert_not_called()
+
+            # Next request should require waiting
+            await rate_limiter.acquire()
+            mock_sleep.assert_called()
+            # Should wait approximately 1/rate seconds = 0.1s
+            assert mock_sleep.call_count >= 1
+
+    async def test_rate_limiter_shared_across_callers(self) -> None:
+        """
+        Two async tasks sharing the same rate_limiter instance both respect the rate.
+
+        This verifies that the rate limiter correctly synchronizes access
+        across multiple concurrent consumers.
+        """
+        rate_limiter = RateLimiter(rate=20.0)
+
+        async def consumer(count: int) -> None:
+            for _ in range(count):
+                await rate_limiter.acquire()
+
+        with patch("asyncio.sleep"):
+            # Two tasks each making 15 requests = 30 total
+            # Burst capacity is 20, so 10 requests should trigger sleep
+            await asyncio.gather(consumer(15), consumer(15))
+
+            # Both tasks should have completed without errors
+            # (implicitly verified by gather not raising)
+
+
+# =============================================================================
+# TestCDXURLConstruction (T011) - URL construction and JSON parsing
+# =============================================================================
+
+
+class TestCDXURLConstruction:
+    """Test URL construction and JSON parsing."""
+
+    async def test_cdx_url_construction(self) -> None:
+        """
+        For video_id "dQw4w9WgXcQ", the CDX URL should contain all required parameters.
+
+        Expected query parameters:
+        - url=youtube.com/watch%3Fv%3DdQw4w9WgXcQ
+        - output=json
+        - filter=statuscode:200
+        - filter=mimetype:text/html
+        - fl=timestamp,original,mimetype,statuscode,digest,length
+        - limit=-100
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        # Mock the HTTP response to inspect the constructed URL
+        mock_response = httpx.Response(
+            status_code=200,
+            json=[],  # Empty CDX response
+        )
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            await client.fetch_snapshots("dQw4w9WgXcQ")
+
+            # Verify get was called once
+            mock_get.assert_called_once()
+
+            # Extract the URL that was requested
+            call_args = mock_get.call_args
+            requested_url = str(call_args[0][0])  # First positional argument
+
+            # Verify all required components are present
+            assert "youtube.com/watch" in requested_url
+            assert "v=dQw4w9WgXcQ" in requested_url or "v%3DdQw4w9WgXcQ" in requested_url
+            assert "output=json" in requested_url
+            assert "filter=statuscode:200" in requested_url
+            assert "filter=mimetype:text/html" in requested_url
+            assert "fl=timestamp,original,mimetype,statuscode,digest,length" in requested_url
+            assert "limit=-100" in requested_url
+
+    async def test_cdx_response_parsing(self) -> None:
+        """
+        CDX returns JSON as array-of-arrays with first row as headers.
+
+        The CDX API response format is:
+        [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            ["20220106075526", "https://...", "text/html", "200", "ABC", 50000],
+            ...
+        ]
+
+        The first row contains field names, subsequent rows contain data.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        # Mock CDX response with header row + 2 data rows
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20220106075526",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "ABCDEF123456",
+                "50000",
+            ],
+            [
+                "20210315120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "GHIJKL789012",
+                "60000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("dQw4w9WgXcQ")
+
+            # Should return 2 snapshots (excluding header row)
+            assert len(snapshots) == 2
+
+            # Verify first snapshot
+            assert snapshots[0].timestamp == "20220106075526"
+            assert snapshots[0].original == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            assert snapshots[0].mimetype == "text/html"
+            assert snapshots[0].statuscode == 200
+            assert snapshots[0].digest == "ABCDEF123456"
+            assert snapshots[0].length == 50000
+
+            # Verify second snapshot
+            assert snapshots[1].timestamp == "20210315120000"
+            assert snapshots[1].digest == "GHIJKL789012"
+
+    async def test_cdx_status_dash_excluded(self) -> None:
+        """
+        CDX rows where statuscode is "-" (redirects) should be excluded.
+
+        The CDX API sometimes returns rows with statuscode="-" for redirects.
+        These should be filtered out during parsing.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        # Mock CDX response with one valid row and one redirect (statuscode="-")
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20220106075526",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "ABCDEF123456",
+                "50000",
+            ],
+            [
+                "20210315120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "-",  # Redirect, should be excluded
+                "GHIJKL789012",
+                "60000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("dQw4w9WgXcQ")
+
+            # Should return only 1 snapshot (the one with statuscode=200)
+            assert len(snapshots) == 1
+            assert snapshots[0].statuscode == 200
+
+    async def test_empty_cdx_response(self) -> None:
+        """
+        CDX returns [] (empty array) with HTTP 200, no error, return empty list.
+
+        An empty CDX response indicates no snapshots are available for the
+        video. This is not an error condition.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        # Mock empty CDX response
+        mock_response = httpx.Response(status_code=200, json=[])
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("dQw4w9WgXcQ")
+
+            # Should return empty list without raising an error
+            assert snapshots == []
+
+
+# =============================================================================
+# TestCDXFiltering (T012) - Filtering and sorting
+# =============================================================================
+
+
+class TestCDXFiltering:
+    """Test filtering and sorting."""
+
+    async def test_filter_status_200_only(self) -> None:
+        """
+        Rows with statuscode != 200 filtered out.
+
+        Only snapshots with HTTP 200 status should be returned.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20220106075526",
+                "https://www.youtube.com/watch?v=test1",
+                "text/html",
+                "200",
+                "ABC123",
+                "50000",
+            ],
+            [
+                "20220106075527",
+                "https://www.youtube.com/watch?v=test2",
+                "text/html",
+                "404",  # Should be filtered out
+                "DEF456",
+                "50000",
+            ],
+            [
+                "20220106075528",
+                "https://www.youtube.com/watch?v=test3",
+                "text/html",
+                "302",  # Should be filtered out
+                "GHI789",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("test123")
+
+            # Only the 200 status should remain
+            assert len(snapshots) == 1
+            assert snapshots[0].statuscode == 200
+
+    async def test_filter_mimetype_text_html(self) -> None:
+        """
+        Non-text/html mimetypes filtered out.
+
+        Only snapshots with mimetype="text/html" should be returned.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20220106075526",
+                "https://www.youtube.com/watch?v=test1",
+                "text/html",
+                "200",
+                "ABC123",
+                "50000",
+            ],
+            [
+                "20220106075527",
+                "https://www.youtube.com/watch?v=test2",
+                "application/json",  # Should be filtered out
+                "200",
+                "DEF456",
+                "50000",
+            ],
+            [
+                "20220106075528",
+                "https://www.youtube.com/watch?v=test3",
+                "text/plain",  # Should be filtered out
+                "200",
+                "GHI789",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("test123")
+
+            # Only the text/html snapshot should remain
+            assert len(snapshots) == 1
+            assert snapshots[0].mimetype == "text/html"
+
+    async def test_filter_length_gt_5000(self) -> None:
+        """
+        Rows with length <= 5000 filtered out.
+
+        Very small responses are likely error pages or stubs, not full YouTube pages.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20220106075526",
+                "https://www.youtube.com/watch?v=test1",
+                "text/html",
+                "200",
+                "ABC123",
+                "50000",  # Valid
+            ],
+            [
+                "20220106075527",
+                "https://www.youtube.com/watch?v=test2",
+                "text/html",
+                "200",
+                "DEF456",
+                "5000",  # Should be filtered out (not greater than 5000)
+            ],
+            [
+                "20220106075528",
+                "https://www.youtube.com/watch?v=test3",
+                "text/html",
+                "200",
+                "GHI789",
+                "1000",  # Should be filtered out
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("test123")
+
+            # Only the snapshot with length > 5000 should remain
+            assert len(snapshots) == 1
+            assert snapshots[0].length == 50000
+
+    async def test_sort_newest_first(self) -> None:
+        """
+        Results sorted by timestamp descending (newest first).
+
+        CDX responses may not be in chronological order. The client should
+        sort by timestamp descending to prioritize newer snapshots.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        # Response with timestamps in mixed order
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20210315120000",  # Middle
+                "https://www.youtube.com/watch?v=test",
+                "text/html",
+                "200",
+                "BBB222",
+                "50000",
+            ],
+            [
+                "20220106075526",  # Newest
+                "https://www.youtube.com/watch?v=test",
+                "text/html",
+                "200",
+                "AAA111",
+                "50000",
+            ],
+            [
+                "20200101000000",  # Oldest
+                "https://www.youtube.com/watch?v=test",
+                "text/html",
+                "200",
+                "CCC333",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("test123")
+
+            # Should be sorted newest first
+            assert len(snapshots) == 3
+            assert snapshots[0].timestamp == "20220106075526"  # Newest
+            assert snapshots[1].timestamp == "20210315120000"  # Middle
+            assert snapshots[2].timestamp == "20200101000000"  # Oldest
+
+    async def test_cdx_limit_100(self) -> None:
+        """
+        CDX query includes limit=-100 parameter.
+
+        The client should request up to 100 snapshots from the CDX API.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        mock_response = httpx.Response(status_code=200, json=[])
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            await client.fetch_snapshots("test123")
+
+            # Extract the URL
+            call_args = mock_get.call_args
+            requested_url = str(call_args[0][0])
+
+            # Verify limit=-100 is present
+            assert "limit=-100" in requested_url
+
+
+# =============================================================================
+# TestCDXCaching (T013) - File-based caching
+# =============================================================================
+
+
+class TestCDXCaching:
+    """Test file-based caching."""
+
+    async def test_cache_hit_returns_cached(self, tmp_path: Path) -> None:
+        """
+        When cache file exists and is fresh (<24h), return cached data without HTTP call.
+
+        A valid cache entry should be returned immediately without making
+        an HTTP request to the CDX API.
+        """
+        cache_dir = tmp_path / "cdx_cache"
+        cache_dir.mkdir(parents=True)
+        cache_file = cache_dir / "cdx" / "dQw4w9WgXcQ.json"
+        cache_file.parent.mkdir(parents=True)
+
+        # Create a fresh cache entry (fetched 1 hour ago)
+        cache_entry = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            snapshots=[
+                CdxSnapshot(
+                    timestamp="20220106075526",
+                    original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                    mimetype="text/html",
+                    statuscode=200,
+                    digest="CACHED123",
+                    length=50000,
+                )
+            ],
+            raw_count=1,
+        )
+
+        # Write cache file
+        cache_file.write_text(cache_entry.model_dump_json())
+
+        client = CDXClient(cache_dir=cache_dir)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            snapshots = await client.fetch_snapshots("dQw4w9WgXcQ")
+
+            # Should not make HTTP request
+            mock_get.assert_not_called()
+
+            # Should return cached snapshot
+            assert len(snapshots) == 1
+            assert snapshots[0].digest == "CACHED123"
+
+    async def test_cache_miss_triggers_fetch(self, tmp_path: Path) -> None:
+        """
+        When cache file doesn't exist, make HTTP call and write cache file.
+
+        A cache miss should trigger a CDX API request and create a new cache file.
+        """
+        cache_dir = tmp_path / "cdx_cache"
+        cache_file = cache_dir / "cdx" / "dQw4w9WgXcQ.json"
+
+        client = CDXClient(cache_dir=cache_dir)
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20220106075526",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "FRESH123",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("dQw4w9WgXcQ")
+
+            # Should make HTTP request
+            mock_get.assert_called_once()
+
+            # Should return fetched snapshot
+            assert len(snapshots) == 1
+            assert snapshots[0].digest == "FRESH123"
+
+            # Cache file should exist
+            assert cache_file.exists()
+
+            # Verify cache contents
+            cached_data = json.loads(cache_file.read_text())
+            assert cached_data["video_id"] == "dQw4w9WgXcQ"
+            assert len(cached_data["snapshots"]) == 1
+
+    async def test_expired_cache_triggers_refetch(self, tmp_path: Path) -> None:
+        """
+        Cache file with fetched_at > 24h ago should trigger re-fetch.
+
+        Expired cache entries should be refreshed from the CDX API.
+        """
+        cache_dir = tmp_path / "cdx_cache"
+        cache_dir.mkdir(parents=True)
+        cache_file = cache_dir / "cdx" / "dQw4w9WgXcQ.json"
+        cache_file.parent.mkdir(parents=True)
+
+        # Create an expired cache entry (fetched 25 hours ago)
+        cache_entry = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=datetime.now(timezone.utc) - timedelta(hours=25),
+            snapshots=[
+                CdxSnapshot(
+                    timestamp="20220106075526",
+                    original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                    mimetype="text/html",
+                    statuscode=200,
+                    digest="EXPIRED123",
+                    length=50000,
+                )
+            ],
+            raw_count=1,
+        )
+
+        cache_file.write_text(cache_entry.model_dump_json())
+
+        client = CDXClient(cache_dir=cache_dir)
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20220106075526",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "FRESH123",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("dQw4w9WgXcQ")
+
+            # Should make HTTP request despite cache file existing
+            mock_get.assert_called_once()
+
+            # Should return fresh snapshot
+            assert len(snapshots) == 1
+            assert snapshots[0].digest == "FRESH123"
+
+    async def test_corrupted_cache_triggers_refetch(self, tmp_path: Path) -> None:
+        """
+        Invalid JSON in cache file → delete file + re-query CDX. Don't crash.
+
+        Corrupted cache files should be handled gracefully by fetching fresh data.
+        """
+        cache_dir = tmp_path / "cdx_cache"
+        cache_dir.mkdir(parents=True)
+        cache_file = cache_dir / "cdx" / "dQw4w9WgXcQ.json"
+        cache_file.parent.mkdir(parents=True)
+
+        # Write invalid JSON to cache file
+        cache_file.write_text("{this is not valid json")
+
+        client = CDXClient(cache_dir=cache_dir)
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20220106075526",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "FRESH123",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            # Should not crash, should fetch fresh data
+            snapshots = await client.fetch_snapshots("dQw4w9WgXcQ")
+
+            # Should make HTTP request
+            mock_get.assert_called_once()
+
+            # Should return fresh snapshot
+            assert len(snapshots) == 1
+            assert snapshots[0].digest == "FRESH123"
+
+    async def test_cache_write_creates_directory(self, tmp_path: Path) -> None:
+        """
+        Cache write should create {cache_dir}/cdx/ directory if missing.
+
+        The client should automatically create the cache directory structure.
+        """
+        cache_dir = tmp_path / "nonexistent_cache"
+        # Directory doesn't exist yet
+        assert not cache_dir.exists()
+
+        client = CDXClient(cache_dir=cache_dir)
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20220106075526",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "ABC123",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            await client.fetch_snapshots("dQw4w9WgXcQ")
+
+            # Cache directory should now exist
+            cache_subdir = cache_dir / "cdx"
+            assert cache_subdir.exists()
+            assert cache_subdir.is_dir()
+
+
+# =============================================================================
+# TestCDXRetry (T014) - Retry and rate limiting
+# =============================================================================
+
+
+class TestCDXRetry:
+    """Test retry and rate limiting."""
+
+    async def test_exponential_backoff_on_503(self) -> None:
+        """
+        HTTP 503 → retry with exponential backoff (3 retries, 2s base).
+
+        Server errors should be retried with exponential backoff.
+        Mock sleep to verify delays: 2s, 4s, 8s.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        # First 3 calls return 503, 4th call succeeds
+        responses = [
+            httpx.Response(status_code=503, text="Service Unavailable"),
+            httpx.Response(status_code=503, text="Service Unavailable"),
+            httpx.Response(status_code=503, text="Service Unavailable"),
+            httpx.Response(
+                status_code=200,
+                json=[
+                    ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+                    [
+                        "20220106075526",
+                        "https://www.youtube.com/watch?v=test",
+                        "text/html",
+                        "200",
+                        "ABC123",
+                        "50000",
+                    ],
+                ],
+            ),
+        ]
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get, patch(
+            "asyncio.sleep"
+        ) as mock_sleep:
+            mock_get.side_effect = responses
+
+            snapshots = await client.fetch_snapshots("test123")
+
+            # Should succeed after retries
+            assert len(snapshots) == 1
+
+            # Verify exponential backoff: 2s, 4s, 8s
+            assert mock_sleep.call_count == 3
+            sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
+            assert sleep_calls[0] == pytest.approx(2.0, rel=0.1)
+            assert sleep_calls[1] == pytest.approx(4.0, rel=0.1)
+            assert sleep_calls[2] == pytest.approx(8.0, rel=0.1)
+
+    async def test_fixed_pause_on_429(self) -> None:
+        """
+        HTTP 429 → 60s fixed pause before retry.
+
+        Rate limit errors should trigger a fixed 60-second pause before retry.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        # First call returns 429, second call succeeds
+        responses = [
+            httpx.Response(status_code=429, text="Too Many Requests"),
+            httpx.Response(
+                status_code=200,
+                json=[
+                    ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+                    [
+                        "20220106075526",
+                        "https://www.youtube.com/watch?v=test",
+                        "text/html",
+                        "200",
+                        "ABC123",
+                        "50000",
+                    ],
+                ],
+            ),
+        ]
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get, patch(
+            "asyncio.sleep"
+        ) as mock_sleep:
+            mock_get.side_effect = responses
+
+            snapshots = await client.fetch_snapshots("test123")
+
+            # Should succeed after retry
+            assert len(snapshots) == 1
+
+            # Verify 60s pause
+            mock_sleep.assert_called_once_with(60.0)
+
+    async def test_user_agent_header(self) -> None:
+        """
+        All requests include User-Agent: chronovista/{version} header.
+
+        The client should identify itself with a proper User-Agent header.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        mock_response = httpx.Response(status_code=200, json=[])
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            await client.fetch_snapshots("test123")
+
+            # Verify get was called
+            mock_get.assert_called_once()
+
+            # Extract headers from the call
+            call_kwargs = mock_get.call_args[1]
+            headers = call_kwargs.get("headers", {})
+
+            # Verify User-Agent header
+            assert "User-Agent" in headers
+            user_agent = headers["User-Agent"]
+            assert user_agent.startswith("chronovista/")
+            # Should contain version (e.g., "chronovista/0.26.0")
+            assert len(user_agent.split("/")) == 2
+
+    async def test_httpx_timeout_30s(self) -> None:
+        """
+        CDX requests use 30s timeout.
+
+        The client should configure httpx with a 30-second timeout for CDX requests.
+        """
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        mock_response = httpx.Response(status_code=200, json=[])
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            await client.fetch_snapshots("test123")
+
+            # Verify get was called
+            mock_get.assert_called_once()
+
+            # Extract timeout from the call
+            call_kwargs = mock_get.call_args[1]
+            timeout = call_kwargs.get("timeout")
+
+            # Verify timeout is 30 seconds
+            assert timeout == 30.0 or timeout == 30
+
+
+# =============================================================================
+# TestCDXYearFiltering - from_year / to_year parameter support
+# =============================================================================
+
+
+class TestCDXYearFilteringURL:
+    """Test that _build_cdx_url correctly appends from/to year parameters."""
+
+    def test_build_cdx_url_with_from_year(self) -> None:
+        """_build_cdx_url with from_year uses positive limit (oldest first from anchor)."""
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        url = client._build_cdx_url("dQw4w9WgXcQ", from_year=2018)
+
+        assert "&from=20180101000000" in url
+        assert "&to=" not in url
+        # Positive limit = oldest first from anchor year
+        assert "limit=100" in url
+        assert "limit=-100" not in url
+
+    def test_build_cdx_url_with_to_year(self) -> None:
+        """_build_cdx_url with only to_year uses negative limit (newest first)."""
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        url = client._build_cdx_url("dQw4w9WgXcQ", to_year=2020)
+
+        assert "&to=20201231235959" in url
+        assert "&from=" not in url
+        # No from_year = newest first (default)
+        assert "limit=-100" in url
+
+    def test_build_cdx_url_with_both_years(self) -> None:
+        """_build_cdx_url with both years uses positive limit (oldest first from anchor)."""
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        url = client._build_cdx_url("dQw4w9WgXcQ", from_year=2018, to_year=2020)
+
+        assert "&from=20180101000000" in url
+        assert "&to=20201231235959" in url
+        # from_year present = oldest first from anchor
+        assert "limit=100" in url
+        assert "limit=-100" not in url
+
+    def test_build_cdx_url_with_neither_year(self) -> None:
+        """_build_cdx_url with no year params produces unchanged URL (newest first)."""
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        url = client._build_cdx_url("dQw4w9WgXcQ")
+
+        assert "&from=" not in url
+        assert "&to=" not in url
+        # Should still contain normal params
+        assert "output=json" in url
+        assert "limit=-100" in url
+
+
+class TestCDXYearFilteringCachePath:
+    """Test that _cache_path incorporates year filters into the cache filename."""
+
+    def test_cache_path_with_from_year(self, tmp_path: Path) -> None:
+        """_cache_path with from_year=2018 returns {video_id}_from2018.json."""
+        client = CDXClient(cache_dir=tmp_path)
+
+        result = client._cache_path("dQw4w9WgXcQ", from_year=2018)
+
+        assert result == tmp_path / "cdx" / "dQw4w9WgXcQ_from2018.json"
+
+    def test_cache_path_with_to_year(self, tmp_path: Path) -> None:
+        """_cache_path with to_year=2020 returns {video_id}_to2020.json."""
+        client = CDXClient(cache_dir=tmp_path)
+
+        result = client._cache_path("dQw4w9WgXcQ", to_year=2020)
+
+        assert result == tmp_path / "cdx" / "dQw4w9WgXcQ_to2020.json"
+
+    def test_cache_path_with_both_years(self, tmp_path: Path) -> None:
+        """_cache_path with both returns {video_id}_from2018_to2020.json."""
+        client = CDXClient(cache_dir=tmp_path)
+
+        result = client._cache_path("dQw4w9WgXcQ", from_year=2018, to_year=2020)
+
+        assert result == tmp_path / "cdx" / "dQw4w9WgXcQ_from2018_to2020.json"
+
+    def test_cache_path_with_neither_year(self, tmp_path: Path) -> None:
+        """_cache_path with neither returns {video_id}.json (backward compat)."""
+        client = CDXClient(cache_dir=tmp_path)
+
+        result = client._cache_path("dQw4w9WgXcQ")
+
+        assert result == tmp_path / "cdx" / "dQw4w9WgXcQ.json"
+
+
+class TestCDXYearFilteringIntegration:
+    """Test that fetch_snapshots threads from_year/to_year through the stack."""
+
+    async def test_fetch_snapshots_passes_years_to_url(self) -> None:
+        """fetch_snapshots threads from_year/to_year to _build_cdx_url via _fetch_with_retries."""
+        client = CDXClient(cache_dir=Path("/tmp/test_cache"))
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20190601120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "ABC123DEF456",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            await client.fetch_snapshots(
+                "dQw4w9WgXcQ", from_year=2018, to_year=2020
+            )
+
+            # Verify the URL includes from/to params
+            mock_get.assert_called_once()
+            call_args = mock_get.call_args
+            requested_url = str(call_args[0][0])
+            assert "&from=20180101000000" in requested_url
+            assert "&to=20201231235959" in requested_url
+
+    async def test_fetch_snapshots_year_filtered_cache_hit(
+        self, tmp_path: Path
+    ) -> None:
+        """Cache hit for year-filtered query uses correct cache file and oldest-first order."""
+        cache_dir = tmp_path / "cdx_cache"
+        cache_dir.mkdir(parents=True)
+        cache_file = cache_dir / "cdx" / "dQw4w9WgXcQ_from2018_to2020.json"
+        cache_file.parent.mkdir(parents=True)
+
+        # Create a fresh cache entry (stored newest-first, as _parse_cdx_response does)
+        cache_entry = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            snapshots=[
+                CdxSnapshot(
+                    timestamp="20200601120000",
+                    original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                    mimetype="text/html",
+                    statuscode=200,
+                    digest="NEWER_2020",
+                    length=50000,
+                ),
+                CdxSnapshot(
+                    timestamp="20180601120000",
+                    original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                    mimetype="text/html",
+                    statuscode=200,
+                    digest="OLDER_2018",
+                    length=50000,
+                ),
+            ],
+            raw_count=2,
+        )
+
+        cache_file.write_text(cache_entry.model_dump_json())
+
+        client = CDXClient(cache_dir=cache_dir)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            snapshots = await client.fetch_snapshots(
+                "dQw4w9WgXcQ", from_year=2018, to_year=2020
+            )
+
+            # Should not make HTTP request (cache hit)
+            mock_get.assert_not_called()
+
+            # Should return oldest-first when from_year is set
+            assert len(snapshots) == 2
+            assert snapshots[0].digest == "OLDER_2018"
+            assert snapshots[1].digest == "NEWER_2020"
+
+    async def test_fetch_snapshots_year_filtered_cache_miss_writes_correct_file(
+        self, tmp_path: Path
+    ) -> None:
+        """Cache miss for year-filtered query writes to correct cache file."""
+        cache_dir = tmp_path / "cdx_cache"
+
+        client = CDXClient(cache_dir=cache_dir)
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20190601120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "FRESH_YEAR01",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            await client.fetch_snapshots(
+                "dQw4w9WgXcQ", from_year=2018, to_year=2020
+            )
+
+        # Cache file should be written at the year-filtered path
+        expected_cache = cache_dir / "cdx" / "dQw4w9WgXcQ_from2018_to2020.json"
+        assert expected_cache.exists()
+
+        # The unfiltered cache file should NOT exist
+        unfiltered_cache = cache_dir / "cdx" / "dQw4w9WgXcQ.json"
+        assert not unfiltered_cache.exists()
+
+    async def test_fetch_snapshots_with_from_year_returns_oldest_first(
+        self, tmp_path: Path
+    ) -> None:
+        """fetch_snapshots with from_year returns snapshots oldest-first."""
+        client = CDXClient(cache_dir=tmp_path)
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20180301120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "OLDEST_2018",
+                "50000",
+            ],
+            [
+                "20190601120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "MIDDLE_2019",
+                "50000",
+            ],
+            [
+                "20200901120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "NEWEST_2020",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots(
+                "dQw4w9WgXcQ", from_year=2018
+            )
+
+        # With from_year, results should be oldest-first (ascending)
+        assert len(snapshots) == 3
+        assert snapshots[0].digest == "OLDEST_2018"
+        assert snapshots[1].digest == "MIDDLE_2019"
+        assert snapshots[2].digest == "NEWEST_2020"
+
+    async def test_fetch_snapshots_without_from_year_returns_newest_first(
+        self, tmp_path: Path
+    ) -> None:
+        """fetch_snapshots without from_year returns snapshots newest-first (default)."""
+        client = CDXClient(cache_dir=tmp_path)
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20180301120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "OLDEST_2018",
+                "50000",
+            ],
+            [
+                "20190601120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "MIDDLE_2019",
+                "50000",
+            ],
+            [
+                "20200901120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "NEWEST_2020",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots("dQw4w9WgXcQ")
+
+        # Without from_year, results should be newest-first (descending)
+        assert len(snapshots) == 3
+        assert snapshots[0].digest == "NEWEST_2020"
+        assert snapshots[1].digest == "MIDDLE_2019"
+        assert snapshots[2].digest == "OLDEST_2018"
+
+    async def test_fetch_snapshots_with_only_to_year_returns_newest_first(
+        self, tmp_path: Path
+    ) -> None:
+        """fetch_snapshots with only to_year (no from_year) returns newest-first."""
+        client = CDXClient(cache_dir=tmp_path)
+
+        cdx_response = [
+            ["timestamp", "original", "mimetype", "statuscode", "digest", "length"],
+            [
+                "20180301120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "OLDER",
+                "50000",
+            ],
+            [
+                "20190601120000",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "text/html",
+                "200",
+                "NEWER",
+                "50000",
+            ],
+        ]
+
+        mock_response = httpx.Response(status_code=200, json=cdx_response)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            snapshots = await client.fetch_snapshots(
+                "dQw4w9WgXcQ", to_year=2020
+            )
+
+        # Only to_year (no from_year) = newest-first (default)
+        assert len(snapshots) == 2
+        assert snapshots[0].digest == "NEWER"
+        assert snapshots[1].digest == "OLDER"

--- a/tests/unit/services/recovery/test_models.py
+++ b/tests/unit/services/recovery/test_models.py
@@ -1,0 +1,590 @@
+"""
+Tests for Recovery Service Models.
+
+Comprehensive unit tests for Pydantic models in chronovista.services.recovery.models.
+Covers CdxSnapshot, RecoveredVideoData, RecoveryResult, and CdxCacheEntry models
+with validation, computed properties, and edge cases.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from chronovista.services.recovery.models import (
+    CdxCacheEntry,
+    CdxSnapshot,
+    RecoveredVideoData,
+    RecoveryResult,
+)
+
+
+class TestCdxSnapshot:
+    """Tests for CdxSnapshot Pydantic model (T006)."""
+
+    def test_valid_snapshot(self) -> None:
+        """Test creating CdxSnapshot with valid data."""
+        snapshot = CdxSnapshot(
+            timestamp="20220106075526",
+            original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            mimetype="text/html",
+            statuscode=200,
+            digest="ABC123",
+            length=50000,
+        )
+
+        assert snapshot.timestamp == "20220106075526"
+        assert snapshot.original == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert snapshot.mimetype == "text/html"
+        assert snapshot.statuscode == 200
+        assert snapshot.digest == "ABC123"
+        assert snapshot.length == 50000
+
+    def test_timestamp_must_be_14_digits(self) -> None:
+        """Test that timestamps must be exactly 14 digits."""
+        # Too short
+        with pytest.raises(ValidationError) as exc_info:
+            CdxSnapshot(
+                timestamp="2022010607",  # Only 10 digits
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=50000,
+            )
+        assert "timestamp" in str(exc_info.value).lower()
+
+        # Too long
+        with pytest.raises(ValidationError) as exc_info:
+            CdxSnapshot(
+                timestamp="123456789012345",  # 15 digits
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=50000,
+            )
+        assert "timestamp" in str(exc_info.value).lower()
+
+        # Non-digits
+        with pytest.raises(ValidationError) as exc_info:
+            CdxSnapshot(
+                timestamp="abcdefghijklmn",  # 14 characters but not digits
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=50000,
+            )
+        assert "timestamp" in str(exc_info.value).lower()
+
+    def test_statuscode_must_be_200(self) -> None:
+        """Test that statuscode field accepts 200."""
+        snapshot = CdxSnapshot(
+            timestamp="20220106075526",
+            original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            mimetype="text/html",
+            statuscode=200,
+            digest="ABC123",
+            length=50000,
+        )
+        assert snapshot.statuscode == 200
+
+    def test_length_must_be_positive(self) -> None:
+        """Test that length must be positive (>0)."""
+        # Length = 0 should fail
+        with pytest.raises(ValidationError) as exc_info:
+            CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=0,
+            )
+        assert "length" in str(exc_info.value).lower()
+
+        # Negative length should fail
+        with pytest.raises(ValidationError) as exc_info:
+            CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=-1000,
+            )
+        assert "length" in str(exc_info.value).lower()
+
+    def test_wayback_url_property(self) -> None:
+        """Test wayback_url computed property returns correct URL."""
+        snapshot = CdxSnapshot(
+            timestamp="20220106075526",
+            original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            mimetype="text/html",
+            statuscode=200,
+            digest="ABC123",
+            length=50000,
+        )
+
+        expected_url = "https://web.archive.org/web/20220106075526id_/https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert snapshot.wayback_url == expected_url
+
+    def test_wayback_url_rendered_property(self) -> None:
+        """Test wayback_url_rendered property returns if_ format URL."""
+        snapshot = CdxSnapshot(
+            timestamp="20220106075526",
+            original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            mimetype="text/html",
+            statuscode=200,
+            digest="ABC123",
+            length=50000,
+        )
+
+        expected_url = "https://web.archive.org/web/20220106075526if_/https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert snapshot.wayback_url_rendered == expected_url
+
+    def test_datetime_property(self) -> None:
+        """Test datetime property parses timestamp into datetime object."""
+        snapshot = CdxSnapshot(
+            timestamp="20220106075526",
+            original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            mimetype="text/html",
+            statuscode=200,
+            digest="ABC123",
+            length=50000,
+        )
+
+        expected_datetime = datetime(2022, 1, 6, 7, 55, 26, tzinfo=timezone.utc)
+        assert snapshot.datetime == expected_datetime
+
+
+class TestRecoveredVideoData:
+    """Tests for RecoveredVideoData Pydantic model (T007)."""
+
+    def test_minimal_valid(self) -> None:
+        """Test creating RecoveredVideoData with only required field."""
+        recovered = RecoveredVideoData(snapshot_timestamp="20220106075526")
+
+        assert recovered.snapshot_timestamp == "20220106075526"
+        assert recovered.title is None
+        assert recovered.description is None
+        assert recovered.channel_id is None
+        assert recovered.channel_name_hint is None
+        assert recovered.view_count is None
+        assert recovered.like_count is None
+        assert recovered.tags == []  # Default empty list
+
+    def test_full_valid(self) -> None:
+        """Test creating RecoveredVideoData with all fields populated."""
+        recovered = RecoveredVideoData(
+            snapshot_timestamp="20220106075526",
+            title="Never Gonna Give You Up",
+            description="The official video for Rick Astley",
+            channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+            channel_name_hint="Rick Astley",
+            view_count=1000000000,
+            like_count=5000000,
+            tags=["music", "80s", "pop"],
+        )
+
+        assert recovered.snapshot_timestamp == "20220106075526"
+        assert recovered.title == "Never Gonna Give You Up"
+        assert recovered.description == "The official video for Rick Astley"
+        assert recovered.channel_id == "UCuAXFkgsw1L7xaCfnd5JJOw"
+        assert recovered.channel_name_hint == "Rick Astley"
+        assert recovered.view_count == 1000000000
+        assert recovered.like_count == 5000000
+        assert recovered.tags == ["music", "80s", "pop"]
+
+    def test_channel_id_regex_validation(self) -> None:
+        """Test channel_id must match UC[A-Za-z0-9_-]{22} pattern."""
+        # Invalid: not a channel ID format
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredVideoData(
+                snapshot_timestamp="20220106075526",
+                channel_id="not_a_channel",
+            )
+        assert "channel_id" in str(exc_info.value).lower()
+
+        # Invalid: UC but too short
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredVideoData(
+                snapshot_timestamp="20220106075526",
+                channel_id="UC_too_short",
+            )
+        assert "channel_id" in str(exc_info.value).lower()
+
+        # Valid: proper channel ID format
+        recovered = RecoveredVideoData(
+            snapshot_timestamp="20220106075526",
+            channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+        )
+        assert recovered.channel_id == "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+    def test_view_count_non_negative(self) -> None:
+        """Test view_count must be non-negative."""
+        # Negative should fail
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredVideoData(
+                snapshot_timestamp="20220106075526",
+                view_count=-1,
+            )
+        assert "view_count" in str(exc_info.value).lower()
+
+        # Zero should pass
+        recovered = RecoveredVideoData(
+            snapshot_timestamp="20220106075526",
+            view_count=0,
+        )
+        assert recovered.view_count == 0
+
+    def test_like_count_non_negative(self) -> None:
+        """Test like_count must be non-negative."""
+        # Negative should fail
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredVideoData(
+                snapshot_timestamp="20220106075526",
+                like_count=-1,
+            )
+        assert "like_count" in str(exc_info.value).lower()
+
+        # Zero should pass
+        recovered = RecoveredVideoData(
+            snapshot_timestamp="20220106075526",
+            like_count=0,
+        )
+        assert recovered.like_count == 0
+
+    def test_snapshot_timestamp_14_digits(self) -> None:
+        """Test snapshot_timestamp must be exactly 14 digits."""
+        # Too short
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredVideoData(snapshot_timestamp="202201")
+        assert "snapshot_timestamp" in str(exc_info.value).lower()
+
+        # Non-digits
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredVideoData(snapshot_timestamp="abcd1234567890")
+        assert "snapshot_timestamp" in str(exc_info.value).lower()
+
+        # Valid 14 digits
+        recovered = RecoveredVideoData(snapshot_timestamp="20220106075526")
+        assert recovered.snapshot_timestamp == "20220106075526"
+
+    def test_recovery_source_property(self) -> None:
+        """Test recovery_source computed property returns wayback:{timestamp}."""
+        recovered = RecoveredVideoData(snapshot_timestamp="20220106075526")
+
+        expected_source = "wayback:20220106075526"
+        assert recovered.recovery_source == expected_source
+
+    def test_recovered_fields_property(self) -> None:
+        """Test recovered_fields returns list of non-None field names."""
+        # Only snapshot_timestamp set
+        recovered_minimal = RecoveredVideoData(snapshot_timestamp="20220106075526")
+        assert recovered_minimal.recovered_fields == ["snapshot_timestamp"]
+
+        # Multiple fields set
+        recovered_multi = RecoveredVideoData(
+            snapshot_timestamp="20220106075526",
+            title="Test Video",
+            view_count=1000,
+        )
+        fields = recovered_multi.recovered_fields
+        assert "snapshot_timestamp" in fields
+        assert "title" in fields
+        assert "view_count" in fields
+        assert len(fields) == 3
+
+        # Check that None fields are not included
+        assert "description" not in fields
+        assert "channel_id" not in fields
+
+    def test_has_data_property(self) -> None:
+        """Test has_data returns True if metadata fields are set."""
+        # Only snapshot_timestamp (no metadata)
+        recovered_no_data = RecoveredVideoData(snapshot_timestamp="20220106075526")
+        assert recovered_no_data.has_data is False
+
+        # With title (has metadata)
+        recovered_with_title = RecoveredVideoData(
+            snapshot_timestamp="20220106075526",
+            title="Test Video",
+        )
+        assert recovered_with_title.has_data is True
+
+        # With view_count (has metadata)
+        recovered_with_views = RecoveredVideoData(
+            snapshot_timestamp="20220106075526",
+            view_count=100,
+        )
+        assert recovered_with_views.has_data is True
+
+    def test_tags_default_empty_list(self) -> None:
+        """Test tags field defaults to empty list."""
+        recovered = RecoveredVideoData(snapshot_timestamp="20220106075526")
+        assert recovered.tags == []
+        assert isinstance(recovered.tags, list)
+
+    def test_channel_id_none_is_valid(self) -> None:
+        """Test channel_id=None is valid (optional field)."""
+        recovered = RecoveredVideoData(
+            snapshot_timestamp="20220106075526",
+            channel_id=None,
+        )
+        assert recovered.channel_id is None
+
+
+class TestRecoveryResult:
+    """Tests for RecoveryResult Pydantic model (T008)."""
+
+    def test_required_fields(self) -> None:
+        """Test video_id and success are required fields."""
+        # Missing video_id
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveryResult(success=True)  # type: ignore[call-arg]
+        assert "video_id" in str(exc_info.value).lower()
+
+        # Missing success
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveryResult(video_id="dQw4w9WgXcQ")  # type: ignore[call-arg]
+        assert "success" in str(exc_info.value).lower()
+
+        # Both provided
+        result = RecoveryResult(video_id="dQw4w9WgXcQ", success=True)
+        assert result.video_id == "dQw4w9WgXcQ"
+        assert result.success is True
+
+    def test_success_result_defaults(self) -> None:
+        """Test default values for successful recovery result."""
+        result = RecoveryResult(video_id="dQw4w9WgXcQ", success=True)
+
+        assert result.success is True
+        assert result.fields_recovered == []
+        assert result.snapshots_available == 0
+        assert result.failure_reason is None
+        assert result.snapshot_used is None
+        assert result.channel_recovery_candidates == []
+
+    def test_failure_result(self) -> None:
+        """Test creating a failure result with failure_reason."""
+        result = RecoveryResult(
+            video_id="dQw4w9WgXcQ",
+            success=False,
+            failure_reason="no_archive_found",
+        )
+
+        assert result.success is False
+        assert result.failure_reason == "no_archive_found"
+
+    def test_all_failure_reasons(self) -> None:
+        """Test all 10 valid failure_reason values."""
+        failure_reasons = [
+            "no_archive_found",
+            "all_snapshots_too_small",
+            "all_removal_notices",
+            "no_extractable_metadata",
+            "extraction_failed",
+            "timeout",
+            "cdx_error",
+            "dependency_missing",
+            "video_not_found",
+            "video_available",
+        ]
+
+        for reason in failure_reasons:
+            result = RecoveryResult(
+                video_id="dQw4w9WgXcQ",
+                success=False,
+                failure_reason=reason,
+            )
+            assert result.failure_reason == reason
+
+    def test_video_id_validation(self) -> None:
+        """Test video_id must be valid VideoId (11 chars alphanumeric)."""
+        # Valid video ID
+        result = RecoveryResult(video_id="dQw4w9WgXcQ", success=True)
+        assert result.video_id == "dQw4w9WgXcQ"
+
+        # Invalid: too short
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveryResult(video_id="short", success=True)
+        assert "video_id" in str(exc_info.value).lower()
+
+        # Invalid: too long
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveryResult(video_id="dQw4w9WgXcQTooLong", success=True)
+        assert "video_id" in str(exc_info.value).lower()
+
+    def test_channel_recovery_candidates_default(self) -> None:
+        """Test channel_recovery_candidates defaults to empty list."""
+        result = RecoveryResult(video_id="dQw4w9WgXcQ", success=True)
+        assert result.channel_recovery_candidates == []
+        assert isinstance(result.channel_recovery_candidates, list)
+
+
+class TestCdxCacheEntry:
+    """Tests for CdxCacheEntry Pydantic model (T009)."""
+
+    def test_valid_cache_entry(self) -> None:
+        """Test creating valid CdxCacheEntry."""
+        now = datetime.now(timezone.utc)
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=50000,
+            )
+        ]
+
+        cache_entry = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=now,
+            snapshots=snapshots,
+            raw_count=5,
+        )
+
+        assert cache_entry.video_id == "dQw4w9WgXcQ"
+        assert cache_entry.fetched_at == now
+        assert len(cache_entry.snapshots) == 1
+        assert cache_entry.snapshots[0].timestamp == "20220106075526"
+        assert cache_entry.raw_count == 5
+
+    def test_fetched_at_must_be_timezone_aware(self) -> None:
+        """Test fetched_at must be timezone-aware datetime."""
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=50000,
+            )
+        ]
+
+        # Naive datetime should fail
+        naive_datetime = datetime(2022, 1, 6, 7, 55, 26)
+        with pytest.raises(ValidationError) as exc_info:
+            CdxCacheEntry(
+                video_id="dQw4w9WgXcQ",
+                fetched_at=naive_datetime,
+                snapshots=snapshots,
+                raw_count=1,
+            )
+        assert "fetched_at" in str(exc_info.value).lower()
+
+        # UTC datetime should pass
+        utc_datetime = datetime(2022, 1, 6, 7, 55, 26, tzinfo=timezone.utc)
+        cache_entry = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=utc_datetime,
+            snapshots=snapshots,
+            raw_count=1,
+        )
+        assert cache_entry.fetched_at.tzinfo == timezone.utc
+
+    def test_cache_validity_check(self) -> None:
+        """Test is_valid method checks cache age against TTL."""
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=50000,
+            )
+        ]
+
+        # Recent cache (1 hour ago) - should be valid with 24hr TTL
+        recent = datetime.now(timezone.utc) - timedelta(hours=1)
+        cache_entry_recent = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=recent,
+            snapshots=snapshots,
+            raw_count=1,
+        )
+        assert cache_entry_recent.is_valid(ttl_hours=24) is True
+
+        # Old cache (25 hours ago) - should be expired with 24hr TTL
+        old = datetime.now(timezone.utc) - timedelta(hours=25)
+        cache_entry_old = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=old,
+            snapshots=snapshots,
+            raw_count=1,
+        )
+        assert cache_entry_old.is_valid(ttl_hours=24) is False
+
+        # Edge case: exactly 24 hours ago
+        exactly_24h = datetime.now(timezone.utc) - timedelta(hours=24, seconds=1)
+        cache_entry_edge = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=exactly_24h,
+            snapshots=snapshots,
+            raw_count=1,
+        )
+        assert cache_entry_edge.is_valid(ttl_hours=24) is False
+
+    def test_snapshots_list(self) -> None:
+        """Test snapshots field accepts list of CdxSnapshot objects."""
+        now = datetime.now(timezone.utc)
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=50000,
+            ),
+            CdxSnapshot(
+                timestamp="20210106075526",
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="DEF456",
+                length=48000,
+            ),
+        ]
+
+        cache_entry = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=now,
+            snapshots=snapshots,
+            raw_count=2,
+        )
+
+        assert len(cache_entry.snapshots) == 2
+        assert cache_entry.snapshots[0].digest == "ABC123"
+        assert cache_entry.snapshots[1].digest == "DEF456"
+
+    def test_raw_count_field(self) -> None:
+        """Test raw_count field stores CDX entry count before filtering."""
+        now = datetime.now(timezone.utc)
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABC123",
+                length=50000,
+            )
+        ]
+
+        # raw_count can be different from len(snapshots) due to filtering
+        cache_entry = CdxCacheEntry(
+            video_id="dQw4w9WgXcQ",
+            fetched_at=now,
+            snapshots=snapshots,
+            raw_count=10,  # 10 raw entries, but only 1 after filtering
+        )
+
+        assert cache_entry.raw_count == 10
+        assert len(cache_entry.snapshots) == 1

--- a/tests/unit/services/recovery/test_orchestrator.py
+++ b/tests/unit/services/recovery/test_orchestrator.py
@@ -1,0 +1,2876 @@
+"""
+Unit tests for the video recovery orchestrator.
+
+Tests the recovery_video function which coordinates CDX API queries,
+page parsing, database updates, and tag persistence for deleted YouTube videos.
+
+Test Coverage
+-------------
+- T033: Three-tier overwrite policy (immutable vs mutable fields, NULL protection)
+- T034: Eligibility checks (availability_status validation, video existence)
+- T035: Snapshot iteration (newest-first, removal notice handling, limits)
+- T036: Tag recovery (bulk_create_video_tags integration)
+- T037: RecoveryResult construction (success/failure reasons, field tracking)
+- T038: Idempotency (multiple recoveries with same/different snapshots)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import Video as VideoDB
+from chronovista.models.enums import AvailabilityStatus
+from chronovista.repositories.video_repository import VideoRepository
+from chronovista.repositories.video_tag_repository import VideoTagRepository
+from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
+from chronovista.services.recovery.models import CdxSnapshot, RecoveredVideoData
+from chronovista.services.recovery.orchestrator import recover_video
+from chronovista.services.recovery.page_parser import PageParser
+
+# Mark all tests in this module as async
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _mock_channel_repo():
+    """Mock ChannelRepository for all orchestrator tests to prevent real DB access."""
+    with patch(
+        "chronovista.services.recovery.orchestrator.ChannelRepository"
+    ) as mock_cls:
+        mock_instance = AsyncMock()
+        mock_cls.return_value = mock_instance
+        mock_instance.get.return_value = None  # Default: no channel found
+        mock_instance.exists.return_value = True  # Default: channel exists (skip stub creation)
+        yield mock_instance
+
+
+class TestOverwritePolicy:
+    """
+    T033: Three-tier overwrite policy tests.
+
+    Validates that immutable fields are only filled when NULL, mutable fields
+    are overwritten when the incoming snapshot is newer, and NULL values
+    never blank existing data.
+    """
+
+    async def test_immutable_fields_fill_if_null_only(self) -> None:
+        """Immutable fields (channel_id, category_id) fill-if-NULL only."""
+        # GIVEN: A video with NULL immutable fields
+        video = VideoDB(
+            video_id="testVid0001",
+            title="Existing Title",
+            description="Existing Description",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id=None,  # NULL - should be filled
+            category_id=None,  # NULL - should be filled
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data with immutable field values
+        recovered_data = RecoveredVideoData(
+            channel_id="UC1234567890123456789012",
+            category_id="10",
+            upload_date=datetime(2019, 6, 15, tzinfo=timezone.utc),
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        # Mock video repository to return our test video
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            # Mock CDX client to return snapshots
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0001",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+
+            # Mock page parser to return recovered data
+            page_parser.extract_metadata.return_value = recovered_data
+
+            # Mock tag repository
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0001",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Immutable NULL fields were filled
+        assert result.success is True
+        assert "channel_id" in result.fields_recovered
+        assert "category_id" in result.fields_recovered
+
+    async def test_immutable_fields_skip_when_existing_value(self) -> None:
+        """Immutable fields with existing value are skipped (not overwritten)."""
+        # GIVEN: A video with existing immutable fields
+        video = VideoDB(
+            video_id="testVid0002",
+            title="Existing Title",
+            description="Existing Description",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC_EXISTING_CHANNEL_ID",  # Has value - should NOT be overwritten
+            category_id="20",  # Has value - should NOT be overwritten
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data attempting to overwrite immutable fields
+        recovered_data = RecoveredVideoData(
+            channel_id="UCSkipChannelId123456789",
+            category_id="10",
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0002",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0002",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Immutable fields were skipped
+        assert result.success is True
+        assert "channel_id" in result.fields_skipped
+        assert "category_id" in result.fields_skipped
+
+    async def test_mutable_fields_fill_if_null_always(self) -> None:
+        """Mutable fields (title, description, view_count, etc.) fill-if-NULL always."""
+        # GIVEN: A video with NULL mutable fields
+        video = VideoDB(
+            video_id="testVid0003",
+            title="Placeholder Title",
+            description=None,  # NULL - should be filled
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            view_count=None,  # NULL - should be filled
+            like_count=None,  # NULL - should be filled
+            channel_name_hint=None,  # NULL - should be filled
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data with mutable field values
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            description="Recovered Description",
+            view_count=100000,
+            like_count=5000,
+            channel_name_hint="Recovered Channel",
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0003",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0003",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Mutable NULL fields were filled
+        assert result.success is True
+        assert "description" in result.fields_recovered
+        assert "view_count" in result.fields_recovered
+        assert "like_count" in result.fields_recovered
+        assert "channel_name_hint" in result.fields_recovered
+
+    async def test_mutable_fields_overwrite_when_newer_snapshot(self) -> None:
+        """Mutable fields overwrite when incoming snapshot is newer than existing recovery_source."""
+        # GIVEN: A video previously recovered from an older snapshot
+        video = VideoDB(
+            video_id="testVid0004",
+            title="Old Recovered Title",
+            description="Old Recovered Description",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            view_count=50000,
+            like_count=2000,
+            recovery_source="wayback:20200106075526",  # Older snapshot
+            recovered_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data from a newer snapshot
+        recovered_data = RecoveredVideoData(
+            title="Newer Recovered Title",
+            description="Newer Recovered Description",
+            view_count=100000,
+            like_count=5000,
+            snapshot_timestamp="20220106075526",  # Newer than existing recovery_source
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0004",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0004",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Mutable fields were overwritten with newer values
+        assert result.success is True
+        assert "title" in result.fields_recovered
+        assert "description" in result.fields_recovered
+        assert "view_count" in result.fields_recovered
+
+    async def test_null_protection_never_blank_existing_values(self) -> None:
+        """NULL values in recovered data never blank existing database values."""
+        # GIVEN: A video with existing values
+        video = VideoDB(
+            video_id="testVid0005",
+            title="Existing Title",
+            description="Existing Description",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            view_count=50000,
+            like_count=2000,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data with NULL/missing fields but one valid field
+        recovered_data = RecoveredVideoData(
+            title=None,  # NULL - should NOT blank existing value
+            description=None,  # NULL - should NOT blank existing value
+            view_count=None,  # NULL - should NOT blank existing value
+            thumbnail_url="https://i.ytimg.com/vi/test/hqdefault.jpg",  # Non-NULL so has_data=True
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0005",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0005",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: NULL values did not blank existing values
+        assert result.success is True
+        assert "title" in result.fields_skipped
+        assert "description" in result.fields_skipped
+        assert "view_count" in result.fields_skipped
+
+    async def test_recovered_at_and_recovery_source_always_set_on_success(self) -> None:
+        """recovered_at and recovery_source are always set on successful recovery."""
+        # GIVEN: A video with no recovery metadata
+        video = VideoDB(
+            video_id="testVid0006",
+            title="Test Video",
+            description="Test Description",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            recovered_at=None,
+            recovery_source=None,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0006",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0006",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: recovery_source was set
+        assert result.success is True
+        assert result.snapshot_used == "20220106075526"
+
+    async def test_upload_date_is_mutable_and_overwritten_when_newer(self) -> None:
+        """upload_date is mutable and overwritten when newer snapshot is available."""
+        # GIVEN: A video with existing upload_date from an older recovery
+        video = VideoDB(
+            video_id="testVid0007",
+            title="Test Video",
+            description="Test Description",
+            upload_date=datetime(2026, 1, 25, tzinfo=timezone.utc),  # Bad date (future)
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            recovery_source="wayback:20180301000000",  # Older snapshot
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data with correct upload_date from newer snapshot
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            upload_date=datetime(2018, 2, 22, tzinfo=timezone.utc),  # Correct date
+            snapshot_timestamp="20200101000000",  # Newer snapshot
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20200101000000",
+                original="https://www.youtube.com/watch?v=testVid0007",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0007",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: upload_date was recovered (newer snapshot wins)
+        assert result.success is True
+        assert "upload_date" in result.fields_recovered
+
+    async def test_upload_date_skipped_when_existing_recovery_is_newer(self) -> None:
+        """upload_date is skipped when existing recovery is from a newer snapshot."""
+        # GIVEN: A video with existing upload_date from a newer recovery
+        video = VideoDB(
+            video_id="testVid0008",
+            title="Test Video",
+            description="Test Description",
+            upload_date=datetime(2018, 2, 22, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            recovery_source="wayback:20210101000000",  # Newer snapshot
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data from an older snapshot
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            upload_date=datetime(2018, 1, 15, tzinfo=timezone.utc),
+            snapshot_timestamp="20200101000000",  # Older snapshot
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20200101000000",
+                original="https://www.youtube.com/watch?v=testVid0008",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0008",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: upload_date was skipped (older snapshot loses)
+        assert result.success is True
+        assert "upload_date" in result.fields_skipped
+
+
+class TestEligibilityChecks:
+    """
+    T034: Eligibility check tests.
+
+    Validates that only unavailable videos are eligible for recovery,
+    and that availability_status is never modified during recovery.
+    """
+
+    async def test_available_video_rejected(self) -> None:
+        """Video with availability_status == AVAILABLE is rejected (video_available failure)."""
+        # GIVEN: A video that is AVAILABLE (not deleted/unavailable)
+        video = VideoDB(
+            video_id="testVid0007",
+            title="Available Video",
+            description="This video is still available",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.AVAILABLE.value,  # AVAILABLE
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            # WHEN: We attempt to recover the video
+            result = await recover_video(
+                session=session,
+                video_id="testVid0007",
+                cdx_client=cdx_client,
+                page_parser=page_parser,
+                rate_limiter=rate_limiter,
+                dry_run=False,
+            )
+
+        # THEN: Recovery failed due to video being available
+        assert result.success is False
+        assert result.failure_reason == "video_available"
+
+    async def test_unavailable_video_eligible(self) -> None:
+        """Video with availability_status == DELETED/PRIVATE/etc. is eligible."""
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        # Test each unavailable status with valid 11-char video IDs
+        statuses_and_ids = [
+            (AvailabilityStatus.DELETED, "tstDelVid01"),
+            (AvailabilityStatus.PRIVATE, "tstPrvVid02"),
+            (AvailabilityStatus.TERMINATED, "tstTrmVid03"),
+            (AvailabilityStatus.COPYRIGHT, "tstCprVid04"),
+            (AvailabilityStatus.TOS_VIOLATION, "tstTosVid05"),
+            (AvailabilityStatus.UNAVAILABLE, "tstUnaVid06"),
+        ]
+        for status, vid_id in statuses_and_ids:
+            video = VideoDB(
+                video_id=vid_id,
+                title=f"Video with status {status.value}",
+                description="Test video",
+                upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+                duration=120,
+                channel_id="UC1234567890123456789012",
+                availability_status=status.value,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoRepository"
+            ) as mock_repo_class:
+                mock_repo = AsyncMock()
+                mock_repo_class.return_value = mock_repo
+                mock_repo.get_by_video_id.return_value = video
+
+                snapshot = CdxSnapshot(
+                    timestamp="20220106075526",
+                    original=f"https://www.youtube.com/watch?v={vid_id}",
+                    mimetype="text/html",
+                    statuscode=200,
+                    digest="ABCD1234567890",
+                    length=50000,
+                )
+                cdx_client.fetch_snapshots.return_value = [snapshot]
+
+                recovered_data = RecoveredVideoData(
+                    title="Recovered Title",
+                    snapshot_timestamp="20220106075526",
+                )
+                page_parser.extract_metadata.return_value = recovered_data
+
+                with patch(
+                    "chronovista.services.recovery.orchestrator.VideoTagRepository"
+                ) as mock_tag_repo_class:
+                    mock_tag_repo = AsyncMock()
+                    mock_tag_repo_class.return_value = mock_tag_repo
+
+                    result = await recover_video(
+                        session=session,
+                        video_id=vid_id,
+                        cdx_client=cdx_client,
+                        page_parser=page_parser,
+                        rate_limiter=rate_limiter,
+                        dry_run=False,
+                    )
+
+            assert result.success is True, f"Status {status.value} should be eligible"
+
+    async def test_video_not_in_database_rejected(self) -> None:
+        """Video ID not in database returns video_not_found failure."""
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            # Return None (video not found)
+            mock_repo.get_by_video_id.return_value = None
+
+            # WHEN: We attempt to recover a non-existent video
+            result = await recover_video(
+                session=session,
+                video_id="noVidExists",
+                cdx_client=cdx_client,
+                page_parser=page_parser,
+                rate_limiter=rate_limiter,
+                dry_run=False,
+            )
+
+        # THEN: Recovery failed due to video not found
+        assert result.success is False
+        assert result.failure_reason == "video_not_found"
+
+    async def test_availability_status_never_modified(self) -> None:
+        """availability_status is NEVER modified during recovery."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0008",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0008",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+
+            recovered_data = RecoveredVideoData(
+                title="Recovered Title",
+                snapshot_timestamp="20220106075526",
+            )
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0008",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Recovery succeeded and availability_status was NOT modified
+        assert result.success is True
+        assert "availability_status" not in result.fields_recovered
+
+
+class TestSnapshotIteration:
+    """
+    T035: Snapshot iteration tests.
+
+    Validates that snapshots are processed newest-first, removal notices
+    are skipped, and iteration respects limits (20 snapshots max, 600s timeout).
+    """
+
+    async def test_iterates_newest_first(self) -> None:
+        """Iterates snapshots newest-first (already sorted by CDXClient)."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0009",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Multiple snapshots (newest-first order from CDXClient)
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",  # Newest
+                original="https://www.youtube.com/watch?v=testVid0009",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            ),
+            CdxSnapshot(
+                timestamp="20210615102030",  # Middle
+                original="https://www.youtube.com/watch?v=testVid0009",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567891",
+                length=50000,
+            ),
+            CdxSnapshot(
+                timestamp="20200101120000",  # Oldest
+                original="https://www.youtube.com/watch?v=testVid0009",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567892",
+                length=50000,
+            ),
+        ]
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        call_order = []
+
+        async def track_parse_calls(snapshot: CdxSnapshot) -> RecoveredVideoData:
+            """Track which snapshot was parsed first."""
+            call_order.append(snapshot.timestamp)
+            # First snapshot succeeds
+            if snapshot.timestamp == "20220106075526":
+                return RecoveredVideoData(
+                    title="Recovered from newest",
+                    snapshot_timestamp=snapshot.timestamp,
+                )
+            # Others would be skipped
+            return RecoveredVideoData(snapshot_timestamp=snapshot.timestamp)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = snapshots
+            page_parser.extract_metadata.side_effect = track_parse_calls
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0009",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Newest snapshot was tried first
+        assert len(call_order) >= 1
+        assert call_order[0] == "20220106075526"  # Newest tried first
+
+    async def test_skips_removal_notices_tries_next(self) -> None:
+        """Skips removal notices and tries next snapshot."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0010",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Snapshots with removal notices
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",  # First - removal notice
+                original="https://www.youtube.com/watch?v=testVid0010",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            ),
+            CdxSnapshot(
+                timestamp="20210615102030",  # Second - has data
+                original="https://www.youtube.com/watch?v=testVid0010",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567891",
+                length=50000,
+            ),
+        ]
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        async def mock_parse(snapshot: CdxSnapshot) -> RecoveredVideoData | None:
+            """First snapshot returns no data (removal notice), second succeeds."""
+            if snapshot.timestamp == "20220106075526":
+                # Removal notice - no data recovered
+                return RecoveredVideoData(snapshot_timestamp=snapshot.timestamp)
+            else:
+                # Second snapshot has data
+                return RecoveredVideoData(
+                    title="Recovered Title",
+                    snapshot_timestamp=snapshot.timestamp,
+                )
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = snapshots
+            page_parser.extract_metadata.side_effect = mock_parse
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0010",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Second snapshot was used after first was skipped
+        assert result.success is True
+        assert result.snapshot_used == "20210615102030"
+        assert result.snapshots_tried == 2
+
+    async def test_stops_after_first_successful_extraction(self) -> None:
+        """Stops after first successful metadata extraction."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0011",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Multiple snapshots (all could succeed)
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0011",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            ),
+            CdxSnapshot(
+                timestamp="20210615102030",
+                original="https://www.youtube.com/watch?v=testVid0011",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567891",
+                length=50000,
+            ),
+            CdxSnapshot(
+                timestamp="20200101120000",
+                original="https://www.youtube.com/watch?v=testVid0011",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567892",
+                length=50000,
+            ),
+        ]
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = snapshots
+
+            # Mock page parser to always return data
+            page_parser.extract_metadata.return_value = RecoveredVideoData(
+                title="Recovered Title",
+                snapshot_timestamp="20220106075526",
+            )
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0011",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Only first snapshot was tried (stopped after success)
+        assert result.success is True
+        assert result.snapshots_tried == 1
+        assert result.snapshot_used == "20220106075526"
+
+    async def test_stops_after_20_snapshots_max(self) -> None:
+        """Stops after trying 20 snapshots (max limit)."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0012",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: 30 snapshots (more than the 20 limit)
+        snapshots = [
+            CdxSnapshot(
+                timestamp=f"2022010607552{i:02d}"[:14],  # Unique timestamps
+                original="https://www.youtube.com/watch?v=testVid0012",
+                mimetype="text/html",
+                statuscode=200,
+                digest=f"ABCD123456789{i:02d}",
+                length=50000 + i,
+            )
+            for i in range(30)
+        ]
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = snapshots
+
+            # All snapshots return no data (removal notices)
+            page_parser.extract_metadata.return_value = RecoveredVideoData(
+                snapshot_timestamp="20220106075526"
+            )
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0012",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Only 20 snapshots were tried (max limit)
+        assert result.snapshots_tried == 20
+        assert result.snapshots_available == 30
+
+    async def test_reports_snapshots_tried_and_available_counts(self) -> None:
+        """Reports accurate snapshots_tried and snapshots_available counts."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0013",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: 5 snapshots
+        snapshots = [
+            CdxSnapshot(
+                timestamp=f"202201060755{i:02d}",
+                original="https://www.youtube.com/watch?v=testVid0013",
+                mimetype="text/html",
+                statuscode=200,
+                digest=f"ABCD123456789{i}",
+                length=50000 + i,
+            )
+            for i in range(5)
+        ]
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        call_count = 0
+
+        async def mock_parse(snapshot: CdxSnapshot) -> RecoveredVideoData:
+            """Third snapshot succeeds."""
+            nonlocal call_count
+            call_count += 1
+            if call_count == 3:
+                return RecoveredVideoData(
+                    title="Recovered Title",
+                    snapshot_timestamp=snapshot.timestamp,
+                )
+            return RecoveredVideoData(snapshot_timestamp=snapshot.timestamp)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = snapshots
+            page_parser.extract_metadata.side_effect = mock_parse
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0013",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Correct counts are reported
+        assert result.snapshots_available == 5
+        assert result.snapshots_tried == 3
+
+
+class TestTagRecovery:
+    """
+    T036: Tag recovery tests.
+
+    Validates that recovered tags are passed to bulk_create_video_tags,
+    empty tag lists are handled correctly, and tag errors don't fail recovery.
+    """
+
+    async def test_recovered_tags_passed_to_bulk_create(self) -> None:
+        """Recovered tags are passed to bulk_create_video_tags with tag_orders=None."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0014",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data with tags
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            tags=["music", "entertainment", "viral"],
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0014",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0014",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: bulk_create_video_tags was called with correct parameters
+        mock_tag_repo.bulk_create_video_tags.assert_called_once()
+        call_args = mock_tag_repo.bulk_create_video_tags.call_args
+        assert call_args[1]["video_id"] == "testVid0014"
+        assert call_args[1]["tags"] == ["music", "entertainment", "viral"]
+        assert call_args[1]["tag_orders"] is None
+
+    async def test_empty_tags_list_no_tag_operation(self) -> None:
+        """Empty tags list results in no tag operation."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0015",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data with no tags
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            tags=[],  # Empty tags list
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0015",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0015",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: bulk_create_video_tags was NOT called
+        mock_tag_repo.bulk_create_video_tags.assert_not_called()
+
+    async def test_tag_errors_do_not_fail_recovery(self) -> None:
+        """Tag persistence errors do not fail the recovery operation."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0016",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data with tags
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            tags=["music", "entertainment"],
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0016",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # Mock tag creation to raise an exception
+                mock_tag_repo.bulk_create_video_tags.side_effect = Exception(
+                    "Tag database error"
+                )
+
+                # WHEN: We recover the video (tag operation fails)
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0016",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Recovery still succeeded despite tag error
+        assert result.success is True
+
+
+class TestRecoveryResultConstruction:
+    """
+    T037: RecoveryResult construction tests.
+
+    Validates that RecoveryResult objects correctly track success/failure,
+    fields recovered/skipped, duration, and channel recovery candidates.
+    """
+
+    async def test_success_result_includes_fields_recovered_and_skipped(self) -> None:
+        """Success result includes fields_recovered and fields_skipped lists."""
+        # GIVEN: A video with some existing and some NULL fields
+        video = VideoDB(
+            video_id="testVid0017",
+            title="Existing Title",  # Existing
+            description=None,  # NULL - will be filled
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",  # Existing - will be skipped
+            view_count=None,  # NULL - will be filled
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data
+        recovered_data = RecoveredVideoData(
+            title="New Title",  # Should be skipped (existing newer than recovery_source)
+            description="Recovered Description",  # Should be recovered (NULL)
+            channel_id="UCNewChannelId1234567890",  # Should be skipped (immutable with existing value)
+            view_count=100000,  # Should be recovered (NULL)
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0017",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0017",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Result includes fields_recovered and fields_skipped
+        assert result.success is True
+        assert "description" in result.fields_recovered
+        assert "view_count" in result.fields_recovered
+        assert "channel_id" in result.fields_skipped
+
+    async def test_failure_results_use_standardized_failure_reasons(self) -> None:
+        """Failure results use standardized failure_reason strings."""
+        # Test video_not_found
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = None  # Video not found
+
+            result = await recover_video(
+                session=session,
+                video_id="noVidExists",
+                cdx_client=cdx_client,
+                page_parser=page_parser,
+                rate_limiter=rate_limiter,
+                dry_run=False,
+            )
+
+        assert result.success is False
+        assert result.failure_reason == "video_not_found"
+
+    async def test_duration_seconds_is_tracked(self) -> None:
+        """duration_seconds is tracked for the recovery operation."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0018",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0018",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0018",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: duration_seconds is set
+        assert result.duration_seconds >= 0.0
+
+    async def test_channel_recovery_candidates_populated_when_channel_unavailable(
+        self,
+    ) -> None:
+        """channel_recovery_candidates populated when extracted channel has availability_status != AVAILABLE."""
+        # GIVEN: A video with DELETED status and orphaned channel
+        video = VideoDB(
+            video_id="testVid0019",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id=None,  # Orphaned - no channel
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data with a channel ID
+        recovered_channel_id = "UC1234567890123456789012"
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            channel_id=recovered_channel_id,
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0019",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            # Mock ChannelRepository to return an unavailable channel
+            with patch(
+                "chronovista.services.recovery.orchestrator.ChannelRepository"
+            ) as mock_channel_repo_class:
+                mock_channel_repo = AsyncMock()
+                mock_channel_repo_class.return_value = mock_channel_repo
+
+                # Mock channel lookup to return a DELETED channel
+                from chronovista.db.models import Channel as ChannelDB
+
+                unavailable_channel = ChannelDB(
+                    channel_id=recovered_channel_id,
+                    title="Deleted Channel",
+                    availability_status=AvailabilityStatus.DELETED.value,
+                    created_at=datetime.now(timezone.utc),
+                    updated_at=datetime.now(timezone.utc),
+                )
+                mock_channel_repo.get.return_value = unavailable_channel
+
+                with patch(
+                    "chronovista.services.recovery.orchestrator.VideoTagRepository"
+                ) as mock_tag_repo_class:
+                    mock_tag_repo = AsyncMock()
+                    mock_tag_repo_class.return_value = mock_tag_repo
+
+                    # WHEN: We recover the video
+                    result = await recover_video(
+                        session=session,
+                        video_id="testVid0019",
+                        cdx_client=cdx_client,
+                        page_parser=page_parser,
+                        rate_limiter=rate_limiter,
+                        dry_run=False,
+                    )
+
+        # THEN: channel_recovery_candidates includes the unavailable channel
+        assert result.success is True
+        assert recovered_channel_id in result.channel_recovery_candidates
+
+
+class TestIdempotency:
+    """
+    T038: Idempotency tests.
+
+    Validates that recovering the same video multiple times with the same
+    or different snapshots produces expected behavior (idempotent updates).
+    """
+
+    async def test_recovering_same_video_twice_with_same_snapshot(self) -> None:
+        """Recovering same video twice with same snapshot produces same DB state (except recovered_at)."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="testVid0020",
+            title="Original Title",
+            description=None,
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data from a snapshot
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            description="Recovered Description",
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        snapshot = CdxSnapshot(
+            timestamp="20220106075526",
+            original="https://www.youtube.com/watch?v=testVid0020",
+            mimetype="text/html",
+            statuscode=200,
+            digest="ABCD1234567890",
+            length=50000,
+        )
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video first time
+                result1 = await recover_video(
+                    session=session,
+                    video_id="testVid0020",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+                # Update video state to reflect first recovery
+                video.title = "Recovered Title"
+                video.description = "Recovered Description"
+                video.recovery_source = "wayback:20220106075526"
+                video.recovered_at = datetime.now(timezone.utc)
+
+                # WHEN: We recover the video second time (same snapshot)
+                result2 = await recover_video(
+                    session=session,
+                    video_id="testVid0020",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Both recoveries succeeded
+        assert result1.success is True
+        assert result2.success is True
+
+        # Second recovery with same snapshot re-applies fields (idempotent)
+        assert "title" in result2.fields_recovered
+        assert "description" in result2.fields_recovered
+
+    async def test_recovering_with_older_snapshot_only_fills_null_fields(self) -> None:
+        """Recovering with older snapshot only fills NULL fields, doesn't overwrite."""
+        # GIVEN: A video recovered from a newer snapshot
+        video = VideoDB(
+            video_id="testVid0021",
+            title="Newer Recovered Title",
+            description="Newer Recovered Description",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            view_count=100000,  # From newer snapshot
+            like_count=None,  # Still NULL
+            recovery_source="wayback:20220106075526",  # Newer snapshot
+            recovered_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data from an older snapshot
+        recovered_data = RecoveredVideoData(
+            title="Older Title",  # Older - should be skipped
+            description="Older Description",  # Older - should be skipped
+            view_count=50000,  # Older - should be skipped
+            like_count=2000,  # NULL - should be filled
+            snapshot_timestamp="20200106075526",  # Older than existing
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20200106075526",
+                original="https://www.youtube.com/watch?v=testVid0021",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover with older snapshot
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0021",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Only NULL fields were filled
+        assert result.success is True
+        assert "like_count" in result.fields_recovered  # NULL - filled
+        assert "title" in result.fields_skipped  # Older - skipped
+        assert "description" in result.fields_skipped  # Older - skipped
+        assert "view_count" in result.fields_skipped  # Older - skipped
+
+    async def test_recovering_with_newer_snapshot_overwrites_mutable_fields(
+        self,
+    ) -> None:
+        """Recovering with newer snapshot overwrites mutable fields."""
+        # GIVEN: A video recovered from an older snapshot
+        video = VideoDB(
+            video_id="testVid0022",
+            title="Older Recovered Title",
+            description="Older Recovered Description",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UC1234567890123456789012",
+            view_count=50000,  # From older snapshot
+            recovery_source="wayback:20200106075526",  # Older snapshot
+            recovered_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data from a newer snapshot
+        recovered_data = RecoveredVideoData(
+            title="Newer Recovered Title",
+            description="Newer Recovered Description",
+            view_count=100000,  # Newer value
+            snapshot_timestamp="20220106075526",  # Newer than existing
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=testVid0022",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover with newer snapshot
+                result = await recover_video(
+                    session=session,
+                    video_id="testVid0022",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Mutable fields were overwritten with newer values
+        assert result.success is True
+        assert "title" in result.fields_recovered
+        assert "description" in result.fields_recovered
+        assert "view_count" in result.fields_recovered
+
+
+class TestEdgeCases:
+    """
+    Edge case tests for orchestrator coverage improvement.
+
+    Tests scenarios not covered by existing test classes:
+    - CDX query timeout
+    - No snapshots found
+    - Dry-run mode
+    - Extraction timeout on individual snapshots
+    - Extraction errors on individual snapshots
+    - Unexpected errors during recovery
+    """
+
+    async def test_cdx_query_timeout(self) -> None:
+        """CDX query timeout returns cdx_query_timeout failure."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="edgCdxTmt01",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UCEdgeChannelId12345678",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            # Mock CDX client to raise TimeoutError
+            cdx_client.fetch_snapshots.side_effect = asyncio.TimeoutError()
+
+            # WHEN: We attempt to recover the video
+            result = await recover_video(
+                session=session,
+                video_id="edgCdxTmt01",
+                cdx_client=cdx_client,
+                page_parser=page_parser,
+                rate_limiter=rate_limiter,
+                dry_run=False,
+            )
+
+        # THEN: Recovery failed due to CDX timeout
+        assert result.success is False
+        assert result.failure_reason == "cdx_query_timeout"
+        assert result.duration_seconds >= 0.0
+
+    async def test_no_snapshots_found(self) -> None:
+        """No snapshots found returns no_snapshots_found failure."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="edgNoSnap02",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UCEdgeChannelId12345678",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            # Mock CDX client to return empty list (no snapshots)
+            cdx_client.fetch_snapshots.return_value = []
+
+            # WHEN: We attempt to recover the video
+            result = await recover_video(
+                session=session,
+                video_id="edgNoSnap02",
+                cdx_client=cdx_client,
+                page_parser=page_parser,
+                rate_limiter=rate_limiter,
+                dry_run=False,
+            )
+
+        # THEN: Recovery failed due to no snapshots
+        assert result.success is False
+        assert result.failure_reason == "no_snapshots_found"
+        assert result.snapshots_available == 0
+        assert result.snapshots_tried == 0
+        assert result.duration_seconds >= 0.0
+
+    async def test_dry_run_mode_skips_page_fetching(self) -> None:
+        """Dry-run mode skips page fetching and creates minimal RecoveredVideoData."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="edgDryRun03",
+            title="Deleted Video",
+            description=None,
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UCEdgeChannelId12345678",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=edgDryRun03",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover in dry-run mode
+                result = await recover_video(
+                    session=session,
+                    video_id="edgDryRun03",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=True,
+                )
+
+        # THEN: Page parser was NOT called (dry-run skips parsing)
+        page_parser.extract_metadata.assert_not_called()
+
+        # THEN: Recovery reports success because dry-run found snapshots
+        assert result.success is True
+        assert result.snapshots_available == 1
+        assert result.snapshots_tried == 1
+
+    async def test_extraction_timeout_continues_to_next_snapshot(self) -> None:
+        """Extraction timeout on a snapshot continues to next snapshot."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="edgExtTmt04",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UCEdgeChannelId12345678",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Multiple snapshots
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",  # First - times out
+                original="https://www.youtube.com/watch?v=edgExtTmt04",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            ),
+            CdxSnapshot(
+                timestamp="20210615102030",  # Second - succeeds
+                original="https://www.youtube.com/watch?v=edgExtTmt04",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567891",
+                length=50000,
+            ),
+        ]
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        call_count = 0
+
+        async def mock_extract(snapshot: CdxSnapshot) -> RecoveredVideoData:
+            """First call times out, second succeeds."""
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise asyncio.TimeoutError()
+            else:
+                return RecoveredVideoData(
+                    title="Recovered Title",
+                    snapshot_timestamp=snapshot.timestamp,
+                )
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = snapshots
+            page_parser.extract_metadata.side_effect = mock_extract
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="edgExtTmt04",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Recovery succeeded using second snapshot
+        assert result.success is True
+        assert result.snapshot_used == "20210615102030"
+        assert result.snapshots_tried == 2
+
+    async def test_extraction_error_continues_to_next_snapshot(self) -> None:
+        """Generic extraction error on a snapshot continues to next snapshot."""
+        # GIVEN: A video with DELETED status
+        video = VideoDB(
+            video_id="edgExtErr05",
+            title="Deleted Video",
+            description="Test video",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            channel_id="UCEdgeChannelId12345678",
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Multiple snapshots
+        snapshots = [
+            CdxSnapshot(
+                timestamp="20220106075526",  # First - raises error
+                original="https://www.youtube.com/watch?v=edgExtErr05",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            ),
+            CdxSnapshot(
+                timestamp="20210615102030",  # Second - succeeds
+                original="https://www.youtube.com/watch?v=edgExtErr05",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567891",
+                length=50000,
+            ),
+        ]
+
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        call_count = 0
+
+        async def mock_extract(snapshot: CdxSnapshot) -> RecoveredVideoData:
+            """First call raises exception, second succeeds."""
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("Parsing error")
+            else:
+                return RecoveredVideoData(
+                    title="Recovered Title",
+                    snapshot_timestamp=snapshot.timestamp,
+                )
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = snapshots
+            page_parser.extract_metadata.side_effect = mock_extract
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                # WHEN: We recover the video
+                result = await recover_video(
+                    session=session,
+                    video_id="edgExtErr05",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Recovery succeeded using second snapshot
+        assert result.success is True
+        assert result.snapshot_used == "20210615102030"
+        assert result.snapshots_tried == 2
+
+    async def test_unexpected_error_during_recovery(self) -> None:
+        """Unexpected error during recovery returns unexpected_error failure."""
+        # GIVEN: Mock dependencies
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+
+            # Mock repository to raise an unexpected exception
+            mock_repo.get_by_video_id.side_effect = Exception("Database connection error")
+
+            # WHEN: We attempt to recover the video
+            result = await recover_video(
+                session=session,
+                video_id="edgUnxErr06",
+                cdx_client=cdx_client,
+                page_parser=page_parser,
+                rate_limiter=rate_limiter,
+                dry_run=False,
+            )
+
+        # THEN: Recovery failed due to unexpected error
+        assert result.success is False
+        assert result.failure_reason == "unexpected_error"
+        assert result.duration_seconds >= 0.0
+
+
+class TestStubChannelCreation:
+    """
+    Tests for stub channel creation when recovered channel_id references
+    a channel not present in the database (FK constraint protection).
+    """
+
+    async def test_stub_channel_created_when_channel_not_in_db(
+        self, _mock_channel_repo: AsyncMock
+    ) -> None:
+        """Creates a stub channel record when recovered channel_id is missing from DB."""
+        # GIVEN: A deleted video with no channel_id
+        video = VideoDB(
+            video_id="stubTest001",
+            title="Deleted Video",
+            description=None,
+            upload_date=None,
+            duration=120,
+            channel_id=None,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # GIVEN: Recovered data with channel_id and channel_name_hint
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            channel_id="UCStub123456789012345678",
+            channel_name_hint="Some Channel Name",
+            snapshot_timestamp="20220106075526",
+        )
+
+        # GIVEN: Channel does NOT exist in DB
+        _mock_channel_repo.exists.return_value = False
+
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=stubTest001",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                result = await recover_video(
+                    session=session,
+                    video_id="stubTest001",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Recovery succeeded and stub channel was created
+        assert result.success is True
+        assert "channel_id" in result.fields_recovered
+
+        # Verify stub channel was created with correct data
+        _mock_channel_repo.create.assert_called_once()
+        call_args = _mock_channel_repo.create.call_args
+        stub_channel = call_args.kwargs.get("obj_in") or call_args[1].get("obj_in")
+        assert stub_channel.channel_id == "UCStub123456789012345678"
+        assert stub_channel.title == "Some Channel Name"
+
+    async def test_stub_channel_uses_channel_id_as_title_fallback(
+        self, _mock_channel_repo: AsyncMock
+    ) -> None:
+        """Stub channel uses channel_id as title when channel_name_hint is None."""
+        video = VideoDB(
+            video_id="stubTest002",
+            title="Deleted Video",
+            description=None,
+            upload_date=None,
+            duration=120,
+            channel_id=None,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            channel_id="UCFallback12345678901234",
+            channel_name_hint=None,  # No hint - should use channel_id
+            snapshot_timestamp="20220106075526",
+        )
+
+        _mock_channel_repo.exists.return_value = False
+
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=stubTest002",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                result = await recover_video(
+                    session=session,
+                    video_id="stubTest002",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        assert result.success is True
+        call_args = _mock_channel_repo.create.call_args
+        stub_channel = call_args.kwargs.get("obj_in") or call_args[1].get("obj_in")
+        assert stub_channel.title == "UCFallback12345678901234"
+
+    async def test_channel_id_skipped_when_stub_creation_fails(
+        self, _mock_channel_repo: AsyncMock
+    ) -> None:
+        """channel_id is removed from update and moved to skipped when stub creation fails."""
+        video = VideoDB(
+            video_id="stubTest003",
+            title="Deleted Video",
+            description=None,
+            upload_date=None,
+            duration=120,
+            channel_id=None,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            channel_id="UCFailStub1234567890123_",
+            channel_name_hint="Failed Channel",
+            snapshot_timestamp="20220106075526",
+        )
+
+        _mock_channel_repo.exists.return_value = False
+        _mock_channel_repo.create.side_effect = Exception("DB error creating channel")
+
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=stubTest003",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                result = await recover_video(
+                    session=session,
+                    video_id="stubTest003",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Recovery still succeeded but channel_id was skipped
+        assert result.success is True
+        assert "channel_id" not in result.fields_recovered
+        assert "channel_id" in result.fields_skipped
+
+    async def test_no_stub_created_when_channel_already_exists(
+        self, _mock_channel_repo: AsyncMock
+    ) -> None:
+        """No stub channel is created when channel already exists in DB."""
+        video = VideoDB(
+            video_id="stubTest004",
+            title="Deleted Video",
+            description=None,
+            upload_date=None,
+            duration=120,
+            channel_id=None,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        recovered_data = RecoveredVideoData(
+            title="Recovered Title",
+            channel_id="UCExisting12345678901234",
+            snapshot_timestamp="20220106075526",
+        )
+
+        # Channel DOES exist
+        _mock_channel_repo.exists.return_value = True
+
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=stubTest004",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+            page_parser.extract_metadata.return_value = recovered_data
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                result = await recover_video(
+                    session=session,
+                    video_id="stubTest004",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=False,
+                )
+
+        # THEN: Recovery succeeded, channel_id was set, no stub created
+        assert result.success is True
+        assert "channel_id" in result.fields_recovered
+        _mock_channel_repo.create.assert_not_called()
+
+    async def test_no_stub_created_in_dry_run(
+        self, _mock_channel_repo: AsyncMock
+    ) -> None:
+        """No stub channel is created during dry-run mode."""
+        video = VideoDB(
+            video_id="stubTest005",
+            title="Deleted Video",
+            description=None,
+            upload_date=None,
+            duration=120,
+            channel_id=None,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            snapshot = CdxSnapshot(
+                timestamp="20220106075526",
+                original="https://www.youtube.com/watch?v=stubTest005",
+                mimetype="text/html",
+                statuscode=200,
+                digest="ABCD1234567890",
+                length=50000,
+            )
+            cdx_client.fetch_snapshots.return_value = [snapshot]
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ) as mock_tag_repo_class:
+                mock_tag_repo = AsyncMock()
+                mock_tag_repo_class.return_value = mock_tag_repo
+
+                result = await recover_video(
+                    session=session,
+                    video_id="stubTest005",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    dry_run=True,
+                )
+
+        # THEN: Dry-run succeeded, no channel operations
+        assert result.success is True
+        _mock_channel_repo.exists.assert_not_called()
+        _mock_channel_repo.create.assert_not_called()
+
+
+# =============================================================================
+# TestYearFiltering - from_year / to_year parameter passthrough
+# =============================================================================
+
+
+class TestYearFiltering:
+    """Test that recover_video passes from_year/to_year to cdx_client.fetch_snapshots."""
+
+    async def test_recover_video_passes_from_year_to_fetch_snapshots(self) -> None:
+        """recover_video passes from_year to cdx_client.fetch_snapshots."""
+        video = VideoDB(
+            video_id="yearTest001",
+            title="Year Filter Test",
+            description="Testing year filtering",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            # Return empty snapshots so we hit "no_snapshots_found"
+            cdx_client.fetch_snapshots.return_value = []
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ):
+                await recover_video(
+                    session=session,
+                    video_id="yearTest001",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    from_year=2018,
+                )
+
+        # THEN: fetch_snapshots was called with from_year
+        cdx_client.fetch_snapshots.assert_called_once_with(
+            "yearTest001", from_year=2018, to_year=None
+        )
+
+    async def test_recover_video_passes_to_year_to_fetch_snapshots(self) -> None:
+        """recover_video passes to_year to cdx_client.fetch_snapshots."""
+        video = VideoDB(
+            video_id="yearTest002",
+            title="Year Filter Test",
+            description="Testing year filtering",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = []
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ):
+                await recover_video(
+                    session=session,
+                    video_id="yearTest002",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    to_year=2020,
+                )
+
+        cdx_client.fetch_snapshots.assert_called_once_with(
+            "yearTest002", from_year=None, to_year=2020
+        )
+
+    async def test_recover_video_passes_both_years_to_fetch_snapshots(self) -> None:
+        """recover_video passes both from_year and to_year to cdx_client.fetch_snapshots."""
+        video = VideoDB(
+            video_id="yearTest003",
+            title="Year Filter Test",
+            description="Testing year filtering",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = []
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ):
+                await recover_video(
+                    session=session,
+                    video_id="yearTest003",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                    from_year=2018,
+                    to_year=2020,
+                )
+
+        cdx_client.fetch_snapshots.assert_called_once_with(
+            "yearTest003", from_year=2018, to_year=2020
+        )
+
+    async def test_recover_video_default_no_year_filter(self) -> None:
+        """recover_video without year params passes None/None to fetch_snapshots."""
+        video = VideoDB(
+            video_id="yearTest004",
+            title="Year Filter Test",
+            description="Testing year filtering",
+            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            duration=120,
+            availability_status=AvailabilityStatus.DELETED.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        session = AsyncMock(spec=AsyncSession)
+        cdx_client = AsyncMock(spec=CDXClient)
+        page_parser = AsyncMock(spec=PageParser)
+        rate_limiter = AsyncMock(spec=RateLimiter)
+
+        with patch(
+            "chronovista.services.recovery.orchestrator.VideoRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_by_video_id.return_value = video
+
+            cdx_client.fetch_snapshots.return_value = []
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.VideoTagRepository"
+            ):
+                await recover_video(
+                    session=session,
+                    video_id="yearTest004",
+                    cdx_client=cdx_client,
+                    page_parser=page_parser,
+                    rate_limiter=rate_limiter,
+                )
+
+        cdx_client.fetch_snapshots.assert_called_once_with(
+            "yearTest004", from_year=None, to_year=None
+        )

--- a/tests/unit/services/recovery/test_page_parser.py
+++ b/tests/unit/services/recovery/test_page_parser.py
@@ -1,0 +1,1112 @@
+"""
+Unit tests for PageParser (Wayback Machine page metadata extraction).
+
+Tests cover:
+- T020: ytInitialPlayerResponse JSON extraction
+- T021: HTML meta tag extraction (BeautifulSoup)
+- T022: Removal notice detection (10 pattern categories)
+- T023: Category name-to-ID mapping
+- T024: Two-era extraction strategy (2017+ JSON vs pre-2017 meta)
+- T025: Optional Selenium fallback
+
+All tests mock httpx responses. No live HTTP calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from chronovista.services.recovery.cdx_client import RateLimiter
+from chronovista.services.recovery.models import CdxSnapshot, RecoveredVideoData
+from chronovista.services.recovery.page_parser import (
+    YOUTUBE_CATEGORY_MAP,
+    PageParser,
+    is_removal_notice,
+)
+
+# CRITICAL: Ensures async tests work with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# ============================================================================
+# HTML Test Fixtures
+# ============================================================================
+
+VALID_PAGE_WITH_JSON = '''
+<html><head>
+<meta property="og:title" content="Meta Title Fallback">
+<meta property="og:description" content="Meta description fallback">
+</head><body>
+<script>var ytInitialPlayerResponse = {"videoDetails":{"title":"JSON Title","shortDescription":"JSON description from videoDetails","author":"Test Channel","channelId":"UCuAXFkgsw1L7xaCfnd5JJOw","viewCount":"1000000","keywords":["music","test","viral"]},"microformat":{"playerMicroformatRenderer":{"publishDate":"2021-06-15","category":"Music"}}};</script>
+</body></html>
+'''
+
+VALID_PAGE_WITH_JSON_NO_VAR = '''
+<html><head></head><body>
+<script>ytInitialPlayerResponse = {"videoDetails":{"title":"JSON Title No Var","shortDescription":"Description without var keyword","author":"Channel Name","channelId":"UCabc123def456ghi789jkl000","viewCount":"5000","keywords":["keyword1","keyword2"]},"microformat":{"playerMicroformatRenderer":{"publishDate":"2020-03-20","category":"Education"}}};</script>
+</body></html>
+'''
+
+VALID_PAGE_META_ONLY = '''
+<html><head>
+<meta property="og:title" content="Meta Video Title">
+<meta property="og:description" content="Meta description from Open Graph tags">
+<meta property="og:image" content="https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg">
+<meta property="og:video:tag" content="music">
+<meta property="og:video:tag" content="classic">
+<meta property="og:video:tag" content="nostalgia">
+<meta itemprop="datePublished" content="2015-03-20">
+<meta itemprop="interactionCount" content="5000000">
+<meta itemprop="genre" content="Entertainment">
+<link itemprop="url" href="https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw">
+</head><body></body></html>
+'''
+
+REMOVAL_NOTICE_TITLE_ONLY_YOUTUBE = '''
+<html><head><title>YouTube</title></head><body></body></html>
+'''
+
+REMOVAL_NOTICE_TITLE_DASH_YOUTUBE = '''
+<html><head><title> - YouTube</title></head><body></body></html>
+'''
+
+REMOVAL_NOTICE_PLAYABILITY_ERROR = '''
+<html><head></head><body>
+<script>var ytInitialPlayerResponse = {"playabilityStatus":{"status":"ERROR","reason":"Video unavailable"}};</script>
+</body></html>
+'''
+
+REMOVAL_NOTICE_PLAYABILITY_UNPLAYABLE = '''
+<html><head></head><body>
+<script>ytInitialPlayerResponse = {"playabilityStatus":{"status":"UNPLAYABLE"}};</script>
+</body></html>
+'''
+
+REMOVAL_NOTICE_PLAYABILITY_LOGIN_REQUIRED = '''
+<html><head></head><body>
+<script>var ytInitialPlayerResponse = {"playabilityStatus":{"status":"LOGIN_REQUIRED"}};</script>
+</body></html>
+'''
+
+REMOVAL_NOTICE_TEXT_VIDEO_UNAVAILABLE = '''
+<html><head><title>Test Video - YouTube</title></head><body>
+<div>Video unavailable</div>
+</body></html>
+'''
+
+REMOVAL_NOTICE_TEXT_REMOVED_BY_UPLOADER = '''
+<html><head><title>Test Video - YouTube</title></head><body>
+<div>This video has been removed by the uploader</div>
+</body></html>
+'''
+
+REMOVAL_NOTICE_TEXT_PRIVATE = '''
+<html><head><title>Test Video - YouTube</title></head><body>
+<div>This video is private</div>
+</body></html>
+'''
+
+REMOVAL_NOTICE_TEXT_COPYRIGHT = '''
+<html><head><title>Test Video - YouTube</title></head><body>
+<div>This video is no longer available due to a copyright claim by XYZ Corporation</div>
+</body></html>
+'''
+
+REMOVAL_NOTICE_TEXT_TOS_VIOLATION = '''
+<html><head><title>Test Video - YouTube</title></head><body>
+<div>This video has been removed for violating YouTube's Terms of Service</div>
+</body></html>
+'''
+
+REMOVAL_NOTICE_TEXT_ACCOUNT_TERMINATED = '''
+<html><head><title>Test Video - YouTube</title></head><body>
+<div>This video is no longer available because the YouTube account associated with this video has been terminated</div>
+</body></html>
+'''
+
+REMOVAL_NOTICE_WITH_POSITIVE_SIGNAL_OVERRIDE = '''
+<html><head>
+<title>YouTube</title>
+<meta property="og:video:url" content="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
+</head><body>
+<div>Video unavailable</div>
+</body></html>
+'''
+
+EMPTY_PAGE = '''
+<html><head></head><body></body></html>
+'''
+
+PAGE_WITH_MALFORMED_JSON = '''
+<html><head></head><body>
+<script>var ytInitialPlayerResponse = {invalid json here, missing quotes};</script>
+</body></html>
+'''
+
+PAGE_WITH_BOTH_JSON_AND_META = '''
+<html><head>
+<meta property="og:title" content="Meta Title Should Be Ignored">
+<meta property="og:description" content="Meta description should be ignored">
+<meta property="og:video:tag" content="meta-tag-1">
+<meta itemprop="datePublished" content="2010-01-01">
+<meta itemprop="interactionCount" content="999">
+</head><body>
+<script>var ytInitialPlayerResponse = {"videoDetails":{"title":"JSON Title Takes Priority","shortDescription":"JSON description takes priority","author":"JSON Channel","channelId":"UCjsonpriorityid123456789","viewCount":"2000000","keywords":["json-keyword"]},"microformat":{"playerMicroformatRenderer":{"publishDate":"2022-12-31","category":"Science & Technology"}}};</script>
+</body></html>
+'''
+
+
+# ============================================================================
+# Test Class: JSON Extraction (T020)
+# ============================================================================
+
+
+class TestJSONExtraction:
+    """
+    Test ytInitialPlayerResponse JSON extraction.
+
+    Covers:
+    - Field extraction from videoDetails (title, description, author, channelId, viewCount, keywords)
+    - Field extraction from microformat.playerMicroformatRenderer (publishDate, category)
+    - Regex pattern matching (var pattern and no-var pattern)
+    - Missing JSON returns None
+    - Malformed JSON handled gracefully
+    """
+
+    async def test_extract_title_from_json(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that videoDetails.title is extracted from JSON."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.title == "JSON Title"
+
+    async def test_extract_description_from_json(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that videoDetails.shortDescription is extracted from JSON."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.description == "JSON description from videoDetails"
+
+    async def test_extract_channel_from_json(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that videoDetails.author and channelId are extracted."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.channel_name_hint == "Test Channel"
+        assert result.channel_id == "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+    async def test_extract_view_count_from_json(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that videoDetails.viewCount (string) is converted to int."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.view_count == 1000000
+
+    async def test_extract_keywords_from_json(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that videoDetails.keywords is extracted as tags list."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.tags == ["music", "test", "viral"]
+
+    async def test_extract_upload_date_from_json(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that microformat.playerMicroformatRenderer.publishDate is extracted."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.upload_date is not None
+        assert result.upload_date.year == 2021
+        assert result.upload_date.month == 6
+        assert result.upload_date.day == 15
+
+    async def test_extract_category_from_json(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that microformat category is mapped to category_id."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # "Music" should map to "10"
+        assert result.category_id == "10"
+
+    async def test_json_regex_var_pattern(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that regex matches 'var ytInitialPlayerResponse = {...};' pattern."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.title == "JSON Title"
+
+    async def test_json_regex_no_var_pattern(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that regex also matches 'ytInitialPlayerResponse = {...};' (no var)."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_WITH_JSON_NO_VAR
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.title == "JSON Title No Var"
+
+    async def test_missing_json_returns_none(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that page without JSON falls back to meta tags."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # Should have extracted from meta tags, not JSON
+        assert result.title == "Meta Video Title"
+
+    async def test_malformed_json_graceful(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that malformed JSON is handled gracefully (returns None, no crash)."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_WITH_MALFORMED_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        # Should not crash - returns RecoveredVideoData with no extracted fields
+        assert result is not None
+        assert result.has_data is False
+
+
+# ============================================================================
+# Test Class: Meta Tag Extraction (T021)
+# ============================================================================
+
+
+class TestMetaTagExtraction:
+    """
+    Test HTML meta tag extraction using BeautifulSoup.
+
+    Covers:
+    - og:title, og:description, og:image extraction
+    - Multiple og:video:tag extraction
+    - itemprop extraction (datePublished, interactionCount, genre)
+    - Channel ID extraction from link itemprop="url"
+    - Graceful handling of missing tags
+    """
+
+    async def test_extract_og_title(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that og:title meta tag is extracted."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.title == "Meta Video Title"
+
+    async def test_extract_og_description(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that og:description meta tag is extracted."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.description == "Meta description from Open Graph tags"
+
+    async def test_extract_og_image(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that og:image is extracted as thumbnail_url."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert (
+            result.thumbnail_url
+            == "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+        )
+
+    async def test_extract_multiple_og_video_tags(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that multiple og:video:tag meta tags are extracted as tags list."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.tags == ["music", "classic", "nostalgia"]
+
+    async def test_extract_date_published(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that itemprop='datePublished' is extracted as upload_date."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.upload_date is not None
+        assert result.upload_date.year == 2015
+        assert result.upload_date.month == 3
+        assert result.upload_date.day == 20
+
+    async def test_extract_interaction_count(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that itemprop='interactionCount' is extracted as view_count."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.view_count == 5000000
+
+    async def test_extract_genre(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that itemprop='genre' is extracted and mapped to category_id."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # "Entertainment" should map to "24"
+        assert result.category_id == "24"
+
+    async def test_extract_channel_from_link(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that channel ID is extracted from link itemprop='url'."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.channel_id == "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+    async def test_extracts_channel_id_from_itemprop_channelid(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that channel ID is extracted from itemprop='channelId' meta tag."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        html = '''
+<html><head>
+<meta itemprop="channelId" content="UCpwvZwUam-URkxB7g4USKpg">
+<meta property="og:title" content="Test Video">
+</head><body></body></html>
+'''
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = html
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.channel_id == "UCpwvZwUam-URkxB7g4USKpg"
+
+    async def test_channel_id_itemprop_takes_priority_over_link_href(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that itemprop='channelId' takes priority over link href pattern."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        html = '''
+<html><head>
+<meta itemprop="channelId" content="UCpwvZwUam-URkxB7g4USKpg">
+<link itemprop="url" href="https://youtube.com/channel/UCDifferentChannelId1234">
+<meta property="og:title" content="Test Video">
+</head><body></body></html>
+'''
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = html
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # itemprop="channelId" should win
+        assert result.channel_id == "UCpwvZwUam-URkxB7g4USKpg"
+
+    async def test_extracts_channel_name_from_user_url(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that channel name is extracted from /user/ URL pattern."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        html = '''
+<html><head>
+<link itemprop="url" href="http://www.youtube.com/user/RussiaToday">
+<meta property="og:title" content="Test Video">
+</head><body></body></html>
+'''
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = html
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.channel_name_hint == "RussiaToday"
+
+    async def test_extracts_channel_name_from_c_url(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that channel name is extracted from /c/ URL pattern."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        html = '''
+<html><head>
+<link itemprop="url" href="https://www.youtube.com/c/SomeChannel">
+<meta property="og:title" content="Test Video">
+</head><body></body></html>
+'''
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = html
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.channel_name_hint == "SomeChannel"
+
+    async def test_missing_tags_graceful(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that page with no meta tags returns RecoveredVideoData with no data."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = EMPTY_PAGE
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.has_data is False
+
+
+# ============================================================================
+# Test Class: Removal Notice Detection (T022)
+# ============================================================================
+
+
+class TestRemovalNoticeDetection:
+    """
+    Test removal notice detection function.
+
+    Covers all 10 removal pattern categories:
+    - Title-based detection ("YouTube", " - YouTube")
+    - JSON playabilityStatus detection (ERROR, UNPLAYABLE, LOGIN_REQUIRED)
+    - Text pattern detection (unavailable, removed, private, copyright, etc.)
+    - Positive signal override (og:video:url)
+    """
+
+    def test_title_only_youtube(self) -> None:
+        """Test that title 'YouTube' is detected as removal."""
+        is_removed, reason = is_removal_notice(REMOVAL_NOTICE_TITLE_ONLY_YOUTUBE)
+        assert is_removed is True
+        assert reason == "title_only_youtube"
+
+    def test_title_dash_youtube(self) -> None:
+        """Test that title ' - YouTube' is detected as removal."""
+        is_removed, reason = is_removal_notice(REMOVAL_NOTICE_TITLE_DASH_YOUTUBE)
+        assert is_removed is True
+        assert reason == "title_dash_youtube"
+
+    def test_playability_status_error(self) -> None:
+        """Test that JSON playabilityStatus.status = 'ERROR' is detected as removal."""
+        is_removed, reason = is_removal_notice(
+            REMOVAL_NOTICE_PLAYABILITY_ERROR
+        )
+        assert is_removed is True
+        assert reason == "playability_status_error"
+
+    def test_playability_status_unplayable(self) -> None:
+        """Test that JSON playabilityStatus.status = 'UNPLAYABLE' is detected."""
+        is_removed, reason = is_removal_notice(
+            REMOVAL_NOTICE_PLAYABILITY_UNPLAYABLE
+        )
+        assert is_removed is True
+        assert reason == "playability_status_unplayable"
+
+    def test_playability_status_login_required(self) -> None:
+        """Test that JSON playabilityStatus.status = 'LOGIN_REQUIRED' is detected."""
+        is_removed, reason = is_removal_notice(
+            REMOVAL_NOTICE_PLAYABILITY_LOGIN_REQUIRED
+        )
+        assert is_removed is True
+        assert reason == "playability_status_login_required"
+
+    def test_text_video_unavailable(self) -> None:
+        """Test that 'Video unavailable' text is detected as removal."""
+        is_removed, reason = is_removal_notice(
+            REMOVAL_NOTICE_TEXT_VIDEO_UNAVAILABLE
+        )
+        assert is_removed is True
+        assert reason == "text_video_unavailable"
+
+    def test_text_removed_by_uploader(self) -> None:
+        """Test that 'removed by the uploader' text is detected."""
+        is_removed, reason = is_removal_notice(
+            REMOVAL_NOTICE_TEXT_REMOVED_BY_UPLOADER
+        )
+        assert is_removed is True
+        assert reason == "text_removed_by_uploader"
+
+    def test_text_private(self) -> None:
+        """Test that 'This video is private' text is detected."""
+        is_removed, reason = is_removal_notice(REMOVAL_NOTICE_TEXT_PRIVATE)
+        assert is_removed is True
+        assert reason == "text_private"
+
+    def test_text_copyright(self) -> None:
+        """Test that copyright claim text is detected."""
+        is_removed, reason = is_removal_notice(REMOVAL_NOTICE_TEXT_COPYRIGHT)
+        assert is_removed is True
+        assert reason == "text_copyright"
+
+    def test_text_tos_violation(self) -> None:
+        """Test that ToS violation text is detected."""
+        is_removed, reason = is_removal_notice(
+            REMOVAL_NOTICE_TEXT_TOS_VIOLATION
+        )
+        assert is_removed is True
+        assert reason == "text_tos_violation"
+
+    def test_text_account_terminated(self) -> None:
+        """Test that account terminated text is detected."""
+        is_removed, reason = is_removal_notice(
+            REMOVAL_NOTICE_TEXT_ACCOUNT_TERMINATED
+        )
+        assert is_removed is True
+        assert reason == "text_account_terminated"
+
+    def test_og_video_url_overrides(self) -> None:
+        """Test that og:video:url presence overrides removal signals."""
+        is_removed, reason = is_removal_notice(
+            REMOVAL_NOTICE_WITH_POSITIVE_SIGNAL_OVERRIDE
+        )
+        # Positive signal (og:video:url) should override removal text
+        assert is_removed is False
+        assert reason is None
+
+    def test_valid_page_not_removal(self) -> None:
+        """Test that normal page with content is not detected as removal."""
+        is_removed, reason = is_removal_notice(VALID_PAGE_WITH_JSON)
+        assert is_removed is False
+        assert reason is None
+
+
+# ============================================================================
+# Test Class: Category Mapping (T023)
+# ============================================================================
+
+
+class TestCategoryMapping:
+    """
+    Test YouTube category name to ID mapping.
+
+    Covers:
+    - Known categories (Entertainment, Music, Education, etc.)
+    - Unknown categories return None
+    - Case-insensitive matching
+    """
+
+    def test_entertainment_to_24(self) -> None:
+        """Test that 'Entertainment' maps to '24'."""
+        assert YOUTUBE_CATEGORY_MAP.get("Entertainment") == "24"
+
+    def test_music_to_10(self) -> None:
+        """Test that 'Music' maps to '10'."""
+        assert YOUTUBE_CATEGORY_MAP.get("Music") == "10"
+
+    def test_education_to_27(self) -> None:
+        """Test that 'Education' maps to '27'."""
+        assert YOUTUBE_CATEGORY_MAP.get("Education") == "27"
+
+    def test_unknown_category_returns_none(self) -> None:
+        """Test that unknown category name returns None."""
+        assert YOUTUBE_CATEGORY_MAP.get("Unknown Category XYZ") is None
+
+    def test_case_insensitive(self) -> None:
+        """Test that category lookup is case-insensitive."""
+        # The map should support lowercase lookups
+        # NOTE: Implementation should handle case-insensitivity in lookup logic
+        # For now, testing that exact case works
+        assert YOUTUBE_CATEGORY_MAP.get("Entertainment") == "24"
+        # Implementation should normalize to title case or use case-insensitive dict
+
+
+# ============================================================================
+# Test Class: Two-Era Strategy (T024)
+# ============================================================================
+
+
+class TestTwoEraStrategy:
+    """
+    Test two-era extraction strategy.
+
+    Covers:
+    - 2017+ pages with JSON → JSON extraction used
+    - Pre-2017 pages without JSON → meta tag extraction used
+    - Pages with both → JSON takes priority
+    - Pages with neither → returns RecoveredVideoData with has_data=False
+    """
+
+    async def test_2017_plus_uses_json(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that 2017+ page with JSON uses JSON extraction, meta tags ignored."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_WITH_BOTH_JSON_AND_META
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # JSON values should be used, not meta tag values
+        assert result.title == "JSON Title Takes Priority"
+        assert result.description == "JSON description takes priority"
+        assert result.tags == ["json-keyword"]
+        assert result.view_count == 2000000
+
+    async def test_pre_2017_uses_meta(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that pre-2017 page without JSON uses meta tag extraction."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.title == "Meta Video Title"
+        assert result.description == "Meta description from Open Graph tags"
+        assert result.tags == ["music", "classic", "nostalgia"]
+
+    async def test_json_takes_priority(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that when both JSON and meta are present, JSON takes priority."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_WITH_BOTH_JSON_AND_META
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # All values should come from JSON, not meta tags
+        assert result.title != "Meta Title Should Be Ignored"
+        assert result.title == "JSON Title Takes Priority"
+
+    async def test_neither_source_returns_empty(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that page with neither JSON nor meta tags returns has_data=False."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = EMPTY_PAGE
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.has_data is False
+
+
+# ============================================================================
+# Test Class: Selenium Fallback (T025)
+# ============================================================================
+
+
+class TestSeleniumFallback:
+    """
+    Test optional Selenium fallback behavior.
+
+    Covers:
+    - When SELENIUM_AVAILABLE=False and primary fails → log warning + return None
+    - When SELENIUM_AVAILABLE=True and primary fails → call Selenium path
+    - Selenium timeout → return None
+    """
+
+    async def test_selenium_unavailable_logs_warning(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that when Selenium is unavailable, warning is logged and None returned."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+
+        with patch(
+            "chronovista.services.recovery.page_parser.SELENIUM_AVAILABLE",
+            False,
+        ):
+            parser = PageParser(rate_limiter=rate_limiter_mock)
+
+            with patch.object(
+                httpx.AsyncClient, "get", new_callable=AsyncMock
+            ) as mock_get:
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.text = EMPTY_PAGE  # No JSON, no meta
+                mock_get.return_value = mock_response
+
+                result = await parser.extract_metadata(snapshot)
+
+            # Should return RecoveredVideoData with has_data=False
+            # (Selenium fallback not attempted)
+            assert result is not None
+            assert result.has_data is False
+
+    async def test_selenium_available_calls_fallback(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that when Selenium is available and primary fails, fallback is called."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+
+        with patch(
+            "chronovista.services.recovery.page_parser.SELENIUM_AVAILABLE",
+            True,
+        ):
+            parser = PageParser(rate_limiter=rate_limiter_mock)
+
+            with patch.object(
+                httpx.AsyncClient, "get", new_callable=AsyncMock
+            ) as mock_get:
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.text = EMPTY_PAGE  # No JSON, no meta
+                mock_get.return_value = mock_response
+
+                # Mock the Selenium fallback method
+                with patch.object(
+                    parser,
+                    "_extract_with_selenium",
+                    new_callable=AsyncMock,
+                ) as mock_selenium:
+                    mock_selenium.return_value = RecoveredVideoData(
+                        title="Selenium Title",
+                        snapshot_timestamp=snapshot.timestamp,
+                    )
+
+                    result = await parser.extract_metadata(snapshot)
+
+            # Selenium fallback should have been called
+            mock_selenium.assert_called_once()
+            assert result is not None
+            assert result.title == "Selenium Title"
+
+    async def test_selenium_timeout_skips(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that Selenium timeout returns None and continues."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+
+        with patch(
+            "chronovista.services.recovery.page_parser.SELENIUM_AVAILABLE",
+            True,
+        ):
+            parser = PageParser(rate_limiter=rate_limiter_mock)
+
+            with patch.object(
+                httpx.AsyncClient, "get", new_callable=AsyncMock
+            ) as mock_get:
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.text = EMPTY_PAGE
+                mock_get.return_value = mock_response
+
+                # Mock Selenium to raise timeout
+                with patch.object(
+                    parser,
+                    "_extract_with_selenium",
+                    new_callable=AsyncMock,
+                ) as mock_selenium:
+                    import asyncio
+
+                    mock_selenium.side_effect = asyncio.TimeoutError(
+                        "Selenium timeout"
+                    )
+
+                    result = await parser.extract_metadata(snapshot)
+
+            # Should return None on Selenium timeout
+            assert result is not None
+            assert result.has_data is False
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def rate_limiter_mock() -> RateLimiter:
+    """Create a mock RateLimiter for testing."""
+    # RateLimiter is a simple class with acquire() method
+    mock = MagicMock(spec=RateLimiter)
+    mock.acquire = AsyncMock()
+    return mock


### PR DESCRIPTION
## Summary

- **Wayback Machine recovery pipeline**: Recover metadata (title, description, channel, tags, upload date, view/like counts, category, thumbnail) for deleted/unavailable YouTube videos from archived Wayback Machine snapshots
- **Three-component architecture**: CDXClient (snapshot discovery with caching + retry), PageParser (JSON + meta tag + optional Selenium extraction), RecoveryOrchestrator (eligibility checks, three-tier overwrite policy, stub channel creation, tag persistence)
- **CLI `recover video` command**: Single-video (`--video-id`) and batch (`--all`) modes with `--start-year`/`--end-year` anchor filtering, `--dry-run` preview, configurable `--delay` rate limiting, and Rich summary reports
- **Frontend deleted content visibility**: Availability status badges, recovery indicators, and `include_deleted` filter toggle across video list, playlist, channel, and search result components
- **Comprehensive documentation**: Updated 10 docs files — CLI reference, architecture diagrams, data model schema, glossary, data population workflow, frontend architecture, README, and changelogs

## Highlights

| Area | Details |
|------|---------|
| New files | 8 production (`services/recovery/`, `cli/commands/recover.py`) + 6 test files |
| Tests added | ~6,200 lines across CDX client, page parser, orchestrator, models, and CLI tests |
| Backend version | 0.26.0 → 0.27.0 |
| Frontend version | 0.5.0 → 0.6.0 |
| Dependencies | `beautifulsoup4` (required), `selenium` + `webdriver-manager` (optional recovery group) |

## Key design decisions

- **CDX sort order**: `--start-year` flips to oldest-first so the orchestrator tries anchor-era snapshots before exhausting the 100-snapshot limit on newer archives
- **Three-tier overwrite policy**: Immutable fields (channel_id, category_id) fill-if-NULL only; mutable fields overwrite-if-newer; NULL protection never blanks existing values
- **Stub channels**: Auto-created when recovered `channel_id` has no DB entry (FK safety), marked `availability_status = unavailable`
- **CDX cache keys**: Year-filtered queries use separate cache files (`{video_id}_from2018.json`) to avoid cache pollution

## Test plan

- [x] All backend unit tests pass (`pytest tests/unit/services/recovery/ tests/unit/cli/test_recover_commands.py`)
- [x] mypy strict mode passes with zero errors
- [x] Single-video recovery tested end-to-end against real Wayback Machine archives
- [x] `--start-year` anchor filtering verified to return oldest-first snapshots
- [x] Batch recovery with `--dry-run` previews without DB writes
- [x] Frontend component tests pass (`vitest`)
- [x] Documentation reviewed for accuracy against implementation