### PR TITLE
feat(recovery): add Recovery API & Channel Archive Recovery (Feature 025)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ make install-docs
 - [Exporting Data](user-guide/exporting.md) - CSV/JSON export with filtering
 - [REST API](user-guide/rest-api.md) - FastAPI endpoints and usage examples
 
-Recovery commands are documented in the [CLI Overview](user-guide/cli-overview.md#recover-commands) under the Recover Commands section.
+Recovery commands (video and channel metadata recovery from the Wayback Machine) are documented in the [CLI Overview](user-guide/cli-overview.md#recover-commands) under the Recover Commands section.
 
 ### Architecture
 

--- a/docs/api/cli/commands.md
+++ b/docs/api/cli/commands.md
@@ -45,6 +45,13 @@ Command-line interface modules.
       show_root_heading: true
       show_source: true
 
+## Recover Commands
+
+::: chronovista.cli.commands.recover
+    options:
+      show_root_heading: true
+      show_source: true
+
 ## Transcript Commands
 
 ::: chronovista.cli.transcript_commands

--- a/docs/api/error-responses.md
+++ b/docs/api/error-responses.md
@@ -249,6 +249,46 @@ Unexpected server error. Internal details are logged server-side:
 }
 ```
 
+### 409 Conflict (Recovery Endpoints)
+
+Attempting to recover an entity that is currently available:
+
+```bash
+curl -s -X POST http://localhost:8765/api/v1/videos/dQw4w9WgXcQ/recover | jq
+```
+
+```json
+{
+  "type": "https://api.chronovista.com/errors/CONFLICT",
+  "title": "Resource Conflict",
+  "status": 409,
+  "detail": "Cannot recover an available video",
+  "instance": "/api/v1/videos/dQw4w9WgXcQ/recover",
+  "code": "CONFLICT",
+  "request_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+The same applies for channel recovery (`POST /api/v1/channels/{channel_id}/recover`).
+
+### 503 Service Unavailable (Recovery Endpoints)
+
+The Wayback Machine CDX API is temporarily unavailable during a recovery request. Includes a `Retry-After` header:
+
+```bash
+curl -si -X POST http://localhost:8765/api/v1/videos/dQw4w9WgXcQ/recover
+```
+
+```http
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json
+Retry-After: 60
+
+{
+  "detail": "Wayback Machine CDX API unavailable: Connection timeout"
+}
+```
+
 ### 502 External Service Error
 
 External service (e.g., YouTube API) unavailable:

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -55,6 +55,8 @@ All endpoints except `/health` require authentication. The API shares OAuth toke
 | `/preferences/languages` | GET, PUT | Language preferences |
 | `/sync/{operation}` | POST | Trigger sync |
 | `/sync/status` | GET | Sync status |
+| `/videos/{id}/recover` | POST | Recover video metadata via Wayback Machine |
+| `/channels/{id}/recover` | POST | Recover channel metadata via Wayback Machine |
 
 ### Interactive Documentation
 

--- a/docs/api/models/channel.md
+++ b/docs/api/models/channel.md
@@ -7,3 +7,29 @@ Channel-related Pydantic models.
       show_root_heading: true
       show_source: true
       members_order: source
+
+## Recovery Fields (Feature 025)
+
+The following fields are added to the channel detail API response when metadata has been recovered from the Wayback Machine:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `recovered_at` | `datetime` or `null` | Timestamp (UTC) when the channel's metadata was recovered via the Wayback Machine. Null if not recovered. |
+| `recovery_source` | `string` or `null` | Source used for metadata recovery (e.g., `wayback_machine`). Null if not recovered. |
+| `availability_status` | `string` | Channel availability status: `available`, `deleted`, `terminated`, or `suspended`. |
+
+## Channel Recovery Response Schema
+
+The `POST /api/v1/channels/{channel_id}/recover` endpoint returns a `ChannelRecoveryResponse` containing:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `channel_id` | `string` | YouTube channel ID (24 characters, starts with UC). |
+| `success` | `boolean` | Whether the recovery attempt succeeded. |
+| `snapshot_used` | `string` or `null` | CDX timestamp of the Wayback Machine snapshot used. |
+| `fields_recovered` | `list[string]` | Names of fields successfully recovered (e.g., `title`, `description`). |
+| `fields_skipped` | `list[string]` | Names of fields skipped during recovery. |
+| `snapshots_available` | `integer` | Total number of CDX snapshots found for this channel. |
+| `snapshots_tried` | `integer` | Number of snapshots attempted before success or exhaustion. |
+| `failure_reason` | `string` or `null` | Reason for failure, if `success` is `false`. |
+| `duration_seconds` | `float` | Wall-clock time for the recovery operation. |

--- a/docs/api/models/video.md
+++ b/docs/api/models/video.md
@@ -7,3 +7,35 @@ Video-related Pydantic models.
       show_root_heading: true
       show_source: true
       members_order: source
+
+## Recovery Fields (Feature 025)
+
+The following fields are added to the video detail API response when metadata has been recovered from the Wayback Machine:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `recovered_at` | `datetime` or `null` | Timestamp (UTC) when the video's metadata was recovered via the Wayback Machine. Null if not recovered. |
+| `recovery_source` | `string` or `null` | Source used for metadata recovery (e.g., `wayback_machine`). Null if not recovered. |
+| `alternative_url` | `string` or `null` | Alternative URL for unavailable content (e.g., mirror on another platform). Max 500 characters. |
+| `availability_status` | `string` | Video availability status: `available`, `deleted`, `private`, or `unavailable`. |
+
+## Video Recovery Response Schema
+
+The `POST /api/v1/videos/{video_id}/recover` endpoint returns a `VideoRecoveryResponse` containing:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `video_id` | `string` | YouTube video ID (11 characters). |
+| `success` | `boolean` | Whether the recovery attempt succeeded. |
+| `snapshot_used` | `string` or `null` | CDX timestamp of the Wayback Machine snapshot used. |
+| `fields_recovered` | `list[string]` | Names of fields successfully recovered (e.g., `title`, `description`, `tags`). |
+| `fields_skipped` | `list[string]` | Names of fields skipped during recovery. |
+| `snapshots_available` | `integer` | Total number of CDX snapshots found for this video. |
+| `snapshots_tried` | `integer` | Number of snapshots attempted before success or exhaustion. |
+| `failure_reason` | `string` or `null` | Reason for failure, if `success` is `false`. |
+| `duration_seconds` | `float` | Wall-clock time for the recovery operation. |
+| `channel_recovery_candidates` | `list[string]` | Channel IDs discovered during recovery that may need their own recovery. |
+| `channel_recovered` | `boolean` | Whether the associated channel's metadata was also recovered. |
+| `channel_fields_recovered` | `list[string]` | Names of channel fields successfully recovered. |
+| `channel_fields_skipped` | `list[string]` | Names of channel fields skipped during recovery. |
+| `channel_failure_reason` | `string` or `null` | Reason for channel recovery failure, if applicable. |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive user guide and API reference
 - Architecture documentation
 
+## [0.28.0] - 2026-02-17
+
+### Added
+- **Feature 025: Recovery API & Channel Archive Recovery**
+  - `POST /api/v1/videos/{video_id}/recover` endpoint with year filter params and structured `RecoveryResult` response
+  - `POST /api/v1/channels/{channel_id}/recover` endpoint with `ChannelRecoveryResult` response
+  - `recovered_at` and `recovery_source` fields in video and channel detail API responses
+  - Channel metadata recovery from Wayback Machine (title, description, subscriber count, video count, thumbnail, country)
+  - Auto-channel recovery triggered during video recovery when channel is unavailable
+  - CDX client `fetch_channel_snapshots()` with separate cache namespace
+  - Page parser `extract_channel_metadata()` with JSON extraction and meta tag fallback
+  - Channel recovery orchestrator with three-tier overwrite policy
+  - Backend idempotency guard (5-minute window) preventing duplicate recovery calls
+  - Recovery dependency injection via `get_recovery_deps()` in `deps.py`
+  - "Recover from Web Archive" button on video and channel detail pages
+  - "Re-recover from Web Archive" label when previously recovered
+  - Year filter UI with collapsible "Advanced Options" section and validation
+  - Zustand v5 recovery store with `persist` middleware for session-level state
+  - Elapsed time counter during recovery ("Recovering... 1m 23s elapsed")
+  - Cancel button with `AbortController` integration
+  - `beforeunload` warning during active recovery
+  - AppShell recovery indicator banner with entity link and elapsed time
+  - Toast notifications for recovery completion (green) and failure (red) with 8s auto-dismiss
+  - localStorage hydration UX with backend polling for orphaned sessions
+  - SPA navigation guard (`useBlocker` modal) on video and channel detail pages
+  - CLI `chronovista recover` channel recovery statistics in batch summary
+  - Transcript panel conditionally rendered based on transcript availability (supports deleted videos with manual transcripts)
+  - React Router v7 `startTransition` future flag opt-in
+
+### Components
+- `RecoverySession` Zustand store (`frontend/src/stores/recoveryStore.ts`)
+- `RecoveredChannelData` and `ChannelRecoveryResult` Pydantic models
+- Recovery indicator banner in AppShell
+- Toast notification system for recovery events
+- Navigation guard modal ("Stay"/"Leave")
+
+### Fixed
+- Recovery timeout mismatch: frontend `apiFetch` now accepts per-call timeout override (660s for recovery vs 10s default)
+- `sessions.get is not a function` error on localStorage hydration (added `merge` callback for Map deserialization)
+- 404 errors for `/transcript/languages` on deleted videos (gated on `transcript_summary.count > 0`)
+- Transcript languages endpoint now passes `include_unavailable=true` for deleted video support
+
+### Technical
+- 1,739 passing frontend tests across 71 files
+- 4,500+ passing backend tests
+- 246 recovery-specific backend tests
+- Zustand v5 (~3KB gzipped) for app-level recovery state
+- mypy strict compliance (0 errors)
+- TypeScript strict mode (0 errors)
+
 ## [0.27.0] - 2026-02-15
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,11 +57,11 @@ chronovista is a CLI application that enables users to access, store, and explor
 
     FastAPI-powered REST API with 20+ endpoints for programmatic access to videos, transcripts, and search
 
--   :material-delete-restore:{ .lg .middle } **Deleted Video Recovery**
+-   :material-delete-restore:{ .lg .middle } **Deleted Content Recovery**
 
     ---
 
-    Recover metadata for deleted/unavailable videos from the Wayback Machine with configurable date ranges and batch processing
+    Recover metadata for deleted/unavailable videos and channels from the Wayback Machine via CLI, REST API, or frontend with year filters, progress tracking, and idempotent caching
 
 </div>
 
@@ -73,8 +73,8 @@ chronovista is a CLI application that enables users to access, store, and explor
     - **Real API integration testing** with YouTube API data validation
     - **Advanced repository pattern** with async support and composite keys
     - **Rate-limited API service** with intelligent error handling and retry logic
-    - **Wayback Machine recovery** for deleted/unavailable video metadata (v0.27.0)
-    - **React frontend** with video browsing, transcript search, and deep link navigation (v0.6.0)
+    - **Wayback Machine recovery** for deleted/unavailable video and channel metadata via CLI, REST API, and frontend (v0.28.0)
+    - **React frontend** with video browsing, transcript search, deep link navigation, and recovery UI (v0.7.0)
 
 ## Quick Example
 
@@ -131,7 +131,7 @@ chronovista is a CLI application that enables users to access, store, and explor
     open http://localhost:8765/docs
     ```
 
-=== "Recover Deleted Videos"
+=== "Recover Deleted Content"
 
     ```bash
     # Recover a specific deleted video
@@ -145,6 +145,23 @@ chronovista is a CLI application that enables users to access, store, and explor
 
     # Preview without making changes
     chronovista recover video --all --dry-run
+
+    # Channel recovery happens automatically during video recovery
+    # when the channel_id is found in a Wayback Machine snapshot
+    ```
+
+=== "Recovery via REST API"
+
+    ```bash
+    # Recover a video via the API
+    curl -X POST "http://localhost:8765/api/v1/recovery/videos/dQw4w9WgXcQ" \
+      -H "Content-Type: application/json" \
+      -d '{"start_year": 2018, "end_year": 2020}'
+
+    # Recover a channel via the API
+    curl -X POST "http://localhost:8765/api/v1/recovery/channels/UCxxxxxx"
+
+    # Repeated requests within 5 minutes return cached results
     ```
 
 ## Architecture Highlights

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -232,6 +232,62 @@ Not all videos have transcripts in all languages.
 chronovista transcript languages VIDEO_ID
 ```
 
+## Recovery (Wayback Machine)
+
+### Recovery times out or hangs
+
+The Wayback Machine and its CDX API can be slow or unresponsive, especially during peak hours.
+
+**Fix:**
+
+- Wait a few minutes and retry. Wayback Machine connections are inherently flaky.
+- Use `--start-year` and `--end-year` to narrow the search window, reducing the number of snapshots the CDX API must scan.
+- For batch recovery, use `--limit` to process smaller batches.
+
+### CDX API returns 429 (Too Many Requests)
+
+You're querying the Wayback Machine CDX API too rapidly.
+
+**Fix:**
+
+- Wait 1-2 minutes before retrying. chronovista has built-in retry with exponential backoff, but sustained high volume can exceed limits.
+- Reduce batch size with `--limit`.
+- Add `--start-year` to reduce CDX result set size.
+
+### CDX API returns 503 (Service Unavailable)
+
+The Wayback Machine is temporarily overloaded or undergoing maintenance.
+
+**Fix:**
+
+- This is transient. Wait a few minutes and retry.
+- Check [Internet Archive status](https://status.archivelab.org/) for ongoing outages.
+
+### "No snapshots found" for a video or channel
+
+The Wayback Machine never archived that YouTube page, or the snapshots were captured before the metadata was populated.
+
+**Fix:**
+
+- Not all YouTube pages are archived. This is expected for less popular content.
+- Try different year ranges with `--start-year` and `--end-year` to check different archive eras.
+- For very old videos (pre-2012), archived pages may use a different HTML format that the parser cannot extract metadata from.
+
+### Recovery returns partial metadata
+
+Some Wayback Machine snapshots contain incomplete page content (e.g., title present but no description or tags).
+
+**Fix:**
+
+- This is expected. The overwrite policy ensures partial data is merged safely (NULL protection prevents blanking existing values).
+- Re-running recovery later may find a different snapshot with more complete data.
+
+### Repeated recovery returns the same result instantly
+
+This is the idempotency guard working as intended. Recovery results are cached for 5 minutes to prevent redundant Wayback Machine queries.
+
+**Fix:** Wait 5 minutes if you want to force a fresh recovery attempt.
+
 ## Docker
 
 ### Docker Compose errors
@@ -265,3 +321,4 @@ make dev-db-down
 - [YouTube API Setup](getting-started/youtube-api-setup.md) - Google Cloud configuration
 - [Installation](getting-started/installation.md) - Setup guide
 - [Database Development](development/database.md) - Database workflow
+- [CLI Overview - Recover Commands](user-guide/cli-overview.md#recover-commands) - Recovery command reference

--- a/docs/user-guide/cli-overview.md
+++ b/docs/user-guide/cli-overview.md
@@ -177,6 +177,8 @@ chronovista recover [COMMAND]
 
 **Note:** Requires `beautifulsoup4` (included in default install). Optional `selenium` enables pre-2017 page fallback.
 
+Video recovery also attempts to recover the associated channel's metadata when the channel is unavailable. In batch mode (`--all`), the summary report includes channel recovery statistics showing how many channels were attempted, recovered, and which fields were restored.
+
 ### API Commands
 
 ```bash
@@ -679,6 +681,8 @@ chronovista recover video --all --delay 2.0
 - Three-tier overwrite policy: immutable fields fill-if-NULL only, mutable fields overwrite-if-newer, NULL protection
 - Results are cached locally for 24 hours to avoid redundant API calls
 - Creates stub channel records when recovered `channel_id` has no existing DB entry
+- Automatically attempts channel recovery when the associated channel is unavailable
+- Batch summary includes channel recovery statistics (channels attempted, recovered, and fields restored)
 
 ### Google Takeout
 

--- a/docs/user-guide/data-sync.md
+++ b/docs/user-guide/data-sync.md
@@ -386,6 +386,25 @@ make dev-db-reset
 chronovista sync all
 ```
 
+## Recovering Deleted Content
+
+Sync only works for videos and channels that are still available on YouTube. For deleted, private, or otherwise unavailable content, use the **recovery** feature to retrieve metadata from the Wayback Machine:
+
+```bash
+# Recover a specific deleted video
+chronovista recover video --video-id VIDEO_ID
+
+# Batch recover all unavailable videos
+chronovista recover video --all --limit 50
+
+# Narrow the Wayback Machine search to a specific era
+chronovista recover video --all --start-year 2018 --end-year 2020
+```
+
+Channel metadata is automatically recovered during video recovery when a channel ID is found in the archived page. Recovery is also available via the REST API and the frontend's "Recover from Web Archive" button.
+
+See the [CLI Overview](cli-overview.md#recover-commands) for full recovery command reference.
+
 ## See Also
 
 - [Google Takeout](google-takeout.md) - Import historical data

--- a/docs/user-guide/transcripts.md
+++ b/docs/user-guide/transcripts.md
@@ -426,6 +426,7 @@ Some videos don't have transcripts:
 - Very new videos may not be processed yet
 - Creator disabled captions
 - Regional restrictions
+- **Deleted or unavailable videos** - Transcripts cannot be downloaded for videos that no longer exist on YouTube. However, you can recover the video's metadata (title, description, tags, etc.) from the Wayback Machine using `chronovista recover video --video-id VIDEO_ID`. Note that transcript text itself is not recoverable from the Wayback Machine.
 
 ### Rate Limited
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "chronovista-frontend",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chronovista-frontend",
-      "version": "0.1.0",
+      "version": "0.7.0",
       "dependencies": {
         "@tanstack/react-query": "^5.64.0",
         "@tanstack/react-virtual": "^3.13.18",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^6.30.3"
+        "react-router-dom": "^6.30.3",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.18",
@@ -2214,6 +2215,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -2501,7 +2562,7 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3270,7 +3331,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -4335,7 +4396,7 @@
       "version": "9.0.21",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
       "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "dev": true,
+      "devOptional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -7728,6 +7789,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -18,7 +18,8 @@
     "@tanstack/react-virtual": "^3.13.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.30.3"
+    "react-router-dom": "^6.30.3",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",

--- a/frontend/scripts/fix-recovery-tests.js
+++ b/frontend/scripts/fix-recovery-tests.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Script to fix recovery tests by replacing isRecovering/recoveryResult props
+ * with Zustand store state setup.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const testFilePath = path.join(
+  __dirname,
+  '../src/components/__tests__/UnavailabilityBanner.recovery.test.tsx'
+);
+
+let content = fs.readFileSync(testFilePath, 'utf8');
+
+// Pattern 1: Replace all instances where recoveryResult prop is passed with completed phase
+const recoveryResultPattern = /render\(\s*<UnavailabilityBanner\s+availabilityStatus="([^"]+)"\s+entityType="([^"]+)"\s+entityId="([^"]+)"\s+onRecover=\{mockRecover\}\s+recoveryResult=\{recoveryResult\}\s*\/>\s*\);/gs;
+
+content = content.replace(recoveryResultPattern, (match, status, entityType, entityId) => {
+  return `// Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["${entityId}", {
+            sessionId: "test-session",
+            entityId: "${entityId}",
+            entityType: "${entityType}",
+            entityTitle: "Test ${entityType === 'video' ? 'Video' : 'Channel'}",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="${status}"
+          entityType="${entityType}"
+          entityId="${entityId}"
+          onRecover={mockRecover}
+        />
+      );`;
+});
+
+// Pattern 2: Replace all instances where isRecovering={true} is passed with in-progress phase
+const isRecoveringPattern = /render\(\s*<UnavailabilityBanner\s+availabilityStatus="([^"]+)"\s+entityType="([^"]+)"\s+entityId="([^"]+)"\s+onRecover=\{mockRecover\}\s+isRecovering=\{true\}\s*\/>\s*\);/gs;
+
+content = content.replace(isRecoveringPattern, (match, status, entityType, entityId) => {
+  return `// Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["${entityId}", {
+            sessionId: "test-session",
+            entityId: "${entityId}",
+            entityType: "${entityType}",
+            entityTitle: "Test ${entityType === 'video' ? 'Video' : 'Channel'}",
+            phase: "in-progress",
+            startedAt: Date.now(),
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="${status}"
+          entityType="${entityType}"
+          entityId="${entityId}"
+          onRecover={mockRecover}
+        />
+      );`;
+});
+
+fs.writeFileSync(testFilePath, content, 'utf8');
+console.log('✅ Fixed UnavailabilityBanner.recovery.test.tsx');

--- a/frontend/scripts/fix_recovery_tests.py
+++ b/frontend/scripts/fix_recovery_tests.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Script to fix recovery tests by replacing isRecovering/recoveryResult props
+with Zustand store state setup.
+"""
+
+import re
+
+# Read the file
+with open('src/components/__tests__/UnavailabilityBanner.recovery.test.tsx', 'r') as f:
+    content = f.read()
+
+# Store setup template for completed sessions with result
+store_setup_template = """// Set up store with completed session and result
+      useRecoveryStore.setState({{
+        sessions: new Map([
+          ["{entity_id}", {{
+            sessionId: "test-session",
+            entityId: "{entity_id}",
+            entityType: "{entity_type}",
+            entityTitle: "Test {entity_title}",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {{}},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }}],
+        ]),
+      }});
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="{availability_status}"
+          entityType="{entity_type}"
+          entityId="{entity_id}"
+          onRecover={{mockRecover}}
+        />
+      );"""
+
+# Pattern to match render with recoveryResult prop
+pattern = r'render\(\s*<UnavailabilityBanner\s+availabilityStatus="([^"]+)"\s+entityType="([^"]+)"\s+entityId="([^"]+)"\s+onRecover=\{mockRecover\}\s+recoveryResult=\{recoveryResult\}\s*\/>\s*\);'
+
+def replace_recovery_result(match):
+    availability_status = match.group(1)
+    entity_type = match.group(2)
+    entity_id = match.group(3)
+    entity_title = "Video" if entity_type == "video" else "Channel"
+
+    return store_setup_template.format(
+        entity_id=entity_id,
+        entity_type=entity_type,
+        entity_title=entity_title,
+        availability_status=availability_status
+    )
+
+# Replace all occurrences
+content = re.sub(pattern, replace_recovery_result, content, flags=re.MULTILINE)
+
+# Store setup template for in-progress sessions (isRecovering=true)
+in_progress_template = """// Set up store with in-progress session
+      useRecoveryStore.setState({{
+        sessions: new Map([
+          ["{entity_id}", {{
+            sessionId: "test-session",
+            entityId: "{entity_id}",
+            entityType: "{entity_type}",
+            entityTitle: "Test {entity_title}",
+            phase: "in-progress",
+            startedAt: Date.now(),
+            completedAt: null,
+            filterOptions: {{}},
+            result: null,
+            error: null,
+            abortController: null,
+          }}],
+        ]),
+      }});
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="{availability_status}"
+          entityType="{entity_type}"
+          entityId="{entity_id}"
+          onRecover={{mockRecover}}
+        />
+      );"""
+
+# Pattern to match render with isRecovering=true prop
+is_recovering_pattern = r'render\(\s*<UnavailabilityBanner\s+availabilityStatus="([^"]+)"\s+entityType="([^"]+)"\s+entityId="([^"]+)"\s+onRecover=\{mockRecover\}\s+isRecovering=\{true\}\s*\/>\s*\);'
+
+def replace_is_recovering(match):
+    availability_status = match.group(1)
+    entity_type = match.group(2)
+    entity_id = match.group(3)
+    entity_title = "Video" if entity_type == "video" else "Channel"
+
+    return in_progress_template.format(
+        entity_id=entity_id,
+        entity_type=entity_type,
+        entity_title=entity_title,
+        availability_status=availability_status
+    )
+
+# Replace all occurrences
+content = re.sub(is_recovering_pattern, replace_is_recovering, content, flags=re.MULTILINE)
+
+# Write back the file
+with open('src/components/__tests__/UnavailabilityBanner.recovery.test.tsx', 'w') as f:
+    f.write(content)
+
+print("✅ Fixed all recoveryResult and isRecovering props in UnavailabilityBanner.recovery.test.tsx")

--- a/frontend/src/components/__tests__/UnavailabilityBanner.recovery.test.tsx
+++ b/frontend/src/components/__tests__/UnavailabilityBanner.recovery.test.tsx
@@ -1,0 +1,2240 @@
+/**
+ * Tests for UnavailabilityBanner Recovery Button (Feature 025)
+ *
+ * Tests recovery button and status feedback features:
+ * - Recovery button visibility based on props
+ * - Loading state during recovery
+ * - Success/failure status messages
+ * - Re-recovery label for previously recovered content
+ * - Keyboard accessibility
+ * - Screen reader announcements
+ * - T034: Elapsed time counter during recovery
+ * - T041: Cancel button for active recovery operations
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { UnavailabilityBanner } from "../UnavailabilityBanner";
+import { useRecoveryStore } from "../../stores/recoveryStore";
+import type { RecoveryResultData } from "../../types/recovery";
+
+describe("UnavailabilityBanner - Recovery Button", () => {
+  beforeEach(() => {
+    // Reset store state before each test
+    useRecoveryStore.setState({ sessions: new Map() });
+    // Use fake timers for elapsed time tests
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Restore real timers
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("Button Visibility", () => {
+    it("should show recovery button when onRecover is provided and entity is unavailable", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("should not show recovery button when onRecover is not provided", () => {
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+        />
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /recover from web archive/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show recovery button when entityId is not provided", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /recover from web archive/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show recovery button for channel entity type", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="channel"
+          entityId="test-channel-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+      expect(button).toBeInTheDocument();
+    });
+  });
+
+  describe("Loading State", () => {
+    it("should show loading spinner when phase is 'in-progress'", () => {
+      const mockRecover = vi.fn();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: Date.now(),
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.getByText(/recovering from web archive/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should disable button when phase is 'in-progress'", () => {
+      const mockRecover = vi.fn();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: Date.now(),
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+      expect(button).toBeDisabled();
+    });
+
+    it("should show spinner icon during recovery", () => {
+      const mockRecover = vi.fn();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: Date.now(),
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const spinnerContainer = screen
+        .getByText(/recovering from web archive/i)
+        .closest("div");
+      const spinner = spinnerContainer?.querySelector("svg.animate-spin");
+      expect(spinner).toBeInTheDocument();
+    });
+  });
+
+  describe("Success Messages", () => {
+    it("should show success message with field count and snapshot date when recovery succeeds", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: ["title", "description"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 2,
+        failure_reason: null,
+        duration_seconds: 3.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.getByText(/recovered 2 fields from archive snapshot 2023-04-15/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should use singular 'field' when only 1 field recovered", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: ["title"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.getByText(/recovered 1 field from archive snapshot 2023-04-15/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should show green success styling for successful recovery", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: ["title", "description"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 2,
+        failure_reason: null,
+        duration_seconds: 3.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const successMessage = screen
+        .getByText(/recovered 2 fields/i)
+        .closest("div");
+      expect(successMessage).toHaveClass("bg-green-50");
+      expect(successMessage).toHaveClass("border-green-200");
+      expect(successMessage).toHaveClass("text-green-700");
+    });
+
+    it("should show CheckCircleIcon for successful recovery", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: ["title"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const successMessage = screen.getByText(/recovered 1 field/i).closest("div");
+      const icon = successMessage?.querySelector("svg");
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("Zero-Field Success", () => {
+    it("should show blue informational message when no fields recovered (all up-to-date)", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: [],
+        fields_skipped: ["title", "description"],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 1.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.getByText(/recovery completed.*all fields already up-to-date/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should show blue styling for zero-field success", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: [],
+        fields_skipped: ["title", "description"],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 1.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const infoMessage = screen
+        .getByText(/all fields already up-to-date/i)
+        .closest("div");
+      expect(infoMessage).toHaveClass("bg-blue-50");
+      expect(infoMessage).toHaveClass("border-blue-200");
+      expect(infoMessage).toHaveClass("text-blue-700");
+    });
+
+    it("should show InformationCircleIcon for zero-field success", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: [],
+        fields_skipped: ["title"],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 1.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const infoMessage = screen
+        .getByText(/all fields already up-to-date/i)
+        .closest("div");
+      const icon = infoMessage?.querySelector("svg");
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("Failure Messages", () => {
+    it("should show contextual message for no_snapshots_found", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: false,
+        snapshot_used: null,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: "no_snapshots_found",
+        duration_seconds: 0.5,
+      };
+
+      // Set up store with completed (failed) session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.getByText(/no archived snapshots found for this content/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should show contextual message for all_snapshots_failed", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: false,
+        snapshot_used: null,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 5,
+        failure_reason: "all_snapshots_failed",
+        duration_seconds: 2.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.getByText(
+          /could not extract metadata from available snapshots/i
+        )
+      ).toBeInTheDocument();
+    });
+
+    it("should show contextual message for cdx_connection_error", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: false,
+        snapshot_used: null,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: "cdx_connection_error",
+        duration_seconds: 10.0,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.getByText(
+          /web archive is temporarily unavailable.*please try again later/i
+        )
+      ).toBeInTheDocument();
+    });
+
+    it("should show generic failure message with custom reason when provided", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: false,
+        snapshot_used: null,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: "unknown_error_occurred",
+        duration_seconds: 0.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.getByText(/recovery failed: unknown_error_occurred/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should show red styling for failure messages", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: false,
+        snapshot_used: null,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: "no_snapshots_found",
+        duration_seconds: 0.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const errorMessage = screen
+        .getByText(/no archived snapshots found/i)
+        .closest("div");
+      expect(errorMessage).toHaveClass("bg-red-50");
+      expect(errorMessage).toHaveClass("border-red-200");
+      expect(errorMessage).toHaveClass("text-red-700");
+    });
+
+    it("should show XCircleIcon for failure messages", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: false,
+        snapshot_used: null,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: "no_snapshots_found",
+        duration_seconds: 0.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const errorMessage = screen
+        .getByText(/no archived snapshots found/i)
+        .closest("div");
+      const icon = errorMessage?.querySelector("svg");
+      expect(icon).toBeInTheDocument();
+    });
+  });
+
+  describe("Re-recover Label", () => {
+    it("should show 'Re-recover from Web Archive' when recoveredAt is set", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+          recoveredAt="2023-04-15T12:00:00Z"
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /re-recover from web archive/i,
+      });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("should show 'Recover from Web Archive' when recoveredAt is null", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+          recoveredAt={null}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /^recover from web archive$/i,
+      });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("should show 'Recover from Web Archive' when recoveredAt is undefined", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /^recover from web archive$/i,
+      });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("should display formatted previous recovery date when recoveredAt is set", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+          recoveredAt="2023-04-15T12:00:00Z"
+        />
+      );
+
+      // The date should be formatted as "Apr 15, 2023" (locale-dependent)
+      expect(screen.getByText(/last:/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("Keyboard Accessibility", () => {
+    it("should trigger onRecover when Enter key is pressed", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+
+      await user.click(button);
+      expect(mockRecover).toHaveBeenCalledTimes(1);
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should trigger onRecover when Space key is pressed", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+
+      button.focus();
+      await user.keyboard(" ");
+      expect(mockRecover).toHaveBeenCalledTimes(1);
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should have visible focus indicator on recovery button", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+
+      expect(button).toHaveClass("focus:outline-none");
+      expect(button).toHaveClass("focus:ring-2");
+      expect(button).toHaveClass("focus:ring-offset-2");
+    });
+
+    it("should not trigger onRecover when button is disabled", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+
+      // Set up store with in-progress session to disable button
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: Date.now(),
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+
+      await user.click(button);
+      expect(mockRecover).not.toHaveBeenCalled();
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+  });
+
+  describe("ARIA Live Region", () => {
+    it("should have aria-live='polite' on recovery status container", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: ["title"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const ariaLiveRegion = container.querySelector('[aria-live="polite"]');
+      // The main banner has aria-live, but the recovery status area should also have it
+      const statusRegions = container.querySelectorAll('[aria-live="polite"]');
+      expect(statusRegions.length).toBeGreaterThan(0);
+    });
+
+    it("should have aria-atomic='true' on recovery status container", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: ["title"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const ariaAtomicRegion = container.querySelector('[aria-atomic="true"]');
+      expect(ariaAtomicRegion).toBeInTheDocument();
+    });
+
+    it("should announce loading state to screen readers", () => {
+      const mockRecover = vi.fn();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: Date.now(),
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const loadingText = screen.getByText(/recovering from web archive/i);
+      expect(loadingText).toBeInTheDocument();
+    });
+
+    it("should announce success to screen readers", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: ["title", "description"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const successMessage = screen.getByText(/recovered 2 fields/i);
+      expect(successMessage).toBeInTheDocument();
+    });
+
+    it("should announce failure to screen readers", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: false,
+        snapshot_used: null,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: "no_snapshots_found",
+        duration_seconds: 0.5,
+      };
+
+      // Set up store with completed session and result
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const errorMessage = screen.getByText(/no archived snapshots found/i);
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
+
+  describe("Button Styling", () => {
+    it("should have archive box icon", () => {
+      const mockRecover = vi.fn();
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+      const icon = button.querySelector("svg");
+      expect(icon).toBeInTheDocument();
+    });
+
+    it("should have correct button classes for enabled state", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+
+      expect(button).toHaveClass("bg-slate-700");
+      expect(button).toHaveClass("hover:bg-slate-800");
+      expect(button).toHaveClass("text-white");
+      expect(button).toHaveClass("rounded-lg");
+    });
+
+    it("should have disabled cursor class when disabled", () => {
+      const mockRecover = vi.fn();
+
+      // Set up store with in-progress session to disable button
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: Date.now(),
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const button = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+
+      expect(button).toHaveClass("disabled:cursor-not-allowed");
+    });
+  });
+
+  describe("Year Filter UI", () => {
+    it("should show advanced options toggle button when onRecover and entityId are provided", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      expect(toggleButton).toBeInTheDocument();
+    });
+
+    it("should not show year filter panel initially (advanced options collapsed by default)", () => {
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const panel = document.getElementById("recovery-advanced-options");
+      expect(panel).not.toBeInTheDocument();
+    });
+
+    it("should expand advanced options panel when toggle is clicked", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      await user.click(toggleButton);
+
+      const panel = document.getElementById("recovery-advanced-options");
+      expect(panel).toBeInTheDocument();
+
+      // Panel should have two select dropdowns
+      const selects = panel?.querySelectorAll("select");
+      expect(selects?.length).toBe(2);
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should have aria-expanded='false' initially and aria-expanded='true' after click", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+
+      expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+
+      await user.click(toggleButton);
+
+      expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should render start year select with all years (2005-current year) plus 'Any year' default", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      const currentYear = new Date().getFullYear();
+      const yearCount = currentYear - 2005 + 1;
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      await user.click(toggleButton);
+
+      const startYearSelect = screen.getByLabelText(/from:/i);
+      const options = startYearSelect.querySelectorAll("option");
+
+      // Should have "Any year" + (current year - 2005 + 1) years
+      expect(options.length).toBe(yearCount + 1);
+      expect(options[0].textContent).toBe("Any year");
+      expect(options[0]).toHaveValue("");
+      expect(options[1]).toHaveValue("2005");
+      expect(options[yearCount]).toHaveValue(String(currentYear));
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should render end year select with all years (2005-current year) and current year as default", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      const currentYear = new Date().getFullYear();
+      const yearCount = currentYear - 2005 + 1;
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      await user.click(toggleButton);
+
+      const endYearSelect = screen.getByLabelText(/to:/i);
+      const options = endYearSelect.querySelectorAll("option");
+
+      // Should have "Any year" + (current year - 2005 + 1) years
+      expect(options.length).toBe(yearCount + 1);
+      expect(options[0].textContent).toBe("Any year");
+      expect(options[0]).toHaveValue("");
+      expect(options[1]).toHaveValue("2005");
+      expect(options[yearCount]).toHaveValue(String(currentYear));
+
+      // The end year should default to current year
+      expect(endYearSelect).toHaveValue(String(currentYear));
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should show year validation error when end year < start year", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      await user.click(toggleButton);
+
+      const startYearSelect = screen.getByLabelText(/from:/i);
+      const endYearSelect = screen.getByLabelText(/to:/i);
+
+      // Set start year to 2020, end year to 2015
+      await user.selectOptions(startYearSelect, "2020");
+      await user.selectOptions(endYearSelect, "2015");
+
+      // Validation error should appear
+      const errorAlert = screen.getByRole("alert");
+      expect(errorAlert).toHaveTextContent("End year must be after start year");
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should clear year validation error when end year is changed to be >= start year", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      await user.click(toggleButton);
+
+      const startYearSelect = screen.getByLabelText(/from:/i);
+      const endYearSelect = screen.getByLabelText(/to:/i);
+
+      // Set invalid range first
+      await user.selectOptions(startYearSelect, "2020");
+      await user.selectOptions(endYearSelect, "2015");
+
+      // Error should be present
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Fix the range
+      await user.selectOptions(endYearSelect, "2022");
+
+      // Error should be gone
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should disable recovery button when year validation error exists", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const recoveryButton = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+
+      // Initially enabled
+      expect(recoveryButton).not.toBeDisabled();
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      await user.click(toggleButton);
+
+      const startYearSelect = screen.getByLabelText(/from:/i);
+      const endYearSelect = screen.getByLabelText(/to:/i);
+
+      // Set invalid range
+      await user.selectOptions(startYearSelect, "2020");
+      await user.selectOptions(endYearSelect, "2015");
+
+      // Button should be disabled
+      expect(recoveryButton).toBeDisabled();
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should show help text when advanced options panel is expanded", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      await user.click(toggleButton);
+
+      expect(
+        screen.getByText(/default searches all years/i)
+      ).toBeInTheDocument();
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should pass year values to onRecover when both years are selected", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      await user.click(toggleButton);
+
+      const startYearSelect = screen.getByLabelText(/from:/i);
+      const endYearSelect = screen.getByLabelText(/to:/i);
+
+      await user.selectOptions(startYearSelect, "2018");
+      await user.selectOptions(endYearSelect, "2022");
+
+      const recoveryButton = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      expect(mockRecover).toHaveBeenCalledWith({
+        startYear: 2018,
+        endYear: 2022,
+      });
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should pass only endYear (current year) to onRecover when 'Any year' is selected for startYear", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      const currentYear = new Date().getFullYear();
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const recoveryButton = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      expect(mockRecover).toHaveBeenCalledWith({ endYear: currentYear });
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should pass both startYear and default endYear (current year) when only startYear is explicitly changed", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      const currentYear = new Date().getFullYear();
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+      await user.click(toggleButton);
+
+      const startYearSelect = screen.getByLabelText(/from:/i);
+
+      await user.selectOptions(startYearSelect, "2020");
+
+      const recoveryButton = screen.getByRole("button", {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      expect(mockRecover).toHaveBeenCalledWith({ startYear: 2020, endYear: currentYear });
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+
+    it("should make toggle button keyboard accessible", async () => {
+      // Use real timers for userEvent to avoid conflicts
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const toggleButton = screen.getByRole("button", {
+        name: /advanced options/i,
+      });
+
+      // Verify it's a button (automatically keyboard accessible)
+      expect(toggleButton.tagName).toBe("BUTTON");
+
+      // Verify it can be triggered via keyboard
+      toggleButton.focus();
+      await user.keyboard(" "); // Space key
+
+      const panel = document.getElementById("recovery-advanced-options");
+      expect(panel).toBeInTheDocument();
+
+      // Restore fake timers
+      vi.useFakeTimers();
+    });
+  });
+
+  describe("Elapsed Time Counter (T034)", () => {
+    it("should show '0s elapsed' initially when recovery starts", () => {
+      const mockRecover = vi.fn();
+      const now = Date.now();
+
+      // Set up store with in-progress session starting now
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: now,
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(screen.getByText(/\(0s elapsed\)/i)).toBeInTheDocument();
+    });
+
+    it("should show elapsed timer updating after 1 second", () => {
+      const mockRecover = vi.fn();
+      const now = Date.now();
+
+      // Set up store with in-progress session that started 1 second ago
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: now - 1000,
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      // Should show 1s elapsed
+      expect(screen.getByText(/\(1s elapsed\)/i)).toBeInTheDocument();
+    });
+
+    it("should show '1m 23s' format after 83 seconds", () => {
+      const mockRecover = vi.fn();
+      const now = Date.now();
+
+      // Set up store with in-progress session that started 83 seconds ago
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: now - 83000,
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(screen.getByText(/\(1m 23s elapsed\)/i)).toBeInTheDocument();
+    });
+
+    it("should not show timer when phase is idle", () => {
+      const mockRecover = vi.fn();
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(screen.queryByText(/elapsed/i)).not.toBeInTheDocument();
+    });
+
+    it("should not show timer when phase is completed", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: ["title"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      // Set up store with completed session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(screen.queryByText(/elapsed/i)).not.toBeInTheDocument();
+    });
+
+    it("should show help text 'This can take 1-5 minutes' during recovery", () => {
+      const mockRecover = vi.fn();
+      const now = Date.now();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: now,
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(
+        screen.getByText(/this can take 1–5 minutes depending on archive availability/i)
+      ).toBeInTheDocument();
+    });
+
+    it("should have aria-live and aria-atomic on elapsed timer for screen readers", () => {
+      const mockRecover = vi.fn();
+      const now = Date.now();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: now,
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const timerElement = screen.getByText(/\(0s elapsed\)/i);
+      expect(timerElement).toHaveAttribute("aria-live", "polite");
+      expect(timerElement).toHaveAttribute("aria-atomic", "true");
+    });
+  });
+
+  describe("Cancel Button (T041)", () => {
+    it("should show cancel button when phase is in-progress", () => {
+      const mockRecover = vi.fn();
+      const now = Date.now();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: now,
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const cancelButton = screen.getByRole("button", { name: /cancel/i });
+      expect(cancelButton).toBeInTheDocument();
+    });
+
+    it("should not show cancel button when phase is idle", () => {
+      const mockRecover = vi.fn();
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(screen.queryByRole("button", { name: /^cancel$/i })).not.toBeInTheDocument();
+    });
+
+    it("should not show cancel button when phase is completed", () => {
+      const mockRecover = vi.fn();
+      const recoveryResult: RecoveryResultData = {
+        success: true,
+        snapshot_used: "20230415120000",
+        fields_recovered: ["title"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      // Set up store with completed session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "completed",
+            startedAt: Date.now() - 5000,
+            completedAt: Date.now(),
+            filterOptions: {},
+            result: recoveryResult,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      expect(screen.queryByRole("button", { name: /^cancel$/i })).not.toBeInTheDocument();
+    });
+
+    it("should call cancelRecovery when cancel button is clicked", async () => {
+      // Use real timers for this test to avoid userEvent timeout issues
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      const mockCancelRecovery = vi.spyOn(useRecoveryStore.getState(), "cancelRecovery");
+      const now = Date.now();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: now,
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const cancelButton = screen.getByRole("button", { name: /cancel/i });
+      await user.click(cancelButton);
+
+      expect(mockCancelRecovery).toHaveBeenCalledWith("test-session");
+
+      // Restore fake timers for other tests
+      vi.useFakeTimers();
+    });
+
+    it("should hide recovery section after clicking cancel", async () => {
+      // Use real timers for this test to avoid userEvent timeout issues
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const mockRecover = vi.fn();
+      const mockCancelRecovery = vi.spyOn(useRecoveryStore.getState(), "cancelRecovery");
+      const now = Date.now();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: now,
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      const { container } = render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      // Verify cancel button exists
+      const cancelButton = screen.getByRole("button", { name: /cancel/i });
+      expect(cancelButton).toBeInTheDocument();
+
+      await user.click(cancelButton);
+
+      // Verify cancelRecovery was called
+      expect(mockCancelRecovery).toHaveBeenCalledWith("test-session");
+
+      // After cancellation, the recovery status section disappears
+      // because phase changes to "cancelled" and isRecovering becomes false
+      await waitFor(() => {
+        expect(screen.queryByRole("button", { name: /cancel/i })).not.toBeInTheDocument();
+      });
+
+      // Restore fake timers for other tests
+      vi.useFakeTimers();
+    });
+
+    it("should have secondary button styling on cancel button", () => {
+      const mockRecover = vi.fn();
+      const now = Date.now();
+
+      // Set up store with in-progress session
+      useRecoveryStore.setState({
+        sessions: new Map([
+          ["test-video-id", {
+            sessionId: "test-session",
+            entityId: "test-video-id",
+            entityType: "video",
+            entityTitle: "Test Video",
+            phase: "in-progress",
+            startedAt: now,
+            completedAt: null,
+            filterOptions: {},
+            result: null,
+            error: null,
+            abortController: null,
+          }],
+        ]),
+      });
+
+      render(
+        <UnavailabilityBanner
+          availabilityStatus="deleted"
+          entityType="video"
+          entityId="test-video-id"
+          onRecover={mockRecover}
+        />
+      );
+
+      const cancelButton = screen.getByRole("button", { name: /cancel/i });
+      expect(cancelButton).toHaveClass("bg-white");
+      expect(cancelButton).toHaveClass("border-slate-300");
+      expect(cancelButton).toHaveClass("text-slate-700");
+    });
+  });
+});

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -4,13 +4,43 @@
  * Implements User Story 5: Responsive Sidebar Layout
  * - VD-005: Main content area background bg-slate-50
  * - CSS Grid works with responsive sidebar (64px or 240px)
+ * - T035: beforeunload warning when recovery is active
+ * - T039: Recovery indicator banner with session status
+ * - T040: localStorage hydration UX with backend polling
  */
 
-import { Outlet } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
+import { Link, Outlet } from "react-router-dom";
 
 import { ErrorBoundary } from "../ErrorBoundary";
 import { Header } from "./Header";
 import { Sidebar } from "./Sidebar";
+import { useRecoveryStore } from "../../stores/recoveryStore";
+import type { RecoverySession } from "../../stores/recoveryStore";
+import { apiFetch } from "../../api/config";
+
+/**
+ * Toast notification for recovery completion/failure.
+ */
+interface Toast {
+  id: string;
+  type: "success" | "error";
+  message: string;
+  entityTitle: string;
+}
+
+/**
+ * Formats elapsed time in milliseconds to human-readable string.
+ * @param ms - Elapsed milliseconds
+ * @returns Formatted time string (e.g., "1m 23s", "45s")
+ */
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+}
 
 /**
  * AppShell provides the main layout structure for the application.
@@ -20,8 +50,153 @@ import { Sidebar } from "./Sidebar";
  * - Sidebar on the left (bg-slate-900) with responsive width (w-16 or lg:w-60)
  * - VD-005: Main area contains Header + content with bg-slate-50
  * - Content area uses Outlet for child routes wrapped in ErrorBoundary
+ * - T035: Registers beforeunload handler when recovery is active
+ * - T039: Displays active recovery indicator and completion toasts
+ * - T040: Polls backend for hydrated sessions to detect completion
  */
 export function AppShell() {
+  const hasActiveRecovery = useRecoveryStore((s) => s.hasActiveRecovery());
+  // Don't subscribe to activeSessions in render - causes infinite loops with persist middleware
+  // Instead, use getActiveSessions() directly when needed
+
+  // Toast state (T039)
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  // Previous sessions ref for detecting completion (T039)
+  const prevSessionsRef = useRef<Map<string, RecoverySession>>(new Map());
+
+  // State for elapsed time counter - forces re-render every second
+  const [, setElapsedTick] = useState(0);
+
+  // T039: Detect session completion/failure and show toasts
+  // Use subscribe pattern instead of useEffect to avoid infinite loops
+  useEffect(() => {
+    const unsubscribe = useRecoveryStore.subscribe((state) => {
+      const currentSessions = state.sessions;
+      const prev = prevSessionsRef.current;
+
+      for (const [entityId, session] of currentSessions) {
+        const prevSession = prev.get(entityId);
+        if (prevSession && ["pending", "in-progress"].includes(prevSession.phase)) {
+          if (session.phase === "completed") {
+            // Show success toast
+            const fieldsRecovered = session.result?.fields_recovered.length ?? 0;
+            const toast: Toast = {
+              id: session.sessionId,
+              type: "success",
+              message: `${fieldsRecovered} field${fieldsRecovered !== 1 ? "s" : ""} recovered`,
+              entityTitle: session.entityTitle ?? `${session.entityType} ${session.entityId}`,
+            };
+            setToasts((prev) => [...prev, toast]);
+
+            // Schedule cleanup after 8 seconds
+            setTimeout(() => {
+              useRecoveryStore.getState().cleanupSession(session.sessionId);
+              setToasts((prev) => prev.filter((t) => t.id !== session.sessionId));
+            }, 8000);
+          } else if (session.phase === "failed") {
+            // Show error toast
+            const toast: Toast = {
+              id: session.sessionId,
+              type: "error",
+              message: session.error ?? "Recovery failed",
+              entityTitle: session.entityTitle ?? `${session.entityType} ${session.entityId}`,
+            };
+            setToasts((prev) => [...prev, toast]);
+
+            // Schedule cleanup after 8 seconds
+            setTimeout(() => {
+              useRecoveryStore.getState().cleanupSession(session.sessionId);
+              setToasts((prev) => prev.filter((t) => t.id !== session.sessionId));
+            }, 8000);
+          }
+        }
+      }
+      prevSessionsRef.current = new Map(currentSessions);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  // T040: Poll backend for hydrated in-progress sessions
+  useEffect(() => {
+    // Get hydrated sessions from store at mount time
+    const hydratedSessions = useRecoveryStore
+      .getState()
+      .getActiveSessions()
+      .filter((session) => {
+        const age = Date.now() - session.startedAt;
+        return age < 600_000; // < 10 minutes
+      });
+
+    if (hydratedSessions.length === 0) return;
+
+    const pollingIntervalId = setInterval(async () => {
+      // Re-check active sessions on each interval
+      const currentActiveSessions = useRecoveryStore.getState().getActiveSessions();
+
+      for (const session of hydratedSessions) {
+        // Skip if session is no longer active
+        if (!currentActiveSessions.some((s) => s.sessionId === session.sessionId)) {
+          continue;
+        }
+
+        try {
+          const endpoint =
+            session.entityType === "video"
+              ? `/videos/${session.entityId}`
+              : `/channels/${session.entityId}`;
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const response = await apiFetch<any>(endpoint);
+
+          // Check if recovered_at changed (indicating completion)
+          if (response.recovered_at) {
+            const currentRecoveredAt = response.recovered_at;
+            const sessionStartedAt = new Date(session.startedAt).toISOString();
+
+            // If recovered_at is more recent than session start, mark as completed
+            if (currentRecoveredAt > sessionStartedAt) {
+              useRecoveryStore.getState().updatePhase(session.sessionId, "completed");
+            }
+          }
+        } catch {
+          // Silently ignore polling errors (best-effort)
+        }
+      }
+    }, 30_000); // Poll every 30 seconds
+
+    return () => clearInterval(pollingIntervalId);
+    // Only run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Elapsed timer effect for indicator
+  // Use hasActiveRecovery instead of activeSessions to avoid infinite loops
+  useEffect(() => {
+    if (hasActiveRecovery) {
+      const intervalId = setInterval(() => {
+        setElapsedTick((prev) => prev + 1);
+      }, 1000);
+
+      return () => clearInterval(intervalId);
+    }
+  }, [hasActiveRecovery]);
+
+  // T035: beforeunload warning when recovery is active
+  useEffect(() => {
+    if (!hasActiveRecovery) return;
+
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Modern browsers ignore the custom message and show their own
+      // but we still need to call preventDefault() to trigger the dialog
+    };
+
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [hasActiveRecovery]);
+
   return (
     <div className="grid grid-cols-[auto_1fr] min-h-screen">
       {/* Sidebar with main navigation */}
@@ -30,6 +205,125 @@ export function AppShell() {
       {/* Main content area */}
       <div className="flex flex-col min-h-screen">
         <Header />
+
+        {/* T039: Active recovery indicator banner */}
+        {hasActiveRecovery && (() => {
+          // Get active sessions directly to avoid subscription issues
+          const activeSessions = useRecoveryStore.getState().getActiveSessions();
+          const firstSession = activeSessions[0];
+          if (!firstSession) return null;
+
+          return (
+            <div
+              className="bg-amber-50 border-b border-amber-200 px-6 py-3"
+              role="status"
+              aria-live="polite"
+            >
+              {activeSessions.length === 1 ? (
+                <div className="flex items-center gap-3 text-sm">
+                  <div className="w-4 h-4 border-2 border-amber-600 border-t-transparent rounded-full animate-spin" />
+                  <span className="text-amber-900">
+                    Recovery in progress for{" "}
+                    <Link
+                      to={`/${firstSession.entityType}s/${firstSession.entityId}`}
+                      className="font-medium underline hover:text-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 rounded"
+                    >
+                      {firstSession.entityTitle ?? firstSession.entityId}
+                    </Link>
+                    ... ({formatElapsed(Date.now() - firstSession.startedAt)})
+                  </span>
+                </div>
+              ) : (
+                <div className="flex items-center gap-3 text-sm">
+                  <div className="w-4 h-4 border-2 border-amber-600 border-t-transparent rounded-full animate-spin" />
+                  <span className="text-amber-900">
+                    {activeSessions.length} recoveries in progress
+                  </span>
+                </div>
+              )}
+
+              {/* T040: Hydration info text for recent sessions */}
+              {activeSessions.some((s) => Date.now() - s.startedAt < 600_000) && (
+                <p className="text-xs text-amber-700 mt-2 ml-7">
+                  A recovery operation started earlier may still be in progress.
+                </p>
+              )}
+            </div>
+          );
+        })()}
+
+        {/* T039: Toast notifications for completion/failure */}
+        {toasts.length > 0 && (
+          <div
+            className="fixed top-20 right-6 z-50 space-y-2"
+            aria-live="polite"
+            role="status"
+          >
+            {toasts.map((toast) => (
+              <div
+                key={toast.id}
+                className={`max-w-md px-4 py-3 rounded-lg shadow-lg border ${
+                  toast.type === "success"
+                    ? "bg-green-50 border-green-200"
+                    : "bg-red-50 border-red-200"
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  {toast.type === "success" ? (
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.5}
+                      stroke="currentColor"
+                      className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"
+                      />
+                    </svg>
+                  ) : (
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.5}
+                      stroke="currentColor"
+                      className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"
+                      />
+                    </svg>
+                  )}
+                  <div>
+                    <p
+                      className={`text-sm font-medium ${
+                        toast.type === "success" ? "text-green-900" : "text-red-900"
+                      }`}
+                    >
+                      {toast.type === "success" ? "Recovery completed" : "Recovery failed"}
+                    </p>
+                    <p
+                      className={`text-sm ${
+                        toast.type === "success" ? "text-green-800" : "text-red-800"
+                      }`}
+                    >
+                      {toast.entityTitle} — {toast.message}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
         <main className="flex-1 overflow-auto bg-slate-50">
           <ErrorBoundary>
             <Outlet />

--- a/frontend/src/components/layout/__tests__/AppShell.beforeunload.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppShell.beforeunload.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Tests for AppShell beforeunload Warning (T035)
+ *
+ * Tests beforeunload handler registration when recovery is active:
+ * - Handler registered when active recovery exists
+ * - Handler NOT registered when no active recovery
+ * - Handler removed when recovery completes
+ */
+
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { AppShell } from "../AppShell";
+import { useRecoveryStore } from "../../../stores/recoveryStore";
+
+describe("AppShell - beforeunload Warning (T035)", () => {
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Reset store state before each test
+    useRecoveryStore.setState({ sessions: new Map() });
+
+    // Spy on window event listeners
+    addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+  });
+
+  afterEach(() => {
+    // Clean up spies
+    vi.restoreAllMocks();
+  });
+
+  it("should register beforeunload listener when active recovery exists", () => {
+    // Set up store with in-progress session
+    useRecoveryStore.setState({
+      sessions: new Map([
+        ["test-video-id", {
+          sessionId: "test-session",
+          entityId: "test-video-id",
+          entityType: "video",
+          entityTitle: "Test Video",
+          phase: "in-progress",
+          startedAt: Date.now(),
+          completedAt: null,
+          filterOptions: {},
+          result: null,
+          error: null,
+          abortController: null,
+        }],
+      ]),
+    });
+
+    render(
+      <MemoryRouter>
+        <AppShell />
+      </MemoryRouter>
+    );
+
+    // Check that beforeunload listener was added
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      "beforeunload",
+      expect.any(Function)
+    );
+  });
+
+  it("should NOT register beforeunload listener when no active recovery", () => {
+    // Store has no sessions (idle state)
+    render(
+      <MemoryRouter>
+        <AppShell />
+      </MemoryRouter>
+    );
+
+    // Check that beforeunload listener was NOT added
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith(
+      "beforeunload",
+      expect.any(Function)
+    );
+  });
+
+  it("should remove beforeunload listener when component unmounts", () => {
+    // Set up store with in-progress session
+    useRecoveryStore.setState({
+      sessions: new Map([
+        ["test-video-id", {
+          sessionId: "test-session",
+          entityId: "test-video-id",
+          entityType: "video",
+          entityTitle: "Test Video",
+          phase: "in-progress",
+          startedAt: Date.now(),
+          completedAt: null,
+          filterOptions: {},
+          result: null,
+          error: null,
+          abortController: null,
+        }],
+      ]),
+    });
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <AppShell />
+      </MemoryRouter>
+    );
+
+    // Verify listener was added
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      "beforeunload",
+      expect.any(Function)
+    );
+
+    // Clear the spy call history
+    addEventListenerSpy.mockClear();
+    removeEventListenerSpy.mockClear();
+
+    // Unmount the component
+    unmount();
+
+    // Check that beforeunload listener was removed
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "beforeunload",
+      expect.any(Function)
+    );
+  });
+
+  it("should register beforeunload listener for pending phase", () => {
+    // Set up store with pending session
+    useRecoveryStore.setState({
+      sessions: new Map([
+        ["test-video-id", {
+          sessionId: "test-session",
+          entityId: "test-video-id",
+          entityType: "video",
+          entityTitle: "Test Video",
+          phase: "pending",
+          startedAt: Date.now(),
+          completedAt: null,
+          filterOptions: {},
+          result: null,
+          error: null,
+          abortController: null,
+        }],
+      ]),
+    });
+
+    render(
+      <MemoryRouter>
+        <AppShell />
+      </MemoryRouter>
+    );
+
+    // Check that beforeunload listener was added
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      "beforeunload",
+      expect.any(Function)
+    );
+  });
+
+  it("should NOT register beforeunload listener for completed phase", () => {
+    // Set up store with completed session
+    useRecoveryStore.setState({
+      sessions: new Map([
+        ["test-video-id", {
+          sessionId: "test-session",
+          entityId: "test-video-id",
+          entityType: "video",
+          entityTitle: "Test Video",
+          phase: "completed",
+          startedAt: Date.now() - 5000,
+          completedAt: Date.now(),
+          filterOptions: {},
+          result: {
+            success: true,
+            snapshot_used: "20230415120000",
+            fields_recovered: ["title"],
+            fields_skipped: [],
+            snapshots_available: 5,
+            snapshots_tried: 1,
+            failure_reason: null,
+            duration_seconds: 2.1,
+          },
+          error: null,
+          abortController: null,
+        }],
+      ]),
+    });
+
+    render(
+      <MemoryRouter>
+        <AppShell />
+      </MemoryRouter>
+    );
+
+    // Check that beforeunload listener was NOT added
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith(
+      "beforeunload",
+      expect.any(Function)
+    );
+  });
+
+  it("should call preventDefault on beforeunload event", () => {
+    // Set up store with in-progress session
+    useRecoveryStore.setState({
+      sessions: new Map([
+        ["test-video-id", {
+          sessionId: "test-session",
+          entityId: "test-video-id",
+          entityType: "video",
+          entityTitle: "Test Video",
+          phase: "in-progress",
+          startedAt: Date.now(),
+          completedAt: null,
+          filterOptions: {},
+          result: null,
+          error: null,
+          abortController: null,
+        }],
+      ]),
+    });
+
+    render(
+      <MemoryRouter>
+        <AppShell />
+      </MemoryRouter>
+    );
+
+    // Get the handler function that was registered
+    const calls = addEventListenerSpy.mock.calls.filter(
+      (call: unknown[]) => call[0] === "beforeunload"
+    );
+    expect(calls.length).toBe(1);
+    const handler = calls[0][1] as (e: BeforeUnloadEvent) => void;
+
+    // Create a mock beforeunload event
+    const mockEvent = {
+      preventDefault: vi.fn(),
+    } as unknown as BeforeUnloadEvent;
+
+    // Call the handler
+    handler(mockEvent);
+
+    // Verify preventDefault was called
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/layout/__tests__/AppShell.indicator.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppShell.indicator.test.tsx
@@ -1,0 +1,587 @@
+/**
+ * Tests for AppShell recovery indicator and localStorage hydration UX.
+ *
+ * Tests T039: AppShell Recovery Indicator
+ * - Active recovery shows banner with entity title
+ * - Banner includes link to entity detail page
+ * - Multiple active sessions show count
+ * - Success toast shown on completion with field count
+ * - Error toast shown on failure with error message
+ * - Toast auto-dismisses after 8 seconds
+ * - Session cleaned up after toast dismiss
+ * - No banner shown when no active sessions
+ *
+ * Tests T040: localStorage Hydration UX
+ * - Hydrated in-progress session shows info text
+ * - Backend polling triggers every 30 seconds
+ * - Polling detects `recovered_at` change and transitions to completed
+ * - Polling stops when session completes
+ * - Polling failure is silently ignored
+ */
+
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AppShell } from "../AppShell";
+import { useRecoveryStore } from "../../../stores/recoveryStore";
+import * as apiConfig from "../../../api/config";
+
+// Mock the API config module
+vi.mock("../../../api/config", () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: "http://localhost:8765/api/v1",
+  API_TIMEOUT: 10000,
+  RECOVERY_TIMEOUT: 660000,
+}));
+
+// Mock the child components
+vi.mock("../Header", () => ({
+  Header: () => <div data-testid="mock-header">Header</div>,
+}));
+
+vi.mock("../Sidebar", () => ({
+  Sidebar: () => <div data-testid="mock-sidebar">Sidebar</div>,
+}));
+
+vi.mock("../../ErrorBoundary", () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("AppShell - T039 Recovery Indicator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Clear the store before each test
+    useRecoveryStore.setState({ sessions: new Map() });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("should show banner when active recovery exists", () => {
+    // Start a recovery session
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video Title");
+    useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    expect(
+      screen.getByText(/Recovery in progress for/i, { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Test Video Title")).toBeInTheDocument();
+  });
+
+  it("should include link to entity detail page", () => {
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+    useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    const link = screen.getByRole("link", { name: /Test Video/i });
+    expect(link).toHaveAttribute("href", "/videos/video123");
+  });
+
+  it("should show count when multiple active sessions exist", () => {
+    const sessionId1 = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Video 1");
+    const sessionId2 = useRecoveryStore
+      .getState()
+      .startRecovery("video456", "video", "Video 2");
+
+    useRecoveryStore.getState().updatePhase(sessionId1, "in-progress");
+    useRecoveryStore.getState().updatePhase(sessionId2, "in-progress");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText("2 recoveries in progress")).toBeInTheDocument();
+  });
+
+  it("should show success toast on completion with field count", async () => {
+    // This test needs real timers because the toast appears via Zustand subscribe + React state update
+    vi.useRealTimers();
+
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Allow useEffect with subscribe to run and populate prevSessionsRef with pending session
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Now transition to in-progress to update prevSessionsRef
+    act(() => {
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+    });
+
+    // Wait for subscribe to update prevSessionsRef
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Now simulate completion
+    act(() => {
+      useRecoveryStore.getState().setResult(sessionId, {
+        success: true,
+        snapshot_used: "20230101120000",
+        fields_recovered: ["title", "description"],
+        fields_skipped: [],
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.5,
+      });
+    });
+
+    // Wait for the toast to appear
+    await waitFor(() => {
+      expect(screen.getByText("Recovery completed")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/2 fields recovered/i)).toBeInTheDocument();
+  });
+
+  it("should show error toast on failure with error message", async () => {
+    // This test needs real timers because the toast appears via Zustand subscribe + React state update
+    vi.useRealTimers();
+
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Allow useEffect with subscribe to run and populate prevSessionsRef with pending session
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Now transition to in-progress to update prevSessionsRef
+    act(() => {
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+    });
+
+    // Wait for subscribe to update prevSessionsRef
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Now simulate failure
+    act(() => {
+      useRecoveryStore.getState().setError(sessionId, "Network timeout");
+    });
+
+    // Wait for the toast to appear
+    await waitFor(() => {
+      expect(screen.getByText("Recovery failed")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Network timeout/i)).toBeInTheDocument();
+  });
+
+  it("should auto-dismiss toast after 8 seconds and cleanup session", { timeout: 10000 }, async () => {
+    // This test uses real timers for the entire flow since mixing fake/real is problematic
+    vi.useRealTimers();
+
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Allow useEffect with subscribe to run and populate prevSessionsRef with pending session
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Now transition to in-progress to update prevSessionsRef
+    act(() => {
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+    });
+
+    // Wait for subscribe to update prevSessionsRef
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Now simulate completion
+    act(() => {
+      useRecoveryStore.getState().setResult(sessionId, {
+        success: true,
+        snapshot_used: "20230101120000",
+        fields_recovered: ["title"],
+        fields_skipped: [],
+        snapshots_available: 1,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 1.0,
+      });
+    });
+
+    // Wait for toast to appear
+    await waitFor(() => {
+      expect(screen.getByText("Recovery completed")).toBeInTheDocument();
+    });
+
+    // Wait for toast auto-dismiss (8 seconds) + cleanup
+    await waitFor(
+      () => {
+        expect(screen.queryByText("Recovery completed")).not.toBeInTheDocument();
+      },
+      { timeout: 9000 }
+    );
+
+    // Verify session was cleaned up
+    const sessions = useRecoveryStore.getState().sessions;
+    expect(sessions.has("video123")).toBe(false);
+  });
+
+  it("should not show banner when no active sessions exist", () => {
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByText(/Recovery in progress/i)).not.toBeInTheDocument();
+  });
+
+  it("should show elapsed time in banner", () => {
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+    useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Should show initial elapsed time (0s)
+    expect(screen.getByText(/\(0s\)/i)).toBeInTheDocument();
+
+    // Advance 5 seconds - wrap in act to flush React state updates
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    // Should update to 5s
+    expect(screen.getByText(/\(5s\)/i)).toBeInTheDocument();
+  });
+});
+
+describe("AppShell - T040 localStorage Hydration UX", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useRecoveryStore.setState({ sessions: new Map() });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("should show info text for hydrated in-progress session", () => {
+    // Simulate a session that was hydrated from localStorage (< 10 min old)
+    const recentSessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+    useRecoveryStore.getState().updatePhase(recentSessionId, "in-progress");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    expect(
+      screen.getByText(
+        /A recovery operation started earlier may still be in progress/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("should poll backend every 30 seconds", async () => {
+    const apiFetchMock = vi.mocked(apiConfig.apiFetch);
+    apiFetchMock.mockResolvedValue({
+      video_id: "video123",
+      title: "Test Video",
+      recovered_at: null,
+    });
+
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+    useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Initial poll should not happen immediately
+    expect(apiFetchMock).not.toHaveBeenCalled();
+
+    // Advance 30 seconds to trigger first poll
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+      // Flush microtasks without running more timers
+      await Promise.resolve();
+    });
+
+    // Check that first poll happened
+    expect(apiFetchMock).toHaveBeenCalledWith("/videos/video123");
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+
+    // Advance another 30 seconds
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+      await Promise.resolve();
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("should detect recovered_at change and transition to completed", async () => {
+    const apiFetchMock = vi.mocked(apiConfig.apiFetch);
+
+    useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+
+    // First poll: no recovery
+    apiFetchMock.mockResolvedValueOnce({
+      video_id: "video123",
+      title: "Test Video",
+      recovered_at: null,
+    });
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Advance to first poll
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+      await Promise.resolve();
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+
+    // Session should still be pending
+    expect(useRecoveryStore.getState().sessions.get("video123")?.phase).toBe(
+      "pending"
+    );
+
+    // Second poll: recovery completed (recovered_at is newer than session start)
+    apiFetchMock.mockResolvedValueOnce({
+      video_id: "video123",
+      title: "Test Video - Recovered",
+      recovered_at: new Date(Date.now() + 1000).toISOString(), // More recent than session start
+    });
+
+    // Advance to second poll
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+      await Promise.resolve();
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+
+    // Session should transition to completed
+    expect(useRecoveryStore.getState().sessions.get("video123")?.phase).toBe(
+      "completed"
+    );
+  });
+
+  it("should stop polling when session completes", async () => {
+    const apiFetchMock = vi.mocked(apiConfig.apiFetch);
+    apiFetchMock.mockResolvedValue({
+      video_id: "video123",
+      title: "Test Video",
+      recovered_at: null,
+    });
+
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+    useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+    const { unmount } = render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // First poll
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+      await Promise.resolve();
+    });
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+
+    // Mark session as completed - wrap in act
+    await act(async () => {
+      useRecoveryStore.getState().setResult(sessionId, {
+        success: true,
+        snapshot_used: "20230101120000",
+        fields_recovered: ["title"],
+        fields_skipped: [],
+        snapshots_available: 1,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 1.0,
+      });
+    });
+
+    // Unmount and remount to trigger cleanup
+    unmount();
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Advance another 30 seconds
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+      await Promise.resolve();
+    });
+
+    // Should not poll again (session is completed, not active)
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should silently ignore polling failures", async () => {
+    const apiFetchMock = vi.mocked(apiConfig.apiFetch);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Mock network error
+    apiFetchMock.mockRejectedValue(new Error("Network error"));
+
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+    useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Advance to first poll
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+      await Promise.resolve();
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+
+    // Session should still be in-progress (error ignored)
+    expect(useRecoveryStore.getState().sessions.get("video123")?.phase).toBe(
+      "in-progress"
+    );
+
+    // Should not log errors (silent failure)
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should handle channel entity type in polling", async () => {
+    const apiFetchMock = vi.mocked(apiConfig.apiFetch);
+    apiFetchMock.mockResolvedValue({
+      channel_id: "channel123",
+      title: "Test Channel",
+      recovered_at: null,
+    });
+
+    const sessionId = useRecoveryStore
+      .getState()
+      .startRecovery("channel123", "channel", "Test Channel");
+    useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Advance to first poll
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+      await Promise.resolve();
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledWith("/channels/channel123");
+  });
+
+  it("should not poll for sessions older than 10 minutes", async () => {
+    const apiFetchMock = vi.mocked(apiConfig.apiFetch);
+
+    // Create a session and manually set its startedAt to 11 minutes ago
+    useRecoveryStore
+      .getState()
+      .startRecovery("video123", "video", "Test Video");
+    const sessions = useRecoveryStore.getState().sessions;
+    const session = sessions.get("video123");
+
+    if (session) {
+      session.startedAt = Date.now() - 660_000; // 11 minutes ago
+      useRecoveryStore.setState({ sessions: new Map(sessions) });
+    }
+
+    render(
+      <BrowserRouter>
+        <AppShell />
+      </BrowserRouter>
+    );
+
+    // Advance 30 seconds
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+      await Promise.resolve();
+    });
+
+    // Should not poll (session is too old)
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useTranscriptLanguages.ts
+++ b/frontend/src/hooks/useTranscriptLanguages.ts
@@ -21,7 +21,7 @@ async function fetchTranscriptLanguages(
   videoId: string
 ): Promise<TranscriptLanguage[]> {
   const response = await apiFetch<TranscriptLanguagesResponse>(
-    `/videos/${videoId}/transcript/languages`
+    `/videos/${videoId}/transcript/languages?include_unavailable=true`
   );
   return response.data;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -31,7 +31,7 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <RouterProvider router={router} future={{ v7_startTransition: true }} />
     </QueryClientProvider>
   </StrictMode>
 );

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -284,6 +284,8 @@ export function SearchPage() {
               descriptionCount={descriptionTotalCount}
               enabledTypes={enabledTypes}
               onToggleType={handleToggleType}
+              includeUnavailable={includeUnavailable}
+              onToggleIncludeUnavailable={() => setIncludeUnavailable(!includeUnavailable)}
             />
           </div>
 

--- a/frontend/src/pages/__tests__/ChannelDetailPage.recovery.test.tsx
+++ b/frontend/src/pages/__tests__/ChannelDetailPage.recovery.test.tsx
@@ -1,0 +1,923 @@
+/**
+ * Tests for ChannelDetailPage Recovery Button (T026, Feature 025).
+ *
+ * Tests the Web Archive recovery functionality integrated into the ChannelDetailPage.
+ *
+ * Key behaviors tested:
+ * - Recovery mutation triggers on button click
+ * - Cache invalidation after successful recovery
+ * - Error message display after failed recovery
+ * - "Re-recover" label when previously recovered
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useBlocker } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { ChannelDetailPage } from '../ChannelDetailPage';
+import type { ChannelDetail } from '../../types/channel';
+import type { RecoveryResultData } from '../../types/recovery';
+
+// Mock the API fetch function
+vi.mock('../../api/config', () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: 'http://localhost:8765/api/v1',
+  API_TIMEOUT: 10000,
+  RECOVERY_TIMEOUT: 660000,
+  isApiError: vi.fn(),
+}));
+
+// Mock useBlocker - will be overridden in tests
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useBlocker: vi.fn(() => ({
+      state: 'unblocked' as const,
+      reset: undefined,
+      proceed: undefined,
+      location: undefined,
+    })),
+  };
+});
+
+// Mock useChannelDetail
+vi.mock('../../hooks/useChannelDetail', () => ({
+  useChannelDetail: vi.fn(),
+}));
+
+// Mock useChannelVideos
+vi.mock('../../hooks/useChannelVideos', () => ({
+  useChannelVideos: vi.fn(() => ({
+    videos: [],
+    total: 0,
+    loadedCount: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    retry: vi.fn(),
+    loadMoreRef: { current: null },
+  })),
+}));
+
+// Mock VideoGrid
+vi.mock('../../components/VideoGrid', () => ({
+  VideoGrid: () => <div data-testid="video-grid" />,
+}));
+
+// Mock LoadingState
+vi.mock('../../components/LoadingState', () => ({
+  LoadingState: () => <div data-testid="loading-state" />,
+}));
+
+// Mock recoveryStore with state tracking
+vi.mock('../../stores/recoveryStore', () => {
+  // Track sessions in the mock
+  const mockSessions = new Map();
+
+  const mockStore = {
+    sessions: mockSessions,
+    startRecovery: vi.fn((entityId, entityType, entityTitle, filterOptions) => {
+      const sessionId = "mock-session-id";
+      const session = {
+        sessionId,
+        entityId,
+        entityType,
+        entityTitle: entityTitle ?? null,
+        phase: "pending" as const,
+        startedAt: Date.now(),
+        completedAt: null,
+        filterOptions: filterOptions ?? {},
+        result: null,
+        error: null,
+        abortController: null,
+      };
+      mockSessions.set(entityId, session);
+      return sessionId;
+    }),
+    updatePhase: vi.fn((sessionId, phase) => {
+      // Find session by sessionId and update phase
+      for (const [entityId, session] of mockSessions.entries()) {
+        if (session.sessionId === sessionId) {
+          mockSessions.set(entityId, { ...session, phase, completedAt: ["completed", "failed", "cancelled"].includes(phase) ? Date.now() : null });
+          break;
+        }
+      }
+    }),
+    setResult: vi.fn((sessionId, result) => {
+      // Find session by sessionId and set result
+      for (const [entityId, session] of mockSessions.entries()) {
+        if (session.sessionId === sessionId) {
+          mockSessions.set(entityId, { ...session, result, phase: "completed" as const, completedAt: Date.now() });
+          break;
+        }
+      }
+    }),
+    setError: vi.fn((sessionId, error) => {
+      // Find session by sessionId and set error
+      for (const [entityId, session] of mockSessions.entries()) {
+        if (session.sessionId === sessionId) {
+          mockSessions.set(entityId, { ...session, error, phase: "failed" as const, completedAt: Date.now() });
+          break;
+        }
+      }
+    }),
+    setAbortController: vi.fn((sessionId, controller) => {
+      // Find session by sessionId and set abortController
+      for (const [entityId, session] of mockSessions.entries()) {
+        if (session.sessionId === sessionId) {
+          mockSessions.set(entityId, { ...session, abortController: controller });
+          break;
+        }
+      }
+    }),
+    cancelRecovery: vi.fn((sessionId) => {
+      // Find session by sessionId and cancel
+      for (const [entityId, session] of mockSessions.entries()) {
+        if (session.sessionId === sessionId) {
+          session.abortController?.abort();
+          mockSessions.set(entityId, { ...session, phase: "cancelled" as const, completedAt: Date.now() });
+          break;
+        }
+      }
+    }),
+    getActiveSession: vi.fn((entityId) => mockSessions.get(entityId)),
+    getActiveSessions: vi.fn(() => Array.from(mockSessions.values()).filter(s => ["pending", "in-progress"].includes(s.phase))),
+    hasActiveRecovery: vi.fn(() => Array.from(mockSessions.values()).some(s => ["pending", "in-progress"].includes(s.phase))),
+  };
+
+  const useRecoveryStore = Object.assign(
+    vi.fn((selector?: Function) => selector ? selector(mockStore) : mockStore),
+    { getState: vi.fn().mockReturnValue(mockStore), setState: vi.fn(() => {}) }
+  );
+
+  return { useRecoveryStore };
+});
+
+// Import mocked functions
+import { useChannelDetail } from '../../hooks/useChannelDetail';
+import { apiFetch } from '../../api/config';
+import { useRecoveryStore } from '../../stores/recoveryStore';
+
+/**
+ * Mock deleted channel for recovery testing.
+ */
+const mockDeletedChannel: ChannelDetail = {
+  channel_id: 'deleted-channel-123',
+  title: 'Deleted Channel',
+  description: 'This channel was deleted',
+  thumbnail_url: 'https://example.com/thumbnail.jpg',
+  subscriber_count: 1000,
+  video_count: 50,
+  country: 'US',
+  is_subscribed: true,
+  availability_status: 'deleted',
+  recovered_at: null,
+  recovery_source: null,
+};
+
+/**
+ * Mock previously recovered channel.
+ */
+const mockRecoveredChannel: ChannelDetail = {
+  ...mockDeletedChannel,
+  recovered_at: '2024-02-01T12:00:00Z',
+};
+
+/**
+ * Mock available channel (recovery button should NOT show).
+ */
+const mockAvailableChannel: ChannelDetail = {
+  ...mockDeletedChannel,
+  availability_status: 'available',
+};
+
+/**
+ * Renders ChannelDetailPage with MemoryRouter and QueryClientProvider.
+ */
+function renderChannelDetailPage(channelData: ChannelDetail) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  vi.mocked(useChannelDetail).mockReturnValue({
+    data: channelData,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useChannelDetail>);
+
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/channels/${channelData.channel_id}`]}>
+          <Routes>
+            <Route path="/channels/:channelId" element={<ChannelDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+describe('ChannelDetailPage - Recovery Button (T026)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear mock sessions
+    const mockStore = useRecoveryStore.getState();
+    mockStore.sessions.clear();
+  });
+
+  describe('Mutation Trigger', () => {
+    it('triggers recovery mutation when recovery button is clicked', async () => {
+      const user = userEvent.setup();
+      const currentYear = new Date().getFullYear();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title', 'description'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 2,
+        failure_reason: null,
+        duration_seconds: 3.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          `/channels/deleted-channel-123/recover?end_year=${currentYear}`,
+          expect.objectContaining({
+            method: 'POST',
+          })
+        );
+      });
+    });
+
+    it('does NOT trigger recovery when button is disabled during loading', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      // Mock a slow API response
+      vi.mocked(apiFetch).mockImplementation(
+        () => new Promise(() => {}) // Never resolves
+      );
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+
+      // First click starts the mutation
+      await user.click(recoveryButton);
+
+      // Button should become disabled
+      await waitFor(() => {
+        expect(recoveryButton).toBeDisabled();
+      });
+
+      // Second click should not trigger another API call
+      await user.click(recoveryButton);
+
+      // Verify API was only called once
+      expect(apiFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Cache Invalidation', () => {
+    it('invalidates channel detail query after successful recovery', async () => {
+      const user = userEvent.setup();
+      const { queryClient } = renderChannelDetailPage(mockDeletedChannel);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title', 'description'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 2,
+        failure_reason: null,
+        duration_seconds: 3.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      // Spy on queryClient.invalidateQueries
+      const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+          queryKey: ['channel', 'deleted-channel-123'],
+        });
+      });
+    });
+
+    it('does NOT invalidate cache when recovery fails', async () => {
+      const user = userEvent.setup();
+      const { queryClient } = renderChannelDetailPage(mockDeletedChannel);
+
+      vi.mocked(apiFetch).mockRejectedValue({
+        message: 'No snapshots found',
+        status: 404,
+      });
+
+      const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      // Wait for mutation to fail
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalled();
+      });
+
+      // Give React Query time to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Cache should NOT be invalidated on error
+      expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Message Display', () => {
+    it('displays error message when recovery fails', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockErrorResponse: RecoveryResultData = {
+        success: false,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshot_used: null,
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: 'no_snapshots_found',
+        duration_seconds: 0.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockErrorResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/no archived snapshots found/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('displays contextual error for CDX connection error', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockErrorResponse: RecoveryResultData = {
+        success: false,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshot_used: null,
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: 'cdx_connection_error',
+        duration_seconds: 10.0,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockErrorResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/web archive is temporarily unavailable/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('displays generic error when failure reason is unknown', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockErrorResponse: RecoveryResultData = {
+        success: false,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshot_used: null,
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: null,
+        duration_seconds: 0.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockErrorResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/recovery failed/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Re-recover Label', () => {
+    it('shows "Recover from Web Archive" label when channel has NOT been recovered', () => {
+      renderChannelDetailPage(mockDeletedChannel);
+
+      expect(
+        screen.getByRole('button', { name: /^recover from web archive/i })
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', { name: /^re-recover from web archive/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows "Re-recover from Web Archive" label when channel has recovered_at set', () => {
+      renderChannelDetailPage(mockRecoveredChannel);
+
+      expect(
+        screen.getByRole('button', { name: /^re-recover from web archive/i })
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', { name: /^recover from web archive$/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows last recovery date when channel was previously recovered', () => {
+      renderChannelDetailPage(mockRecoveredChannel);
+
+      // The recovered_at date is 2024-02-01
+      expect(screen.getByText(/last: feb 1, 2024/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Button Visibility', () => {
+    it('shows recovery button when channel is deleted', () => {
+      renderChannelDetailPage(mockDeletedChannel);
+
+      expect(
+        screen.getByRole('button', { name: /recover from web archive/i })
+      ).toBeInTheDocument();
+    });
+
+    it('shows recovery button when channel is private', () => {
+      const privateChannel = { ...mockDeletedChannel, availability_status: 'private' };
+      renderChannelDetailPage(privateChannel);
+
+      expect(
+        screen.getByRole('button', { name: /recover from web archive/i })
+      ).toBeInTheDocument();
+    });
+
+    it('shows recovery button when channel is terminated', () => {
+      const terminatedChannel = { ...mockDeletedChannel, availability_status: 'terminated' };
+      renderChannelDetailPage(terminatedChannel);
+
+      expect(
+        screen.getByRole('button', { name: /recover from web archive/i })
+      ).toBeInTheDocument();
+    });
+
+    it('does NOT show recovery button when channel is available', () => {
+      renderChannelDetailPage(mockAvailableChannel);
+
+      expect(
+        screen.queryByRole('button', { name: /recover from web archive/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Button Disabled During Loading', () => {
+    it('disables recovery button while mutation is pending', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      // Mock a slow API response
+      vi.mocked(apiFetch).mockImplementation(
+        () => new Promise(() => {}) // Never resolves
+      );
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+
+      // Initially enabled
+      expect(recoveryButton).not.toBeDisabled();
+
+      // Click starts the mutation
+      await user.click(recoveryButton);
+
+      // Button should become disabled
+      await waitFor(() => {
+        expect(recoveryButton).toBeDisabled();
+      });
+    });
+
+    it('re-enables recovery button after mutation completes', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+
+      await user.click(recoveryButton);
+
+      // Wait for mutation to complete
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalled();
+      });
+
+      // Button should be re-enabled after success
+      await waitFor(() => {
+        expect(recoveryButton).not.toBeDisabled();
+      });
+    });
+
+    it('re-enables recovery button after mutation fails', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      vi.mocked(apiFetch).mockRejectedValue({
+        message: 'Recovery failed',
+      });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+
+      await user.click(recoveryButton);
+
+      // Wait for mutation to fail
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalled();
+      });
+
+      // Button should be re-enabled after failure
+      await waitFor(() => {
+        expect(recoveryButton).not.toBeDisabled();
+      });
+    });
+  });
+
+  describe('Success Message Display', () => {
+    it('displays success message with field count after successful recovery', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title', 'description', 'subscriber_count'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 2,
+        failure_reason: null,
+        duration_seconds: 3.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/recovered 3 fields/i)).toBeInTheDocument();
+      });
+    });
+
+    it('displays snapshot date in success message', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/2024-01-15/i)).toBeInTheDocument();
+      });
+    });
+
+    it('displays informational message when no fields were updated', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: [],
+        fields_skipped: ['title', 'description'],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 1.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/all fields already up-to-date/i)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Year Filter Integration', () => {
+    it('passes year params to API when years are selected', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      // Open advanced options
+      const advancedOptionsToggle = screen.getByRole('button', {
+        name: /advanced options/i,
+      });
+      await user.click(advancedOptionsToggle);
+
+      // Set year range
+      const startYearSelect = screen.getByLabelText(/from:/i);
+      const endYearSelect = screen.getByLabelText(/to:/i);
+      await user.selectOptions(startYearSelect, '2020');
+      await user.selectOptions(endYearSelect, '2024');
+
+      // Click recovery button
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          '/channels/deleted-channel-123/recover?start_year=2020&end_year=2024',
+          expect.objectContaining({
+            method: 'POST',
+          })
+        );
+      });
+    });
+
+    it('adds only endYear param (current year) when using default values without opening advanced options', async () => {
+      const user = userEvent.setup();
+      const currentYear = new Date().getFullYear();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      // Click recovery button without opening advanced options
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          `/channels/deleted-channel-123/recover?end_year=${currentYear}`,
+          expect.objectContaining({
+            method: 'POST',
+          })
+        );
+      });
+    });
+
+    it('uses recovery timeout for API call', async () => {
+      const user = userEvent.setup();
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            method: 'POST',
+            timeout: 660000,
+          })
+        );
+      });
+    });
+  });
+
+  describe('Navigation Blocker (T042)', () => {
+    beforeEach(() => {
+      // Reset the mock implementation for each test
+      vi.mocked(useBlocker).mockReturnValue({
+        state: 'unblocked' as const,
+        reset: undefined,
+        proceed: undefined,
+        location: undefined,
+      });
+    });
+
+    it('does NOT activate blocker when no recovery is happening', () => {
+      renderChannelDetailPage(mockDeletedChannel);
+
+      // Blocker should be called with false when no active recovery
+      expect(useBlocker).toHaveBeenCalledWith(false);
+    });
+
+    it('renders modal with "Stay" button when blocker state is blocked', () => {
+      const mockBlocker = {
+        state: 'blocked' as const,
+        reset: vi.fn(),
+        proceed: vi.fn(),
+        location: {} as any,
+      };
+      vi.mocked(useBlocker).mockReturnValue(mockBlocker);
+
+      // Set up in-progress session
+      const mockStore = useRecoveryStore.getState();
+      const sessionId = mockStore.startRecovery('deleted-channel-123', 'channel', 'Test Channel', {});
+      mockStore.updatePhase(sessionId, 'in-progress');
+
+      renderChannelDetailPage(mockDeletedChannel);
+
+      // Modal should render
+      expect(screen.getByRole('dialog', { name: /recovery in progress/i })).toBeInTheDocument();
+      expect(screen.getByText(/navigating away will not cancel the recovery/i)).toBeInTheDocument();
+
+      // Buttons should be present
+      expect(screen.getByRole('button', { name: /stay/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /leave/i })).toBeInTheDocument();
+    });
+
+    it('calls blocker.reset when "Stay" button is clicked', async () => {
+      const user = userEvent.setup();
+      const mockBlocker = {
+        state: 'blocked' as const,
+        reset: vi.fn(),
+        proceed: vi.fn(),
+        location: {} as any,
+      };
+      vi.mocked(useBlocker).mockReturnValue(mockBlocker);
+
+      // Set up in-progress session
+      const mockStore = useRecoveryStore.getState();
+      const sessionId = mockStore.startRecovery('deleted-channel-123', 'channel', 'Test Channel', {});
+      mockStore.updatePhase(sessionId, 'in-progress');
+
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const stayButton = screen.getByRole('button', { name: /stay/i });
+      await user.click(stayButton);
+
+      expect(mockBlocker.reset).toHaveBeenCalled();
+    });
+
+    it('calls blocker.proceed when "Leave" button is clicked', async () => {
+      const user = userEvent.setup();
+      const mockBlocker = {
+        state: 'blocked' as const,
+        reset: vi.fn(),
+        proceed: vi.fn(),
+        location: {} as any,
+      };
+      vi.mocked(useBlocker).mockReturnValue(mockBlocker);
+
+      // Set up in-progress session
+      const mockStore = useRecoveryStore.getState();
+      const sessionId = mockStore.startRecovery('deleted-channel-123', 'channel', 'Test Channel', {});
+      mockStore.updatePhase(sessionId, 'in-progress');
+
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const leaveButton = screen.getByRole('button', { name: /leave/i });
+      await user.click(leaveButton);
+
+      expect(mockBlocker.proceed).toHaveBeenCalled();
+    });
+
+    it('modal has correct ARIA attributes and Stay button has focus priority', () => {
+      const mockBlocker = {
+        state: 'blocked' as const,
+        reset: vi.fn(),
+        proceed: vi.fn(),
+        location: {} as any,
+      };
+      vi.mocked(useBlocker).mockReturnValue(mockBlocker);
+
+      // Set up in-progress session
+      const mockStore = useRecoveryStore.getState();
+      const sessionId = mockStore.startRecovery('deleted-channel-123', 'channel', 'Test Channel', {});
+      mockStore.updatePhase(sessionId, 'in-progress');
+
+      renderChannelDetailPage(mockDeletedChannel);
+
+      const modal = screen.getByRole('dialog');
+      expect(modal).toHaveAttribute('aria-modal', 'true');
+      expect(modal).toHaveAttribute('aria-labelledby', 'nav-guard-title');
+
+      const title = screen.getByText(/recovery in progress/i);
+      expect(title).toHaveAttribute('id', 'nav-guard-title');
+
+      // Stay button should be present (autoFocus is tested via visual/manual testing)
+      const stayButton = screen.getByRole('button', { name: /stay/i });
+      expect(stayButton).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/VideoDetailPage.alternative-url.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.alternative-url.test.tsx
@@ -101,6 +101,8 @@ const mockDeletedVideo: VideoDetail = {
   },
   availability_status: 'deleted',
   alternative_url: null,
+  recovered_at: null,
+  recovery_source: null,
 };
 
 /**

--- a/frontend/src/pages/__tests__/VideoDetailPage.recovery.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.recovery.test.tsx
@@ -1,0 +1,973 @@
+/**
+ * Tests for VideoDetailPage Recovery Button (T023, Feature 025).
+ *
+ * Tests the Web Archive recovery functionality integrated into the VideoDetailPage.
+ *
+ * Key behaviors tested:
+ * - Recovery mutation triggers on button click
+ * - Cache invalidation after successful recovery
+ * - Error message display after failed recovery
+ * - Button disabled state during loading
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useBlocker } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { VideoDetailPage } from '../VideoDetailPage';
+import type { VideoDetail } from '../../types/video';
+import type { RecoveryResultData } from '../../types/recovery';
+
+// Mock the API fetch function
+vi.mock('../../api/config', () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: 'http://localhost:8765/api/v1',
+  API_TIMEOUT: 10000,
+  RECOVERY_TIMEOUT: 660000,
+  isApiError: vi.fn(),
+}));
+
+// Mock useBlocker - will be overridden in tests
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useBlocker: vi.fn(() => ({
+      state: 'unblocked' as const,
+      reset: undefined,
+      proceed: undefined,
+      location: undefined,
+    })),
+  };
+});
+
+// Mock the deep link params hook
+vi.mock('../../hooks/useDeepLinkParams', () => ({
+  useDeepLinkParams: vi.fn(() => ({
+    lang: null,
+    segmentId: null,
+    timestamp: null,
+    clearDeepLinkParams: vi.fn(),
+  })),
+}));
+
+// Mock useVideoDetail
+vi.mock('../../hooks/useVideoDetail', () => ({
+  useVideoDetail: vi.fn(),
+}));
+
+// Mock useVideoPlaylists
+vi.mock('../../hooks/useVideoPlaylists', () => ({
+  useVideoPlaylists: vi.fn(() => ({ playlists: [] })),
+}));
+
+// Mock TranscriptPanel
+vi.mock('../../components/transcript', () => ({
+  TranscriptPanel: () => <div data-testid="transcript-panel" />,
+}));
+
+// Mock ClassificationSection
+vi.mock('../../components/ClassificationSection', () => ({
+  ClassificationSection: () => <div data-testid="classification-section" />,
+}));
+
+// Mock LoadingState
+vi.mock('../../components/LoadingState', () => ({
+  LoadingState: () => <div data-testid="loading-state" />,
+}));
+
+// Mock recoveryStore with state tracking
+vi.mock('../../stores/recoveryStore', () => {
+  // Track sessions in the mock
+  const mockSessions = new Map();
+
+  const mockStore = {
+    sessions: mockSessions,
+    startRecovery: vi.fn((entityId, entityType, entityTitle, filterOptions) => {
+      const sessionId = "mock-session-id";
+      const session = {
+        sessionId,
+        entityId,
+        entityType,
+        entityTitle: entityTitle ?? null,
+        phase: "pending" as const,
+        startedAt: Date.now(),
+        completedAt: null,
+        filterOptions: filterOptions ?? {},
+        result: null,
+        error: null,
+        abortController: null,
+      };
+      mockSessions.set(entityId, session);
+      return sessionId;
+    }),
+    updatePhase: vi.fn((sessionId, phase) => {
+      // Find session by sessionId and update phase
+      for (const [entityId, session] of mockSessions.entries()) {
+        if (session.sessionId === sessionId) {
+          mockSessions.set(entityId, { ...session, phase, completedAt: ["completed", "failed", "cancelled"].includes(phase) ? Date.now() : null });
+          break;
+        }
+      }
+    }),
+    setResult: vi.fn((sessionId, result) => {
+      // Find session by sessionId and set result
+      for (const [entityId, session] of mockSessions.entries()) {
+        if (session.sessionId === sessionId) {
+          mockSessions.set(entityId, { ...session, result, phase: "completed" as const, completedAt: Date.now() });
+          break;
+        }
+      }
+    }),
+    setError: vi.fn((sessionId, error) => {
+      // Find session by sessionId and set error
+      for (const [entityId, session] of mockSessions.entries()) {
+        if (session.sessionId === sessionId) {
+          mockSessions.set(entityId, { ...session, error, phase: "failed" as const, completedAt: Date.now() });
+          break;
+        }
+      }
+    }),
+    setAbortController: vi.fn((sessionId, controller) => {
+      // Find session by sessionId and set abortController
+      for (const [entityId, session] of mockSessions.entries()) {
+        if (session.sessionId === sessionId) {
+          mockSessions.set(entityId, { ...session, abortController: controller });
+          break;
+        }
+      }
+    }),
+    getActiveSession: vi.fn((entityId) => mockSessions.get(entityId)),
+    getActiveSessions: vi.fn(() => Array.from(mockSessions.values()).filter(s => ["pending", "in-progress"].includes(s.phase))),
+    hasActiveRecovery: vi.fn(() => Array.from(mockSessions.values()).some(s => ["pending", "in-progress"].includes(s.phase))),
+  };
+
+  const useRecoveryStore = Object.assign(
+    vi.fn((selector?: Function) => selector ? selector(mockStore) : mockStore),
+    { getState: vi.fn().mockReturnValue(mockStore), setState: vi.fn(() => {}) }
+  );
+
+  return { useRecoveryStore };
+});
+
+// Import mocked functions
+import { useVideoDetail } from '../../hooks/useVideoDetail';
+import { apiFetch } from '../../api/config';
+import { useRecoveryStore } from '../../stores/recoveryStore';
+
+/**
+ * Mock deleted video for recovery testing.
+ */
+const mockDeletedVideo: VideoDetail = {
+  video_id: 'deleted-video-123',
+  title: 'Deleted Video Title',
+  description: 'This video was deleted',
+  channel_id: 'channel-1',
+  channel_title: 'Test Channel',
+  upload_date: '2024-01-15T00:00:00Z',
+  duration: 300,
+  view_count: 1000,
+  like_count: 50,
+  comment_count: 25,
+  tags: [],
+  category_id: '22',
+  category_name: 'People & Blogs',
+  topics: [],
+  default_language: 'en',
+  made_for_kids: false,
+  transcript_summary: {
+    count: 0,
+    languages: [],
+    has_manual: false,
+  },
+  availability_status: 'deleted',
+  alternative_url: null,
+  recovered_at: null,
+  recovery_source: null,
+};
+
+/**
+ * Mock previously recovered video.
+ */
+const mockRecoveredVideo: VideoDetail = {
+  ...mockDeletedVideo,
+  recovered_at: '2024-02-01T12:00:00Z',
+};
+
+/**
+ * Mock available video (recovery button should NOT show).
+ */
+const mockAvailableVideo: VideoDetail = {
+  ...mockDeletedVideo,
+  availability_status: 'available',
+};
+
+/**
+ * Renders VideoDetailPage with MemoryRouter and QueryClientProvider.
+ */
+function renderVideoDetailPage(videoData: VideoDetail) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  vi.mocked(useVideoDetail).mockReturnValue({
+    data: videoData,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useVideoDetail>);
+
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/videos/${videoData.video_id}`]}>
+          <Routes>
+            <Route path="/videos/:videoId" element={<VideoDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+describe('VideoDetailPage - Recovery Button (T023)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear mock sessions
+    const mockStore = useRecoveryStore.getState();
+    mockStore.sessions.clear();
+  });
+
+  describe('Mutation Trigger', () => {
+    it('triggers recovery mutation when recovery button is clicked', async () => {
+      const user = userEvent.setup();
+      const currentYear = new Date().getFullYear();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title', 'description'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 2,
+        failure_reason: null,
+        duration_seconds: 3.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          `/videos/deleted-video-123/recover?end_year=${currentYear}`,
+          expect.objectContaining({
+            method: 'POST',
+          })
+        );
+      });
+    });
+
+    it('does NOT trigger recovery when button is disabled during loading', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      // Mock a slow API response
+      vi.mocked(apiFetch).mockImplementation(
+        () => new Promise(() => {}) // Never resolves
+      );
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+
+      // First click starts the mutation
+      await user.click(recoveryButton);
+
+      // Button should become disabled
+      await waitFor(() => {
+        expect(recoveryButton).toBeDisabled();
+      });
+
+      // Second click should not trigger another API call
+      await user.click(recoveryButton);
+
+      // Verify API was only called once
+      expect(apiFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Cache Invalidation', () => {
+    it('invalidates video detail query after successful recovery', async () => {
+      const user = userEvent.setup();
+      const { queryClient } = renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title', 'description'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 2,
+        failure_reason: null,
+        duration_seconds: 3.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      // Spy on queryClient.invalidateQueries
+      const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+          queryKey: ['video', 'deleted-video-123'],
+        });
+      });
+    });
+
+    it('does NOT invalidate cache when recovery fails', async () => {
+      const user = userEvent.setup();
+      const { queryClient } = renderVideoDetailPage(mockDeletedVideo);
+
+      vi.mocked(apiFetch).mockRejectedValue({
+        message: 'No snapshots found',
+        status: 404,
+      });
+
+      const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      // Wait for mutation to fail
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalled();
+      });
+
+      // Give React Query time to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Cache should NOT be invalidated on error
+      expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Message Display', () => {
+    it('displays error message when recovery fails', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockErrorResponse: RecoveryResultData = {
+        success: false,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshot_used: null,
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: 'no_snapshots_found',
+        duration_seconds: 0.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockErrorResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/no archived snapshots found/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('displays contextual error for CDX connection error', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockErrorResponse: RecoveryResultData = {
+        success: false,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshot_used: null,
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: 'cdx_connection_error',
+        duration_seconds: 10.0,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockErrorResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/web archive is temporarily unavailable/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('displays generic error when failure reason is unknown', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockErrorResponse: RecoveryResultData = {
+        success: false,
+        fields_recovered: [],
+        fields_skipped: [],
+        snapshot_used: null,
+        snapshots_available: 0,
+        snapshots_tried: 0,
+        failure_reason: null,
+        duration_seconds: 0.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockErrorResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/recovery failed/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Button Disabled During Loading', () => {
+    it('disables recovery button while mutation is pending', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      // Mock a slow API response
+      vi.mocked(apiFetch).mockImplementation(
+        () => new Promise(() => {}) // Never resolves
+      );
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+
+      // Initially enabled
+      expect(recoveryButton).not.toBeDisabled();
+
+      // Click starts the mutation
+      await user.click(recoveryButton);
+
+      // Button should become disabled
+      await waitFor(() => {
+        expect(recoveryButton).toBeDisabled();
+      });
+    });
+
+    it('re-enables recovery button after mutation completes', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+
+      await user.click(recoveryButton);
+
+      // Wait for mutation to complete
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalled();
+      });
+
+      // Button should be re-enabled after success
+      await waitFor(() => {
+        expect(recoveryButton).not.toBeDisabled();
+      });
+    });
+
+    it('re-enables recovery button after mutation fails', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      vi.mocked(apiFetch).mockRejectedValue({
+        message: 'Recovery failed',
+      });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+
+      await user.click(recoveryButton);
+
+      // Wait for mutation to fail
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalled();
+      });
+
+      // Button should be re-enabled after failure
+      await waitFor(() => {
+        expect(recoveryButton).not.toBeDisabled();
+      });
+    });
+  });
+
+  describe('Button Visibility and Labels', () => {
+    it('shows recovery button when video is deleted', () => {
+      renderVideoDetailPage(mockDeletedVideo);
+
+      expect(
+        screen.getByRole('button', { name: /recover from web archive/i })
+      ).toBeInTheDocument();
+    });
+
+    it('shows recovery button when video is private', () => {
+      const privateVideo = { ...mockDeletedVideo, availability_status: 'private' };
+      renderVideoDetailPage(privateVideo);
+
+      expect(
+        screen.getByRole('button', { name: /recover from web archive/i })
+      ).toBeInTheDocument();
+    });
+
+    it('does NOT show recovery button when video is available', () => {
+      renderVideoDetailPage(mockAvailableVideo);
+
+      expect(
+        screen.queryByRole('button', { name: /recover from web archive/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows "Re-recover" label when video was previously recovered', () => {
+      renderVideoDetailPage(mockRecoveredVideo);
+
+      expect(
+        screen.getByRole('button', { name: /re-recover from web archive/i })
+      ).toBeInTheDocument();
+    });
+
+    it('shows last recovery date when video was previously recovered', () => {
+      renderVideoDetailPage(mockRecoveredVideo);
+
+      // The recovered_at date is 2024-02-01
+      expect(screen.getByText(/last: feb 1, 2024/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Success Message Display', () => {
+    it('displays success message with field count after successful recovery', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title', 'description', 'view_count'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 2,
+        failure_reason: null,
+        duration_seconds: 3.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/recovered 3 fields/i)).toBeInTheDocument();
+      });
+    });
+
+    it('displays snapshot date in success message', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/2024-01-15/i)).toBeInTheDocument();
+      });
+    });
+
+    it('displays informational message when no fields were updated', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: [],
+        fields_skipped: ['title', 'description'],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 1.5,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/all fields already up-to-date/i)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Year Filter Integration', () => {
+    it('passes year params to API when years are selected', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      // Open advanced options
+      const advancedOptionsToggle = screen.getByRole('button', {
+        name: /advanced options/i,
+      });
+      await user.click(advancedOptionsToggle);
+
+      // Set year range
+      const startYearSelect = screen.getByLabelText(/from:/i);
+      const endYearSelect = screen.getByLabelText(/to:/i);
+      await user.selectOptions(startYearSelect, '2020');
+      await user.selectOptions(endYearSelect, '2024');
+
+      // Click recovery button
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          '/videos/deleted-video-123/recover?start_year=2020&end_year=2024',
+          expect.objectContaining({
+            method: 'POST',
+          })
+        );
+      });
+    });
+
+    it('adds only endYear param (current year) when using default values without opening advanced options', async () => {
+      const user = userEvent.setup();
+      const currentYear = new Date().getFullYear();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      // Click recovery button without opening advanced options
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          `/videos/deleted-video-123/recover?end_year=${currentYear}`,
+          expect.objectContaining({
+            method: 'POST',
+          })
+        );
+      });
+    });
+
+    it('uses recovery timeout for API call', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            method: 'POST',
+            timeout: 660000,
+          })
+        );
+      });
+    });
+  });
+
+  describe('AbortController Registration (T041)', () => {
+    it('should call setAbortController after starting recovery', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const mockStore = useRecoveryStore.getState();
+      const setAbortControllerSpy = vi.spyOn(mockStore, 'setAbortController');
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(setAbortControllerSpy).toHaveBeenCalledWith(
+          'mock-session-id',
+          expect.any(AbortController)
+        );
+      });
+    });
+
+    it('should pass signal to apiFetch options', async () => {
+      const user = userEvent.setup();
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const mockRecoveryResponse: RecoveryResultData = {
+        success: true,
+        fields_recovered: ['title'],
+        fields_skipped: [],
+        snapshot_used: '20240115120000',
+        snapshots_available: 5,
+        snapshots_tried: 1,
+        failure_reason: null,
+        duration_seconds: 2.1,
+      };
+
+      vi.mocked(apiFetch).mockResolvedValue({ data: mockRecoveryResponse });
+
+      const recoveryButton = screen.getByRole('button', {
+        name: /recover from web archive/i,
+      });
+      await user.click(recoveryButton);
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            method: 'POST',
+            timeout: 660000,
+            signal: expect.any(AbortSignal),
+          })
+        );
+      });
+    });
+  });
+
+  describe('Navigation Blocker (T042)', () => {
+    beforeEach(() => {
+      // Reset the mock implementation for each test
+      vi.mocked(useBlocker).mockReturnValue({
+        state: 'unblocked' as const,
+        reset: undefined,
+        proceed: undefined,
+        location: undefined,
+      });
+    });
+
+    it('does NOT activate blocker when no recovery is happening', () => {
+      renderVideoDetailPage(mockDeletedVideo);
+
+      // Blocker should be called with false when no active recovery
+      expect(useBlocker).toHaveBeenCalledWith(false);
+    });
+
+    it('renders modal with "Stay" button when blocker state is blocked', () => {
+      const mockBlocker = {
+        state: 'blocked' as const,
+        reset: vi.fn(),
+        proceed: vi.fn(),
+        location: {} as any,
+      };
+      vi.mocked(useBlocker).mockReturnValue(mockBlocker);
+
+      // Set up in-progress session
+      const mockStore = useRecoveryStore.getState();
+      const sessionId = mockStore.startRecovery('deleted-video-123', 'video', 'Test Video', {});
+      mockStore.updatePhase(sessionId, 'in-progress');
+
+      renderVideoDetailPage(mockDeletedVideo);
+
+      // Modal should render
+      expect(screen.getByRole('dialog', { name: /recovery in progress/i })).toBeInTheDocument();
+      expect(screen.getByText(/navigating away will not cancel the recovery/i)).toBeInTheDocument();
+
+      // Buttons should be present
+      expect(screen.getByRole('button', { name: /stay/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /leave/i })).toBeInTheDocument();
+    });
+
+    it('calls blocker.reset when "Stay" button is clicked', async () => {
+      const user = userEvent.setup();
+      const mockBlocker = {
+        state: 'blocked' as const,
+        reset: vi.fn(),
+        proceed: vi.fn(),
+        location: {} as any,
+      };
+      vi.mocked(useBlocker).mockReturnValue(mockBlocker);
+
+      // Set up in-progress session
+      const mockStore = useRecoveryStore.getState();
+      const sessionId = mockStore.startRecovery('deleted-video-123', 'video', 'Test Video', {});
+      mockStore.updatePhase(sessionId, 'in-progress');
+
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const stayButton = screen.getByRole('button', { name: /stay/i });
+      await user.click(stayButton);
+
+      expect(mockBlocker.reset).toHaveBeenCalled();
+    });
+
+    it('calls blocker.proceed when "Leave" button is clicked', async () => {
+      const user = userEvent.setup();
+      const mockBlocker = {
+        state: 'blocked' as const,
+        reset: vi.fn(),
+        proceed: vi.fn(),
+        location: {} as any,
+      };
+      vi.mocked(useBlocker).mockReturnValue(mockBlocker);
+
+      // Set up in-progress session
+      const mockStore = useRecoveryStore.getState();
+      const sessionId = mockStore.startRecovery('deleted-video-123', 'video', 'Test Video', {});
+      mockStore.updatePhase(sessionId, 'in-progress');
+
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const leaveButton = screen.getByRole('button', { name: /leave/i });
+      await user.click(leaveButton);
+
+      expect(mockBlocker.proceed).toHaveBeenCalled();
+    });
+
+    it('modal has correct ARIA attributes and Stay button has focus priority', () => {
+      const mockBlocker = {
+        state: 'blocked' as const,
+        reset: vi.fn(),
+        proceed: vi.fn(),
+        location: {} as any,
+      };
+      vi.mocked(useBlocker).mockReturnValue(mockBlocker);
+
+      // Set up in-progress session
+      const mockStore = useRecoveryStore.getState();
+      const sessionId = mockStore.startRecovery('deleted-video-123', 'video', 'Test Video', {});
+      mockStore.updatePhase(sessionId, 'in-progress');
+
+      renderVideoDetailPage(mockDeletedVideo);
+
+      const modal = screen.getByRole('dialog');
+      expect(modal).toHaveAttribute('aria-modal', 'true');
+      expect(modal).toHaveAttribute('aria-labelledby', 'nav-guard-title');
+
+      const title = screen.getByText(/recovery in progress/i);
+      expect(title).toHaveAttribute('id', 'nav-guard-title');
+
+      // Stay button should be present (autoFocus is tested via visual/manual testing)
+      const stayButton = screen.getByRole('button', { name: /stay/i });
+      expect(stayButton).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -84,6 +84,8 @@ const mockVideo: VideoDetail = {
   },
   availability_status: 'available',
   alternative_url: null,
+  recovered_at: null,
+  recovery_source: null,
 };
 
 /**

--- a/frontend/src/stores/__tests__/recoveryStore.test.ts
+++ b/frontend/src/stores/__tests__/recoveryStore.test.ts
@@ -1,0 +1,977 @@
+/**
+ * Unit tests for recoveryStore.
+ *
+ * Tests all store actions, selectors, phase transitions, and persistence logic.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { useRecoveryStore } from "../recoveryStore";
+import type { RecoveryResultData } from "../../types/recovery";
+
+describe("recoveryStore", () => {
+  beforeEach(() => {
+    // Reset store state before each test
+    useRecoveryStore.setState({ sessions: new Map() });
+    // Clear localStorage
+    localStorage.clear();
+    // Reset all mocks
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("Session Creation (startRecovery)", () => {
+    it("should create session with correct entityId, entityType, and phase='pending'", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session).toBeDefined();
+      expect(session?.sessionId).toBe(sessionId);
+      expect(session?.entityId).toBe("test-video-id");
+      expect(session?.entityType).toBe("video");
+      expect(session?.phase).toBe("pending");
+      expect(session?.completedAt).toBeNull();
+      expect(session?.result).toBeNull();
+      expect(session?.error).toBeNull();
+      expect(session?.abortController).toBeNull();
+    });
+
+    it("should generate unique sessionId (UUID format)", () => {
+      const sessionId1 = useRecoveryStore
+        .getState()
+        .startRecovery("video-1", "video");
+      const sessionId2 = useRecoveryStore
+        .getState()
+        .startRecovery("video-2", "video");
+
+      expect(sessionId1).not.toBe(sessionId2);
+      // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+      expect(sessionId1).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+      expect(sessionId2).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it("should set startedAt to current timestamp", () => {
+      vi.useFakeTimers();
+      const mockTimestamp = 1700000000000;
+      vi.setSystemTime(mockTimestamp);
+
+      useRecoveryStore.getState().startRecovery("test-video-id", "video");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.startedAt).toBe(mockTimestamp);
+    });
+
+    it("should set entityTitle when provided", () => {
+      useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video", "Test Video Title");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.entityTitle).toBe("Test Video Title");
+    });
+
+    it("should set entityTitle to null when not provided", () => {
+      useRecoveryStore.getState().startRecovery("test-video-id", "video");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.entityTitle).toBeNull();
+    });
+
+    it("should set filterOptions when provided", () => {
+      const filterOptions = { startYear: 2018, endYear: 2020 };
+      useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video", null, filterOptions);
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.filterOptions).toEqual(filterOptions);
+    });
+
+    it("should set empty filterOptions when not provided", () => {
+      useRecoveryStore.getState().startRecovery("test-video-id", "video");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.filterOptions).toEqual({});
+    });
+
+    it("should overwrite existing session for same entityId", () => {
+      const sessionId1 = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video", "First Title");
+      const sessionId2 = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video", "Second Title");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(sessionId1).not.toBe(sessionId2);
+      expect(session?.sessionId).toBe(sessionId2);
+      expect(session?.entityTitle).toBe("Second Title");
+    });
+
+    it("should support multiple sessions for different entities", () => {
+      const sessionId1 = useRecoveryStore
+        .getState()
+        .startRecovery("video-1", "video");
+      const sessionId2 = useRecoveryStore
+        .getState()
+        .startRecovery("channel-1", "channel");
+
+      const session1 = useRecoveryStore.getState().getActiveSession("video-1");
+      const session2 = useRecoveryStore
+        .getState()
+        .getActiveSession("channel-1");
+
+      expect(session1?.sessionId).toBe(sessionId1);
+      expect(session2?.sessionId).toBe(sessionId2);
+      expect(session1?.entityType).toBe("video");
+      expect(session2?.entityType).toBe("channel");
+    });
+  });
+
+  describe("Phase Transitions (updatePhase)", () => {
+    it("should transition from pending to in-progress", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.phase).toBe("in-progress");
+      expect(session?.completedAt).toBeNull();
+    });
+
+    it("should transition from in-progress to completed and set completedAt", () => {
+      vi.useFakeTimers();
+      const startTime = 1700000000000;
+      const endTime = 1700000010000;
+
+      vi.setSystemTime(startTime);
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+      vi.setSystemTime(endTime);
+      useRecoveryStore.getState().updatePhase(sessionId, "completed");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.phase).toBe("completed");
+      expect(session?.completedAt).toBe(endTime);
+    });
+
+    it("should transition from in-progress to failed and set completedAt", () => {
+      vi.useFakeTimers();
+      const startTime = 1700000000000;
+      const endTime = 1700000010000;
+
+      vi.setSystemTime(startTime);
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+      vi.setSystemTime(endTime);
+      useRecoveryStore.getState().updatePhase(sessionId, "failed");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.phase).toBe("failed");
+      expect(session?.completedAt).toBe(endTime);
+    });
+
+    it("should transition from in-progress to cancelled and set completedAt", () => {
+      vi.useFakeTimers();
+      const startTime = 1700000000000;
+      const endTime = 1700000010000;
+
+      vi.setSystemTime(startTime);
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+      vi.setSystemTime(endTime);
+      useRecoveryStore.getState().updatePhase(sessionId, "cancelled");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.phase).toBe("cancelled");
+      expect(session?.completedAt).toBe(endTime);
+    });
+
+    it("should not set completedAt for non-terminal phase transitions", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.phase).toBe("in-progress");
+      expect(session?.completedAt).toBeNull();
+    });
+
+    it("should handle updatePhase for non-existent sessionId gracefully", () => {
+      // This should not throw, just no-op
+      expect(() => {
+        useRecoveryStore.getState().updatePhase("non-existent-id", "completed");
+      }).not.toThrow();
+    });
+  });
+
+  describe("Result Handling (setResult)", () => {
+    it("should set result data and phase='completed' and completedAt", () => {
+      vi.useFakeTimers();
+      const startTime = 1700000000000;
+      const endTime = 1700000010000;
+
+      vi.setSystemTime(startTime);
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+      const mockResult: RecoveryResultData = {
+        videoId: "test-video-id",
+        channelId: "test-channel-id",
+        videoTitle: "Test Video",
+        channelTitle: "Test Channel",
+        thumbnailUrl: "https://example.com/thumb.jpg",
+        uploadDate: "2020-01-01",
+        description: "Test description",
+        viewCount: 1000,
+        likeCount: 100,
+        commentCount: 10,
+        duration: 120,
+        snapshotUrl: "https://web.archive.org/web/20200101000000/...",
+        snapshotTimestamp: "2020-01-01T00:00:00Z",
+        recoveredFields: ["videoTitle", "description"],
+      };
+
+      vi.setSystemTime(endTime);
+      useRecoveryStore.getState().setResult(sessionId, mockResult);
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.result).toEqual(mockResult);
+      expect(session?.phase).toBe("completed");
+      expect(session?.completedAt).toBe(endTime);
+    });
+
+    it("should find session by sessionId not entityId", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+
+      const mockResult: RecoveryResultData = {
+        videoId: "test-video-id",
+        channelId: "test-channel-id",
+        videoTitle: "Test Video",
+        channelTitle: "Test Channel",
+        thumbnailUrl: "https://example.com/thumb.jpg",
+        uploadDate: "2020-01-01",
+        description: "Test description",
+        viewCount: 1000,
+        likeCount: 100,
+        commentCount: 10,
+        duration: 120,
+        snapshotUrl: "https://web.archive.org/web/20200101000000/...",
+        snapshotTimestamp: "2020-01-01T00:00:00Z",
+        recoveredFields: ["videoTitle", "description"],
+      };
+
+      useRecoveryStore.getState().setResult(sessionId, mockResult);
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.result).toEqual(mockResult);
+    });
+
+    it("should handle setResult for non-existent sessionId gracefully", () => {
+      const mockResult: RecoveryResultData = {
+        videoId: "test-video-id",
+        channelId: "test-channel-id",
+        videoTitle: "Test Video",
+        channelTitle: "Test Channel",
+        thumbnailUrl: "https://example.com/thumb.jpg",
+        uploadDate: "2020-01-01",
+        description: "Test description",
+        viewCount: 1000,
+        likeCount: 100,
+        commentCount: 10,
+        duration: 120,
+        snapshotUrl: "https://web.archive.org/web/20200101000000/...",
+        snapshotTimestamp: "2020-01-01T00:00:00Z",
+        recoveredFields: ["videoTitle", "description"],
+      };
+
+      expect(() => {
+        useRecoveryStore.getState().setResult("non-existent-id", mockResult);
+      }).not.toThrow();
+    });
+  });
+
+  describe("Error Handling (setError)", () => {
+    it("should set error string and phase='failed' and completedAt", () => {
+      vi.useFakeTimers();
+      const startTime = 1700000000000;
+      const endTime = 1700000010000;
+
+      vi.setSystemTime(startTime);
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+      useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+      vi.setSystemTime(endTime);
+      useRecoveryStore
+        .getState()
+        .setError(sessionId, "Network error: Unable to fetch snapshot");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.error).toBe("Network error: Unable to fetch snapshot");
+      expect(session?.phase).toBe("failed");
+      expect(session?.completedAt).toBe(endTime);
+    });
+
+    it("should find session by sessionId", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+
+      useRecoveryStore.getState().setError(sessionId, "Test error");
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.error).toBe("Test error");
+      expect(session?.phase).toBe("failed");
+    });
+
+    it("should handle setError for non-existent sessionId gracefully", () => {
+      expect(() => {
+        useRecoveryStore.getState().setError("non-existent-id", "Test error");
+      }).not.toThrow();
+    });
+  });
+
+  describe("AbortController (setAbortController)", () => {
+    it("should store controller reference", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+      const mockController = new AbortController();
+
+      useRecoveryStore.getState().setAbortController(sessionId, mockController);
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.abortController).toBe(mockController);
+    });
+
+    it("should make controller accessible on the session", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+      const mockController = new AbortController();
+
+      useRecoveryStore.getState().setAbortController(sessionId, mockController);
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.abortController).toBeInstanceOf(AbortController);
+      expect(session?.abortController?.signal).toBeDefined();
+    });
+
+    it("should handle setAbortController for non-existent sessionId gracefully", () => {
+      const mockController = new AbortController();
+
+      expect(() => {
+        useRecoveryStore
+          .getState()
+          .setAbortController("non-existent-id", mockController);
+      }).not.toThrow();
+    });
+  });
+
+  describe("Cancel (cancelRecovery)", () => {
+    it("should call abort() on the controller", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+      const mockController = new AbortController();
+      const abortSpy = vi.spyOn(mockController, "abort");
+
+      useRecoveryStore.getState().setAbortController(sessionId, mockController);
+      useRecoveryStore.getState().cancelRecovery(sessionId);
+
+      expect(abortSpy).toHaveBeenCalledOnce();
+    });
+
+    it("should set phase='cancelled' and completedAt", () => {
+      vi.useFakeTimers();
+      const startTime = 1700000000000;
+      const endTime = 1700000010000;
+
+      vi.setSystemTime(startTime);
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+      const mockController = new AbortController();
+      useRecoveryStore.getState().setAbortController(sessionId, mockController);
+
+      vi.setSystemTime(endTime);
+      useRecoveryStore.getState().cancelRecovery(sessionId);
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.phase).toBe("cancelled");
+      expect(session?.completedAt).toBe(endTime);
+    });
+
+    it("should work when no abortController is set (does not throw)", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+
+      expect(() => {
+        useRecoveryStore.getState().cancelRecovery(sessionId);
+      }).not.toThrow();
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session?.phase).toBe("cancelled");
+    });
+
+    it("should handle cancelRecovery for non-existent sessionId gracefully", () => {
+      expect(() => {
+        useRecoveryStore.getState().cancelRecovery("non-existent-id");
+      }).not.toThrow();
+    });
+  });
+
+  describe("Cleanup (cleanupSession)", () => {
+    it("should remove session from store", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("test-video-id", "video");
+
+      useRecoveryStore.getState().cleanupSession(sessionId);
+
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("test-video-id");
+
+      expect(session).toBeUndefined();
+    });
+
+    it("should leave other sessions untouched", () => {
+      const sessionId1 = useRecoveryStore
+        .getState()
+        .startRecovery("video-1", "video");
+      const sessionId2 = useRecoveryStore
+        .getState()
+        .startRecovery("video-2", "video");
+
+      useRecoveryStore.getState().cleanupSession(sessionId1);
+
+      const session1 = useRecoveryStore.getState().getActiveSession("video-1");
+      const session2 = useRecoveryStore.getState().getActiveSession("video-2");
+
+      expect(session1).toBeUndefined();
+      expect(session2).toBeDefined();
+      expect(session2?.sessionId).toBe(sessionId2);
+    });
+
+    it("should handle cleanupSession for non-existent sessionId gracefully", () => {
+      expect(() => {
+        useRecoveryStore.getState().cleanupSession("non-existent-id");
+      }).not.toThrow();
+    });
+  });
+
+  describe("Selectors", () => {
+    describe("getActiveSession(entityId)", () => {
+      it("should return correct session for entityId", () => {
+        const sessionId = useRecoveryStore
+          .getState()
+          .startRecovery("test-video-id", "video", "Test Video");
+
+        const session = useRecoveryStore
+          .getState()
+          .getActiveSession("test-video-id");
+
+        expect(session).toBeDefined();
+        expect(session?.sessionId).toBe(sessionId);
+        expect(session?.entityId).toBe("test-video-id");
+        expect(session?.entityTitle).toBe("Test Video");
+      });
+
+      it("should return undefined for unknown entityId", () => {
+        const session = useRecoveryStore
+          .getState()
+          .getActiveSession("non-existent-id");
+
+        expect(session).toBeUndefined();
+      });
+
+      it("should return session even if it is in terminal phase", () => {
+        const sessionId = useRecoveryStore
+          .getState()
+          .startRecovery("test-video-id", "video");
+        useRecoveryStore.getState().updatePhase(sessionId, "completed");
+
+        const session = useRecoveryStore
+          .getState()
+          .getActiveSession("test-video-id");
+
+        expect(session).toBeDefined();
+        expect(session?.phase).toBe("completed");
+      });
+    });
+
+    describe("getActiveSessions()", () => {
+      it("should return only pending sessions", () => {
+        useRecoveryStore.getState().startRecovery("video-1", "video");
+        useRecoveryStore.getState().startRecovery("video-2", "video");
+
+        const activeSessions = useRecoveryStore.getState().getActiveSessions();
+
+        expect(activeSessions).toHaveLength(2);
+        expect(activeSessions.every((s) => s.phase === "pending")).toBe(true);
+      });
+
+      it("should return only in-progress sessions", () => {
+        const sessionId1 = useRecoveryStore
+          .getState()
+          .startRecovery("video-1", "video");
+        const sessionId2 = useRecoveryStore
+          .getState()
+          .startRecovery("video-2", "video");
+
+        useRecoveryStore.getState().updatePhase(sessionId1, "in-progress");
+        useRecoveryStore.getState().updatePhase(sessionId2, "in-progress");
+
+        const activeSessions = useRecoveryStore.getState().getActiveSessions();
+
+        expect(activeSessions).toHaveLength(2);
+        expect(activeSessions.every((s) => s.phase === "in-progress")).toBe(
+          true
+        );
+      });
+
+      it("should exclude completed sessions", () => {
+        const sessionId1 = useRecoveryStore
+          .getState()
+          .startRecovery("video-1", "video");
+        useRecoveryStore
+          .getState()
+          .startRecovery("video-2", "video"); // pending
+
+        useRecoveryStore.getState().updatePhase(sessionId1, "completed");
+
+        const activeSessions = useRecoveryStore.getState().getActiveSessions();
+
+        expect(activeSessions).toHaveLength(1);
+        expect(activeSessions[0].entityId).toBe("video-2");
+      });
+
+      it("should exclude failed sessions", () => {
+        const sessionId1 = useRecoveryStore
+          .getState()
+          .startRecovery("video-1", "video");
+        useRecoveryStore
+          .getState()
+          .startRecovery("video-2", "video"); // pending
+
+        useRecoveryStore.getState().updatePhase(sessionId1, "failed");
+
+        const activeSessions = useRecoveryStore.getState().getActiveSessions();
+
+        expect(activeSessions).toHaveLength(1);
+        expect(activeSessions[0].entityId).toBe("video-2");
+      });
+
+      it("should exclude cancelled sessions", () => {
+        const sessionId1 = useRecoveryStore
+          .getState()
+          .startRecovery("video-1", "video");
+        useRecoveryStore
+          .getState()
+          .startRecovery("video-2", "video"); // pending
+
+        useRecoveryStore.getState().updatePhase(sessionId1, "cancelled");
+
+        const activeSessions = useRecoveryStore.getState().getActiveSessions();
+
+        expect(activeSessions).toHaveLength(1);
+        expect(activeSessions[0].entityId).toBe("video-2");
+      });
+
+      it("should return empty array when no active sessions", () => {
+        const sessionId = useRecoveryStore
+          .getState()
+          .startRecovery("video-1", "video");
+        useRecoveryStore.getState().updatePhase(sessionId, "completed");
+
+        const activeSessions = useRecoveryStore.getState().getActiveSessions();
+
+        expect(activeSessions).toHaveLength(0);
+      });
+    });
+
+    describe("hasActiveRecovery()", () => {
+      it("should return true when active sessions exist (pending)", () => {
+        useRecoveryStore.getState().startRecovery("video-1", "video");
+
+        const hasActive = useRecoveryStore.getState().hasActiveRecovery();
+
+        expect(hasActive).toBe(true);
+      });
+
+      it("should return true when active sessions exist (in-progress)", () => {
+        const sessionId = useRecoveryStore
+          .getState()
+          .startRecovery("video-1", "video");
+        useRecoveryStore.getState().updatePhase(sessionId, "in-progress");
+
+        const hasActive = useRecoveryStore.getState().hasActiveRecovery();
+
+        expect(hasActive).toBe(true);
+      });
+
+      it("should return false when no active sessions (completed)", () => {
+        const sessionId = useRecoveryStore
+          .getState()
+          .startRecovery("video-1", "video");
+        useRecoveryStore.getState().updatePhase(sessionId, "completed");
+
+        const hasActive = useRecoveryStore.getState().hasActiveRecovery();
+
+        expect(hasActive).toBe(false);
+      });
+
+      it("should return false when no active sessions (failed)", () => {
+        const sessionId = useRecoveryStore
+          .getState()
+          .startRecovery("video-1", "video");
+        useRecoveryStore.getState().updatePhase(sessionId, "failed");
+
+        const hasActive = useRecoveryStore.getState().hasActiveRecovery();
+
+        expect(hasActive).toBe(false);
+      });
+
+      it("should return false when no active sessions (cancelled)", () => {
+        const sessionId = useRecoveryStore
+          .getState()
+          .startRecovery("video-1", "video");
+        useRecoveryStore.getState().updatePhase(sessionId, "cancelled");
+
+        const hasActive = useRecoveryStore.getState().hasActiveRecovery();
+
+        expect(hasActive).toBe(false);
+      });
+
+      it("should return false when no sessions at all", () => {
+        const hasActive = useRecoveryStore.getState().hasActiveRecovery();
+
+        expect(hasActive).toBe(false);
+      });
+    });
+  });
+
+  describe("Persistence", () => {
+    it("should only persist active sessions via partialize", () => {
+      const sessionId1 = useRecoveryStore
+        .getState()
+        .startRecovery("video-1", "video");
+      const sessionId2 = useRecoveryStore
+        .getState()
+        .startRecovery("video-2", "video");
+      useRecoveryStore.getState().updatePhase(sessionId2, "completed");
+
+      // Test the partialize logic directly
+      const state = useRecoveryStore.getState();
+      const partializedState = {
+        sessions: new Map(
+          Array.from(state.sessions.entries()).filter(([_key, session]) =>
+            ["pending", "in-progress"].includes(session.phase)
+          )
+        ),
+      };
+
+      // Should only have the pending session
+      expect(partializedState.sessions.size).toBe(1);
+      const pendingSession = Array.from(partializedState.sessions.values())[0];
+      expect(pendingSession.sessionId).toBe(sessionId1);
+      expect(pendingSession.phase).toBe("pending");
+    });
+
+    it("should filter out completed sessions via partialize", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("video-1", "video");
+      useRecoveryStore.getState().updatePhase(sessionId, "completed");
+
+      // Test the partialize logic directly
+      const state = useRecoveryStore.getState();
+      const partializedState = {
+        sessions: new Map(
+          Array.from(state.sessions.entries()).filter(([_key, session]) =>
+            ["pending", "in-progress"].includes(session.phase)
+          )
+        ),
+      };
+
+      expect(partializedState.sessions.size).toBe(0);
+    });
+
+    it("should filter out failed sessions via partialize", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("video-1", "video");
+      useRecoveryStore.getState().updatePhase(sessionId, "failed");
+
+      // Test the partialize logic directly
+      const state = useRecoveryStore.getState();
+      const partializedState = {
+        sessions: new Map(
+          Array.from(state.sessions.entries()).filter(([_key, session]) =>
+            ["pending", "in-progress"].includes(session.phase)
+          )
+        ),
+      };
+
+      expect(partializedState.sessions.size).toBe(0);
+    });
+
+    it("should exclude abortController via custom storage", () => {
+      const sessionId = useRecoveryStore
+        .getState()
+        .startRecovery("video-1", "video");
+      const mockController = new AbortController();
+      useRecoveryStore.getState().setAbortController(sessionId, mockController);
+
+      // Verify abortController exists in store
+      const session = useRecoveryStore
+        .getState()
+        .getActiveSession("video-1");
+      expect(session?.abortController).toBe(mockController);
+
+      // Test the partialize/storage logic
+      const state = useRecoveryStore.getState();
+      const partializedState = {
+        sessions: new Map(
+          Array.from(state.sessions.entries()).filter(([_key, session]) =>
+            ["pending", "in-progress"].includes(session.phase)
+          )
+        ),
+      };
+
+      // abortController should still be in partializedState (filtering happens in storage)
+      // The storage layer explicitly excludes it during serialization
+      const serialized = Array.from(partializedState.sessions.entries()).map(
+        ([key, session]) => [
+          key,
+          {
+            sessionId: session.sessionId,
+            entityId: session.entityId,
+            entityType: session.entityType,
+            entityTitle: session.entityTitle,
+            phase: session.phase,
+            startedAt: session.startedAt,
+            completedAt: session.completedAt,
+            filterOptions: session.filterOptions,
+            result: session.result,
+            error: session.error,
+            // abortController is explicitly excluded here
+          },
+        ]
+      );
+
+      expect(serialized).toHaveLength(1);
+      expect(serialized[0][1]).not.toHaveProperty("abortController");
+    });
+
+    it("should discard stale sessions (>10 min) on hydration", () => {
+      vi.useFakeTimers();
+      const now = 1700000000000;
+      const staleTime = now - 11 * 60 * 1000; // 11 minutes ago
+
+      // Create a stale session directly in localStorage
+      const staleSession = {
+        sessionId: "stale-session-id",
+        entityId: "video-1",
+        entityType: "video",
+        entityTitle: null,
+        phase: "pending",
+        startedAt: staleTime,
+        completedAt: null,
+        filterOptions: {},
+        result: null,
+        error: null,
+      };
+
+      const freshSession = {
+        sessionId: "fresh-session-id",
+        entityId: "video-2",
+        entityType: "video",
+        entityTitle: null,
+        phase: "pending",
+        startedAt: now - 5 * 60 * 1000, // 5 minutes ago
+        completedAt: null,
+        filterOptions: {},
+        result: null,
+        error: null,
+      };
+
+      localStorage.setItem(
+        "chronovista:recovery:sessions",
+        JSON.stringify({
+          state: {
+            sessions: [
+              ["video-1", staleSession],
+              ["video-2", freshSession],
+            ],
+          },
+          version: 0,
+        })
+      );
+
+      vi.setSystemTime(now);
+
+      // Create a new store instance to trigger hydration
+      // In practice, this happens on app load
+      // We simulate by reading from localStorage
+      const stored = localStorage.getItem("chronovista:recovery:sessions");
+      expect(stored).not.toBeNull();
+
+      // The mapStorage getItem should filter out stale sessions
+      // We need to trigger the store's hydration logic
+      // For testing, we'll manually verify the filtering logic works
+
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        const sessions = parsed.state.sessions;
+
+        // After filtering, only fresh session should remain
+        const filteredSessions = sessions.filter(
+          ([_key, session]: [string, any]) => {
+            return now - session.startedAt <= 600_000; // 10 minutes
+          }
+        );
+
+        expect(filteredSessions).toHaveLength(1);
+        expect(filteredSessions[0][1].sessionId).toBe("fresh-session-id");
+      }
+    });
+
+    it("should restore sessions via custom storage hydration logic", () => {
+      // Simulate persisted data in localStorage
+      const sessionId = "test-session-id";
+      const persistedData = {
+        state: {
+          sessions: [
+            [
+              "video-1",
+              {
+                sessionId,
+                entityId: "video-1",
+                entityType: "video",
+                entityTitle: "Test Video",
+                phase: "pending",
+                startedAt: Date.now(),
+                completedAt: null,
+                filterOptions: { startYear: 2018 },
+                result: null,
+                error: null,
+                // abortController is excluded from persisted data
+              },
+            ],
+          ],
+        },
+        version: 0,
+      };
+
+      // Simulate the storage getItem logic
+      const sessionsArray = persistedData.state.sessions;
+      const restoredSessions = new Map(
+        sessionsArray.map(([key, session]: [string, any]) => [
+          key,
+          { ...session, abortController: null }, // Restored sessions have null abortController
+        ])
+      );
+
+      // Apply to store
+      useRecoveryStore.setState({ sessions: restoredSessions });
+
+      // Verify session is restored
+      const session = useRecoveryStore.getState().getActiveSession("video-1");
+      expect(session).toBeDefined();
+      expect(session?.sessionId).toBe(sessionId);
+      expect(session?.entityTitle).toBe("Test Video");
+      expect(session?.filterOptions).toEqual({ startYear: 2018 });
+      expect(session?.abortController).toBeNull(); // Should be null after hydration
+    });
+  });
+});

--- a/frontend/src/stores/recoveryStore.ts
+++ b/frontend/src/stores/recoveryStore.ts
@@ -1,0 +1,430 @@
+/**
+ * Zustand store for managing recovery sessions.
+ *
+ * Features:
+ * - Session-based recovery tracking keyed by entityId
+ * - Phase-based state machine (idle, pending, in-progress, completed, failed, cancelled)
+ * - AbortController integration for cancellation
+ * - Persistent storage with 10-minute stale session cleanup
+ * - Year filter support for recovery operations
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type { RecoveryResultData } from "../types/recovery";
+
+/**
+ * Recovery operation phase.
+ */
+export type RecoveryPhase =
+  | "idle"
+  | "pending"
+  | "in-progress"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+/**
+ * Recovery session state.
+ */
+export interface RecoverySession {
+  /** Unique session identifier (crypto.randomUUID()) */
+  sessionId: string;
+  /** Video ID or Channel ID being recovered */
+  entityId: string;
+  /** Entity type (video or channel) */
+  entityType: "video" | "channel";
+  /** Entity title for display in AppShell indicator (nullable) */
+  entityTitle: string | null;
+  /** Current recovery phase */
+  phase: RecoveryPhase;
+  /** Start timestamp (Date.now()) */
+  startedAt: number;
+  /** Completion timestamp (null until terminal phase) */
+  completedAt: number | null;
+  /** Year filter options */
+  filterOptions: {
+    startYear?: number;
+    endYear?: number;
+  };
+  /** Recovery result data (null until completed) */
+  result: RecoveryResultData | null;
+  /** Human-readable error message (null unless failed) */
+  error: string | null;
+  /** AbortController for cancellation (non-serializable, excluded from persistence) */
+  abortController: AbortController | null;
+}
+
+/**
+ * Recovery store state.
+ */
+interface RecoveryStore {
+  /** Map of entityId -> RecoverySession */
+  sessions: Map<string, RecoverySession>;
+
+  /**
+   * Start a new recovery session.
+   *
+   * @param entityId - Video ID or Channel ID
+   * @param entityType - Entity type (video or channel)
+   * @param entityTitle - Entity title for display (optional)
+   * @param filterOptions - Year filter options (optional)
+   * @returns Session ID
+   */
+  startRecovery: (
+    entityId: string,
+    entityType: "video" | "channel",
+    entityTitle?: string | null,
+    filterOptions?: { startYear?: number; endYear?: number }
+  ) => string;
+
+  /**
+   * Update the phase of a recovery session.
+   *
+   * @param sessionId - Session ID
+   * @param phase - New phase
+   */
+  updatePhase: (sessionId: string, phase: RecoveryPhase) => void;
+
+  /**
+   * Set the recovery result and mark as completed.
+   *
+   * @param sessionId - Session ID
+   * @param result - Recovery result data
+   */
+  setResult: (sessionId: string, result: RecoveryResultData) => void;
+
+  /**
+   * Set the error message and mark as failed.
+   *
+   * @param sessionId - Session ID
+   * @param error - Human-readable error message
+   */
+  setError: (sessionId: string, error: string) => void;
+
+  /**
+   * Store the AbortController reference for a session.
+   *
+   * @param sessionId - Session ID
+   * @param controller - AbortController instance
+   */
+  setAbortController: (sessionId: string, controller: AbortController) => void;
+
+  /**
+   * Cancel a recovery session.
+   *
+   * @param sessionId - Session ID
+   */
+  cancelRecovery: (sessionId: string) => void;
+
+  /**
+   * Remove a session from the store.
+   *
+   * @param sessionId - Session ID
+   */
+  cleanupSession: (sessionId: string) => void;
+
+  /**
+   * Get the active session for an entity (if exists).
+   *
+   * @param entityId - Video ID or Channel ID
+   * @returns Recovery session or undefined
+   */
+  getActiveSession: (entityId: string) => RecoverySession | undefined;
+
+  /**
+   * Get all active sessions (pending or in-progress).
+   *
+   * @returns Array of active recovery sessions
+   */
+  getActiveSessions: () => RecoverySession[];
+
+  /**
+   * Check if any recovery is currently active.
+   *
+   * @returns True if any session is pending or in-progress
+   */
+  hasActiveRecovery: () => boolean;
+}
+
+/**
+ * Terminal phases that set completedAt timestamp.
+ */
+const TERMINAL_PHASES: RecoveryPhase[] = ["completed", "failed", "cancelled"];
+
+/**
+ * Active phases for filtering.
+ */
+const ACTIVE_PHASES: RecoveryPhase[] = ["pending", "in-progress"];
+
+/**
+ * Session staleness threshold (10 minutes in milliseconds).
+ */
+const SESSION_STALE_THRESHOLD = 600_000;
+
+/**
+ * Custom storage configuration for Map serialization.
+ */
+const mapStorage = createJSONStorage(() => ({
+  getItem: (name: string) => {
+    const value = localStorage.getItem(name);
+    if (!value) return null;
+
+    try {
+      const parsed = JSON.parse(value);
+      // Convert sessions array back to Map, filtering stale sessions
+      const now = Date.now();
+      const sessionEntries = (parsed.state?.sessions ?? [])
+        .filter(([_key, session]: [string, RecoverySession]) => {
+          // Keep only active sessions that aren't stale
+          if (!ACTIVE_PHASES.includes(session.phase)) {
+            return false;
+          }
+          return now - session.startedAt <= SESSION_STALE_THRESHOLD;
+        })
+        .map(([key, session]: [string, RecoverySession]) => [
+          key,
+          { ...session, abortController: null }, // AbortController can't be serialized
+        ]);
+
+      return JSON.stringify({
+        ...parsed,
+        state: {
+          ...parsed.state,
+          sessions: sessionEntries,
+        },
+      });
+    } catch {
+      return null;
+    }
+  },
+  setItem: (name: string, value: string) => {
+    try {
+      const parsed = JSON.parse(value);
+      // Convert Map to array entries, excluding abortController
+      const sessions = Array.from(
+        (parsed.state?.sessions ?? new Map()) as Map<string, RecoverySession>
+      )
+        .filter(([_key, session]) => ACTIVE_PHASES.includes(session.phase))
+        .map(([key, session]) => [
+          key,
+          {
+            sessionId: session.sessionId,
+            entityId: session.entityId,
+            entityType: session.entityType,
+            entityTitle: session.entityTitle,
+            phase: session.phase,
+            startedAt: session.startedAt,
+            completedAt: session.completedAt,
+            filterOptions: session.filterOptions,
+            result: session.result,
+            error: session.error,
+            // Exclude abortController (non-serializable)
+          },
+        ]);
+
+      localStorage.setItem(
+        name,
+        JSON.stringify({
+          ...parsed,
+          state: {
+            ...parsed.state,
+            sessions,
+          },
+        })
+      );
+    } catch {
+      // Ignore serialization errors
+    }
+  },
+  removeItem: (name: string) => {
+    localStorage.removeItem(name);
+  },
+}));
+
+/**
+ * Recovery store instance.
+ */
+export const useRecoveryStore = create<RecoveryStore>()(
+  persist(
+    (set, get) => ({
+      sessions: new Map(),
+
+      startRecovery: (entityId, entityType, entityTitle = null, filterOptions = {}) => {
+        const sessionId = crypto.randomUUID();
+        const session: RecoverySession = {
+          sessionId,
+          entityId,
+          entityType,
+          entityTitle,
+          phase: "pending",
+          startedAt: Date.now(),
+          completedAt: null,
+          filterOptions,
+          result: null,
+          error: null,
+          abortController: null,
+        };
+
+        set((state) => {
+          const newSessions = new Map(state.sessions);
+          newSessions.set(entityId, session);
+          return { sessions: newSessions };
+        });
+
+        return sessionId;
+      },
+
+      updatePhase: (sessionId, phase) => {
+        set((state) => {
+          const newSessions = new Map(state.sessions);
+          for (const [entityId, session] of newSessions.entries()) {
+            if (session.sessionId === sessionId) {
+              newSessions.set(entityId, {
+                ...session,
+                phase,
+                completedAt: TERMINAL_PHASES.includes(phase) ? Date.now() : session.completedAt,
+              });
+              break;
+            }
+          }
+          return { sessions: newSessions };
+        });
+      },
+
+      setResult: (sessionId, result) => {
+        set((state) => {
+          const newSessions = new Map(state.sessions);
+          for (const [entityId, session] of newSessions.entries()) {
+            if (session.sessionId === sessionId) {
+              newSessions.set(entityId, {
+                ...session,
+                result,
+                phase: "completed",
+                completedAt: Date.now(),
+              });
+              break;
+            }
+          }
+          return { sessions: newSessions };
+        });
+      },
+
+      setError: (sessionId, error) => {
+        set((state) => {
+          const newSessions = new Map(state.sessions);
+          for (const [entityId, session] of newSessions.entries()) {
+            if (session.sessionId === sessionId) {
+              newSessions.set(entityId, {
+                ...session,
+                error,
+                phase: "failed",
+                completedAt: Date.now(),
+              });
+              break;
+            }
+          }
+          return { sessions: newSessions };
+        });
+      },
+
+      setAbortController: (sessionId, controller) => {
+        set((state) => {
+          const newSessions = new Map(state.sessions);
+          for (const [entityId, session] of newSessions.entries()) {
+            if (session.sessionId === sessionId) {
+              newSessions.set(entityId, {
+                ...session,
+                abortController: controller,
+              });
+              break;
+            }
+          }
+          return { sessions: newSessions };
+        });
+      },
+
+      cancelRecovery: (sessionId) => {
+        const { sessions } = get();
+        for (const session of sessions.values()) {
+          if (session.sessionId === sessionId) {
+            // Call abort on the controller if it exists
+            session.abortController?.abort();
+
+            // Update the session state
+            set((state) => {
+              const newSessions = new Map(state.sessions);
+              newSessions.set(session.entityId, {
+                ...session,
+                phase: "cancelled",
+                completedAt: Date.now(),
+              });
+              return { sessions: newSessions };
+            });
+            break;
+          }
+        }
+      },
+
+      cleanupSession: (sessionId) => {
+        set((state) => {
+          const newSessions = new Map(state.sessions);
+          for (const [entityId, session] of newSessions.entries()) {
+            if (session.sessionId === sessionId) {
+              newSessions.delete(entityId);
+              break;
+            }
+          }
+          return { sessions: newSessions };
+        });
+      },
+
+      getActiveSession: (entityId) => {
+        const { sessions } = get();
+        return sessions.get(entityId);
+      },
+
+      getActiveSessions: () => {
+        const { sessions } = get();
+        return Array.from(sessions.values()).filter((session) =>
+          ACTIVE_PHASES.includes(session.phase)
+        );
+      },
+
+      hasActiveRecovery: () => {
+        const { sessions } = get();
+        for (const session of sessions.values()) {
+          if (ACTIVE_PHASES.includes(session.phase)) {
+            return true;
+          }
+        }
+        return false;
+      },
+    }),
+    {
+      name: "chronovista:recovery:sessions",
+      storage: mapStorage,
+      partialize: (state) => ({
+        // Only persist active sessions, exclude abortController
+        sessions: new Map(
+          Array.from(state.sessions.entries()).filter(([_key, session]) =>
+            ACTIVE_PHASES.includes(session.phase)
+          )
+        ),
+      }),
+      // Convert hydrated sessions array back to a Map
+      // (JSON.parse produces an array of entries, not a Map)
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<RecoveryStore> | undefined;
+        const hydratedSessions = persisted?.sessions;
+        return {
+          ...currentState,
+          sessions:
+            hydratedSessions instanceof Map
+              ? hydratedSessions
+              : new Map(Array.isArray(hydratedSessions) ? hydratedSessions : []),
+        };
+      },
+    }
+  )
+);

--- a/frontend/src/tests/components/SearchFilters.test.tsx
+++ b/frontend/src/tests/components/SearchFilters.test.tsx
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { SearchFilters } from "../../components/SearchFilters";
 import type { EnabledSearchTypes } from "../../types/search";
 
@@ -178,9 +179,118 @@ describe("SearchFilters", () => {
       // No "Coming Soon" placeholders
       expect(screen.queryByText("Coming Soon")).not.toBeInTheDocument();
 
-      // Only three checkboxes rendered
+      // Only three checkboxes rendered (without includeUnavailable toggle)
       const checkboxes = screen.getAllByRole("checkbox");
       expect(checkboxes).toHaveLength(3);
+    });
+  });
+
+  describe("Include unavailable content toggle", () => {
+    it("should render the toggle when onToggleIncludeUnavailable is provided", () => {
+      const handleToggle = vi.fn();
+      render(
+        <SearchFilters
+          availableLanguages={["en"]}
+          selectedLanguage=""
+          onLanguageChange={() => {}}
+          totalResults={10}
+          enabledTypes={defaultEnabledTypes}
+          onToggleType={vi.fn()}
+          includeUnavailable={false}
+          onToggleIncludeUnavailable={handleToggle}
+        />
+      );
+
+      // Should have 4 checkboxes: 3 search types + 1 unavailable toggle
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes).toHaveLength(4);
+
+      // Verify the toggle is present and labeled correctly
+      const unavailableToggle = screen.getByLabelText("Include unavailable content");
+      expect(unavailableToggle).toBeInTheDocument();
+      expect(unavailableToggle).not.toBeChecked();
+    });
+
+    it("should not render the toggle when onToggleIncludeUnavailable is not provided", () => {
+      render(
+        <SearchFilters
+          availableLanguages={["en"]}
+          selectedLanguage=""
+          onLanguageChange={() => {}}
+          totalResults={10}
+          enabledTypes={defaultEnabledTypes}
+          onToggleType={vi.fn()}
+        />
+      );
+
+      // Should only have 3 checkboxes for search types
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes).toHaveLength(3);
+
+      // Verify the toggle is not present
+      expect(screen.queryByLabelText("Include unavailable content")).not.toBeInTheDocument();
+    });
+
+    it("should reflect the checked state correctly", () => {
+      const handleToggle = vi.fn();
+      render(
+        <SearchFilters
+          availableLanguages={["en"]}
+          selectedLanguage=""
+          onLanguageChange={() => {}}
+          totalResults={10}
+          enabledTypes={defaultEnabledTypes}
+          onToggleType={vi.fn()}
+          includeUnavailable={true}
+          onToggleIncludeUnavailable={handleToggle}
+        />
+      );
+
+      const unavailableToggle = screen.getByLabelText("Include unavailable content") as HTMLInputElement;
+      expect(unavailableToggle).toBeChecked();
+    });
+
+    it("should call onToggleIncludeUnavailable when clicked", async () => {
+      const handleToggle = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <SearchFilters
+          availableLanguages={["en"]}
+          selectedLanguage=""
+          onLanguageChange={() => {}}
+          totalResults={10}
+          enabledTypes={defaultEnabledTypes}
+          onToggleType={vi.fn()}
+          includeUnavailable={false}
+          onToggleIncludeUnavailable={handleToggle}
+        />
+      );
+
+      const unavailableToggle = screen.getByLabelText("Include unavailable content");
+      await user.click(unavailableToggle);
+
+      expect(handleToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it("should display the toggle in the correct section with border separator", () => {
+      const handleToggle = vi.fn();
+      const { container } = render(
+        <SearchFilters
+          availableLanguages={["en"]}
+          selectedLanguage=""
+          onLanguageChange={() => {}}
+          totalResults={10}
+          enabledTypes={defaultEnabledTypes}
+          onToggleType={vi.fn()}
+          includeUnavailable={false}
+          onToggleIncludeUnavailable={handleToggle}
+        />
+      );
+
+      // Verify the toggle section has the border-top separator
+      const toggleSection = container.querySelector('.border-t');
+      expect(toggleSection).toBeInTheDocument();
+      expect(toggleSection).toHaveClass('pt-4');
     });
   });
 });

--- a/frontend/src/tests/components/VideoSearchResult.test.tsx
+++ b/frontend/src/tests/components/VideoSearchResult.test.tsx
@@ -767,7 +767,6 @@ describe("VideoSearchResult", () => {
       expect(paragraph).toHaveClass("mt-2");
       expect(paragraph).toHaveClass("text-sm");
       expect(paragraph).toHaveClass("text-gray-600");
-      expect(paragraph).toHaveClass("dark:text-gray-300");
       expect(paragraph).toHaveClass("leading-relaxed");
     });
 

--- a/frontend/src/tests/hooks/useChannelVideos.test.tsx
+++ b/frontend/src/tests/hooks/useChannelVideos.test.tsx
@@ -47,6 +47,8 @@ describe("useChannelVideos", () => {
         category_name: "Music",
         topics: [],
         availability_status: "available",
+        recovered_at: null,
+        recovery_source: null,
       },
       {
         video_id: "unavail123",
@@ -66,6 +68,8 @@ describe("useChannelVideos", () => {
         category_name: null,
         topics: [],
         availability_status: "deleted",
+        recovered_at: null,
+        recovery_source: null,
       },
     ],
     pagination: {

--- a/frontend/src/tests/hooks/useTranscriptLanguages.test.tsx
+++ b/frontend/src/tests/hooks/useTranscriptLanguages.test.tsx
@@ -90,7 +90,7 @@ describe("useTranscriptLanguages", () => {
       });
 
       await waitFor(() => {
-        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages");
+        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages?include_unavailable=true");
       });
     });
 
@@ -278,7 +278,7 @@ describe("useTranscriptLanguages", () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages");
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages?include_unavailable=true");
     });
   });
 

--- a/frontend/src/tests/hooks/useVideoDetail.test.tsx
+++ b/frontend/src/tests/hooks/useVideoDetail.test.tsx
@@ -48,6 +48,8 @@ describe("useVideoDetail", () => {
     },
     availability_status: "available",
     alternative_url: null,
+    recovered_at: null,
+    recovery_source: null,
   };
 
   beforeEach(() => {

--- a/frontend/src/tests/pages/VideoDetailPage.test.tsx
+++ b/frontend/src/tests/pages/VideoDetailPage.test.tsx
@@ -49,6 +49,8 @@ describe("VideoDetailPage", () => {
     },
     availability_status: "available",
     alternative_url: null,
+    recovered_at: null,
+    recovery_source: null,
   };
 
   beforeEach(() => {

--- a/frontend/src/types/channel.ts
+++ b/frontend/src/types/channel.ts
@@ -26,6 +26,10 @@ export interface ChannelListItem {
   custom_url: string | null;
   /** Content availability status */
   availability_status: string;
+  /** ISO 8601 datetime when channel was recovered (null if not recovered) */
+  recovered_at: string | null;
+  /** Source of recovery data (e.g., "wayback_machine", null if not recovered) */
+  recovery_source: string | null;
 }
 
 /**
@@ -45,6 +49,10 @@ export interface ChannelDetail extends ChannelListItem {
   updated_at: string;
   /** Content availability status */
   availability_status: string;
+  /** ISO 8601 datetime when channel was recovered (null if not recovered) */
+  recovered_at: string | null;
+  /** Source of recovery data (e.g., "wayback_machine", null if not recovered) */
+  recovery_source: string | null;
 }
 
 /**

--- a/frontend/src/types/recovery.ts
+++ b/frontend/src/types/recovery.ts
@@ -1,0 +1,27 @@
+/**
+ * Recovery data types for the Chronovista frontend.
+ * These types match the backend API recovery response schemas.
+ */
+
+/**
+ * Result data from a Wayback Machine recovery operation.
+ * Contains detailed information about the recovery attempt.
+ */
+export interface RecoveryResultData {
+  /** Whether the recovery operation succeeded */
+  success: boolean;
+  /** ISO 8601 timestamp of the Wayback snapshot used (null if none) */
+  snapshot_used: string | null;
+  /** List of field names that were successfully recovered */
+  fields_recovered: string[];
+  /** List of field names that were skipped (already present) */
+  fields_skipped: string[];
+  /** Total number of snapshots found in the archive */
+  snapshots_available: number;
+  /** Number of snapshots attempted during recovery */
+  snapshots_tried: number;
+  /** Human-readable reason for failure (null if successful) */
+  failure_reason: string | null;
+  /** Duration of the recovery operation in seconds */
+  duration_seconds: number;
+}

--- a/frontend/src/types/video.ts
+++ b/frontend/src/types/video.ts
@@ -58,6 +58,10 @@ export interface VideoListItem {
   topics: TopicSummary[];
   /** Content availability status */
   availability_status: string;
+  /** ISO 8601 datetime when video was recovered (null if not recovered) */
+  recovered_at: string | null;
+  /** Source of recovery data (e.g., "wayback_machine", null if not recovered) */
+  recovery_source: string | null;
 }
 
 /**
@@ -102,6 +106,10 @@ export interface VideoDetail {
   availability_status: string;
   /** Alternative URL for deleted/unavailable content */
   alternative_url: string | null;
+  /** ISO 8601 datetime when video was recovered (null if not recovered) */
+  recovered_at: string | null;
+  /** Source of recovery data (e.g., "wayback_machine", null if not recovered) */
+  recovery_source: string | null;
 }
 
 /**

--- a/frontend/tests/pages/VideoDetailPage.test.tsx
+++ b/frontend/tests/pages/VideoDetailPage.test.tsx
@@ -46,6 +46,7 @@ describe('VideoDetailPage', () => {
     category_id: '22',
     default_language: 'en',
     made_for_kids: false,
+    availability_status: 'available',
     transcript_summary: {
       count: 2,
       languages: ['en', 'es'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.27.0"
+version = "0.28.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/deps.py
+++ b/src/chronovista/api/deps.py
@@ -7,6 +7,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.auth import youtube_oauth
 from chronovista.config.database import db_manager
+from chronovista.config.settings import settings
+from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
+from chronovista.services.recovery.page_parser import PageParser
+
+# Module-level singleton: shared across all recovery API calls
+_recovery_rate_limiter = RateLimiter(rate=40.0)
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
@@ -45,3 +51,26 @@ async def require_auth() -> None:
                 "message": "Not authenticated. Run: chronovista auth login",
             },
         )
+
+
+def get_recovery_deps() -> tuple[CDXClient, PageParser, RateLimiter]:
+    """
+    Dependency for recovery service components.
+
+    Creates a CDXClient and PageParser per-call (they hold no
+    request-scoped state) and returns the module-level RateLimiter
+    singleton so that all recovery API calls share one token bucket.
+
+    Returns
+    -------
+    tuple[CDXClient, PageParser, RateLimiter]
+        A 3-tuple of (cdx_client, page_parser, rate_limiter) that
+        recovery endpoints can unpack for use with the orchestrator.
+    """
+    cache_dir = settings.cache_dir
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    cdx_client = CDXClient(cache_dir=cache_dir)
+    page_parser = PageParser(rate_limiter=_recovery_rate_limiter)
+
+    return cdx_client, page_parser, _recovery_rate_limiter

--- a/src/chronovista/api/schemas/channels.py
+++ b/src/chronovista/api/schemas/channels.py
@@ -12,7 +12,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from chronovista.api.schemas.responses import PaginationMeta
+from chronovista.api.schemas.responses import ApiResponse, PaginationMeta
 
 
 class ChannelListItem(BaseModel):
@@ -84,6 +84,8 @@ class ChannelDetail(ChannelListItem):
     is_subscribed: bool = Field(False, description="Whether user is subscribed")
     created_at: datetime = Field(..., description="Record creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
+    recovered_at: Optional[datetime] = Field(None, description="Timestamp when metadata was recovered via Wayback Machine")
+    recovery_source: Optional[str] = Field(None, description="Source used for metadata recovery (e.g., wayback_machine)")
 
 
 class ChannelListResponse(BaseModel):
@@ -119,3 +121,50 @@ class ChannelDetailResponse(BaseModel):
     model_config = ConfigDict(strict=True)
 
     data: ChannelDetail
+
+
+class ChannelRecoveryResultData(BaseModel):
+    """Recovery result data for a single channel recovery attempt.
+
+    Mirrors VideoRecoveryResultData but uses channel_id instead of video_id
+    and omits channel sub-recovery fields (since this IS the channel recovery).
+
+    Attributes
+    ----------
+    channel_id : str
+        YouTube channel ID (24 characters, starts with UC).
+    success : bool
+        Whether the recovery attempt succeeded.
+    snapshot_used : Optional[str]
+        CDX timestamp of the snapshot used for recovery.
+    fields_recovered : List[str]
+        Names of fields successfully recovered.
+    fields_skipped : List[str]
+        Names of fields that were skipped during recovery.
+    snapshots_available : int
+        Total number of CDX snapshots found.
+    snapshots_tried : int
+        Number of snapshots attempted before success or exhaustion.
+    failure_reason : Optional[str]
+        Reason for failure, if success is False.
+    duration_seconds : float
+        Wall-clock time for the recovery operation.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    channel_id: str
+    success: bool
+    snapshot_used: Optional[str] = None
+    fields_recovered: List[str] = Field(default_factory=list)
+    fields_skipped: List[str] = Field(default_factory=list)
+    snapshots_available: int = 0
+    snapshots_tried: int = 0
+    failure_reason: Optional[str] = None
+    duration_seconds: float = 0.0
+
+
+class ChannelRecoveryResponse(ApiResponse[ChannelRecoveryResultData]):
+    """Response for channel recovery endpoint."""
+
+    pass

--- a/src/chronovista/api/schemas/videos.py
+++ b/src/chronovista/api/schemas/videos.py
@@ -135,6 +135,8 @@ class VideoDetail(BaseModel):
     topics: List[TopicSummary] = Field(default_factory=list)  # Associated topics
     availability_status: str = Field(..., description="Video availability status")
     alternative_url: Optional[str] = Field(None, description="Alternative URL for deleted/unavailable content")
+    recovered_at: Optional[datetime] = Field(None, description="Timestamp when metadata was recovered via Wayback Machine")
+    recovery_source: Optional[str] = Field(None, description="Source used for metadata recovery (e.g., wayback_machine)")
 
 
 class VideoDetailResponse(ApiResponse[VideoDetail]):
@@ -173,6 +175,65 @@ class AlternativeUrlRequest(BaseModel):
         max_length=500,
         description="Alternative URL for unavailable video (max 500 characters). Set to null to clear.",
     )
+
+
+class VideoRecoveryResultData(BaseModel):
+    """Recovery result data for a single video recovery attempt.
+
+    Attributes
+    ----------
+    video_id : str
+        YouTube video ID (11 characters).
+    success : bool
+        Whether the recovery attempt succeeded.
+    snapshot_used : str | None
+        CDX timestamp of the snapshot used for recovery.
+    fields_recovered : List[str]
+        Names of fields successfully recovered.
+    fields_skipped : List[str]
+        Names of fields that were skipped during recovery.
+    snapshots_available : int
+        Total number of CDX snapshots found.
+    snapshots_tried : int
+        Number of snapshots attempted before success or exhaustion.
+    failure_reason : str | None
+        Reason for failure, if success is False.
+    duration_seconds : float
+        Wall-clock time for the recovery operation.
+    channel_recovery_candidates : List[str]
+        Channel IDs discovered during recovery that may need their own recovery.
+    channel_recovered : bool
+        Whether channel metadata was successfully recovered.
+    channel_fields_recovered : List[str]
+        Names of channel fields successfully recovered.
+    channel_fields_skipped : List[str]
+        Names of channel fields that were skipped during recovery.
+    channel_failure_reason : str | None
+        Reason for channel recovery failure, if applicable.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    video_id: str
+    success: bool
+    snapshot_used: Optional[str] = None
+    fields_recovered: List[str] = Field(default_factory=list)
+    fields_skipped: List[str] = Field(default_factory=list)
+    snapshots_available: int = 0
+    snapshots_tried: int = 0
+    failure_reason: Optional[str] = None
+    duration_seconds: float = 0.0
+    channel_recovery_candidates: List[str] = Field(default_factory=list)
+    channel_recovered: bool = False
+    channel_fields_recovered: List[str] = Field(default_factory=list)
+    channel_fields_skipped: List[str] = Field(default_factory=list)
+    channel_failure_reason: Optional[str] = None
+
+
+class VideoRecoveryResponse(ApiResponse[VideoRecoveryResultData]):
+    """Response for video recovery endpoint."""
+
+    pass
 
 
 # Rebuild models to resolve forward references

--- a/src/chronovista/services/recovery/__init__.py
+++ b/src/chronovista/services/recovery/__init__.py
@@ -29,7 +29,7 @@ and rely on static HTML parsing only.
 
 # Try to import selenium to check availability
 try:
-    import selenium.webdriver  # type: ignore[import-not-found]  # noqa: F401
+    import selenium.webdriver  # noqa: F401
     SELENIUM_AVAILABLE = True
 except ImportError:
     SELENIUM_AVAILABLE = False

--- a/src/chronovista/services/recovery/cdx_client.py
+++ b/src/chronovista/services/recovery/cdx_client.py
@@ -550,3 +550,357 @@ class CDXClient:
         )
 
         cache_file.write_text(entry.model_dump_json())
+
+    # ------------------------------------------------------------------
+    # Channel snapshot methods
+    # ------------------------------------------------------------------
+
+    async def fetch_channel_snapshots(
+        self,
+        channel_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> list[CdxSnapshot]:
+        """
+        Fetch CDX snapshots for a YouTube channel, using cache when available.
+
+        Checks the file-based cache first. If a fresh cache entry exists
+        (less than 24 hours old), returns the cached snapshots without
+        making an HTTP request. Otherwise, queries the CDX API, filters
+        and sorts the results, caches them, and returns the snapshots.
+
+        Parameters
+        ----------
+        channel_id : str
+            YouTube channel ID (e.g., "UCuAXFkgsw1L7xaCfnd5JJOw").
+        from_year : int | None, optional
+            Only return snapshots from this year onward (default: None).
+        to_year : int | None, optional
+            Only return snapshots up to this year (default: None).
+
+        Returns
+        -------
+        list[CdxSnapshot]
+            List of CDX snapshots. Sorted newest-first by default, or
+            oldest-first when ``from_year`` is specified (so iteration
+            starts near the anchor year). May be empty.
+
+        Raises
+        ------
+        CDXError
+            If the CDX API request fails after all retries are exhausted.
+        """
+        # Check cache first
+        cached = self._read_channel_cache(
+            channel_id, from_year=from_year, to_year=to_year,
+        )
+        if cached is not None:
+            snapshots = cached
+        else:
+            # Fetch from CDX API with retries
+            raw_rows = await self._fetch_channel_with_retries(
+                channel_id, from_year=from_year, to_year=to_year,
+            )
+
+            # Parse and filter
+            snapshots = self._parse_cdx_response(raw_rows)
+
+            # Cache the results
+            self._write_channel_cache(
+                channel_id, snapshots, raw_count=len(raw_rows),
+                from_year=from_year, to_year=to_year,
+            )
+
+        # When from_year is set, return oldest-first (ascending) so the
+        # orchestrator tries snapshots closest to the anchor year first.
+        if from_year is not None:
+            snapshots = list(reversed(snapshots))
+
+        return snapshots
+
+    def _build_channel_cdx_url(
+        self,
+        channel_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> str:
+        """
+        Build the CDX API query URL for a given channel ID.
+
+        Parameters
+        ----------
+        channel_id : str
+            YouTube channel ID.
+        from_year : int | None, optional
+            Only return snapshots from this year onward (default: None).
+        to_year : int | None, optional
+            Only return snapshots up to this year (default: None).
+
+        Returns
+        -------
+        str
+            Fully-formed CDX API URL with all required query parameters.
+        """
+        # When from_year is set, use positive limit (oldest first from anchor)
+        # so snapshots near the anchor year are returned.
+        # Without from_year, use negative limit (newest first).
+        limit = _CDX_RESULT_LIMIT if from_year is not None else -_CDX_RESULT_LIMIT
+        url = (
+            f"{_CDX_BASE_URL}"
+            f"?url=youtube.com/channel/{channel_id}"
+            f"&output=json"
+            f"&filter=statuscode:200"
+            f"&filter=mimetype:text/html"
+            f"&fl=timestamp,original,mimetype,statuscode,digest,length"
+            f"&limit={limit}"
+        )
+        if from_year is not None:
+            url += f"&from={from_year}0101000000"
+        if to_year is not None:
+            url += f"&to={to_year}1231235959"
+        return url
+
+    async def _fetch_channel_with_retries(
+        self,
+        channel_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> list[list[str]]:
+        """
+        Fetch CDX data for a channel with retry logic for transient HTTP errors.
+
+        Implements exponential backoff for HTTP 503 (base 2s, 3 retries)
+        and a fixed 60s pause for HTTP 429 (rate limit).
+
+        Parameters
+        ----------
+        channel_id : str
+            YouTube channel ID.
+        from_year : int | None, optional
+            Only return snapshots from this year onward (default: None).
+        to_year : int | None, optional
+            Only return snapshots up to this year (default: None).
+
+        Returns
+        -------
+        list[list[str]]
+            Raw CDX response rows (array of arrays, first row is headers).
+
+        Raises
+        ------
+        CDXError
+            If all retries are exhausted without a successful response.
+        """
+        url = self._build_channel_cdx_url(
+            channel_id, from_year=from_year, to_year=to_year,
+        )
+        headers = {"User-Agent": f"chronovista/{__version__}"}
+        retries_remaining = _MAX_RETRIES
+
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            while True:
+                try:
+                    response = await client.get(
+                        url,
+                        headers=headers,
+                        timeout=_REQUEST_TIMEOUT_SECONDS,
+                    )
+                except (
+                    httpx.ConnectTimeout,
+                    httpx.ReadTimeout,
+                    httpx.ConnectError,
+                ) as e:
+                    if retries_remaining <= 0:
+                        raise CDXError(
+                            message=(
+                                f"CDX API connection failed for channel "
+                                f"'{channel_id}' after retries: "
+                                f"{type(e).__name__}"
+                            ),
+                            video_id=channel_id,
+                            status_code=0,
+                        ) from e
+                    attempt = _MAX_RETRIES - retries_remaining
+                    delay = _BACKOFF_BASE_SECONDS * (2 ** attempt)
+                    retries_remaining -= 1
+                    logger.warning(
+                        "CDX fetch attempt %d/%d for channel %s failed "
+                        "(%s), retrying in %.0fs",
+                        attempt + 1,
+                        _MAX_RETRIES,
+                        channel_id,
+                        type(e).__name__,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+
+                if response.status_code == 200:
+                    return cast(list[list[str]], response.json())
+
+                if response.status_code == 429:
+                    if retries_remaining <= 0:
+                        raise CDXError(
+                            message=(
+                                f"CDX API rate limit exceeded for channel "
+                                f"'{channel_id}' after retries"
+                            ),
+                            video_id=channel_id,
+                            status_code=429,
+                        )
+                    retries_remaining -= 1
+                    await asyncio.sleep(_RATE_LIMIT_PAUSE_SECONDS)
+                    continue
+
+                if response.status_code == 503:
+                    if retries_remaining <= 0:
+                        raise CDXError(
+                            message=(
+                                f"CDX API unavailable (503) for channel "
+                                f"'{channel_id}' after retries"
+                            ),
+                            video_id=channel_id,
+                            status_code=503,
+                        )
+                    attempt = _MAX_RETRIES - retries_remaining
+                    delay = _BACKOFF_BASE_SECONDS * (2 ** attempt)
+                    retries_remaining -= 1
+                    await asyncio.sleep(delay)
+                    continue
+
+                # Unexpected status code — raise immediately
+                raise CDXError(
+                    message=(
+                        f"CDX API returned unexpected status "
+                        f"{response.status_code} for channel '{channel_id}'"
+                    ),
+                    video_id=channel_id,
+                    status_code=response.status_code,
+                )
+
+    def _channel_cache_path(
+        self,
+        channel_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> Path:
+        """
+        Compute the cache file path for a given channel ID and year range.
+
+        Parameters
+        ----------
+        channel_id : str
+            YouTube channel ID.
+        from_year : int | None, optional
+            Start year filter used in the CDX query (default: None).
+        to_year : int | None, optional
+            End year filter used in the CDX query (default: None).
+
+        Returns
+        -------
+        Path
+            Path to the cache file. Uses a ``_channel`` namespace suffix
+            to avoid collisions with video cache keys, e.g.
+            ``{cache_dir}/cdx/{channel_id}_channel_from2018_to2020.json``.
+        """
+        suffix = "_channel"
+        if from_year is not None:
+            suffix += f"_from{from_year}"
+        if to_year is not None:
+            suffix += f"_to{to_year}"
+        return self.cache_dir / "cdx" / f"{channel_id}{suffix}.json"
+
+    def _read_channel_cache(
+        self,
+        channel_id: str,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> list[CdxSnapshot] | None:
+        """
+        Read and validate a cached CDX response for a channel.
+
+        Returns the cached snapshots if the cache file exists, contains
+        valid JSON, and is still fresh (less than 24 hours old). Returns
+        None on cache miss, expiration, or corruption. Corrupted cache
+        files are deleted automatically.
+
+        Parameters
+        ----------
+        channel_id : str
+            YouTube channel ID.
+        from_year : int | None, optional
+            Start year filter used in the CDX query (default: None).
+        to_year : int | None, optional
+            End year filter used in the CDX query (default: None).
+
+        Returns
+        -------
+        list[CdxSnapshot] | None
+            Cached snapshots if valid, or None if cache miss/expired/corrupt.
+        """
+        cache_file = self._channel_cache_path(
+            channel_id, from_year=from_year, to_year=to_year,
+        )
+        if not cache_file.exists():
+            return None
+
+        try:
+            raw_text = cache_file.read_text()
+            entry = CdxCacheEntry.model_validate_json(raw_text)
+        except Exception:
+            # Corrupted cache — delete and re-fetch
+            logger.warning(
+                "Corrupted CDX cache for channel '%s', deleting: %s",
+                channel_id,
+                cache_file,
+            )
+            try:
+                cache_file.unlink()
+            except OSError:
+                pass
+            return None
+
+        if not entry.is_valid(ttl_hours=_CACHE_TTL_HOURS):
+            return None
+
+        return entry.snapshots
+
+    def _write_channel_cache(
+        self,
+        channel_id: str,
+        snapshots: list[CdxSnapshot],
+        raw_count: int,
+        from_year: int | None = None,
+        to_year: int | None = None,
+    ) -> None:
+        """
+        Write a CDX channel response to the file cache.
+
+        Creates the cache directory structure if it does not exist.
+
+        Parameters
+        ----------
+        channel_id : str
+            YouTube channel ID.
+        snapshots : list[CdxSnapshot]
+            Filtered CDX snapshots to cache.
+        raw_count : int
+            Total number of raw CDX rows before filtering.
+        from_year : int | None, optional
+            Start year filter used in the CDX query (default: None).
+        to_year : int | None, optional
+            End year filter used in the CDX query (default: None).
+        """
+        cache_file = self._channel_cache_path(
+            channel_id, from_year=from_year, to_year=to_year,
+        )
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+
+        entry = CdxCacheEntry(
+            video_id=channel_id,
+            fetched_at=_dt.datetime.now(_dt.timezone.utc),
+            snapshots=snapshots,
+            raw_count=raw_count,
+        )
+
+        cache_file.write_text(entry.model_dump_json())

--- a/src/chronovista/services/recovery/orchestrator.py
+++ b/src/chronovista/services/recovery/orchestrator.py
@@ -1,13 +1,18 @@
 """
-Recovery orchestrator for deleted YouTube videos.
+Recovery orchestrator for deleted YouTube videos and channels.
 
 Coordinates CDX API queries, page parsing, database updates, and tag persistence
-to recover metadata for unavailable YouTube videos using Wayback Machine snapshots.
+to recover metadata for unavailable YouTube videos and channels using Wayback
+Machine snapshots.
 
 Functions
 ---------
 recover_video
     Main orchestration function for recovering a single video's metadata.
+    Includes best-effort auto-channel recovery when the video's channel
+    is unavailable.
+recover_channel
+    Standalone orchestration function for recovering a single channel's metadata.
 """
 
 from __future__ import annotations
@@ -20,14 +25,19 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.exceptions import CDXError
-from chronovista.models.channel import ChannelCreate
+from chronovista.models.channel import ChannelCreate, ChannelUpdate
 from chronovista.models.enums import AvailabilityStatus
 from chronovista.models.video import VideoUpdate
 from chronovista.repositories.channel_repository import ChannelRepository
 from chronovista.repositories.video_repository import VideoRepository
 from chronovista.repositories.video_tag_repository import VideoTagRepository
 from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
-from chronovista.services.recovery.models import RecoveredVideoData, RecoveryResult
+from chronovista.services.recovery.models import (
+    ChannelRecoveryResult,
+    RecoveredChannelData,
+    RecoveredVideoData,
+    RecoveryResult,
+)
 from chronovista.services.recovery.page_parser import PageParser
 
 logger = logging.getLogger(__name__)
@@ -42,6 +52,11 @@ _IMMUTABLE_FIELDS = frozenset(["channel_id", "category_id"])
 # Mutable fields that can be overwritten if snapshot is newer than existing recovery_source
 _MUTABLE_FIELDS = frozenset(
     ["title", "description", "upload_date", "view_count", "like_count", "channel_name_hint", "thumbnail_url"]
+)
+
+# Channel mutable fields (channels have NO immutable fields — all are mutable overwrite-if-newer)
+_CHANNEL_MUTABLE_FIELDS = frozenset(
+    ["title", "description", "subscriber_count", "video_count", "thumbnail_url", "country", "default_language"]
 )
 
 
@@ -305,13 +320,50 @@ async def recover_video(
             # Commit changes
             await session.commit()
 
-        # Identify channel recovery candidates
+        # Auto-channel recovery (best-effort, never blocks video recovery)
         channel_recovery_candidates: list[str] = []
+        channel_recovered = False
+        channel_fields_recovered: list[str] = []
+        channel_fields_skipped: list[str] = []
+        channel_failure_reason: str | None = None
+
         if recovered_data.channel_id:
             # Check if this channel exists and is unavailable
             channel = await channel_repo.get(session, recovered_data.channel_id)
             if channel is not None and channel.availability_status != AvailabilityStatus.AVAILABLE.value:
                 channel_recovery_candidates.append(recovered_data.channel_id)
+
+                # Attempt auto-channel recovery with remaining time budget
+                try:
+                    elapsed = (datetime.now(timezone.utc) - start_time).total_seconds()
+                    remaining_timeout = max(
+                        _RECOVERY_TIMEOUT_SECONDS - elapsed, 30.0
+                    )
+                    channel_result = await recover_channel(
+                        session=session,
+                        channel_id=recovered_data.channel_id,
+                        cdx_client=cdx_client,
+                        page_parser=page_parser,
+                        rate_limiter=rate_limiter,
+                        from_year=from_year,
+                        to_year=to_year,
+                        timeout_seconds=remaining_timeout,
+                    )
+                    if channel_result.success:
+                        channel_recovered = True
+                        channel_fields_recovered = channel_result.fields_recovered
+                        channel_fields_skipped = channel_result.fields_skipped
+                    else:
+                        channel_failure_reason = channel_result.failure_reason
+                except Exception as e:
+                    logger.warning(
+                        "Auto-channel recovery failed for channel %s "
+                        "(video %s): %s",
+                        recovered_data.channel_id,
+                        video_id,
+                        e,
+                    )
+                    channel_failure_reason = f"exception: {e}"
 
         # Build success result
         duration = (datetime.now(timezone.utc) - start_time).total_seconds()
@@ -325,6 +377,10 @@ async def recover_video(
             snapshots_tried=snapshots_tried,
             duration_seconds=duration,
             channel_recovery_candidates=channel_recovery_candidates,
+            channel_recovered=channel_recovered,
+            channel_fields_recovered=channel_fields_recovered,
+            channel_fields_skipped=channel_fields_skipped,
+            channel_failure_reason=channel_failure_reason,
         )
 
     except Exception as e:
@@ -443,3 +499,330 @@ def _build_video_update(
             continue
 
     return update_dict, fields_recovered, fields_skipped
+
+
+def _build_channel_update(
+    existing_channel: Any, recovered_data: RecoveredChannelData
+) -> tuple[dict[str, Any], list[str], list[str]]:
+    """
+    Build channel update dictionary with two-tier overwrite policy.
+
+    Applies the following policy for channels (no immutable fields):
+    1. **Mutable fields** (title, description, subscriber_count, video_count,
+       thumbnail_url, country, default_language):
+       - Fill-if-NULL always
+       - Overwrite existing values only if incoming snapshot is newer than
+         existing recovery_source
+    2. **NULL protection**: Never blank existing values with None/NULL from
+       recovered data.
+
+    Parameters
+    ----------
+    existing_channel : Any
+        SQLAlchemy Channel model instance from database.
+    recovered_data : RecoveredChannelData
+        Metadata extracted from Wayback Machine channel snapshot.
+
+    Returns
+    -------
+    tuple[dict[str, Any], list[str], list[str]]
+        A 3-tuple containing:
+        - update_dict: Dictionary of field updates to apply
+        - fields_recovered: List of field names successfully recovered
+        - fields_skipped: List of field names that were skipped
+    """
+    update_dict: dict[str, Any] = {}
+    fields_recovered: list[str] = []
+    fields_skipped: list[str] = []
+
+    # Extract existing recovery_source timestamp (if any)
+    existing_recovery_timestamp: str | None = None
+    if existing_channel.recovery_source:
+        # Format: "wayback:20220106075526"
+        parts = existing_channel.recovery_source.split(":")
+        if len(parts) == 2 and parts[0] == "wayback":
+            existing_recovery_timestamp = parts[1]
+
+    # Determine if incoming snapshot is newer than existing recovery
+    incoming_is_newer = False
+    if existing_recovery_timestamp is None:
+        # No existing recovery - incoming is considered "newer"
+        incoming_is_newer = True
+    elif recovered_data.snapshot_timestamp >= existing_recovery_timestamp:
+        # Incoming snapshot has same or later timestamp
+        incoming_is_newer = True
+
+    # Map RecoveredChannelData fields to Channel model fields
+    field_mapping = {
+        "title": "title",
+        "description": "description",
+        "subscriber_count": "subscriber_count",
+        "video_count": "video_count",
+        "thumbnail_url": "thumbnail_url",
+        "country": "country",
+        "default_language": "default_language",
+    }
+
+    for recovered_field, db_field in field_mapping.items():
+        recovered_value = getattr(recovered_data, recovered_field, None)
+        existing_value = getattr(existing_channel, db_field, None)
+
+        # NULL protection: never blank existing values
+        if recovered_value is None:
+            if existing_value is not None:
+                # Skip: incoming is NULL, existing has value
+                fields_skipped.append(db_field)
+            # If both are NULL, do nothing (not recovered, not skipped)
+            continue
+
+        # All channel fields are mutable: fill-if-NULL always, overwrite if newer
+        if db_field in _CHANNEL_MUTABLE_FIELDS:
+            if existing_value is None:
+                # Fill NULL mutable field
+                update_dict[db_field] = recovered_value
+                fields_recovered.append(db_field)
+            elif incoming_is_newer:
+                # Overwrite existing value with newer snapshot data
+                update_dict[db_field] = recovered_value
+                fields_recovered.append(db_field)
+            else:
+                # Skip: existing value is from newer or same snapshot
+                fields_skipped.append(db_field)
+            continue
+
+    return update_dict, fields_recovered, fields_skipped
+
+
+async def recover_channel(
+    session: AsyncSession,
+    channel_id: str,
+    cdx_client: CDXClient,
+    page_parser: PageParser,
+    rate_limiter: RateLimiter,
+    from_year: int | None = None,
+    to_year: int | None = None,
+    timeout_seconds: float = _RECOVERY_TIMEOUT_SECONDS,
+) -> ChannelRecoveryResult:
+    """
+    Recover metadata for an unavailable YouTube channel using Wayback Machine snapshots.
+
+    This function coordinates the full channel recovery process:
+    1. Fetch channel from database and check eligibility (availability_status != AVAILABLE)
+    2. Query CDX API for archived channel page snapshots
+    3. Iterate snapshots newest-first (max 20, configurable timeout)
+    4. Extract metadata via PageParser.extract_channel_metadata()
+    5. Apply two-tier overwrite policy (mutable overwrite-if-newer, NULL protection)
+    6. Update database with recovered metadata
+    7. Return ChannelRecoveryResult with success/failure status
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session for querying and updating channel records.
+    channel_id : str
+        YouTube channel ID to recover (e.g., "UCuAXFkgsw1L7xaCfnd5JJOw").
+    cdx_client : CDXClient
+        CDX API client for fetching Wayback Machine snapshots.
+    page_parser : PageParser
+        Page parser for extracting channel metadata from archived pages.
+    rate_limiter : RateLimiter
+        Rate limiter for throttling page fetch requests.
+    from_year : int | None, optional
+        Only search Wayback snapshots from this year onward (default: None).
+    to_year : int | None, optional
+        Only search Wayback snapshots up to this year (default: None).
+    timeout_seconds : float, optional
+        Maximum wall-clock seconds for the entire recovery (default: 600.0).
+        When called from recover_video(), the remaining time budget is passed.
+
+    Returns
+    -------
+    ChannelRecoveryResult
+        Result object containing success status, fields recovered/skipped,
+        snapshot information, failure reason (if applicable), and duration.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
+    >>> from chronovista.services.recovery.page_parser import PageParser
+    >>> cdx_client = CDXClient(cache_dir=Path("/tmp/cdx_cache"))
+    >>> rate_limiter = RateLimiter(rate=40.0)
+    >>> page_parser = PageParser(rate_limiter=rate_limiter)
+    >>> result = await recover_channel(
+    ...     session=session,
+    ...     channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+    ...     cdx_client=cdx_client,
+    ...     page_parser=page_parser,
+    ...     rate_limiter=rate_limiter,
+    ... )
+    >>> if result.success:
+    ...     print(f"Recovered {len(result.fields_recovered)} fields")
+    """
+    start_time = datetime.now(timezone.utc)
+
+    # Initialize repository
+    channel_repo = ChannelRepository()
+
+    try:
+        # Fetch channel from database
+        channel = await channel_repo.get(session, channel_id)
+
+        # Check eligibility: channel must exist
+        if channel is None:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return ChannelRecoveryResult(
+                channel_id=channel_id,
+                success=False,
+                failure_reason="channel_not_found",
+                duration_seconds=duration,
+            )
+
+        # Check eligibility: channel must not be AVAILABLE
+        if channel.availability_status == AvailabilityStatus.AVAILABLE.value:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return ChannelRecoveryResult(
+                channel_id=channel_id,
+                success=False,
+                failure_reason="channel_available",
+                duration_seconds=duration,
+            )
+
+        # Query CDX API for channel snapshots
+        try:
+            snapshots = await asyncio.wait_for(
+                cdx_client.fetch_channel_snapshots(
+                    channel_id, from_year=from_year, to_year=to_year
+                ),
+                timeout=timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return ChannelRecoveryResult(
+                channel_id=channel_id,
+                success=False,
+                failure_reason="cdx_query_timeout",
+                duration_seconds=duration,
+            )
+        except CDXError as e:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            logger.warning("CDX error for channel %s: %s", channel_id, e.message)
+            return ChannelRecoveryResult(
+                channel_id=channel_id,
+                success=False,
+                failure_reason="cdx_connection_error",
+                duration_seconds=duration,
+            )
+
+        snapshots_available = len(snapshots)
+
+        # No snapshots available
+        if snapshots_available == 0:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return ChannelRecoveryResult(
+                channel_id=channel_id,
+                success=False,
+                failure_reason="no_snapshots_found",
+                snapshots_available=0,
+                snapshots_tried=0,
+                duration_seconds=duration,
+            )
+
+        # Iterate snapshots newest-first (already sorted by CDXClient)
+        snapshots_tried = 0
+        recovered_data: RecoveredChannelData | None = None
+
+        for snapshot in snapshots[: _MAX_SNAPSHOTS_TO_TRY]:
+            snapshots_tried += 1
+
+            # Check remaining time budget
+            elapsed = (datetime.now(timezone.utc) - start_time).total_seconds()
+            if elapsed >= timeout_seconds:
+                logger.warning(
+                    "Channel recovery timeout for %s after %d snapshots (%.1fs)",
+                    channel_id,
+                    snapshots_tried,
+                    elapsed,
+                )
+                break
+
+            # Extract metadata from snapshot
+            try:
+                extracted_data = await page_parser.extract_channel_metadata(
+                    snapshot, channel_id
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Timeout extracting channel metadata from snapshot %s for channel %s",
+                    snapshot.timestamp,
+                    channel_id,
+                )
+                continue
+            except Exception as e:
+                logger.warning(
+                    "Error extracting channel metadata from snapshot %s for channel %s: %s",
+                    snapshot.timestamp,
+                    channel_id,
+                    e,
+                )
+                continue
+
+            # Check if we got usable data
+            if extracted_data is None or not extracted_data.has_data:
+                continue
+
+            # Found usable data - stop iteration
+            recovered_data = extracted_data
+            break
+
+        # No usable data found after trying all snapshots
+        if recovered_data is None:
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            return ChannelRecoveryResult(
+                channel_id=channel_id,
+                success=False,
+                failure_reason="all_snapshots_failed",
+                snapshots_available=snapshots_available,
+                snapshots_tried=snapshots_tried,
+                duration_seconds=duration,
+            )
+
+        # Build update dictionary with overwrite policy
+        update_dict, fields_recovered, fields_skipped = _build_channel_update(
+            channel, recovered_data
+        )
+
+        # Add recovery metadata (always set on success)
+        update_dict["recovered_at"] = datetime.now(timezone.utc)
+        update_dict["recovery_source"] = recovered_data.recovery_source
+
+        # Update channel in database
+        channel_update = ChannelUpdate(**update_dict)
+        await channel_repo.update(session, db_obj=channel, obj_in=channel_update)
+
+        # Commit changes
+        await session.commit()
+
+        # Build success result
+        duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+        return ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=True,
+            snapshot_used=recovered_data.snapshot_timestamp,
+            fields_recovered=fields_recovered,
+            fields_skipped=fields_skipped,
+            snapshots_available=snapshots_available,
+            snapshots_tried=snapshots_tried,
+            duration_seconds=duration,
+        )
+
+    except Exception as e:
+        # Unexpected error during recovery
+        duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+        logger.error("Unexpected error recovering channel %s: %s", channel_id, e)
+        return ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=False,
+            failure_reason="unexpected_error",
+            duration_seconds=duration,
+        )

--- a/tests/integration/api/test_channel_recovery.py
+++ b/tests/integration/api/test_channel_recovery.py
@@ -1,0 +1,498 @@
+"""Integration tests for POST /api/v1/channels/{channel_id}/recover endpoint.
+
+This module tests the channel recovery endpoint that uses the Wayback Machine
+to recover metadata for unavailable YouTube channels.
+
+Tests cover:
+- Success case with recovered metadata
+- 404 error when channel doesn't exist
+- 409 conflict when channel is available
+- 422 validation errors for invalid year ranges
+- 503 error when CDX API is unavailable
+- Zero-new-fields success case
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.exceptions import CDXError
+from chronovista.models.enums import AvailabilityStatus
+from chronovista.services.recovery.models import ChannelRecoveryResult
+
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+async def unavailable_channel(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a channel with availability_status = 'deleted'.
+
+    Returns channel data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        channel = ChannelDB(
+            channel_id="UCdeleted123456789012345",
+            title="Deleted Channel for Recovery",
+            description="A deleted channel that needs recovery",
+            subscriber_count=500,
+            video_count=20,
+            availability_status=AvailabilityStatus.DELETED.value,
+        )
+
+        # Check if channel already exists
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing_channel = result.scalar_one_or_none()
+
+        if existing_channel:
+            # Update to ensure deleted status
+            existing_channel.availability_status = AvailabilityStatus.DELETED.value
+            existing_channel.recovered_at = None
+            existing_channel.recovery_source = None
+            await session.commit()
+            return {
+                "channel_id": existing_channel.channel_id,
+                "title": existing_channel.title,
+                "availability_status": existing_channel.availability_status,
+            }
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {
+            "channel_id": channel.channel_id,
+            "title": channel.title,
+            "availability_status": channel.availability_status,
+        }
+
+
+@pytest.fixture
+async def available_channel(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a channel with availability_status = 'available'.
+
+    Returns channel data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        channel = ChannelDB(
+            channel_id="UCavailable3456789012345",
+            title="Available Channel",
+            description="An available channel that should not be recovered",
+            subscriber_count=10000,
+            video_count=200,
+            availability_status=AvailabilityStatus.AVAILABLE.value,
+        )
+
+        # Check if channel already exists
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing_channel = result.scalar_one_or_none()
+
+        if existing_channel:
+            # Update to ensure available status
+            existing_channel.availability_status = AvailabilityStatus.AVAILABLE.value
+            await session.commit()
+            return {
+                "channel_id": existing_channel.channel_id,
+                "title": existing_channel.title,
+                "availability_status": existing_channel.availability_status,
+            }
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {
+            "channel_id": channel.channel_id,
+            "title": channel.title,
+            "availability_status": channel.availability_status,
+        }
+
+
+# =============================================================================
+# Success Tests
+# =============================================================================
+
+
+class TestChannelRecoverySuccess:
+    """Tests for successful channel recovery."""
+
+    async def test_recover_channel_success_with_metadata(
+        self,
+        async_client: AsyncClient,
+        unavailable_channel: Dict[str, Any],
+    ) -> None:
+        """Test successful channel recovery with populated ChannelRecoveryResult."""
+        channel_id = unavailable_channel["channel_id"]
+
+        # Mock the recover_channel orchestrator to return success
+        mock_result = ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title", "description", "subscriber_count"],
+            fields_skipped=["video_count"],
+            snapshots_available=15,
+            snapshots_tried=3,
+            duration_seconds=2.45,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ):
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover"
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+
+                # Verify response structure
+                assert "data" in data
+                result_data = data["data"]
+
+                # Verify success fields
+                assert result_data["channel_id"] == channel_id
+                assert result_data["success"] is True
+                assert result_data["snapshot_used"] == "20220106075526"
+                assert result_data["fields_recovered"] == [
+                    "title",
+                    "description",
+                    "subscriber_count",
+                ]
+                assert result_data["fields_skipped"] == ["video_count"]
+                assert result_data["snapshots_available"] == 15
+                assert result_data["snapshots_tried"] == 3
+                assert result_data["failure_reason"] is None
+                assert result_data["duration_seconds"] == 2.45
+
+    async def test_recover_channel_zero_new_fields(
+        self,
+        async_client: AsyncClient,
+        unavailable_channel: Dict[str, Any],
+    ) -> None:
+        """Test successful recovery with empty fields_recovered list."""
+        channel_id = unavailable_channel["channel_id"]
+
+        # Mock the recover_channel orchestrator to return success with no new fields
+        mock_result = ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=[],  # No new fields recovered
+            fields_skipped=["title", "description", "subscriber_count"],
+            snapshots_available=10,
+            snapshots_tried=1,
+            duration_seconds=1.2,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ):
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover"
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+
+                # Verify response structure
+                assert "data" in data
+                result_data = data["data"]
+
+                # Verify zero-new-fields scenario
+                assert result_data["success"] is True
+                assert result_data["fields_recovered"] == []
+                assert len(result_data["fields_skipped"]) > 0
+                assert result_data["snapshot_used"] == "20220106075526"
+
+
+# =============================================================================
+# Error Tests
+# =============================================================================
+
+
+class TestChannelRecoveryErrors:
+    """Tests for channel recovery error cases."""
+
+    async def test_recover_nonexistent_channel_404(
+        self,
+        async_client: AsyncClient,
+    ) -> None:
+        """Test 404 error when channel doesn't exist in database."""
+        channel_id = "UCnonexistent12345678901"
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.post(
+                f"/api/v1/channels/{channel_id}/recover"
+            )
+
+            assert response.status_code == 404
+            data = response.json()
+
+            # Verify error structure (RFC 7807)
+            assert "detail" in data
+            assert "Channel" in data["detail"]
+            assert channel_id in data["detail"]
+
+    async def test_recover_available_channel_409(
+        self,
+        async_client: AsyncClient,
+        available_channel: Dict[str, Any],
+    ) -> None:
+        """Test 409 conflict when channel is available."""
+        channel_id = available_channel["channel_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.post(
+                f"/api/v1/channels/{channel_id}/recover"
+            )
+
+            assert response.status_code == 409
+            data = response.json()
+
+            # Verify conflict error
+            assert "detail" in data
+            assert "available" in data["detail"].lower()
+
+    async def test_recover_invalid_year_range_422(
+        self,
+        async_client: AsyncClient,
+        unavailable_channel: Dict[str, Any],
+    ) -> None:
+        """Test 422 validation error when end_year < start_year."""
+        channel_id = unavailable_channel["channel_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.post(
+                f"/api/v1/channels/{channel_id}/recover?start_year=2020&end_year=2015"
+            )
+
+            assert response.status_code == 400  # BadRequestError maps to 400
+            data = response.json()
+
+            # Verify validation error
+            assert "detail" in data
+            assert "year" in data["detail"].lower()
+            assert "2020" in data["detail"]
+            assert "2015" in data["detail"]
+
+    async def test_recover_year_out_of_range_422(
+        self,
+        async_client: AsyncClient,
+        unavailable_channel: Dict[str, Any],
+    ) -> None:
+        """Test 422 validation error when year is out of range."""
+        channel_id = unavailable_channel["channel_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            # Year too early (before 2005)
+            response = await async_client.post(
+                f"/api/v1/channels/{channel_id}/recover?start_year=1990"
+            )
+
+            # FastAPI's Query validation will return 422
+            assert response.status_code == 422
+            data = response.json()
+
+            # Verify validation error structure
+            assert "detail" in data
+
+    async def test_recover_cdx_error_503(
+        self,
+        async_client: AsyncClient,
+        unavailable_channel: Dict[str, Any],
+    ) -> None:
+        """Test 503 error when CDX API is unavailable."""
+        channel_id = unavailable_channel["channel_id"]
+
+        # Mock the recover_channel orchestrator to raise CDXError
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+                side_effect=CDXError(
+                    message="CDX API connection timeout",
+                    video_id=channel_id,
+                    status_code=503,
+                ),
+            ):
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover"
+                )
+
+                assert response.status_code == 503
+                data = response.json()
+
+                # Verify 503 error structure
+                assert "detail" in data
+                assert "Wayback Machine" in data["detail"]
+                assert "CDX API" in data["detail"]
+
+                # Verify Retry-After header
+                assert "Retry-After" in response.headers
+                assert response.headers["Retry-After"] == "60"
+
+
+# =============================================================================
+# Query Parameter Tests
+# =============================================================================
+
+
+class TestChannelRecoveryQueryParameters:
+    """Tests for year filtering query parameters."""
+
+    async def test_recover_with_start_year(
+        self,
+        async_client: AsyncClient,
+        unavailable_channel: Dict[str, Any],
+    ) -> None:
+        """Test recovery with start_year parameter."""
+        channel_id = unavailable_channel["channel_id"]
+
+        mock_result = ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=True,
+            snapshot_used="20180101120000",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover?start_year=2018"
+                )
+
+                assert response.status_code == 200
+
+                # Verify that recover_channel was called with start_year
+                mock_recover.assert_called_once()
+                call_kwargs = mock_recover.call_args.kwargs
+                assert call_kwargs["from_year"] == 2018
+                assert call_kwargs["to_year"] is None
+
+    async def test_recover_with_end_year(
+        self,
+        async_client: AsyncClient,
+        unavailable_channel: Dict[str, Any],
+    ) -> None:
+        """Test recovery with end_year parameter."""
+        channel_id = unavailable_channel["channel_id"]
+
+        mock_result = ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=True,
+            snapshot_used="20200101120000",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover?end_year=2020"
+                )
+
+                assert response.status_code == 200
+
+                # Verify that recover_channel was called with end_year
+                mock_recover.assert_called_once()
+                call_kwargs = mock_recover.call_args.kwargs
+                assert call_kwargs["from_year"] is None
+                assert call_kwargs["to_year"] == 2020
+
+    async def test_recover_with_year_range(
+        self,
+        async_client: AsyncClient,
+        unavailable_channel: Dict[str, Any],
+    ) -> None:
+        """Test recovery with both start_year and end_year parameters."""
+        channel_id = unavailable_channel["channel_id"]
+
+        mock_result = ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=True,
+            snapshot_used="20190101120000",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover?start_year=2018&end_year=2020"
+                )
+
+                assert response.status_code == 200
+
+                # Verify that recover_channel was called with both parameters
+                mock_recover.assert_called_once()
+                call_kwargs = mock_recover.call_args.kwargs
+                assert call_kwargs["from_year"] == 2018
+                assert call_kwargs["to_year"] == 2020

--- a/tests/integration/api/test_recovery_fields.py
+++ b/tests/integration/api/test_recovery_fields.py
@@ -1,0 +1,440 @@
+"""Integration tests for recovered_at and recovery_source fields in API responses.
+
+This module tests that the recovery metadata fields (recovered_at, recovery_source)
+appear correctly in video and channel detail API responses.
+
+Tests cover:
+- Video detail endpoint - fields are null when not recovered
+- Video detail endpoint - fields populated when recovered
+- Channel detail endpoint - fields are null when not recovered
+- Channel detail endpoint - fields populated when recovered
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import Video as VideoDB
+
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+async def video_not_recovered(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a video with recovered_at=NULL and recovery_source=NULL.
+
+    Returns video data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        # First create a channel for FK constraint
+        channel = ChannelDB(
+            channel_id="UCrec123456789012345678",
+            title="Recovery Test Channel",
+            description="Channel for recovery field tests",
+            subscriber_count=500,
+            video_count=10,
+            availability_status="available",
+        )
+
+        # Check if channel already exists
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing_channel = result.scalar_one_or_none()
+
+        if not existing_channel:
+            session.add(channel)
+            await session.commit()
+            await session.refresh(channel)
+
+        # Create video without recovery fields (NULL)
+        video = VideoDB(
+            video_id="notrecovr01",  # 11 chars
+            channel_id="UCrec123456789012345678",
+            title="Not Recovered Video",
+            description="A video that was never recovered",
+            upload_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            duration=300,
+            made_for_kids=False,
+            availability_status="available",
+            recovered_at=None,  # Explicitly NULL
+            recovery_source=None,  # Explicitly NULL
+        )
+
+        # Check if video already exists
+        result = await session.execute(
+            select(VideoDB).where(VideoDB.video_id == video.video_id)
+        )
+        existing_video = result.scalar_one_or_none()
+
+        if existing_video:
+            # Update to ensure NULL values
+            existing_video.recovered_at = None
+            existing_video.recovery_source = None
+            await session.commit()
+            return {
+                "video_id": existing_video.video_id,
+                "title": existing_video.title,
+                "recovered_at": existing_video.recovered_at,
+                "recovery_source": existing_video.recovery_source,
+            }
+
+        session.add(video)
+        await session.commit()
+        await session.refresh(video)
+
+        return {
+            "video_id": video.video_id,
+            "title": video.title,
+            "recovered_at": video.recovered_at,
+            "recovery_source": video.recovery_source,
+        }
+
+
+@pytest.fixture
+async def video_recovered(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a video with recovered_at and recovery_source populated.
+
+    Returns video data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        # First create a channel for FK constraint
+        channel = ChannelDB(
+            channel_id="UCrec123456789012345678",
+            title="Recovery Test Channel",
+            description="Channel for recovery field tests",
+            subscriber_count=500,
+            video_count=10,
+            availability_status="available",
+        )
+
+        # Check if channel already exists
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing_channel = result.scalar_one_or_none()
+
+        if not existing_channel:
+            session.add(channel)
+            await session.commit()
+            await session.refresh(channel)
+
+        # Create video with recovery fields populated
+        recovery_timestamp = datetime(2024, 2, 10, 14, 30, 0, tzinfo=timezone.utc)
+        video = VideoDB(
+            video_id="yesrecovr01",  # 11 chars
+            channel_id="UCrec123456789012345678",
+            title="Recovered Video",
+            description="A video that was recovered from Wayback Machine",
+            upload_date=datetime(2023, 5, 20, tzinfo=timezone.utc),
+            duration=420,
+            made_for_kids=False,
+            availability_status="deleted",
+            recovered_at=recovery_timestamp,
+            recovery_source="wayback_machine",
+        )
+
+        # Check if video already exists
+        result = await session.execute(
+            select(VideoDB).where(VideoDB.video_id == video.video_id)
+        )
+        existing_video = result.scalar_one_or_none()
+
+        if existing_video:
+            # Update with recovery values
+            existing_video.recovered_at = recovery_timestamp
+            existing_video.recovery_source = "wayback_machine"
+            await session.commit()
+            return {
+                "video_id": existing_video.video_id,
+                "title": existing_video.title,
+                "recovered_at": existing_video.recovered_at,
+                "recovery_source": existing_video.recovery_source,
+            }
+
+        session.add(video)
+        await session.commit()
+        await session.refresh(video)
+
+        return {
+            "video_id": video.video_id,
+            "title": video.title,
+            "recovered_at": video.recovered_at,
+            "recovery_source": video.recovery_source,
+        }
+
+
+@pytest.fixture
+async def channel_not_recovered(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a channel with recovered_at=NULL and recovery_source=NULL.
+
+    Returns channel data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        channel = ChannelDB(
+            channel_id="UCnotrec1234567890123456",
+            title="Not Recovered Channel",
+            description="A channel that was never recovered",
+            subscriber_count=1000,
+            video_count=50,
+            availability_status="available",
+            recovered_at=None,  # Explicitly NULL
+            recovery_source=None,  # Explicitly NULL
+        )
+
+        # Check if channel already exists
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            # Update to ensure NULL values
+            existing.recovered_at = None
+            existing.recovery_source = None
+            await session.commit()
+            return {
+                "channel_id": existing.channel_id,
+                "title": existing.title,
+                "recovered_at": existing.recovered_at,
+                "recovery_source": existing.recovery_source,
+            }
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {
+            "channel_id": channel.channel_id,
+            "title": channel.title,
+            "recovered_at": channel.recovered_at,
+            "recovery_source": channel.recovery_source,
+        }
+
+
+@pytest.fixture
+async def channel_recovered(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a channel with recovered_at and recovery_source populated.
+
+    Returns channel data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        recovery_timestamp = datetime(2024, 3, 5, 10, 15, 0, tzinfo=timezone.utc)
+        channel = ChannelDB(
+            channel_id="UCyesrec1234567890123456",
+            title="Recovered Channel",
+            description="A channel that was recovered from Wayback Machine",
+            subscriber_count=5000,
+            video_count=100,
+            availability_status="terminated",
+            recovered_at=recovery_timestamp,
+            recovery_source="wayback_machine",
+        )
+
+        # Check if channel already exists
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            # Update with recovery values
+            existing.recovered_at = recovery_timestamp
+            existing.recovery_source = "wayback_machine"
+            await session.commit()
+            return {
+                "channel_id": existing.channel_id,
+                "title": existing.title,
+                "recovered_at": existing.recovered_at,
+                "recovery_source": existing.recovery_source,
+            }
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {
+            "channel_id": channel.channel_id,
+            "title": channel.title,
+            "recovered_at": channel.recovered_at,
+            "recovery_source": channel.recovery_source,
+        }
+
+
+# =============================================================================
+# Video Detail Recovery Fields Tests
+# =============================================================================
+
+
+class TestVideoRecoveryFields:
+    """Tests for recovered_at and recovery_source in video detail endpoint."""
+
+    async def test_video_detail_fields_null_when_not_recovered(
+        self,
+        async_client: AsyncClient,
+        video_not_recovered: Dict[str, Any],
+    ) -> None:
+        """Test that recovered_at and recovery_source are null for non-recovered video."""
+        video_id = video_not_recovered["video_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.get(f"/api/v1/videos/{video_id}")
+
+            assert response.status_code == 200
+            data = response.json()
+
+            # Check response structure
+            assert "data" in data
+            video_data = data["data"]
+
+            # Verify recovery fields exist and are null
+            assert "recovered_at" in video_data
+            assert "recovery_source" in video_data
+            assert video_data["recovered_at"] is None
+            assert video_data["recovery_source"] is None
+
+            # Verify other fields are present
+            assert video_data["video_id"] == video_id
+            assert video_data["title"] == video_not_recovered["title"]
+
+    async def test_video_detail_fields_populated_when_recovered(
+        self,
+        async_client: AsyncClient,
+        video_recovered: Dict[str, Any],
+    ) -> None:
+        """Test that recovered_at and recovery_source are populated for recovered video."""
+        video_id = video_recovered["video_id"]
+        expected_timestamp = video_recovered["recovered_at"]
+        expected_source = video_recovered["recovery_source"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.get(f"/api/v1/videos/{video_id}")
+
+            assert response.status_code == 200
+            data = response.json()
+
+            # Check response structure
+            assert "data" in data
+            video_data = data["data"]
+
+            # Verify recovery fields exist and have correct values
+            assert "recovered_at" in video_data
+            assert "recovery_source" in video_data
+            assert video_data["recovered_at"] is not None
+            assert video_data["recovery_source"] == expected_source
+
+            # Parse the timestamp and compare
+            recovered_timestamp = datetime.fromisoformat(
+                video_data["recovered_at"].replace("Z", "+00:00")
+            )
+            assert recovered_timestamp == expected_timestamp
+
+            # Verify other fields are present
+            assert video_data["video_id"] == video_id
+            assert video_data["title"] == video_recovered["title"]
+
+
+# =============================================================================
+# Channel Detail Recovery Fields Tests
+# =============================================================================
+
+
+class TestChannelRecoveryFields:
+    """Tests for recovered_at and recovery_source in channel detail endpoint."""
+
+    async def test_channel_detail_fields_null_when_not_recovered(
+        self,
+        async_client: AsyncClient,
+        channel_not_recovered: Dict[str, Any],
+    ) -> None:
+        """Test that recovered_at and recovery_source are null for non-recovered channel."""
+        channel_id = channel_not_recovered["channel_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.get(f"/api/v1/channels/{channel_id}")
+
+            assert response.status_code == 200
+            data = response.json()
+
+            # Check response structure
+            assert "data" in data
+            channel_data = data["data"]
+
+            # Verify recovery fields exist and are null
+            assert "recovered_at" in channel_data
+            assert "recovery_source" in channel_data
+            assert channel_data["recovered_at"] is None
+            assert channel_data["recovery_source"] is None
+
+            # Verify other fields are present
+            assert channel_data["channel_id"] == channel_id
+            assert channel_data["title"] == channel_not_recovered["title"]
+
+    async def test_channel_detail_fields_populated_when_recovered(
+        self,
+        async_client: AsyncClient,
+        channel_recovered: Dict[str, Any],
+    ) -> None:
+        """Test that recovered_at and recovery_source are populated for recovered channel."""
+        channel_id = channel_recovered["channel_id"]
+        expected_timestamp = channel_recovered["recovered_at"]
+        expected_source = channel_recovered["recovery_source"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.get(f"/api/v1/channels/{channel_id}")
+
+            assert response.status_code == 200
+            data = response.json()
+
+            # Check response structure
+            assert "data" in data
+            channel_data = data["data"]
+
+            # Verify recovery fields exist and have correct values
+            assert "recovered_at" in channel_data
+            assert "recovery_source" in channel_data
+            assert channel_data["recovered_at"] is not None
+            assert channel_data["recovery_source"] == expected_source
+
+            # Parse the timestamp and compare
+            recovered_timestamp = datetime.fromisoformat(
+                channel_data["recovered_at"].replace("Z", "+00:00")
+            )
+            assert recovered_timestamp == expected_timestamp
+
+            # Verify other fields are present
+            assert channel_data["channel_id"] == channel_id
+            assert channel_data["title"] == channel_recovered["title"]

--- a/tests/integration/api/test_recovery_idempotency.py
+++ b/tests/integration/api/test_recovery_idempotency.py
@@ -1,0 +1,815 @@
+"""Integration tests for T033 — Recovery Idempotency Guard.
+
+This module tests the idempotency guard added to both video and channel
+recovery endpoints. When an entity was recovered within the last 5 minutes,
+the endpoint should return a 200 with success=True and empty fields_recovered
+instead of calling the Wayback Machine orchestrator again.
+
+Tests cover:
+- Entity recovered < 5 min ago -> returns 200 with empty fields_recovered
+- Entity recovered > 5 min ago -> proceeds normally to orchestrator
+- Entity never recovered (recovered_at is None) -> proceeds normally
+- Edge case: recovered_at exactly 5 min ago -> proceeds normally
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import Video as VideoDB
+from chronovista.models.enums import AvailabilityStatus
+from chronovista.services.recovery.models import ChannelRecoveryResult, RecoveryResult
+
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# Video Recovery Idempotency Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+async def idempotency_channel(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a test channel for FK constraints in idempotency tests.
+
+    Returns channel data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        channel = ChannelDB(
+            channel_id="UCidempotency_test012345",
+            title="Idempotency Test Channel",
+            description="Channel for idempotency guard tests",
+            subscriber_count=1000,
+            video_count=50,
+            availability_status=AvailabilityStatus.AVAILABLE.value,
+        )
+
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if not existing:
+            session.add(channel)
+            await session.commit()
+            await session.refresh(channel)
+        else:
+            channel = existing
+
+        return {
+            "channel_id": channel.channel_id,
+            "title": channel.title,
+        }
+
+
+@pytest.fixture
+async def recently_recovered_video(
+    integration_session_factory,
+    idempotency_channel: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Create a deleted video that was recovered 2 minutes ago.
+
+    This should trigger the idempotency guard (< 5 min).
+    """
+    async with integration_session_factory() as session:
+        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=2)
+
+        video = VideoDB(
+            video_id="recvid00001",  # 11 chars
+            channel_id=idempotency_channel["channel_id"],
+            title="Recently Recovered Video",
+            description="Recovered 2 minutes ago",
+            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            duration=300,
+            made_for_kids=False,
+            availability_status=AvailabilityStatus.DELETED.value,
+            recovered_at=recovered_time,
+            recovery_source="wayback:20220106075526",
+        )
+
+        result = await session.execute(
+            select(VideoDB).where(VideoDB.video_id == video.video_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.availability_status = AvailabilityStatus.DELETED.value
+            existing.recovered_at = recovered_time
+            existing.recovery_source = "wayback:20220106075526"
+            await session.commit()
+            return {
+                "video_id": existing.video_id,
+                "recovered_at": recovered_time,
+            }
+
+        session.add(video)
+        await session.commit()
+        await session.refresh(video)
+
+        return {
+            "video_id": video.video_id,
+            "recovered_at": recovered_time,
+        }
+
+
+@pytest.fixture
+async def stale_recovered_video(
+    integration_session_factory,
+    idempotency_channel: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Create a deleted video that was recovered 10 minutes ago.
+
+    This should NOT trigger the idempotency guard (> 5 min).
+    """
+    async with integration_session_factory() as session:
+        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+        video = VideoDB(
+            video_id="oldvid00001",  # 11 chars
+            channel_id=idempotency_channel["channel_id"],
+            title="Stale Recovered Video",
+            description="Recovered 10 minutes ago",
+            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            duration=300,
+            made_for_kids=False,
+            availability_status=AvailabilityStatus.DELETED.value,
+            recovered_at=recovered_time,
+            recovery_source="wayback:20220106075526",
+        )
+
+        result = await session.execute(
+            select(VideoDB).where(VideoDB.video_id == video.video_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.availability_status = AvailabilityStatus.DELETED.value
+            existing.recovered_at = recovered_time
+            existing.recovery_source = "wayback:20220106075526"
+            await session.commit()
+            return {
+                "video_id": existing.video_id,
+                "recovered_at": recovered_time,
+            }
+
+        session.add(video)
+        await session.commit()
+        await session.refresh(video)
+
+        return {
+            "video_id": video.video_id,
+            "recovered_at": recovered_time,
+        }
+
+
+@pytest.fixture
+async def never_recovered_video(
+    integration_session_factory,
+    idempotency_channel: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Create a deleted video that has never been recovered (recovered_at is None).
+
+    This should NOT trigger the idempotency guard.
+    """
+    async with integration_session_factory() as session:
+        video = VideoDB(
+            video_id="nevvid00001",  # 11 chars
+            channel_id=idempotency_channel["channel_id"],
+            title="Never Recovered Video",
+            description="Has never been recovered",
+            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            duration=300,
+            made_for_kids=False,
+            availability_status=AvailabilityStatus.DELETED.value,
+            recovered_at=None,
+            recovery_source=None,
+        )
+
+        result = await session.execute(
+            select(VideoDB).where(VideoDB.video_id == video.video_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.availability_status = AvailabilityStatus.DELETED.value
+            existing.recovered_at = None
+            existing.recovery_source = None
+            await session.commit()
+            return {"video_id": existing.video_id}
+
+        session.add(video)
+        await session.commit()
+        await session.refresh(video)
+
+        return {"video_id": video.video_id}
+
+
+@pytest.fixture
+async def edge_case_video(
+    integration_session_factory,
+    idempotency_channel: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Create a deleted video recovered exactly 5 minutes ago.
+
+    At exactly 5 minutes, timedelta(minutes=5) is NOT less than
+    timedelta(minutes=5), so the guard should NOT trigger.
+    """
+    async with integration_session_factory() as session:
+        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+
+        video = VideoDB(
+            video_id="edgvid00001",  # 11 chars
+            channel_id=idempotency_channel["channel_id"],
+            title="Edge Case Video",
+            description="Recovered exactly 5 minutes ago",
+            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            duration=300,
+            made_for_kids=False,
+            availability_status=AvailabilityStatus.DELETED.value,
+            recovered_at=recovered_time,
+            recovery_source="wayback:20220106075526",
+        )
+
+        result = await session.execute(
+            select(VideoDB).where(VideoDB.video_id == video.video_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.availability_status = AvailabilityStatus.DELETED.value
+            existing.recovered_at = recovered_time
+            existing.recovery_source = "wayback:20220106075526"
+            await session.commit()
+            return {
+                "video_id": existing.video_id,
+                "recovered_at": recovered_time,
+            }
+
+        session.add(video)
+        await session.commit()
+        await session.refresh(video)
+
+        return {
+            "video_id": video.video_id,
+            "recovered_at": recovered_time,
+        }
+
+
+# =============================================================================
+# Channel Recovery Idempotency Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+async def recently_recovered_channel(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a deleted channel that was recovered 2 minutes ago.
+
+    This should trigger the idempotency guard (< 5 min).
+    """
+    async with integration_session_factory() as session:
+        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=2)
+
+        channel = ChannelDB(
+            channel_id="UCrecent_recovery_test01",
+            title="Recently Recovered Channel",
+            description="Recovered 2 minutes ago",
+            subscriber_count=500,
+            video_count=20,
+            availability_status=AvailabilityStatus.DELETED.value,
+            recovered_at=recovered_time,
+            recovery_source="wayback:20220106075526",
+        )
+
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.availability_status = AvailabilityStatus.DELETED.value
+            existing.recovered_at = recovered_time
+            existing.recovery_source = "wayback:20220106075526"
+            await session.commit()
+            return {
+                "channel_id": existing.channel_id,
+                "recovered_at": recovered_time,
+            }
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {
+            "channel_id": channel.channel_id,
+            "recovered_at": recovered_time,
+        }
+
+
+@pytest.fixture
+async def stale_recovered_channel(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a deleted channel that was recovered 10 minutes ago.
+
+    This should NOT trigger the idempotency guard (> 5 min).
+    """
+    async with integration_session_factory() as session:
+        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+        channel = ChannelDB(
+            channel_id="UCstale_recovery_test001",
+            title="Stale Recovered Channel",
+            description="Recovered 10 minutes ago",
+            subscriber_count=500,
+            video_count=20,
+            availability_status=AvailabilityStatus.DELETED.value,
+            recovered_at=recovered_time,
+            recovery_source="wayback:20220106075526",
+        )
+
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.availability_status = AvailabilityStatus.DELETED.value
+            existing.recovered_at = recovered_time
+            existing.recovery_source = "wayback:20220106075526"
+            await session.commit()
+            return {
+                "channel_id": existing.channel_id,
+                "recovered_at": recovered_time,
+            }
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {
+            "channel_id": channel.channel_id,
+            "recovered_at": recovered_time,
+        }
+
+
+@pytest.fixture
+async def never_recovered_channel(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a deleted channel that has never been recovered.
+
+    This should NOT trigger the idempotency guard.
+    """
+    async with integration_session_factory() as session:
+        channel = ChannelDB(
+            channel_id="UCnever_recovery_test001",
+            title="Never Recovered Channel",
+            description="Has never been recovered",
+            subscriber_count=500,
+            video_count=20,
+            availability_status=AvailabilityStatus.DELETED.value,
+            recovered_at=None,
+            recovery_source=None,
+        )
+
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.availability_status = AvailabilityStatus.DELETED.value
+            existing.recovered_at = None
+            existing.recovery_source = None
+            await session.commit()
+            return {"channel_id": existing.channel_id}
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {"channel_id": channel.channel_id}
+
+
+@pytest.fixture
+async def edge_case_channel(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a deleted channel recovered exactly 5 minutes ago.
+
+    At exactly 5 minutes, the guard should NOT trigger.
+    """
+    async with integration_session_factory() as session:
+        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+
+        channel = ChannelDB(
+            channel_id="UCedge_recovery_test0001",
+            title="Edge Case Channel",
+            description="Recovered exactly 5 minutes ago",
+            subscriber_count=500,
+            video_count=20,
+            availability_status=AvailabilityStatus.DELETED.value,
+            recovered_at=recovered_time,
+            recovery_source="wayback:20220106075526",
+        )
+
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.availability_status = AvailabilityStatus.DELETED.value
+            existing.recovered_at = recovered_time
+            existing.recovery_source = "wayback:20220106075526"
+            await session.commit()
+            return {
+                "channel_id": existing.channel_id,
+                "recovered_at": recovered_time,
+            }
+
+        session.add(channel)
+        await session.commit()
+        await session.refresh(channel)
+
+        return {
+            "channel_id": channel.channel_id,
+            "recovered_at": recovered_time,
+        }
+
+
+# =============================================================================
+# Video Recovery Idempotency Tests
+# =============================================================================
+
+
+class TestVideoRecoveryIdempotency:
+    """Tests for video recovery idempotency guard (T033)."""
+
+    async def test_recently_recovered_video_returns_cached(
+        self,
+        async_client: AsyncClient,
+        recently_recovered_video: Dict[str, Any],
+    ) -> None:
+        """
+        Video recovered < 5 min ago should return 200 with empty fields_recovered.
+
+        The orchestrator should NOT be called, protecting the Wayback Machine
+        rate budget.
+        """
+        video_id = recently_recovered_video["video_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/videos/{video_id}/recover"
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+
+                # Verify response structure
+                assert "data" in data
+                result_data = data["data"]
+
+                # Verify idempotency guard response
+                assert result_data["video_id"] == video_id
+                assert result_data["success"] is True
+                assert result_data["fields_recovered"] == []
+                assert result_data["failure_reason"] is None
+                assert result_data["duration_seconds"] == 0.0
+
+                # Orchestrator should NOT have been called
+                mock_recover.assert_not_called()
+
+    async def test_stale_recovered_video_proceeds_to_orchestrator(
+        self,
+        async_client: AsyncClient,
+        stale_recovered_video: Dict[str, Any],
+    ) -> None:
+        """
+        Video recovered > 5 min ago should proceed normally to orchestrator.
+
+        The idempotency guard should not block the request.
+        """
+        video_id = stale_recovered_video["video_id"]
+
+        mock_result = RecoveryResult(
+            video_id=video_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title", "description"],
+            snapshots_available=10,
+            snapshots_tried=2,
+            duration_seconds=1.5,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/videos/{video_id}/recover"
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+
+                result_data = data["data"]
+                assert result_data["fields_recovered"] == ["title", "description"]
+                assert result_data["snapshot_used"] == "20220106075526"
+
+                # Orchestrator SHOULD have been called
+                mock_recover.assert_called_once()
+
+    async def test_never_recovered_video_proceeds_to_orchestrator(
+        self,
+        async_client: AsyncClient,
+        never_recovered_video: Dict[str, Any],
+    ) -> None:
+        """
+        Video with recovered_at=None should proceed normally to orchestrator.
+
+        The idempotency guard should not block the request.
+        """
+        video_id = never_recovered_video["video_id"]
+
+        mock_result = RecoveryResult(
+            video_id=video_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/videos/{video_id}/recover"
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+
+                result_data = data["data"]
+                assert result_data["fields_recovered"] == ["title"]
+
+                # Orchestrator SHOULD have been called
+                mock_recover.assert_called_once()
+
+    async def test_edge_case_exactly_5_min_proceeds(
+        self,
+        async_client: AsyncClient,
+        edge_case_video: Dict[str, Any],
+    ) -> None:
+        """
+        Video recovered exactly 5 min ago should proceed to orchestrator.
+
+        The guard uses strict less-than: elapsed < 5 min. At exactly 5 min
+        (or slightly over due to test execution time), the guard should
+        NOT trigger.
+        """
+        video_id = edge_case_video["video_id"]
+
+        mock_result = RecoveryResult(
+            video_id=video_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/videos/{video_id}/recover"
+                )
+
+                assert response.status_code == 200
+
+                # Orchestrator SHOULD have been called (exactly 5 min is not < 5 min)
+                mock_recover.assert_called_once()
+
+
+# =============================================================================
+# Channel Recovery Idempotency Tests
+# =============================================================================
+
+
+class TestChannelRecoveryIdempotency:
+    """Tests for channel recovery idempotency guard (T033)."""
+
+    async def test_recently_recovered_channel_returns_cached(
+        self,
+        async_client: AsyncClient,
+        recently_recovered_channel: Dict[str, Any],
+    ) -> None:
+        """
+        Channel recovered < 5 min ago should return 200 with empty fields_recovered.
+
+        The orchestrator should NOT be called, protecting the Wayback Machine
+        rate budget.
+        """
+        channel_id = recently_recovered_channel["channel_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover"
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+
+                # Verify response structure
+                assert "data" in data
+                result_data = data["data"]
+
+                # Verify idempotency guard response
+                assert result_data["channel_id"] == channel_id
+                assert result_data["success"] is True
+                assert result_data["fields_recovered"] == []
+                assert result_data["failure_reason"] is None
+                assert result_data["duration_seconds"] == 0.0
+
+                # Orchestrator should NOT have been called
+                mock_recover.assert_not_called()
+
+    async def test_stale_recovered_channel_proceeds_to_orchestrator(
+        self,
+        async_client: AsyncClient,
+        stale_recovered_channel: Dict[str, Any],
+    ) -> None:
+        """
+        Channel recovered > 5 min ago should proceed normally to orchestrator.
+
+        The idempotency guard should not block the request.
+        """
+        channel_id = stale_recovered_channel["channel_id"]
+
+        mock_result = ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title", "description"],
+            snapshots_available=10,
+            snapshots_tried=2,
+            duration_seconds=1.5,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover"
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+
+                result_data = data["data"]
+                assert result_data["fields_recovered"] == ["title", "description"]
+                assert result_data["snapshot_used"] == "20220106075526"
+
+                # Orchestrator SHOULD have been called
+                mock_recover.assert_called_once()
+
+    async def test_never_recovered_channel_proceeds_to_orchestrator(
+        self,
+        async_client: AsyncClient,
+        never_recovered_channel: Dict[str, Any],
+    ) -> None:
+        """
+        Channel with recovered_at=None should proceed normally to orchestrator.
+
+        The idempotency guard should not block the request.
+        """
+        channel_id = never_recovered_channel["channel_id"]
+
+        mock_result = ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover"
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+
+                result_data = data["data"]
+                assert result_data["fields_recovered"] == ["title"]
+
+                # Orchestrator SHOULD have been called
+                mock_recover.assert_called_once()
+
+    async def test_edge_case_exactly_5_min_proceeds(
+        self,
+        async_client: AsyncClient,
+        edge_case_channel: Dict[str, Any],
+    ) -> None:
+        """
+        Channel recovered exactly 5 min ago should proceed to orchestrator.
+
+        The guard uses strict less-than: elapsed < 5 min. At exactly 5 min
+        (or slightly over due to test execution time), the guard should
+        NOT trigger.
+        """
+        channel_id = edge_case_channel["channel_id"]
+
+        mock_result = ChannelRecoveryResult(
+            channel_id=channel_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_channel",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/channels/{channel_id}/recover"
+                )
+
+                assert response.status_code == 200
+
+                # Orchestrator SHOULD have been called (exactly 5 min is not < 5 min)
+                mock_recover.assert_called_once()

--- a/tests/integration/api/test_video_recovery.py
+++ b/tests/integration/api/test_video_recovery.py
@@ -1,0 +1,538 @@
+"""Integration tests for POST /api/v1/videos/{video_id}/recover endpoint.
+
+This module tests the video recovery endpoint that uses the Wayback Machine
+to recover metadata for unavailable YouTube videos.
+
+Tests cover:
+- Success case with recovered metadata
+- 404 error when video doesn't exist
+- 409 conflict when video is available
+- 422 validation errors for invalid year ranges
+- 503 error when CDX API is unavailable
+- Zero-new-fields success case
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import Video as VideoDB
+from chronovista.exceptions import CDXError
+from chronovista.models.enums import AvailabilityStatus
+from chronovista.services.recovery.models import RecoveryResult
+
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+async def test_channel(
+    integration_session_factory,
+) -> Dict[str, Any]:
+    """
+    Create a test channel for FK constraints.
+
+    Returns channel data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        channel = ChannelDB(
+            channel_id="UCrecovery12345678901234",
+            title="Recovery Test Channel",
+            description="Channel for recovery endpoint tests",
+            subscriber_count=1000,
+            video_count=50,
+            availability_status=AvailabilityStatus.AVAILABLE.value,
+        )
+
+        # Check if channel already exists
+        result = await session.execute(
+            select(ChannelDB).where(ChannelDB.channel_id == channel.channel_id)
+        )
+        existing_channel = result.scalar_one_or_none()
+
+        if not existing_channel:
+            session.add(channel)
+            await session.commit()
+            await session.refresh(channel)
+        else:
+            channel = existing_channel
+
+        return {
+            "channel_id": channel.channel_id,
+            "title": channel.title,
+        }
+
+
+@pytest.fixture
+async def deleted_video(
+    integration_session_factory,
+    test_channel: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Create a video with availability_status = 'deleted'.
+
+    Returns video data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        video = VideoDB(
+            video_id="delvid12345",  # 11 chars
+            channel_id=test_channel["channel_id"],
+            title="Deleted Video for Recovery",
+            description="A deleted video that needs recovery",
+            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            duration=420,
+            made_for_kids=False,
+            availability_status=AvailabilityStatus.DELETED.value,
+        )
+
+        # Check if video already exists
+        result = await session.execute(
+            select(VideoDB).where(VideoDB.video_id == video.video_id)
+        )
+        existing_video = result.scalar_one_or_none()
+
+        if existing_video:
+            # Update to ensure deleted status
+            existing_video.availability_status = AvailabilityStatus.DELETED.value
+            existing_video.recovered_at = None
+            existing_video.recovery_source = None
+            await session.commit()
+            return {
+                "video_id": existing_video.video_id,
+                "title": existing_video.title,
+                "availability_status": existing_video.availability_status,
+            }
+
+        session.add(video)
+        await session.commit()
+        await session.refresh(video)
+
+        return {
+            "video_id": video.video_id,
+            "title": video.title,
+            "availability_status": video.availability_status,
+        }
+
+
+@pytest.fixture
+async def available_video(
+    integration_session_factory,
+    test_channel: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Create a video with availability_status = 'available'.
+
+    Returns video data dict for use in tests.
+    """
+    async with integration_session_factory() as session:
+        video = VideoDB(
+            video_id="avlvid12345",  # 11 chars
+            channel_id=test_channel["channel_id"],
+            title="Available Video",
+            description="An available video that should not be recovered",
+            upload_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            duration=300,
+            made_for_kids=False,
+            availability_status=AvailabilityStatus.AVAILABLE.value,
+        )
+
+        # Check if video already exists
+        result = await session.execute(
+            select(VideoDB).where(VideoDB.video_id == video.video_id)
+        )
+        existing_video = result.scalar_one_or_none()
+
+        if existing_video:
+            # Update to ensure available status
+            existing_video.availability_status = AvailabilityStatus.AVAILABLE.value
+            await session.commit()
+            return {
+                "video_id": existing_video.video_id,
+                "title": existing_video.title,
+                "availability_status": existing_video.availability_status,
+            }
+
+        session.add(video)
+        await session.commit()
+        await session.refresh(video)
+
+        return {
+            "video_id": video.video_id,
+            "title": video.title,
+            "availability_status": video.availability_status,
+        }
+
+
+# =============================================================================
+# Success Tests
+# =============================================================================
+
+
+class TestVideoRecoverySuccess:
+    """Tests for successful video recovery."""
+
+    async def test_recover_video_success_with_metadata(
+        self,
+        async_client: AsyncClient,
+        deleted_video: Dict[str, Any],
+    ) -> None:
+        """Test successful video recovery with populated RecoveryResult."""
+        video_id = deleted_video["video_id"]
+
+        # Mock the recover_video orchestrator to return success
+        mock_result = RecoveryResult(
+            video_id=video_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title", "description", "view_count", "like_count"],
+            fields_skipped=["channel_id"],
+            snapshots_available=15,
+            snapshots_tried=3,
+            duration_seconds=2.45,
+            channel_recovery_candidates=["UCrecovery12345678901234"],
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ):
+                response = await async_client.post(f"/api/v1/videos/{video_id}/recover")
+
+                assert response.status_code == 200
+                data = response.json()
+
+                # Verify response structure
+                assert "data" in data
+                result_data = data["data"]
+
+                # Verify success fields
+                assert result_data["video_id"] == video_id
+                assert result_data["success"] is True
+                assert result_data["snapshot_used"] == "20220106075526"
+                assert result_data["fields_recovered"] == [
+                    "title",
+                    "description",
+                    "view_count",
+                    "like_count",
+                ]
+                assert result_data["fields_skipped"] == ["channel_id"]
+                assert result_data["snapshots_available"] == 15
+                assert result_data["snapshots_tried"] == 3
+                assert result_data["failure_reason"] is None
+                assert result_data["duration_seconds"] == 2.45
+                assert result_data["channel_recovery_candidates"] == [
+                    "UCrecovery12345678901234"
+                ]
+
+    async def test_recover_video_zero_new_fields(
+        self,
+        async_client: AsyncClient,
+        deleted_video: Dict[str, Any],
+    ) -> None:
+        """Test successful recovery with empty fields_recovered list."""
+        video_id = deleted_video["video_id"]
+
+        # Mock the recover_video orchestrator to return success with no new fields
+        mock_result = RecoveryResult(
+            video_id=video_id,
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=[],  # No new fields recovered
+            fields_skipped=["title", "description", "channel_id"],
+            snapshots_available=10,
+            snapshots_tried=1,
+            duration_seconds=1.2,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ):
+                response = await async_client.post(f"/api/v1/videos/{video_id}/recover")
+
+                assert response.status_code == 200
+                data = response.json()
+
+                # Verify response structure
+                assert "data" in data
+                result_data = data["data"]
+
+                # Verify zero-new-fields scenario
+                assert result_data["success"] is True
+                assert result_data["fields_recovered"] == []
+                assert len(result_data["fields_skipped"]) > 0
+                assert result_data["snapshot_used"] == "20220106075526"
+
+
+# =============================================================================
+# Error Tests
+# =============================================================================
+
+
+class TestVideoRecoveryErrors:
+    """Tests for video recovery error cases."""
+
+    async def test_recover_nonexistent_video_404(
+        self,
+        async_client: AsyncClient,
+    ) -> None:
+        """Test 404 error when video doesn't exist in database."""
+        video_id = "nonexistent"
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.post(f"/api/v1/videos/{video_id}/recover")
+
+            assert response.status_code == 404
+            data = response.json()
+
+            # Verify error structure (RFC 7807)
+            assert "detail" in data
+            assert "Video" in data["detail"]
+            assert video_id in data["detail"]
+
+    async def test_recover_available_video_409(
+        self,
+        async_client: AsyncClient,
+        available_video: Dict[str, Any],
+    ) -> None:
+        """Test 409 conflict when video is available."""
+        video_id = available_video["video_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.post(f"/api/v1/videos/{video_id}/recover")
+
+            assert response.status_code == 409
+            data = response.json()
+
+            # Verify conflict error
+            assert "detail" in data
+            assert "available" in data["detail"].lower()
+
+    async def test_recover_invalid_year_range_422(
+        self,
+        async_client: AsyncClient,
+        deleted_video: Dict[str, Any],
+    ) -> None:
+        """Test 422 validation error when end_year < start_year."""
+        video_id = deleted_video["video_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            response = await async_client.post(
+                f"/api/v1/videos/{video_id}/recover?start_year=2020&end_year=2015"
+            )
+
+            assert response.status_code == 400  # BadRequestError maps to 400
+            data = response.json()
+
+            # Verify validation error
+            assert "detail" in data
+            assert "year" in data["detail"].lower()
+            assert "2020" in data["detail"]
+            assert "2015" in data["detail"]
+
+    async def test_recover_year_out_of_range_422(
+        self,
+        async_client: AsyncClient,
+        deleted_video: Dict[str, Any],
+    ) -> None:
+        """Test 422 validation error when year is out of range."""
+        video_id = deleted_video["video_id"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            # Year too early (before 2005)
+            response = await async_client.post(
+                f"/api/v1/videos/{video_id}/recover?start_year=1990"
+            )
+
+            # FastAPI's Query validation will return 422
+            assert response.status_code == 422
+            data = response.json()
+
+            # Verify validation error structure
+            assert "detail" in data
+
+    async def test_recover_cdx_error_503(
+        self,
+        async_client: AsyncClient,
+        deleted_video: Dict[str, Any],
+    ) -> None:
+        """Test 503 error when CDX API is unavailable."""
+        video_id = deleted_video["video_id"]
+
+        # Mock the recover_video orchestrator to raise CDXError
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+                side_effect=CDXError(
+                    message="CDX API connection timeout",
+                    video_id=video_id,
+                    status_code=503,
+                ),
+            ):
+                response = await async_client.post(f"/api/v1/videos/{video_id}/recover")
+
+                assert response.status_code == 503
+                data = response.json()
+
+                # Verify 503 error structure
+                assert "detail" in data
+                assert "Wayback Machine" in data["detail"]
+                assert "CDX API" in data["detail"]
+
+                # Verify Retry-After header
+                assert "Retry-After" in response.headers
+                assert response.headers["Retry-After"] == "60"
+
+
+# =============================================================================
+# Query Parameter Tests
+# =============================================================================
+
+
+class TestVideoRecoveryQueryParameters:
+    """Tests for year filtering query parameters."""
+
+    async def test_recover_with_start_year(
+        self,
+        async_client: AsyncClient,
+        deleted_video: Dict[str, Any],
+    ) -> None:
+        """Test recovery with start_year parameter."""
+        video_id = deleted_video["video_id"]
+
+        mock_result = RecoveryResult(
+            video_id=video_id,
+            success=True,
+            snapshot_used="20180101120000",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/videos/{video_id}/recover?start_year=2018"
+                )
+
+                assert response.status_code == 200
+
+                # Verify that recover_video was called with start_year
+                mock_recover.assert_called_once()
+                call_kwargs = mock_recover.call_args.kwargs
+                assert call_kwargs["from_year"] == 2018
+                assert call_kwargs["to_year"] is None
+
+    async def test_recover_with_end_year(
+        self,
+        async_client: AsyncClient,
+        deleted_video: Dict[str, Any],
+    ) -> None:
+        """Test recovery with end_year parameter."""
+        video_id = deleted_video["video_id"]
+
+        mock_result = RecoveryResult(
+            video_id=video_id,
+            success=True,
+            snapshot_used="20200101120000",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/videos/{video_id}/recover?end_year=2020"
+                )
+
+                assert response.status_code == 200
+
+                # Verify that recover_video was called with end_year
+                mock_recover.assert_called_once()
+                call_kwargs = mock_recover.call_args.kwargs
+                assert call_kwargs["from_year"] is None
+                assert call_kwargs["to_year"] == 2020
+
+    async def test_recover_with_year_range(
+        self,
+        async_client: AsyncClient,
+        deleted_video: Dict[str, Any],
+    ) -> None:
+        """Test recovery with both start_year and end_year parameters."""
+        video_id = deleted_video["video_id"]
+
+        mock_result = RecoveryResult(
+            video_id=video_id,
+            success=True,
+            snapshot_used="20190101120000",
+            fields_recovered=["title"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=1.0,
+        )
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            with patch(
+                "chronovista.services.recovery.orchestrator.recover_video",
+                new_callable=AsyncMock,
+                return_value=mock_result,
+            ) as mock_recover:
+                response = await async_client.post(
+                    f"/api/v1/videos/{video_id}/recover?start_year=2018&end_year=2020"
+                )
+
+                assert response.status_code == 200
+
+                # Verify that recover_video was called with both parameters
+                mock_recover.assert_called_once()
+                call_kwargs = mock_recover.call_args.kwargs
+                assert call_kwargs["from_year"] == 2018
+                assert call_kwargs["to_year"] == 2020

--- a/tests/unit/services/recovery/test_models.py
+++ b/tests/unit/services/recovery/test_models.py
@@ -14,6 +14,8 @@ from pydantic import ValidationError
 from chronovista.services.recovery.models import (
     CdxCacheEntry,
     CdxSnapshot,
+    ChannelRecoveryResult,
+    RecoveredChannelData,
     RecoveredVideoData,
     RecoveryResult,
 )
@@ -336,6 +338,308 @@ class TestRecoveredVideoData:
         assert recovered.channel_id is None
 
 
+class TestRecoveredChannelData:
+    """Tests for RecoveredChannelData Pydantic model (T003)."""
+
+    def test_minimal_valid(self) -> None:
+        """Test creating RecoveredChannelData with only required field."""
+        recovered = RecoveredChannelData(snapshot_timestamp="20220106075526")
+
+        assert recovered.snapshot_timestamp == "20220106075526"
+        assert recovered.title is None
+        assert recovered.description is None
+        assert recovered.subscriber_count is None
+        assert recovered.video_count is None
+        assert recovered.thumbnail_url is None
+        assert recovered.country is None
+        assert recovered.default_language is None
+
+    def test_full_valid(self) -> None:
+        """Test creating RecoveredChannelData with all fields populated."""
+        recovered = RecoveredChannelData(
+            snapshot_timestamp="20220106075526",
+            title="Rick Astley",
+            description="Official Rick Astley YouTube Channel",
+            subscriber_count=3000000,
+            video_count=150,
+            thumbnail_url="https://yt3.ggpht.com/ytc/channel_avatar.jpg",
+            country="US",
+            default_language="en",
+        )
+
+        assert recovered.snapshot_timestamp == "20220106075526"
+        assert recovered.title == "Rick Astley"
+        assert recovered.description == "Official Rick Astley YouTube Channel"
+        assert recovered.subscriber_count == 3000000
+        assert recovered.video_count == 150
+        assert recovered.thumbnail_url == "https://yt3.ggpht.com/ytc/channel_avatar.jpg"
+        assert recovered.country == "US"
+        assert recovered.default_language == "en"
+
+    def test_snapshot_timestamp_14_digits(self) -> None:
+        """Test snapshot_timestamp must be exactly 14 digits."""
+        # Too short
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredChannelData(snapshot_timestamp="202201")
+        assert "snapshot_timestamp" in str(exc_info.value).lower()
+
+        # Too long
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredChannelData(snapshot_timestamp="202201061234567")
+        assert "snapshot_timestamp" in str(exc_info.value).lower()
+
+        # Non-digits
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredChannelData(snapshot_timestamp="abcd1234567890")
+        assert "snapshot_timestamp" in str(exc_info.value).lower()
+
+        # Valid 14 digits
+        recovered = RecoveredChannelData(snapshot_timestamp="20220106075526")
+        assert recovered.snapshot_timestamp == "20220106075526"
+
+    def test_subscriber_count_non_negative(self) -> None:
+        """Test subscriber_count must be non-negative."""
+        # Negative should fail
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredChannelData(
+                snapshot_timestamp="20220106075526",
+                subscriber_count=-1,
+            )
+        assert "subscriber_count" in str(exc_info.value).lower()
+
+        # Zero should pass
+        recovered = RecoveredChannelData(
+            snapshot_timestamp="20220106075526",
+            subscriber_count=0,
+        )
+        assert recovered.subscriber_count == 0
+
+    def test_video_count_non_negative(self) -> None:
+        """Test video_count must be non-negative."""
+        # Negative should fail
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredChannelData(
+                snapshot_timestamp="20220106075526",
+                video_count=-1,
+            )
+        assert "video_count" in str(exc_info.value).lower()
+
+        # Zero should pass
+        recovered = RecoveredChannelData(
+            snapshot_timestamp="20220106075526",
+            video_count=0,
+        )
+        assert recovered.video_count == 0
+
+    def test_country_must_be_2_char_uppercase_iso(self) -> None:
+        """Test country must be 2-character uppercase ISO code if provided."""
+        # Valid: 2-char uppercase
+        recovered_valid = RecoveredChannelData(
+            snapshot_timestamp="20220106075526",
+            country="US",
+        )
+        assert recovered_valid.country == "US"
+
+        # Invalid: lowercase
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredChannelData(
+                snapshot_timestamp="20220106075526",
+                country="us",
+            )
+        assert "country" in str(exc_info.value).lower()
+
+        # Invalid: full country name
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredChannelData(
+                snapshot_timestamp="20220106075526",
+                country="United States",
+            )
+        assert "country" in str(exc_info.value).lower()
+
+        # Invalid: too short
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredChannelData(
+                snapshot_timestamp="20220106075526",
+                country="U",
+            )
+        assert "country" in str(exc_info.value).lower()
+
+        # Invalid: too long
+        with pytest.raises(ValidationError) as exc_info:
+            RecoveredChannelData(
+                snapshot_timestamp="20220106075526",
+                country="USA",
+            )
+        assert "country" in str(exc_info.value).lower()
+
+    def test_recovery_source_property(self) -> None:
+        """Test recovery_source computed property returns wayback:{timestamp}."""
+        recovered = RecoveredChannelData(snapshot_timestamp="20220106075526")
+
+        expected_source = "wayback:20220106075526"
+        assert recovered.recovery_source == expected_source
+
+    def test_recovered_fields_property(self) -> None:
+        """Test recovered_fields returns list of non-None metadata field names."""
+        # Only snapshot_timestamp set (no metadata)
+        recovered_minimal = RecoveredChannelData(snapshot_timestamp="20220106075526")
+        assert recovered_minimal.recovered_fields == []
+
+        # Multiple fields set
+        recovered_multi = RecoveredChannelData(
+            snapshot_timestamp="20220106075526",
+            title="Test Channel",
+            subscriber_count=1000,
+            country="US",
+        )
+        fields = recovered_multi.recovered_fields
+        assert "title" in fields
+        assert "subscriber_count" in fields
+        assert "country" in fields
+        assert len(fields) == 3
+
+        # Check that None fields are not included
+        assert "description" not in fields
+        assert "video_count" not in fields
+        # snapshot_timestamp is infrastructure, not metadata
+        assert "snapshot_timestamp" not in fields
+
+    def test_has_data_property(self) -> None:
+        """Test has_data returns True if metadata fields are set."""
+        # Only snapshot_timestamp (no metadata)
+        recovered_no_data = RecoveredChannelData(snapshot_timestamp="20220106075526")
+        assert recovered_no_data.has_data is False
+
+        # With title (has metadata)
+        recovered_with_title = RecoveredChannelData(
+            snapshot_timestamp="20220106075526",
+            title="Test Channel",
+        )
+        assert recovered_with_title.has_data is True
+
+        # With subscriber_count (has metadata)
+        recovered_with_subs = RecoveredChannelData(
+            snapshot_timestamp="20220106075526",
+            subscriber_count=100,
+        )
+        assert recovered_with_subs.has_data is True
+
+        # With country (has metadata)
+        recovered_with_country = RecoveredChannelData(
+            snapshot_timestamp="20220106075526",
+            country="GB",
+        )
+        assert recovered_with_country.has_data is True
+
+
+class TestChannelRecoveryResult:
+    """Tests for ChannelRecoveryResult Pydantic model (T003)."""
+
+    def test_required_fields(self) -> None:
+        """Test channel_id and success are required fields."""
+        # Missing channel_id
+        with pytest.raises(ValidationError) as exc_info:
+            ChannelRecoveryResult(success=True)  # type: ignore[call-arg]
+        assert "channel_id" in str(exc_info.value).lower()
+
+        # Missing success
+        with pytest.raises(ValidationError) as exc_info:
+            ChannelRecoveryResult(channel_id="UCuAXFkgsw1L7xaCfnd5JJOw")  # type: ignore[call-arg]
+        assert "success" in str(exc_info.value).lower()
+
+        # Both provided
+        result = ChannelRecoveryResult(
+            channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+            success=True,
+        )
+        assert result.channel_id == "UCuAXFkgsw1L7xaCfnd5JJOw"
+        assert result.success is True
+
+    def test_default_values(self) -> None:
+        """Test default values for optional fields."""
+        result = ChannelRecoveryResult(
+            channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+            success=True,
+        )
+
+        assert result.success is True
+        assert result.snapshot_used is None
+        assert result.fields_recovered == []
+        assert result.fields_skipped == []
+        assert result.snapshots_available == 0
+        assert result.snapshots_tried == 0
+        assert result.failure_reason is None
+        assert result.duration_seconds == 0.0
+
+    def test_full_success_result(self) -> None:
+        """Test creating a full success result with all fields."""
+        result = ChannelRecoveryResult(
+            channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title", "description", "subscriber_count"],
+            fields_skipped=["country", "default_language"],
+            snapshots_available=10,
+            snapshots_tried=2,
+            duration_seconds=3.5,
+        )
+
+        assert result.channel_id == "UCuAXFkgsw1L7xaCfnd5JJOw"
+        assert result.success is True
+        assert result.snapshot_used == "20220106075526"
+        assert result.fields_recovered == ["title", "description", "subscriber_count"]
+        assert result.fields_skipped == ["country", "default_language"]
+        assert result.snapshots_available == 10
+        assert result.snapshots_tried == 2
+        assert result.failure_reason is None
+        assert result.duration_seconds == 3.5
+
+    def test_failure_result(self) -> None:
+        """Test creating a failure result with failure_reason."""
+        result = ChannelRecoveryResult(
+            channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+            success=False,
+            failure_reason="no_archive_found",
+            snapshots_available=0,
+            snapshots_tried=0,
+            duration_seconds=1.2,
+        )
+
+        assert result.success is False
+        assert result.failure_reason == "no_archive_found"
+        assert result.snapshot_used is None
+        assert result.fields_recovered == []
+
+    def test_serialization_round_trip(self) -> None:
+        """Test serialization and deserialization round-trip."""
+        original = ChannelRecoveryResult(
+            channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title", "description"],
+            snapshots_available=5,
+            snapshots_tried=1,
+            duration_seconds=2.3,
+        )
+
+        # Serialize to dict
+        data = original.model_dump()
+
+        # Deserialize back to model
+        restored = ChannelRecoveryResult(**data)
+
+        # Verify all fields match
+        assert restored.channel_id == original.channel_id
+        assert restored.success == original.success
+        assert restored.snapshot_used == original.snapshot_used
+        assert restored.fields_recovered == original.fields_recovered
+        assert restored.fields_skipped == original.fields_skipped
+        assert restored.snapshots_available == original.snapshots_available
+        assert restored.snapshots_tried == original.snapshots_tried
+        assert restored.failure_reason == original.failure_reason
+        assert restored.duration_seconds == original.duration_seconds
+
+
 class TestRecoveryResult:
     """Tests for RecoveryResult Pydantic model (T008)."""
 
@@ -366,6 +670,58 @@ class TestRecoveryResult:
         assert result.failure_reason is None
         assert result.snapshot_used is None
         assert result.channel_recovery_candidates == []
+
+    def test_channel_field_defaults(self) -> None:
+        """Test default values for channel recovery fields (T003)."""
+        result = RecoveryResult(video_id="dQw4w9WgXcQ", success=True)
+
+        assert result.channel_recovered is False
+        assert result.channel_fields_recovered == []
+        assert result.channel_fields_skipped == []
+        assert result.channel_failure_reason is None
+
+    def test_backward_compatibility_without_channel_fields(self) -> None:
+        """Test existing RecoveryResult construction still works (T003)."""
+        # This should work without providing any channel-specific fields
+        result = RecoveryResult(
+            video_id="dQw4w9WgXcQ",
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title", "description"],
+            snapshots_available=5,
+            snapshots_tried=2,
+        )
+
+        assert result.video_id == "dQw4w9WgXcQ"
+        assert result.success is True
+        assert result.snapshot_used == "20220106075526"
+        assert result.fields_recovered == ["title", "description"]
+        # Channel fields should have defaults
+        assert result.channel_recovered is False
+        assert result.channel_fields_recovered == []
+
+    def test_construction_with_channel_fields(self) -> None:
+        """Test RecoveryResult construction with channel recovery fields (T003)."""
+        result = RecoveryResult(
+            video_id="dQw4w9WgXcQ",
+            success=True,
+            snapshot_used="20220106075526",
+            fields_recovered=["title", "description"],
+            snapshots_available=5,
+            snapshots_tried=2,
+            channel_recovered=True,
+            channel_fields_recovered=["title", "subscriber_count"],
+            channel_fields_skipped=["country"],
+            channel_failure_reason=None,
+        )
+
+        assert result.video_id == "dQw4w9WgXcQ"
+        assert result.success is True
+        # Channel fields are populated
+        assert result.channel_recovered is True
+        assert result.channel_fields_recovered == ["title", "subscriber_count"]
+        assert result.channel_fields_skipped == ["country"]
+        assert result.channel_failure_reason is None
 
     def test_failure_result(self) -> None:
         """Test creating a failure result with failure_reason."""

--- a/tests/unit/services/recovery/test_page_parser.py
+++ b/tests/unit/services/recovery/test_page_parser.py
@@ -139,6 +139,121 @@ REMOVAL_NOTICE_WITH_POSITIVE_SIGNAL_OVERRIDE = '''
 </body></html>
 '''
 
+VALID_PAGE_META_WITH_EOW_DESCRIPTION = '''
+<html><head>
+<meta property="og:title" content="Old Format Video Title">
+<meta property="og:description" content="FULL RECIPE: https://example.com/pasta Learn how to make the perfect homemade pasta from scratch using just three simple ingredients. This step-by-step tutori...">
+<meta property="og:image" content="https://i.ytimg.com/vi/test123/hqdefault.jpg">
+<meta property="og:video:tag" content="cooking">
+<meta itemprop="datePublished" content="2018-09-28">
+<meta itemprop="interactionCount" content="12345">
+<link itemprop="url" href="http://www.youtube.com/user/CookingWithSarah">
+</head><body>
+<div id="watch-description-text" class="">
+<p id="eow-description" class="">FULL RECIPE: <a href="/web/20190604182457/https://www.youtube.com/redirect?q=https%3A%2F%2Fexample.com%2Fpasta">https://example.com/pasta</a><br><br>Learn how to make the perfect homemade pasta from scratch using just three simple ingredients. This step-by-step tutorial covers everything from mixing the dough to cutting your own fettuccine.<br>We also show you how to make a classic marinara sauce to pair with your fresh pasta.<br><br>TIMESTAMPS <a href="/web/20190604182457/https://www.youtube.com/watch?v=IFAcqaNzNSc">https://www.youtube.com/watch?v=IFAcq...</a> <br><br>Check out <a href="/web/20190604182457/http://example.com">http://example.com</a><br><br>Subscribe to our channel! <a href="http://www.youtube.com/subscription_center?add_user=CookingWithSarah">http://www.youtube.com/subscription_c...</a><br><br>Follow us on Twitter <a href="/web/20190604182457/http://twitter.com/CookWithSarah">http://twitter.com/CookWithSarah</a><br>Follow us on Instagram <a href="/web/20190604182457/http://instagram.com/cookingwithsarah">http://instagram.com/cookingwithsarah</a><br><br>Cooking With Sarah is a home cooking channel dedicated to simple, delicious recipes anyone can make. We were the first cooking channel to reach 500 million YouTube views.</p>
+</div>
+</body></html>
+'''
+
+VALID_PAGE_META_WITH_EMPTY_EOW = '''
+<html><head>
+<meta property="og:title" content="Empty EOW Video">
+<meta property="og:description" content="This is the og:description fallback text">
+</head><body>
+<div id="watch-description-text" class="">
+<p id="eow-description" class="">   </p>
+</div>
+</body></html>
+'''
+
+VALID_PAGE_META_WITH_EOW_NO_OG_DESC = '''
+<html><head>
+<meta property="og:title" content="No OG Desc Video">
+</head><body>
+<div id="watch-description-text" class="">
+<p id="eow-description" class="">This is the full description only available in the HTML element.</p>
+</div>
+</body></html>
+'''
+
+PAGE_JSON_WITH_EOW_AND_OLD_LIKE_BUTTON = '''
+<html><head>
+<meta property="og:title" content="Truncated OG Title">
+<meta property="og:description" content="FULL GUIDE: https://example.com/bookshelf Learn how to build a simple bookshelf using basic hand tools and reclaimed wood from a local salvage yard. Step-by-s...">
+</head><body>
+<script>var ytInitialPlayerResponse = {"videoDetails":{"title":"JSON Title From Transitional Page","channelId":"UCuAXFkgsw1L7xaCfnd5JJOw","author":"Test Channel","viewCount":"50000","keywords":["woodworking","diy"]},"microformat":{"playerMicroformatRenderer":{"publishDate":"2019-04-05","category":"Howto & Style"}}};</script>
+<div id="watch-description-text" class="">
+<p id="eow-description" class="">Sarah demonstrates how to build a simple bookshelf using basic hand tools and reclaimed wood.<br><br>PLANS @ <a href="http://example.com/bookshelf-plans">http://example.com/bookshelf-plans</a><br>FOLLOW Sarah @ <a href="http://twitter.com/SarahBuilds">http://twitter.com/SarahBuilds</a></p>
+</div>
+<span class="yt-uix-clickcard">
+<button class="yt-uix-button like-button-renderer-like-button like-button-renderer-like-button-unclicked" type="button" aria-label="Ich mag das Video (wie 2.510 andere auch)"><span class="yt-uix-button-content">2.510</span></button>
+</span>
+</body></html>
+'''
+
+PAGE_JSON_WITH_MODERN_LIKE_BUTTON = '''
+<html><head></head><body>
+<script>var ytInitialPlayerResponse = {"videoDetails":{"title":"Modern Transitional Page","channelId":"UCuAXFkgsw1L7xaCfnd5JJOw","author":"Test Channel","viewCount":"100000","keywords":["test"]},"microformat":{"playerMicroformatRenderer":{"publishDate":"2020-08-10","category":"Entertainment"}}};</script>
+<div id="watch-description-text" class="">
+<p id="eow-description" class="">This is the full description from the HTML element.</p>
+</div>
+<yt-formatted-string id="text" aria-label="1,230 likes">1.2K</yt-formatted-string>
+</body></html>
+'''
+
+PAGE_JSON_WITH_ENGLISH_LIKE_ARIA = '''
+<html><head></head><body>
+<script>var ytInitialPlayerResponse = {"videoDetails":{"title":"English Like Page","channelId":"UCuAXFkgsw1L7xaCfnd5JJOw","author":"Channel","viewCount":"5000"},"microformat":{"playerMicroformatRenderer":{}}};</script>
+<button aria-label="like this video along with 3,456 other people" class="like-button"><span>3.4K</span></button>
+</body></html>
+'''
+
+PAGE_JSON_WITH_GERMAN_LIKE_DISLIKE = '''
+<html><head></head><body>
+<script>var ytInitialPlayerResponse = {"videoDetails":{"title":"German Locale Page","channelId":"UCuAXFkgsw1L7xaCfnd5JJOw","author":"Test Channel","viewCount":"80000"},"microformat":{"playerMicroformatRenderer":{"publishDate":"2020-02-11","category":"Entertainment"}}};</script>
+<div id="watch-description-text" class="">
+<p id="eow-description" class="">This is the full description for the German locale test page.</p>
+</div>
+<span class="like-button-renderer " data-button-toggle-group="optional">
+    <span class="yt-uix-clickcard">
+      <button class="yt-uix-button yt-uix-button-size-default yt-uix-button-opacity yt-uix-button-has-icon no-icon-markup like-button-renderer-like-button like-button-renderer-like-button-unclicked yt-uix-clickcard-target   yt-uix-tooltip" type="button" onclick=";return false;" aria-label="Ich mag das Video (wie 2.510 andere auch)" title="Mag ich" data-force-position="true" data-orientation="vertical" data-position="bottomright"><span class="yt-uix-button-content">2.510</span></button>
+    </span>
+    <span class="yt-uix-clickcard">
+      <button class="yt-uix-button yt-uix-button-size-default yt-uix-button-opacity like-button-renderer-like-button like-button-renderer-like-button-clicked yt-uix-button-toggled  hid" type="button" aria-label="Ich mag das Video (wie 2.510 andere auch)"><span class="yt-uix-button-content">2.511</span></button>
+    </span>
+    <span class="yt-uix-clickcard">
+      <button class="yt-uix-button yt-uix-button-size-default yt-uix-button-opacity like-button-renderer-dislike-button like-button-renderer-dislike-button-unclicked yt-uix-clickcard-target" type="button" aria-label="Ich mag das Video nicht (wie 112 andere)" title="Mag ich nicht"><span class="yt-uix-button-content">112</span></button>
+    </span>
+    <span class="yt-uix-clickcard">
+      <button class="yt-uix-button like-button-renderer-dislike-button like-button-renderer-dislike-button-clicked hid" type="button" aria-label="Ich mag das Video nicht (wie 112 andere)"><span class="yt-uix-button-content">113</span></button>
+    </span>
+</span>
+</body></html>
+'''
+
+PAGE_JSON_WITH_LIKE_BUTTON_NO_CONTENT_SPAN = '''
+<html><head></head><body>
+<script>var ytInitialPlayerResponse = {"videoDetails":{"title":"No Content Span Page","channelId":"UCuAXFkgsw1L7xaCfnd5JJOw","author":"Test Channel","viewCount":"30000"},"microformat":{"playerMicroformatRenderer":{}}};</script>
+<button class="yt-uix-button like-button-renderer-like-button like-button-renderer-like-button-unclicked" type="button" aria-label="Ich mag das Video (wie 1.234 andere auch)" title="Mag ich">Mag ich</button>
+</body></html>
+'''
+
+PAGE_JSON_COMPLETE_NO_SUPPLEMENT_NEEDED = '''
+<html><head></head><body>
+<script>var ytInitialPlayerResponse = {"videoDetails":{"title":"Complete JSON Page","shortDescription":"Full description from JSON","channelId":"UCuAXFkgsw1L7xaCfnd5JJOw","author":"Channel","viewCount":"5000","keywords":["test"]},"microformat":{"playerMicroformatRenderer":{"publishDate":"2021-01-01","category":"Education"}}};</script>
+<script>var ytInitialData = {"contents":{"twoColumnWatchNextResults":{"results":{"results":{"contents":[{"videoPrimaryInfoRenderer":{"videoActions":{"menuRenderer":{"topLevelButtons":[{"toggleButtonRenderer":{"defaultText":{"accessibility":{"accessibilityData":{"label":"9,999 likes"}}}}}]}}}}]}}}}};</script>
+</body></html>
+'''
+
+PAGE_JSON_WITH_TRUNCATED_DESC_AND_EOW = '''
+<html><head></head><body>
+<script>var ytInitialPlayerResponse = {"videoDetails":{"title":"Truncated Desc Page","shortDescription":"Learn how to build a simple bookshelf using basic hand tools and reclaimed wood from a local salvage yard. Step-by-step guide for beg...","channelId":"UCuAXFkgsw1L7xaCfnd5JJOw","author":"Test Channel","viewCount":"75000","keywords":["woodworking"]},"microformat":{"playerMicroformatRenderer":{"publishDate":"2019-12-04","category":"Howto & Style"}}};</script>
+<div id="watch-description-text" class="">
+<p id="eow-description" class="">Learn how to build a simple bookshelf using basic hand tools and reclaimed wood from a local salvage yard. Step-by-step guide for beginners and experienced woodworkers alike.<br><br>PLANS @ <a href="http://example.com/bookshelf-plans">http://example.com/bookshelf-plans</a><br>FOLLOW Sarah @ <a href="http://twitter.com/SarahBuilds">http://twitter.com/SarahBuilds</a></p>
+</div>
+</body></html>
+'''
+
 EMPTY_PAGE = '''
 <html><head></head><body></body></html>
 '''
@@ -701,6 +816,150 @@ class TestMetaTagExtraction:
         assert result is not None
         assert result.channel_name_hint == "SomeChannel"
 
+    async def test_eow_description_preferred_over_og(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that #eow-description full text is preferred over truncated og:description."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_WITH_EOW_DESCRIPTION
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # Should have the full description from #eow-description, not the
+        # truncated 160-char og:description
+        assert result.description is not None
+        assert len(result.description) > 160
+        assert "homemade pasta from scratch" in result.description
+        assert "YouTube views" in result.description
+        # Should NOT end with "..."
+        assert not result.description.endswith("...")
+
+    async def test_eow_description_br_tags_become_newlines(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that <br> tags in #eow-description are converted to newlines."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_WITH_EOW_DESCRIPTION
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.description is not None
+        # <br> tags should become newlines
+        assert "\n" in result.description
+        # No more than 2 consecutive newlines (triple+ collapsed)
+        assert "\n\n\n" not in result.description
+
+    async def test_eow_description_strips_html_tags(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that <a> tags are stripped but their text content preserved."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_WITH_EOW_DESCRIPTION
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.description is not None
+        # Link text should be preserved
+        assert "https://example.com/pasta" in result.description
+        assert "http://example.com" in result.description
+        # HTML tags should not appear
+        assert "<a " not in result.description
+        assert "<br" not in result.description
+
+    async def test_empty_eow_description_falls_back_to_og(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that empty #eow-description falls back to og:description."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_WITH_EMPTY_EOW
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.description == "This is the og:description fallback text"
+
+    async def test_eow_description_without_og_desc(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that #eow-description works when og:description is absent."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_WITH_EOW_NO_OG_DESC
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.description == "This is the full description only available in the HTML element."
+
+    async def test_eow_preserves_other_meta_fields(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that #eow-description enhancement doesn't break other meta field extraction."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = VALID_PAGE_META_WITH_EOW_DESCRIPTION
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # All other fields should still be extracted from meta tags
+        assert result.title == "Old Format Video Title"
+        assert result.thumbnail_url == "https://i.ytimg.com/vi/test123/hqdefault.jpg"
+        assert result.tags == ["cooking"]
+        assert result.upload_date is not None
+        assert result.upload_date.year == 2018
+        assert result.view_count == 12345
+        assert result.channel_name_hint == "CookingWithSarah"
+
     async def test_missing_tags_graceful(
         self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
     ) -> None:
@@ -980,6 +1239,256 @@ class TestTwoEraStrategy:
 
 
 # ============================================================================
+# Test Class: HTML Supplement for Transitional Pages
+# ============================================================================
+
+
+class TestHTMLSupplement:
+    """
+    Test _supplement_from_html() behavior for transitional-era pages.
+
+    When _extract_from_json succeeds but videoDetails lacks shortDescription
+    and ytInitialData lacks the like count, the supplement pass fills gaps
+    from #eow-description and like button HTML elements.
+
+    Covers:
+    - Description supplemented from #eow-description when JSON has none
+    - Like count from old-format button content (European locale)
+    - Like count from modern aria-label="N likes"
+    - Like count from "along with N other people" aria-label
+    - No supplement when JSON already has both fields
+    """
+
+    async def test_supplements_description_from_eow(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that missing description is filled from #eow-description."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_WITH_EOW_AND_OLD_LIKE_BUTTON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # JSON title should be used (JSON takes priority for fields it has)
+        assert result.title == "JSON Title From Transitional Page"
+        # Description should come from #eow-description (JSON had none)
+        assert result.description is not None
+        assert "Sarah demonstrates how to build a simple bookshelf" in result.description
+        assert "http://example.com/bookshelf-plans" in result.description
+        assert not result.description.endswith("...")
+
+    async def test_supplements_like_count_from_old_button(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that like count is extracted from old-format button content."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_WITH_EOW_AND_OLD_LIKE_BUTTON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # Like count from button content "2.510" (European format = 2510)
+        assert result.like_count == 2510
+
+    async def test_supplements_like_count_from_modern_aria_label(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that like count is extracted from modern aria-label='N likes'."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_WITH_MODERN_LIKE_BUTTON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.like_count == 1230
+
+    async def test_supplements_like_count_from_along_with_pattern(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that like count is extracted from 'along with N other people'."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_WITH_ENGLISH_LIKE_ARIA
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.like_count == 3456
+
+    async def test_no_supplement_when_json_complete(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that supplement is skipped when JSON has both description and likes."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_COMPLETE_NO_SUPPLEMENT_NEEDED
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # Values should come from JSON, not HTML supplement
+        assert result.description == "Full description from JSON"
+        assert result.like_count == 9999
+
+    async def test_supplement_preserves_json_fields(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that supplement doesn't overwrite fields already extracted by JSON."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_WITH_EOW_AND_OLD_LIKE_BUTTON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # JSON-sourced fields must be preserved
+        assert result.title == "JSON Title From Transitional Page"
+        assert result.channel_id == "UCuAXFkgsw1L7xaCfnd5JJOw"
+        assert result.channel_name_hint == "Test Channel"
+        assert result.view_count == 50000
+        assert result.tags == ["woodworking", "diy"]
+        assert result.category_id == "26"  # "Howto & Style"
+        assert result.upload_date is not None
+        assert result.upload_date.year == 2019
+
+    async def test_supplements_truncated_description_from_eow(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that truncated JSON shortDescription is replaced by full #eow-description."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_WITH_TRUNCATED_DESC_AND_EOW
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.title == "Truncated Desc Page"
+        # The JSON shortDescription ends with "..." and is ~130 chars.
+        # The #eow-description has the full text, which is longer.
+        assert result.description is not None
+        assert not result.description.endswith("...")
+        assert "beginners and experienced woodworkers" in result.description
+        assert "http://example.com/bookshelf-plans" in result.description
+
+    async def test_supplements_like_count_from_german_locale(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test like count extraction from full German like/dislike button HTML."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_WITH_GERMAN_LIKE_DISLIKE
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        assert result.title == "German Locale Page"
+        # Like count from button content "2.510" (European format = 2510)
+        assert result.like_count == 2510
+
+    async def test_supplements_like_count_german_dislike_not_matched(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that German dislike button (112) is not returned as like count."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_WITH_GERMAN_LIKE_DISLIKE
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # Must be 2510 (like), NOT 112 (dislike)
+        assert result.like_count != 112
+        assert result.like_count == 2510
+
+    async def test_supplements_like_from_aria_label_when_no_content_span(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test like count from aria-label when button has no yt-uix-button-content span."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = PAGE_JSON_WITH_LIKE_BUTTON_NO_CONTENT_SPAN
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_metadata(snapshot)
+
+        assert result is not None
+        # Extracted from aria-label "Ich mag das Video (wie 1.234 andere auch)"
+        assert result.like_count == 1234
+
+
+# ============================================================================
 # Test Class: Selenium Fallback (T025)
 # ============================================================================
 
@@ -1110,3 +1619,404 @@ def rate_limiter_mock() -> RateLimiter:
     mock = MagicMock(spec=RateLimiter)
     mock.acquire = AsyncMock()
     return mock
+
+
+# ============================================================================
+# HTML Test Fixtures for Channel Metadata Extraction
+# ============================================================================
+
+CHANNEL_PAGE_WITH_JSON = '''
+<html><head></head><body>
+<script>var ytInitialData = {"metadata":{"channelMetadataRenderer":{"title":"Tech Channel","description":"A channel about technology and gadgets","externalId":"UCuAXFkgsw1L7xaCfnd5JJOw","country":"US","defaultLanguage":"en","avatar":{"thumbnails":[{"url":"https://yt3.googleusercontent.com/channel/avatar.jpg"}]}}},"header":{"c4TabbedHeaderRenderer":{"subscriberCountText":{"simpleText":"1.2M subscribers"},"videosCountText":{"runs":[{"text":"1,234"}]}}}};</script>
+</body></html>
+'''
+
+CHANNEL_PAGE_META_ONLY = '''
+<html><head>
+<meta property="og:title" content="Classic Channel">
+<meta property="og:description" content="A classic YouTube channel">
+<meta property="og:image" content="https://yt3.googleusercontent.com/channel/classic.jpg">
+</head><body></body></html>
+'''
+
+CHANNEL_PAGE_ID_MISMATCH = '''
+<html><head></head><body>
+<script>var ytInitialData = {"metadata":{"channelMetadataRenderer":{"title":"Wrong Channel","externalId":"UCDifferentChannelId123456","country":"GB"}}};</script>
+</body></html>
+'''
+
+CHANNEL_PAGE_NO_DATA = '''
+<html><head></head><body></body></html>
+'''
+
+CHANNEL_PAGE_SUBSCRIBER_VARIANTS = '''
+<html><head></head><body>
+<script>var ytInitialData = {"metadata":{"channelMetadataRenderer":{"title":"Test Channel","externalId":"UCuAXFkgsw1L7xaCfnd5JJOw"}},"header":{"c4TabbedHeaderRenderer":{"subscriberCountText":{"simpleText":"500K subscribers"},"videosCountText":{"runs":[{"text":"500"}]}}}};</script>
+</body></html>
+'''
+
+CHANNEL_PAGE_NO_SUBSCRIBERS = '''
+<html><head></head><body>
+<script>var ytInitialData = {"metadata":{"channelMetadataRenderer":{"title":"New Channel","externalId":"UCuAXFkgsw1L7xaCfnd5JJOw"}},"header":{"c4TabbedHeaderRenderer":{"subscriberCountText":{"simpleText":"No subscribers"},"videosCountText":{"runs":[{"text":"5"}]}}}};</script>
+</body></html>
+'''
+
+CHANNEL_PAGE_PLAIN_NUMBERS = '''
+<html><head></head><body>
+<script>var ytInitialData = {"metadata":{"channelMetadataRenderer":{"title":"Small Channel","externalId":"UCuAXFkgsw1L7xaCfnd5JJOw"}},"header":{"c4TabbedHeaderRenderer":{"subscriberCountText":{"simpleText":"1,234 subscribers"},"videosCountText":{"runs":[{"text":"1,234"}]}}}};</script>
+</body></html>
+'''
+
+
+# ============================================================================
+# Test Class: Channel Metadata Extraction (T014)
+# ============================================================================
+
+
+class TestExtractChannelMetadata:
+    """
+    Test extract_channel_metadata() and channel-specific helpers.
+
+    Covers:
+    - JSON extraction from 2017+ channel pages (ytInitialData)
+    - Meta tag fallback for pre-2017 channel pages
+    - Subscriber count parsing with SI suffixes and commas
+    - Video count parsing
+    - Channel ID cross-validation
+    - Missing data handling
+    - Fetch failure handling
+    """
+
+    async def test_extract_channel_from_json_all_fields(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test JSON extraction with all fields present."""
+        from chronovista.services.recovery.models import RecoveredChannelData
+
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+        channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = CHANNEL_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_channel_metadata(snapshot, channel_id)
+
+        assert result is not None
+        assert isinstance(result, RecoveredChannelData)
+        assert result.title == "Tech Channel"
+        assert result.description == "A channel about technology and gadgets"
+        assert result.subscriber_count == 1200000
+        assert result.video_count == 1234
+        assert (
+            result.thumbnail_url
+            == "https://yt3.googleusercontent.com/channel/avatar.jpg"
+        )
+        assert result.country == "US"
+        assert result.default_language == "en"
+        assert result.snapshot_timestamp == snapshot.timestamp
+
+    async def test_extract_channel_from_meta_tags(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test meta tag extraction for pre-2017 channel pages."""
+        from chronovista.services.recovery.models import RecoveredChannelData
+
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+        channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = CHANNEL_PAGE_META_ONLY
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_channel_metadata(snapshot, channel_id)
+
+        assert result is not None
+        assert isinstance(result, RecoveredChannelData)
+        assert result.title == "Classic Channel"
+        assert result.description == "A classic YouTube channel"
+        assert (
+            result.thumbnail_url
+            == "https://yt3.googleusercontent.com/channel/classic.jpg"
+        )
+        # Meta tag extraction cannot recover subscriber_count or video_count
+        assert result.subscriber_count is None
+        assert result.video_count is None
+
+    async def test_channel_id_cross_validation_success(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that matching channel_id passes cross-validation."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+        channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = CHANNEL_PAGE_WITH_JSON
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_channel_metadata(snapshot, channel_id)
+
+        assert result is not None
+        assert result.title == "Tech Channel"
+
+    async def test_channel_id_cross_validation_mismatch(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that mismatched channel_id returns None."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+        # Expected channel_id doesn't match the one in the page
+        channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = CHANNEL_PAGE_ID_MISMATCH
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_channel_metadata(snapshot, channel_id)
+
+        # Should return None due to ID mismatch
+        assert result is None
+
+    async def test_channel_page_no_extractable_data(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that page with no extractable data returns None."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+        channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = CHANNEL_PAGE_NO_DATA
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_channel_metadata(snapshot, channel_id)
+
+        assert result is None
+
+    async def test_channel_page_fetch_failure(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test that HTTP fetch failure returns None without raising."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+        channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.side_effect = httpx.ConnectTimeout("Connection timeout")
+
+            result = await parser.extract_channel_metadata(snapshot, channel_id)
+
+        # Should return None, not raise exception
+        assert result is None
+
+
+class TestParseSubscriberCount:
+    """
+    Test _parse_subscriber_count() helper method.
+
+    Covers:
+    - SI suffix parsing (K, M, B)
+    - Comma-separated numbers
+    - "No subscribers" special case
+    - Invalid input handling
+    """
+
+    def test_parse_1_2m_subscribers(self) -> None:
+        """Test parsing '1.2M subscribers' -> 1200000."""
+        result = PageParser._parse_subscriber_count("1.2M subscribers")
+        assert result == 1200000
+
+    def test_parse_500k_subscribers(self) -> None:
+        """Test parsing '500K subscribers' -> 500000."""
+        result = PageParser._parse_subscriber_count("500K subscribers")
+        assert result == 500000
+
+    def test_parse_comma_separated_subscribers(self) -> None:
+        """Test parsing '1,234 subscribers' -> 1234."""
+        result = PageParser._parse_subscriber_count("1,234 subscribers")
+        assert result == 1234
+
+    def test_parse_plain_number_subscribers(self) -> None:
+        """Test parsing '1234 subscribers' -> 1234."""
+        result = PageParser._parse_subscriber_count("1234 subscribers")
+        assert result == 1234
+
+    def test_parse_no_subscribers(self) -> None:
+        """Test parsing 'No subscribers' -> 0."""
+        result = PageParser._parse_subscriber_count("No subscribers")
+        assert result == 0
+
+    def test_parse_billion_suffix(self) -> None:
+        """Test parsing '1.5B subscribers' -> 1500000000."""
+        result = PageParser._parse_subscriber_count("1.5B subscribers")
+        assert result == 1500000000
+
+    def test_parse_empty_string(self) -> None:
+        """Test that empty string returns None."""
+        result = PageParser._parse_subscriber_count("")
+        assert result is None
+
+    def test_parse_whitespace_only(self) -> None:
+        """Test that whitespace-only string returns None."""
+        result = PageParser._parse_subscriber_count("   ")
+        assert result is None
+
+    def test_parse_invalid_format(self) -> None:
+        """Test that invalid format returns None."""
+        result = PageParser._parse_subscriber_count("abc subscribers")
+        assert result is None
+
+    def test_parse_lowercase_k_suffix(self) -> None:
+        """Test parsing with lowercase 'k' suffix (normalized to uppercase)."""
+        result = PageParser._parse_subscriber_count("500k subscribers")
+        assert result == 500000
+
+
+class TestParseVideoCount:
+    """
+    Test _parse_video_count() helper method.
+
+    Covers:
+    - Comma-separated numbers
+    - Plain numbers
+    - Invalid input handling
+    """
+
+    def test_parse_comma_separated_videos(self) -> None:
+        """Test parsing '1,234 videos' -> 1234."""
+        result = PageParser._parse_video_count("1,234 videos")
+        assert result == 1234
+
+    def test_parse_plain_number_videos(self) -> None:
+        """Test parsing '500' -> 500."""
+        result = PageParser._parse_video_count("500")
+        assert result == 500
+
+    def test_parse_with_videos_suffix(self) -> None:
+        """Test parsing '500 videos' -> 500."""
+        result = PageParser._parse_video_count("500 videos")
+        assert result == 500
+
+    def test_parse_large_number_with_commas(self) -> None:
+        """Test parsing '10,000 videos' -> 10000."""
+        result = PageParser._parse_video_count("10,000 videos")
+        assert result == 10000
+
+    def test_parse_empty_string(self) -> None:
+        """Test that empty string returns None."""
+        result = PageParser._parse_video_count("")
+        assert result is None
+
+    def test_parse_whitespace_only(self) -> None:
+        """Test that whitespace-only string returns None."""
+        result = PageParser._parse_video_count("   ")
+        assert result is None
+
+    def test_parse_invalid_format(self) -> None:
+        """Test that invalid format returns None."""
+        result = PageParser._parse_video_count("abc videos")
+        assert result is None
+
+    def test_parse_singular_video(self) -> None:
+        """Test parsing '1 video' (singular) -> 1."""
+        result = PageParser._parse_video_count("1 video")
+        assert result == 1
+
+
+class TestChannelMetadataIntegration:
+    """
+    Integration tests for channel metadata extraction.
+
+    Tests the full extraction flow with various subscriber/video count formats.
+    """
+
+    async def test_subscriber_count_500k(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test extraction with '500K subscribers' format."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+        channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = CHANNEL_PAGE_SUBSCRIBER_VARIANTS
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_channel_metadata(snapshot, channel_id)
+
+        assert result is not None
+        assert result.subscriber_count == 500000
+        assert result.video_count == 500
+
+    async def test_no_subscribers(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test extraction with 'No subscribers' special case."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+        channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = CHANNEL_PAGE_NO_SUBSCRIBERS
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_channel_metadata(snapshot, channel_id)
+
+        assert result is not None
+        assert result.subscriber_count == 0
+        assert result.video_count == 5
+
+    async def test_plain_numbers(
+        self, cdx_snapshot_factory: Any, rate_limiter_mock: RateLimiter
+    ) -> None:
+        """Test extraction with plain comma-separated numbers."""
+        snapshot = CdxSnapshot(**cdx_snapshot_factory())
+        parser = PageParser(rate_limiter=rate_limiter_mock)
+        channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.text = CHANNEL_PAGE_PLAIN_NUMBERS
+            mock_get.return_value = mock_response
+
+            result = await parser.extract_channel_metadata(snapshot, channel_id)
+
+        assert result is not None
+        assert result.subscriber_count == 1234
+        assert result.video_count == 1234


### PR DESCRIPTION
## Summary

- **Recovery API endpoints**: `POST /api/v1/videos/{video_id}/recover` and `POST /api/v1/channels/{channel_id}/recover` with year filters, structured responses, and 5-minute idempotency guard
- **Channel archive recovery**: Extract channel metadata (title, description, subscriber/video counts, thumbnail, country) from Wayback Machine snapshots with two-tier overwrite policy; auto-triggered during video recovery when channel is unavailable
- **Page parser enhancements**: Truncated description replacement via `#eow-description` HTML, 5-pattern like count extraction with international locale support (German `2.510` → 2510, etc.)
- **Frontend recovery UX**: "Recover from Web Archive" button on video/channel detail pages, Zustand v5 store with localStorage persistence, elapsed timer, cancel via AbortController, AppShell indicator banner, toast notifications, `beforeunload` warning, SPA navigation guard (`useBlocker` modal)
- **CLI**: Channel recovery statistics in batch summary for `chronovista recover`
- **Documentation**: Updated 17 docs files (API reference, architecture, user guides, glossary, troubleshooting, changelog)

## Test plan

- [x] Backend: `pytest tests/unit/services/recovery/ tests/unit/cli/test_recover_commands.py tests/integration/api/test_video_recovery.py tests/integration/api/test_channel_recovery.py tests/integration/api/test_recovery_idempotency.py tests/integration/api/test_recovery_fields.py`
- [x] Frontend: `cd frontend && npx vitest run`
- [x] Type checking: `mypy src/chronovista` and `cd frontend && npx tsc --noEmit`
- [x] Manual: Recover a deleted video via frontend button, verify channel auto-recovery, confirm idempotency guard on repeated clicks
- [x] Manual: Verify cancel button aborts in-flight recovery, navigation guard blocks page leave during recovery