### PR TITLE
feat(cache): add local image cache proxy (Feature 026)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive user guide and API reference
 - Architecture documentation
 
+## [0.29.0] - 2026-02-19
+
+### Added
+- **Feature 026: Local Image Cache Proxy**
+  - Backend image proxy caching YouTube channel avatars and video thumbnails locally to eliminate 429 rate-limit errors
+  - `ImageCacheService` with async fetch, atomic writes, magic-byte content type detection, and `.missing` marker files
+  - Filesystem storage under `cache/images/` with two-character prefix sharding for video thumbnails
+  - `asyncio.Semaphore(5)` concurrent fetch limiting with dual timeouts (2s on-demand, 10s warming)
+  - `ImageQuality` enum: `default`, `mqdefault`, `hqdefault`, `sddefault`, `maxresdefault`
+  - `GET /api/v1/images/channels/{channel_id}` proxy endpoint for channel avatars
+  - `GET /api/v1/images/videos/{video_id}?quality=mqdefault` proxy endpoint for video thumbnails
+  - `X-Cache` response header (`HIT`, `MISS`, `PLACEHOLDER`) and appropriate `Cache-Control`
+  - `chronovista cache warm` CLI command with Rich Progress, `--type`, `--quality`, `--limit`, `--delay`, `--dry-run`
+  - `chronovista cache status` CLI command with Rich table display
+  - `chronovista cache purge` CLI command with `--type`, `--force`, and unavailable content warning
+  - Enrichment invalidation hook: auto-deletes cached avatar when channel `thumbnail_url` changes
+  - Frontend: all YouTube CDN URLs replaced with proxy URLs in ChannelCard, ChannelDetailPage, VideoCard, VideoDetailPage, PlaylistVideoCard
+  - Video thumbnails added to VideoCard (`mqdefault`), VideoDetailPage (`sddefault`), and PlaylistVideoCard (`mqdefault`)
+  - Client-side SVG placeholder fallback on image load error
+
+### Fixed
+- Wayback page parser failing to extract `channel_id` from pre-2020 YouTube archive pages (added `data-channel-external-id` and `<a>` anchor tag fallback extraction)
+
+### Technical
+- 108 new backend tests (45 service + 22 router + 31 CLI + 10 integration)
+- 94 new frontend tests across 4 component test files
+- 96 page parser tests (4 new for channel_id fallback extraction)
+- Zero new third-party dependencies
+- mypy strict compliance (0 errors)
+- TypeScript strict mode (0 errors)
+
 ## [0.28.0] - 2026-02-17
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/ChannelCard.tsx
+++ b/frontend/src/components/ChannelCard.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 
 import { cardPatterns, colorTokens } from "../styles";
 import type { ChannelListItem } from "../types/channel";
+import { API_BASE_URL } from "../api/config";
 
 interface ChannelCardProps {
   /** Channel data to display */
@@ -52,8 +53,10 @@ export function ChannelCard({ channel }: ChannelCardProps) {
     video_count,
   } = channel;
 
-  // Use placeholder if no thumbnail
-  const displayThumbnail = thumbnail_url || PLACEHOLDER_THUMBNAIL;
+  // Use proxy URL for channel thumbnails (Feature 026)
+  const displayThumbnail = thumbnail_url
+    ? `${API_BASE_URL}/images/channels/${channel_id}`
+    : PLACEHOLDER_THUMBNAIL;
 
   // Format video count with singular/plural
   const formattedVideoCount = formatCount(video_count);
@@ -80,6 +83,9 @@ export function ChannelCard({ channel }: ChannelCardProps) {
             src={displayThumbnail}
             alt={title}
             className="w-22 h-22 rounded-full object-cover"
+            onError={(e) => {
+              e.currentTarget.src = PLACEHOLDER_THUMBNAIL;
+            }}
           />
         </div>
 

--- a/frontend/src/components/PlaylistVideoCard.tsx
+++ b/frontend/src/components/PlaylistVideoCard.tsx
@@ -2,6 +2,7 @@
  * PlaylistVideoCard component displays a single video item within a playlist.
  *
  * Features:
+ * - Video thumbnail (320x180 mqdefault quality via proxy, Feature 026)
  * - Position badge showing 1-indexed position (#1, #2, #3, etc.)
  * - Video title, channel name, upload date, duration
  * - Unavailable indicator: opacity-50, line-through title, tooltip
@@ -10,6 +11,7 @@
  * - Accessible with keyboard navigation support
  *
  * Visual design:
+ * - Thumbnail: 160px width (w-40), 16:9 aspect ratio, rounded corners
  * - Position badge: circular, bg-gray-100, text-gray-700, w-8 h-8
  * - Card: bg-white, rounded-lg, shadow-sm, hover:shadow-md
  * - Unavailable state: opacity-50 on entire card, line-through on title only
@@ -27,11 +29,18 @@ import type { PlaylistVideoItem } from "../types/playlist";
 import { formatDate, formatTimestamp } from "../utils/formatters";
 import { AvailabilityBadge } from "./AvailabilityBadge";
 import { isVideoUnavailable } from "../utils/availability";
+import { API_BASE_URL } from "../api/config";
 
 interface PlaylistVideoCardProps {
   /** Playlist video data to display */
   video: PlaylistVideoItem;
 }
+
+/**
+ * Placeholder image URL for videos without thumbnails.
+ * Uses a play icon SVG on gray background matching project patterns.
+ */
+const PLACEHOLDER_THUMBNAIL = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='180' viewBox='0 0 320 180'%3E%3Crect fill='%23e2e8f0' width='320' height='180'/%3E%3Cpath fill='%2394a3b8' d='M128 60l48 30-48 30z'/%3E%3C/svg%3E";
 
 /**
  * PlaylistVideoCard displays a video within a playlist context.
@@ -59,6 +68,9 @@ export function PlaylistVideoCard({ video }: PlaylistVideoCardProps) {
   const cardOpacity = isUnavailable && !hasRecoveredData ? "opacity-50" : "";
   const titleDecoration = isUnavailable && !hasRecoveredData ? "line-through" : "";
 
+  // Use proxy URL for video thumbnails (Feature 026)
+  const thumbnailUrl = `${API_BASE_URL}/images/videos/${video_id}?quality=mqdefault`;
+
   return (
     <Link
       to={`/videos/${video_id}`}
@@ -70,6 +82,17 @@ export function PlaylistVideoCard({ video }: PlaylistVideoCardProps) {
         role="article"
       >
         <div className="flex items-start gap-3">
+          {/* Video Thumbnail */}
+          <img
+            src={thumbnailUrl}
+            alt={title || "Video thumbnail"}
+            className="flex-shrink-0 w-40 aspect-video object-cover rounded"
+            loading="lazy"
+            onError={(e) => {
+              e.currentTarget.src = PLACEHOLDER_THUMBNAIL;
+            }}
+          />
+
           {/* Position Badge */}
           <div
             className="flex-shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-full bg-gray-100 text-gray-700 text-sm font-semibold"

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -8,6 +8,7 @@ import { cardPatterns, colorTokens } from "../styles";
 import type { VideoListItem } from "../types/video";
 import { AvailabilityBadge } from "./AvailabilityBadge";
 import { isVideoUnavailable } from "../utils/availability";
+import { API_BASE_URL } from "../api/config";
 
 interface VideoCardProps {
   /** Video data to display */
@@ -94,6 +95,12 @@ function formatViewCount(count: number | null): string {
 }
 
 /**
+ * Placeholder image URL for videos without thumbnails.
+ * Uses a play icon SVG on gray background matching project patterns.
+ */
+const PLACEHOLDER_THUMBNAIL = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='180' viewBox='0 0 320 180'%3E%3Crect fill='%23e2e8f0' width='320' height='180'/%3E%3Cpath fill='%2394a3b8' d='M128 60l48 30-48 30z'/%3E%3C/svg%3E";
+
+/**
  * VideoCard displays video metadata in a card format.
  * Includes title, channel, duration, upload date, and transcript info.
  * Shows unavailability indicators when content is not available (Feature 023, FR-021).
@@ -116,16 +123,32 @@ export function VideoCard({ video }: VideoCardProps) {
   const cardOpacity = isUnavailable && !hasRecoveredData ? "opacity-50" : "";
   const titleDecoration = isUnavailable && !hasRecoveredData ? "line-through" : "";
 
+  // Use proxy URL for video thumbnails (Feature 026)
+  const thumbnailUrl = `${API_BASE_URL}/images/videos/${video.video_id}?quality=mqdefault`;
+
   return (
     <Link
       to={`/videos/${video.video_id}`}
       className="block no-underline text-inherit focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-xl"
     >
       <article
-        className={`${cardPatterns.base} ${cardPatterns.hover} ${cardPatterns.transition} p-5 ${cardOpacity}`}
+        className={`${cardPatterns.base} ${cardPatterns.hover} ${cardPatterns.transition} overflow-hidden ${cardOpacity}`}
         role="article"
         aria-label={isUnavailable && !title ? `Unavailable video` : `Video: ${title}`}
       >
+      {/* Video Thumbnail */}
+      <img
+        src={thumbnailUrl}
+        alt={title || "Video thumbnail"}
+        className="w-full aspect-video object-cover"
+        loading="lazy"
+        onError={(e) => {
+          e.currentTarget.src = PLACEHOLDER_THUMBNAIL;
+        }}
+      />
+
+      {/* Video Content */}
+      <div className="p-5">
       {/* Video Title with Availability Badge */}
       <div className="flex items-start justify-between gap-2 mb-2">
         <h3 className={`text-lg font-semibold text-${colorTokens.text.primary} line-clamp-2 flex-1 ${titleDecoration}`}>
@@ -181,6 +204,7 @@ export function VideoCard({ video }: VideoCardProps) {
           </div>
         </div>
       )}
+      </div>
       </article>
     </Link>
   );

--- a/frontend/src/pages/ChannelDetailPage.tsx
+++ b/frontend/src/pages/ChannelDetailPage.tsx
@@ -11,7 +11,7 @@ import { LoadingState } from "../components/LoadingState";
 import { UnavailabilityBanner } from "../components/UnavailabilityBanner";
 import { useChannelDetail, useChannelVideos } from "../hooks";
 import { cardPatterns, colorTokens } from "../styles";
-import { apiFetch, RECOVERY_TIMEOUT } from "../api/config";
+import { apiFetch, API_BASE_URL, RECOVERY_TIMEOUT } from "../api/config";
 import type { ApiError } from "../types/video";
 import type { RecoveryResultData } from "../types/recovery";
 import { useRecoveryStore } from "../stores/recoveryStore";
@@ -400,9 +400,24 @@ export function ChannelDetailPage() {
           <div className="flex-shrink-0">
             {thumbnail_url ? (
               <img
-                src={thumbnail_url}
+                src={`${API_BASE_URL}/images/channels/${channelIdFromData}`}
                 alt={`${title} channel thumbnail`}
                 className="w-32 h-32 rounded-full object-cover"
+                onError={(e) => {
+                  // Fallback to SVG placeholder on error (FR-026 defense in depth)
+                  const target = e.currentTarget;
+                  target.style.display = "none";
+                  const parent = target.parentElement;
+                  if (parent) {
+                    parent.innerHTML = `
+                      <div class="w-32 h-32 rounded-full bg-gray-200 flex items-center justify-center" role="img" aria-label="${title} channel thumbnail">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16 text-gray-400" aria-hidden="true">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
+                        </svg>
+                      </div>
+                    `;
+                  }
+                }}
               />
             ) : (
               <div

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -27,9 +27,15 @@ import { useDeepLinkParams } from "../hooks/useDeepLinkParams";
 import { useVideoDetail } from "../hooks/useVideoDetail";
 import { useVideoPlaylists } from "../hooks/useVideoPlaylists";
 import { CONTRAST_SAFE_COLORS } from "../styles/tokens";
-import { apiFetch, RECOVERY_TIMEOUT } from "../api/config";
+import { API_BASE_URL, apiFetch, RECOVERY_TIMEOUT } from "../api/config";
 import type { RecoveryResultData } from "../types/recovery";
 import { useRecoveryStore } from "../stores/recoveryStore";
+
+/**
+ * Placeholder image URL for videos without thumbnails.
+ * Uses a play icon SVG on gray background matching project patterns.
+ */
+const PLACEHOLDER_THUMBNAIL = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='480' viewBox='0 0 640 480'%3E%3Crect fill='%23e2e8f0' width='640' height='480'/%3E%3Cpath fill='%2394a3b8' d='M256 120l96 60-96 60z'/%3E%3C/svg%3E";
 
 /** Default page title when no video is loaded */
 const DEFAULT_PAGE_TITLE = "Chronovista";
@@ -771,7 +777,18 @@ export function VideoDetailPage() {
       )}
 
       {/* Video Content Card */}
-      <article className="bg-white rounded-xl shadow-md border border-gray-100 p-6 lg:p-8">
+      <article className="bg-white rounded-xl shadow-md border border-gray-100 overflow-hidden">
+        {/* Video Thumbnail */}
+        <img
+          src={`${API_BASE_URL}/images/videos/${video_id}?quality=sddefault`}
+          alt={title}
+          className="w-full aspect-video object-cover"
+          onError={(e) => {
+            e.currentTarget.src = PLACEHOLDER_THUMBNAIL;
+          }}
+        />
+
+        <div className="p-6 lg:p-8">
         {/* Video Title (FR-002) */}
         <h1 className="text-2xl lg:text-3xl font-bold text-gray-900 mb-4">
           {title}
@@ -870,6 +887,7 @@ export function VideoDetailPage() {
           <div className="prose prose-sm max-w-none text-gray-600 whitespace-pre-wrap">
             {description || "No description available"}
           </div>
+        </div>
         </div>
       </article>
 

--- a/frontend/tests/components/VideoCard.test.tsx
+++ b/frontend/tests/components/VideoCard.test.tsx
@@ -1,0 +1,324 @@
+/**
+ * Tests for VideoCard component - Image Proxy URLs (Feature 026, T032).
+ *
+ * Covers:
+ * - Thumbnail renders with proxy URL pattern
+ * - 16:9 aspect ratio class (aspect-video)
+ * - Lazy loading attribute
+ * - Error fallback to SVG placeholder
+ * - No YouTube CDN URLs in rendered output
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { VideoCard } from '../../src/components/VideoCard';
+import type { VideoListItem } from '../../src/types/video';
+
+/**
+ * Test factory to generate VideoListItem test data.
+ */
+function createTestVideo(overrides: Partial<VideoListItem> = {}): VideoListItem {
+  return {
+    video_id: 'test-video-123',
+    title: 'Test Video Title',
+    channel_id: 'channel-1',
+    channel_title: 'Test Channel',
+    upload_date: '2024-01-15T00:00:00Z',
+    duration: 300,
+    view_count: 1000,
+    transcript_summary: {
+      count: 1,
+      languages: ['en'],
+      has_manual: true,
+    },
+    availability_status: 'available',
+    ...overrides,
+  };
+}
+
+/**
+ * Helper to render VideoCard with MemoryRouter.
+ */
+function renderVideoCard(video: VideoListItem) {
+  return render(
+    <MemoryRouter>
+      <VideoCard video={video} />
+    </MemoryRouter>
+  );
+}
+
+describe('VideoCard - Image Proxy URLs (Feature 026, T032)', () => {
+  describe('Thumbnail Proxy URL', () => {
+    it('should render thumbnail with proxy URL /api/v1/images/videos/{video_id}?quality=mqdefault', () => {
+      const video = createTestVideo({ video_id: 'test-video-123' });
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img', { name: /test video title/i });
+      const src = thumbnail.getAttribute('src');
+
+      // Verify proxy URL pattern
+      expect(src).toMatch(/\/images\/videos\/test-video-123\?quality=mqdefault$/);
+      expect(src).toContain('test-video-123');
+      expect(src).toContain('quality=mqdefault');
+    });
+
+    it('should include video_id in proxy URL path', () => {
+      const video = createTestVideo({ video_id: 'abc-xyz-456' });
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      expect(src).toContain('/images/videos/abc-xyz-456');
+    });
+
+    it('should append quality query parameter', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      expect(src).toContain('?quality=mqdefault');
+    });
+  });
+
+  describe('Aspect Ratio', () => {
+    it('should have 16:9 aspect ratio class (aspect-video)', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+
+      // Verify aspect-video class is present
+      expect(thumbnail).toHaveClass('aspect-video');
+    });
+
+    it('should maintain aspect ratio across different videos', () => {
+      const videos = [
+        createTestVideo({ video_id: 'video-1' }),
+        createTestVideo({ video_id: 'video-2' }),
+        createTestVideo({ video_id: 'video-3' }),
+      ];
+
+      videos.forEach((video) => {
+        const { unmount } = renderVideoCard(video);
+        const thumbnail = screen.getByRole('img');
+        expect(thumbnail).toHaveClass('aspect-video');
+        unmount();
+      });
+    });
+  });
+
+  describe('Lazy Loading', () => {
+    it('should have loading="lazy" attribute', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      expect(thumbnail).toHaveAttribute('loading', 'lazy');
+    });
+  });
+
+  describe('Error Fallback', () => {
+    it('should render SVG placeholder on image error', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+
+      // Simulate image load error
+      const errorEvent = new Event('error', { bubbles: true });
+      thumbnail.dispatchEvent(errorEvent);
+
+      // After error, should fall back to placeholder
+      // The onError handler sets src to PLACEHOLDER_THUMBNAIL (SVG data URI)
+      const src = thumbnail.getAttribute('src');
+      expect(src).toContain('data:image/svg+xml');
+    });
+
+    it('should fallback to placeholder with play icon SVG', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+
+      // Trigger error
+      const errorEvent = new Event('error', { bubbles: true });
+      thumbnail.dispatchEvent(errorEvent);
+
+      const src = thumbnail.getAttribute('src');
+      // Placeholder should be an SVG data URI
+      expect(src).toMatch(/^data:image\/svg\+xml/);
+    });
+  });
+
+  describe('No YouTube CDN URLs', () => {
+    it('should NOT include ytimg.com in rendered output', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      expect(src).not.toContain('ytimg.com');
+    });
+
+    it('should NOT include ggpht.com in rendered output', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      expect(src).not.toContain('ggpht.com');
+    });
+
+    it('should NOT include youtube.com in rendered output', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      expect(src).not.toContain('youtube.com');
+    });
+
+    it('should only use local proxy URL', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      // Should start with API base URL or relative path
+      expect(src).toMatch(/^(http:\/\/localhost|\/).*\/images\/videos\//);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have alt text with video title', () => {
+      const video = createTestVideo({ title: 'My Awesome Video' });
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img', { name: /my awesome video/i });
+      expect(thumbnail).toHaveAttribute('alt', 'My Awesome Video');
+    });
+
+    it('should have alt text for unavailable videos', () => {
+      const video = createTestVideo({
+        title: '',
+        availability_status: 'deleted',
+      });
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img', { name: /video thumbnail/i });
+      expect(thumbnail).toHaveAttribute('alt');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle video with special characters in video_id', () => {
+      const video = createTestVideo({ video_id: 'dQw4w9WgXcQ' });
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      expect(src).toContain('/images/videos/dQw4w9WgXcQ');
+      expect(src).toContain('?quality=mqdefault');
+    });
+
+    it('should render correctly for unavailable videos', () => {
+      const video = createTestVideo({
+        availability_status: 'deleted',
+        title: 'Deleted Video',
+      });
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      // Should still use proxy URL even for unavailable videos
+      expect(src).toMatch(/\/images\/videos\//);
+      expect(src).toContain('?quality=mqdefault');
+    });
+
+    it('should render correctly for private videos', () => {
+      const video = createTestVideo({
+        availability_status: 'private',
+      });
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      // Should still use proxy URL
+      expect(src).toMatch(/\/images\/videos\//);
+    });
+
+    it('should handle empty title gracefully', () => {
+      const video = createTestVideo({ title: '' });
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      expect(thumbnail).toBeInTheDocument();
+      expect(thumbnail).toHaveAttribute('alt');
+    });
+  });
+
+  describe('Image Dimensions', () => {
+    it('should use full width with aspect ratio', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+
+      // Should have full width class
+      expect(thumbnail).toHaveClass('w-full');
+    });
+
+    it('should have object-cover for image fitting', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+
+      // Should use object-cover to maintain aspect ratio
+      expect(thumbnail).toHaveClass('object-cover');
+    });
+  });
+
+  describe('Consistent Quality Parameter', () => {
+    it('should always use mqdefault quality', () => {
+      const videos = [
+        createTestVideo({ video_id: 'video-1' }),
+        createTestVideo({ video_id: 'video-2' }),
+        createTestVideo({ video_id: 'video-3' }),
+      ];
+
+      videos.forEach((video) => {
+        const { unmount } = renderVideoCard(video);
+        const thumbnail = screen.getByRole('img');
+        const src = thumbnail.getAttribute('src');
+        expect(src).toContain('quality=mqdefault');
+        unmount();
+      });
+    });
+
+    it('should not use other quality parameters', () => {
+      const video = createTestVideo();
+      renderVideoCard(video);
+
+      const thumbnail = screen.getByRole('img');
+      const src = thumbnail.getAttribute('src');
+
+      // Should NOT use other YouTube quality parameters
+      expect(src).not.toContain('maxresdefault');
+      expect(src).not.toContain('sddefault');
+      expect(src).not.toContain('hqdefault');
+      expect(src).not.toContain('default.jpg');
+    });
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.28.0"
+version = "0.29.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/main.py
+++ b/src/chronovista/api/main.py
@@ -17,6 +17,7 @@ from chronovista.api.routers import (
     categories,
     channels,
     health,
+    images,
     playlists,
     preferences,
     search,
@@ -198,3 +199,4 @@ app.include_router(search.router, prefix="/api/v1", tags=["search"])
 app.include_router(preferences.router, prefix="/api/v1", tags=["preferences"])
 app.include_router(sync.router, prefix="/api/v1", tags=["sync"])
 app.include_router(sidebar.router, prefix="/api/v1", tags=["sidebar"])
+app.include_router(images.router, prefix="/api/v1", tags=["images"])

--- a/src/chronovista/api/routers/images.py
+++ b/src/chronovista/api/routers/images.py
@@ -1,0 +1,168 @@
+"""Image cache proxy endpoints.
+
+This module provides REST API endpoints for serving cached YouTube
+thumbnail images:
+
+- GET /images/channels/{channel_id} — Serve channel thumbnail (public)
+- GET /images/videos/{video_id} — Serve video thumbnail (public)
+
+All image endpoints are public (no authentication required) and return
+binary image responses or SVG placeholders.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from chronovista.api.deps import get_db
+from chronovista.config.settings import settings
+from chronovista.models.enums import ImageQuality
+from chronovista.services.image_cache import ImageCacheConfig, ImageCacheService
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Router — no auth dependency (images are public)
+# ---------------------------------------------------------------------------
+router = APIRouter(tags=["images"])
+
+# ---------------------------------------------------------------------------
+# Module-level service singleton
+# ---------------------------------------------------------------------------
+_image_cache_config = ImageCacheConfig(
+    cache_dir=settings.cache_dir,
+    channels_dir=settings.cache_dir / "images" / "channels",
+    videos_dir=settings.cache_dir / "images" / "videos",
+)
+
+_image_cache_service = ImageCacheService(config=_image_cache_config)
+
+
+@router.get(
+    "/images/channels/{channel_id}",
+    responses={
+        200: {
+            "content": {
+                "image/jpeg": {},
+                "image/png": {},
+                "image/webp": {},
+                "image/svg+xml": {},
+            },
+            "description": "Channel thumbnail image or SVG placeholder",
+        },
+        422: {"description": "Invalid channel ID format"},
+    },
+    response_class=Response,
+)
+async def get_channel_image(
+    channel_id: str = Path(
+        ...,
+        min_length=24,
+        max_length=24,
+        pattern=r"^UC[A-Za-z0-9_-]+$",
+        description="YouTube channel ID (24 characters, starts with UC)",
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Serve a channel thumbnail image from local cache.
+
+    Returns the cached image if available, fetches and caches on first
+    request, or returns an SVG placeholder if the image cannot be
+    obtained.
+
+    Parameters
+    ----------
+    channel_id : str
+        YouTube channel ID (exactly 24 characters, starts with ``UC``).
+    db : AsyncSession
+        Database session for thumbnail URL lookup.
+
+    Returns
+    -------
+    Response
+        Image bytes with appropriate Content-Type, Cache-Control, and
+        X-Cache headers.
+    """
+    return await _image_cache_service.get_channel_image(
+        session=db,
+        channel_id=channel_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Valid quality values (derived from ImageQuality enum)
+# ---------------------------------------------------------------------------
+_VALID_QUALITIES = {q.value for q in ImageQuality}
+
+
+@router.get(
+    "/images/videos/{video_id}",
+    responses={
+        200: {
+            "content": {
+                "image/jpeg": {},
+                "image/png": {},
+                "image/webp": {},
+                "image/svg+xml": {},
+            },
+            "description": "Video thumbnail image or SVG placeholder",
+        },
+        422: {"description": "Invalid video ID format or quality value"},
+    },
+    response_class=Response,
+)
+async def get_video_image(
+    video_id: str = Path(
+        ...,
+        min_length=11,
+        max_length=11,
+        pattern=r"^[A-Za-z0-9_-]{11}$",
+        description="YouTube video ID (exactly 11 characters)",
+    ),
+    quality: str = Query(
+        default="mqdefault",
+        description=(
+            "Thumbnail quality level. Valid values: "
+            + ", ".join(sorted(q.value for q in ImageQuality))
+        ),
+    ),
+) -> Response:
+    """Serve a video thumbnail image from local cache.
+
+    Returns the cached image if available, fetches and caches on first
+    request, or returns an SVG placeholder if the image cannot be
+    obtained. Video thumbnails use deterministic YouTube URLs (no DB
+    lookup required).
+
+    Parameters
+    ----------
+    video_id : str
+        YouTube video ID (exactly 11 characters).
+    quality : str
+        Thumbnail quality level (default ``"mqdefault"``). Must be one
+        of: ``default``, ``mqdefault``, ``hqdefault``, ``sddefault``,
+        ``maxresdefault``.
+
+    Returns
+    -------
+    Response
+        Image bytes with appropriate Content-Type, Cache-Control, and
+        X-Cache headers.
+    """
+    if quality not in _VALID_QUALITIES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid quality '{quality}'. "
+                f"Valid values: {', '.join(sorted(_VALID_QUALITIES))}"
+            ),
+        )
+
+    return await _image_cache_service.get_video_image(
+        video_id=video_id,
+        quality=quality,
+    )

--- a/src/chronovista/cli/commands/cache.py
+++ b/src/chronovista/cli/commands/cache.py
@@ -1,0 +1,656 @@
+"""
+CLI commands for managing the local image cache.
+
+Provides the ``chronovista cache warm`` command for pre-downloading
+channel avatar and video thumbnail images with rate limiting,
+exponential backoff, dry-run mode, and graceful interrupt handling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from rich.table import Table
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.config.database import db_manager
+from chronovista.config.settings import settings
+from chronovista.models.enums import ImageQuality
+from chronovista.services.image_cache import (
+    ImageCacheConfig,
+    ImageCacheService,
+    WarmResult,
+)
+
+console = Console()
+
+# Valid --type values
+_VALID_TYPES = {"channels", "videos", "all"}
+
+# Valid --quality values (from ImageQuality enum)
+_VALID_QUALITIES = {q.value for q in ImageQuality}
+
+app = typer.Typer(
+    name="cache",
+    help="Manage the local image cache.",
+    no_args_is_help=True,
+)
+
+
+def _build_cache_service() -> ImageCacheService:
+    """Build an ImageCacheService from application settings.
+
+    Returns
+    -------
+    ImageCacheService
+        Configured image cache service.
+    """
+    config = ImageCacheConfig(
+        cache_dir=settings.cache_dir,
+        channels_dir=settings.cache_dir / "images" / "channels",
+        videos_dir=settings.cache_dir / "images" / "videos",
+    )
+    return ImageCacheService(config=config)
+
+
+@app.command(name="warm")
+def warm(
+    type_: str = typer.Option(
+        "all",
+        "--type",
+        help='Image type to warm: "channels", "videos", or "all"',
+    ),
+    quality: str = typer.Option(
+        "mqdefault",
+        "--quality",
+        help="Video thumbnail quality level",
+    ),
+    limit: Optional[int] = typer.Option(
+        None,
+        "--limit",
+        "-l",
+        help="Maximum number of images to download",
+    ),
+    delay: float = typer.Option(
+        0.5,
+        "--delay",
+        "-d",
+        help="Seconds between requests",
+        min=0.0,
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview mode: show counts without downloading",
+    ),
+) -> None:
+    """
+    Pre-download missing images with rate-limited fetching.
+
+    Re-attempts images with .missing markers (retries previously failed
+    downloads). The command is implicitly resumable: when re-run after
+    interruption it skips already-cached images.
+
+    Examples:
+        chronovista cache warm
+        chronovista cache warm --type channels
+        chronovista cache warm --type videos --quality hqdefault --limit 100
+        chronovista cache warm --dry-run
+    """
+    # Validate --type
+    if type_ not in _VALID_TYPES:
+        console.print(
+            f'[red]Error: Invalid --type "{type_}". '
+            f"Must be one of: {', '.join(sorted(_VALID_TYPES))}[/red]"
+        )
+        raise typer.Exit(code=2)
+
+    # Validate --quality
+    if quality not in _VALID_QUALITIES:
+        console.print(
+            f'[red]Error: Invalid --quality "{quality}". '
+            f"Must be one of: {', '.join(sorted(_VALID_QUALITIES))}[/red]"
+        )
+        raise typer.Exit(code=2)
+
+    # Validate --limit
+    if limit is not None and limit <= 0:
+        console.print("[red]Error: --limit must be a positive integer[/red]")
+        raise typer.Exit(code=2)
+
+    # Validate --delay
+    if delay < 0:
+        console.print("[red]Error: --delay must be non-negative[/red]")
+        raise typer.Exit(code=2)
+
+    try:
+        asyncio.run(
+            _warm_async(
+                type_=type_,
+                quality=quality,
+                limit=limit,
+                delay=delay,
+                dry_run=dry_run,
+            )
+        )
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Cache warming interrupted by user[/yellow]")
+        raise typer.Exit(code=130)
+
+
+async def _warm_async(
+    *,
+    type_: str,
+    quality: str,
+    limit: int | None,
+    delay: float,
+    dry_run: bool,
+) -> None:
+    """Async implementation of the cache warm command.
+
+    Parameters
+    ----------
+    type_ : str
+        Image type to warm (``"channels"``, ``"videos"``, or ``"all"``).
+    quality : str
+        Video thumbnail quality level.
+    limit : int | None
+        Maximum number of images to download per entity type.
+    delay : float
+        Seconds to sleep between downloads.
+    dry_run : bool
+        If ``True``, only report counts without downloading.
+    """
+    service = _build_cache_service()
+
+    channel_result: WarmResult | None = None
+    video_result: WarmResult | None = None
+    had_errors = False
+
+    if dry_run:
+        console.print(
+            "[yellow]Dry run - no images will be downloaded.[/yellow]\n"
+        )
+
+    async for session in db_manager.get_session(echo=False):
+        # --- Warm channels ---
+        if type_ in ("channels", "all"):
+            channel_result = await _warm_channels(
+                service=service,
+                session=session,
+                delay=delay,
+                limit=limit,
+                dry_run=dry_run,
+            )
+            if channel_result.failed > 0:
+                had_errors = True
+
+        # --- Warm videos ---
+        if type_ in ("videos", "all"):
+            video_result = await _warm_videos(
+                service=service,
+                session=session,
+                quality=quality,
+                delay=delay,
+                limit=limit,
+                dry_run=dry_run,
+            )
+            if video_result.failed > 0:
+                had_errors = True
+
+    # Display summary
+    _display_summary(
+        channel_result=channel_result,
+        video_result=video_result,
+        dry_run=dry_run,
+    )
+
+    # Exit code: 0 = success, 1 = partial/errors
+    if had_errors:
+        raise typer.Exit(code=1)
+
+
+async def _warm_channels(
+    *,
+    service: ImageCacheService,
+    session: AsyncSession,
+    delay: float,
+    limit: int | None,
+    dry_run: bool,
+) -> WarmResult:
+    """Warm channel avatars with Rich progress display.
+
+    Parameters
+    ----------
+    service : ImageCacheService
+        The image cache service.
+    session : AsyncSession
+        Database session.
+    delay : float
+        Inter-request delay.
+    limit : int | None
+        Download limit.
+    dry_run : bool
+        Dry-run flag.
+
+    Returns
+    -------
+    WarmResult
+        Channel warming result.
+    """
+    if dry_run:
+        console.print("[cyan]Scanning channel avatars...[/cyan]")
+    else:
+        console.print("[cyan]Warming channel avatars...[/cyan]")
+
+    downloaded_count = 0
+    skipped_count = 0
+    failed_count = 0
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        task = progress.add_task("Channels", total=None)
+
+        def channel_callback(entity_id: str, status: str) -> None:
+            nonlocal downloaded_count, skipped_count, failed_count
+            if status == "downloaded" or status == "dry_run":
+                downloaded_count += 1
+            elif status == "skipped" or status == "limit_reached":
+                skipped_count += 1
+            elif status.startswith("failed"):
+                failed_count += 1
+
+            if status == "__backoff__":
+                # Don't update progress for backoff notifications
+                return
+
+            progress.update(
+                task,
+                advance=1 if status != "__backoff__" else 0,
+                description=(
+                    f"Channels ({downloaded_count} "
+                    f"{'to download' if dry_run else 'downloaded'}, "
+                    f"{skipped_count} cached)"
+                ),
+            )
+
+            # Log 429 backoffs to console
+            if entity_id == "__backoff__":
+                console.print(f"  [yellow]Warning: {status}[/yellow]")
+
+        result = await service.warm_channels(
+            session=session,
+            delay=delay,
+            limit=limit,
+            dry_run=dry_run,
+            progress_callback=channel_callback,
+        )
+
+        progress.update(task, total=result.total, completed=result.total)
+
+    return result
+
+
+async def _warm_videos(
+    *,
+    service: ImageCacheService,
+    session: AsyncSession,
+    quality: str,
+    delay: float,
+    limit: int | None,
+    dry_run: bool,
+) -> WarmResult:
+    """Warm video thumbnails with Rich progress display.
+
+    Parameters
+    ----------
+    service : ImageCacheService
+        The image cache service.
+    session : AsyncSession
+        Database session.
+    quality : str
+        Thumbnail quality level.
+    delay : float
+        Inter-request delay.
+    limit : int | None
+        Download limit.
+    dry_run : bool
+        Dry-run flag.
+
+    Returns
+    -------
+    WarmResult
+        Video warming result.
+    """
+    if dry_run:
+        console.print(f"\n[cyan]Scanning video thumbnails ({quality})...[/cyan]")
+    else:
+        console.print(f"\n[cyan]Warming video thumbnails ({quality})...[/cyan]")
+
+    downloaded_count = 0
+    skipped_count = 0
+    failed_count = 0
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        task = progress.add_task("Videos", total=None)
+
+        def video_callback(entity_id: str, status: str) -> None:
+            nonlocal downloaded_count, skipped_count, failed_count
+            if status == "downloaded" or status == "dry_run":
+                downloaded_count += 1
+            elif status == "skipped" or status == "limit_reached":
+                skipped_count += 1
+            elif status.startswith("failed"):
+                failed_count += 1
+
+            if status == "__backoff__":
+                return
+
+            progress.update(
+                task,
+                advance=1 if status != "__backoff__" else 0,
+                description=(
+                    f"Videos ({downloaded_count} "
+                    f"{'to download' if dry_run else 'downloaded'}, "
+                    f"{skipped_count} cached)"
+                ),
+            )
+
+            # Log 429 backoffs to console
+            if entity_id == "__backoff__":
+                console.print(f"  [yellow]Warning: {status}[/yellow]")
+
+        result = await service.warm_videos(
+            session=session,
+            quality=quality,
+            delay=delay,
+            limit=limit,
+            dry_run=dry_run,
+            progress_callback=video_callback,
+        )
+
+        progress.update(task, total=result.total, completed=result.total)
+
+    return result
+
+
+def _display_summary(
+    *,
+    channel_result: WarmResult | None,
+    video_result: WarmResult | None,
+    dry_run: bool,
+) -> None:
+    """Display a summary table of warming results.
+
+    Parameters
+    ----------
+    channel_result : WarmResult | None
+        Result from channel warming, or ``None`` if not performed.
+    video_result : WarmResult | None
+        Result from video warming, or ``None`` if not performed.
+    dry_run : bool
+        Whether this was a dry-run operation.
+    """
+    console.print()
+
+    table = Table(title="Cache Warm Summary")
+    dl_label = "To Download" if dry_run else "Downloaded"
+    table.add_column("Type", style="cyan")
+    table.add_column(dl_label, style="green", justify="right")
+    table.add_column("Cached", style="blue", justify="right")
+    table.add_column("Failed", style="red", justify="right")
+    table.add_column("No URL", style="yellow", justify="right")
+    table.add_column("Total", style="bold", justify="right")
+
+    if channel_result is not None:
+        table.add_row(
+            "Channels",
+            str(channel_result.downloaded),
+            str(channel_result.skipped),
+            str(channel_result.failed),
+            str(channel_result.no_url),
+            str(channel_result.total),
+        )
+
+    if video_result is not None:
+        table.add_row(
+            "Videos",
+            str(video_result.downloaded),
+            str(video_result.skipped),
+            str(video_result.failed),
+            str(video_result.no_url),
+            str(video_result.total),
+        )
+
+    console.print(table)
+
+    if dry_run:
+        # Estimate download sizes
+        ch_dl = channel_result.downloaded if channel_result else 0
+        vid_dl = video_result.downloaded if video_result else 0
+        ch_est_mb = ch_dl * 100 / 1024  # ~100 KB per channel avatar
+        vid_est_mb = vid_dl * 12 / 1024  # ~12 KB per video thumbnail
+        total_est_mb = ch_est_mb + vid_est_mb
+        console.print(
+            f"\n  Estimated download: "
+            f"~{ch_est_mb:.1f} MB (channels, ~100 KB each) + "
+            f"~{vid_est_mb:.1f} MB (videos, ~12 KB each) = "
+            f"~{total_est_mb:.1f} MB"
+        )
+
+
+@app.command(name="status")
+def status() -> None:
+    """
+    Display cache statistics.
+
+    Shows counts of cached images, missing markers, total size, and file ages.
+
+    Examples:
+        chronovista cache status
+    """
+    try:
+        asyncio.run(_status_async())
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Status check interrupted by user[/yellow]")
+        raise typer.Exit(code=130)
+
+
+async def _status_async() -> None:
+    """Async implementation of the cache status command."""
+    service = _build_cache_service()
+    stats = await service.get_stats()
+
+    # Format human-readable size
+    def format_size(size_bytes: int) -> str:
+        """Convert bytes to human-readable format."""
+        if size_bytes < 1024:
+            return f"{size_bytes} B"
+        elif size_bytes < 1024 * 1024:
+            return f"{size_bytes / 1024:.1f} KB"
+        elif size_bytes < 1024 * 1024 * 1024:
+            return f"{size_bytes / (1024 * 1024):.1f} MB"
+        else:
+            return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+
+    # Build statistics table
+    table = Table(title="Image Cache Status")
+    table.add_column("Type", style="cyan")
+    table.add_column("Cached", style="green", justify="right")
+    table.add_column("Missing", style="yellow", justify="right")
+    table.add_column("Size", style="blue", justify="right")
+
+    # Calculate sizes (approximate since we don't track per-type)
+    total_cached = stats.channel_count + stats.video_count
+    channel_size_bytes = 0
+    video_size_bytes = 0
+    if total_cached > 0:
+        # Approximate split based on counts
+        channel_size_bytes = int(
+            stats.total_size_bytes * (stats.channel_count / total_cached)
+        )
+        video_size_bytes = stats.total_size_bytes - channel_size_bytes
+
+    # Add rows
+    table.add_row(
+        "Channels",
+        f"{stats.channel_count:,}",
+        str(stats.channel_missing_count),
+        format_size(channel_size_bytes),
+    )
+    table.add_row(
+        "Videos",
+        f"{stats.video_count:,}",
+        str(stats.video_missing_count),
+        format_size(video_size_bytes),
+    )
+
+    # Add total row
+    total_missing = stats.channel_missing_count + stats.video_missing_count
+    table.add_row(
+        "[bold]Total[/bold]",
+        f"[bold]{total_cached:,}[/bold]",
+        f"[bold]{total_missing}[/bold]",
+        f"[bold]{format_size(stats.total_size_bytes)}[/bold]",
+    )
+
+    console.print()
+    console.print(table)
+    console.print()
+
+    # Display cache directory and file ages
+    console.print(f"  Cache directory: {settings.cache_dir / 'images'}")
+    if stats.oldest_file is not None:
+        console.print(f"  Oldest file:     {stats.oldest_file.strftime('%Y-%m-%d')}")
+    if stats.newest_file is not None:
+        console.print(f"  Newest file:     {stats.newest_file.strftime('%Y-%m-%d')}")
+    console.print()
+
+
+@app.command(name="purge")
+def purge(
+    type_: str = typer.Option(
+        "all",
+        "--type",
+        help='Image type to purge: "channels", "videos", or "all"',
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Skip confirmation prompt",
+    ),
+) -> None:
+    """
+    Delete cached images selectively or entirely.
+
+    Warns about unavailable content that cannot be re-downloaded before
+    prompting for confirmation. Use --force to skip the confirmation prompt.
+
+    Examples:
+        chronovista cache purge
+        chronovista cache purge --type channels
+        chronovista cache purge --type videos --force
+    """
+    # Validate --type
+    if type_ not in _VALID_TYPES:
+        console.print(
+            f'[red]Error: Invalid --type "{type_}". '
+            f"Must be one of: {', '.join(sorted(_VALID_TYPES))}[/red]"
+        )
+        raise typer.Exit(code=2)
+
+    try:
+        asyncio.run(_purge_async(type_=type_, force=force))
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Purge interrupted by user[/yellow]")
+        raise typer.Exit(code=130)
+
+
+async def _purge_async(*, type_: str, force: bool) -> None:
+    """Async implementation of the cache purge command.
+
+    Parameters
+    ----------
+    type_ : str
+        Image type to purge (``"channels"``, ``"videos"``, or ``"all"``).
+    force : bool
+        If ``True``, skip confirmation prompt.
+    """
+    service = _build_cache_service()
+
+    # Check for unavailable content warning
+    unavailable_count = 0
+    async for session in db_manager.get_session(echo=False):
+        unavailable_count = await service.count_unavailable_cached(
+            session=session,
+            type_=type_,
+        )
+
+    # Display warning if unavailable content exists
+    if unavailable_count > 0:
+        console.print(
+            f"\n[yellow]Warning: {unavailable_count} cached image(s) belong to "
+            f"unavailable content that CANNOT be re-downloaded from YouTube.[/yellow]\n"
+        )
+
+    # Confirmation prompt unless --force
+    if not force:
+        type_label = {
+            "channels": "channel images",
+            "videos": "video thumbnails",
+            "all": "all cached images",
+        }[type_]
+
+        confirmation = typer.confirm(
+            f"Are you sure you want to purge {type_label}?",
+            default=False,
+        )
+
+        if not confirmation:
+            console.print("[yellow]Purge cancelled by user[/yellow]")
+            raise typer.Exit(code=1)
+
+    # Perform purge
+    bytes_freed = await service.purge(type_=type_)
+
+    # Format human-readable size
+    def format_size(size_bytes: int) -> str:
+        """Convert bytes to human-readable format."""
+        if size_bytes < 1024:
+            return f"{size_bytes} B"
+        elif size_bytes < 1024 * 1024:
+            return f"{size_bytes / 1024:.1f} KB"
+        elif size_bytes < 1024 * 1024 * 1024:
+            return f"{size_bytes / (1024 * 1024):.1f} MB"
+        else:
+            return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+
+    # Display result
+    console.print()
+    console.print(f"[green]Purge complete: freed {format_size(bytes_freed)}[/green]")
+    console.print()

--- a/src/chronovista/cli/main.py
+++ b/src/chronovista/cli/main.py
@@ -12,6 +12,7 @@ from chronovista import __version__
 from chronovista.cli.auth_commands import auth_app
 from chronovista.cli.category_commands import category_app
 from chronovista.cli.commands.api import api_app
+from chronovista.cli.commands.cache import app as cache_app
 from chronovista.cli.commands.enrich import app as enrich_app
 from chronovista.cli.commands.playlist import playlist_app
 from chronovista.cli.commands.recover import recover_app
@@ -35,6 +36,7 @@ app = typer.Typer(
 # Add subcommands
 app.add_typer(api_app, name="api", help="API server management")
 app.add_typer(auth_app, name="auth", help="Authentication commands")
+app.add_typer(cache_app, name="cache", help="Manage the local image cache")
 app.add_typer(
     category_app, name="categories", help="📂 Video category exploration (creator-assigned)"
 )

--- a/src/chronovista/models/enums.py
+++ b/src/chronovista/models/enums.py
@@ -86,6 +86,20 @@ class PlaylistType(str, Enum):
     FAVORITES = "favorites"  # Legacy Favorites playlist
 
 
+class ImageQuality(str, Enum):
+    """YouTube thumbnail image quality levels.
+
+    Maps to standard YouTube thumbnail URL suffixes for different
+    resolution variants.
+    """
+
+    DEFAULT = "default"
+    MEDIUM = "mqdefault"
+    HIGH = "hqdefault"
+    STANDARD = "sddefault"
+    MAX = "maxresdefault"
+
+
 class LanguageCode(str, Enum):
     """BCP-47 language codes for international content.
 

--- a/src/chronovista/services/image_cache.py
+++ b/src/chronovista/services/image_cache.py
@@ -1,0 +1,1338 @@
+"""
+Image cache proxy service for YouTube thumbnails.
+
+Provides local caching of channel and video thumbnail images with
+automatic fetching, content-type detection via magic bytes, atomic
+writes, and placeholder SVG generation for missing images.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import Video as VideoDB
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Maximum image size: 5 MB (FR-029)
+# ---------------------------------------------------------------------------
+_MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+# ---------------------------------------------------------------------------
+# Minimum image size: 1024 bytes (FR-025 — corrupted file detection)
+# ---------------------------------------------------------------------------
+_MIN_IMAGE_BYTES = 1024
+
+# ---------------------------------------------------------------------------
+# Cache-Control headers
+# ---------------------------------------------------------------------------
+_CACHE_CONTROL_HIT = "public, max-age=604800, immutable"  # 7 days
+_CACHE_CONTROL_PLACEHOLDER = "public, max-age=3600"  # 1 hour
+
+
+# ---------------------------------------------------------------------------
+# Placeholder SVGs
+# ---------------------------------------------------------------------------
+_CHANNEL_PLACEHOLDER_SVG = (
+    b'<svg xmlns="http://www.w3.org/2000/svg" width="240" height="240" '
+    b'viewBox="0 0 240 240">'
+    b'<rect width="240" height="240" fill="#e2e8f0" rx="120"/>'
+    b'<circle cx="120" cy="96" r="40" fill="#94a3b8"/>'
+    b'<ellipse cx="120" cy="196" rx="64" ry="48" fill="#94a3b8"/>'
+    b"</svg>"
+)
+
+_VIDEO_PLACEHOLDER_SVG = (
+    b'<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" '
+    b'viewBox="0 0 320 180">'
+    b'<rect width="320" height="180" fill="#e2e8f0"/>'
+    b'<polygon points="128,60 128,120 192,90" fill="#94a3b8"/>'
+    b"</svg>"
+)
+
+
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║  Pydantic V2 models                                                ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+
+
+class ImageCacheConfig(BaseModel):
+    """Configuration for the image cache proxy.
+
+    Attributes
+    ----------
+    cache_dir : Path
+        Root cache directory (e.g. ``./cache``).
+    channels_dir : Path
+        Derived directory for channel thumbnails.
+    videos_dir : Path
+        Derived directory for video thumbnails.
+    on_demand_timeout : float
+        HTTP timeout in seconds for proxy endpoint cache misses (NFR-001).
+    warm_timeout : float
+        HTTP timeout in seconds for CLI warming operations (NFR-001).
+    max_concurrent_fetches : int
+        Maximum concurrent HTTP fetches (semaphore limit).
+    """
+
+    cache_dir: Path
+    channels_dir: Path
+    videos_dir: Path
+    on_demand_timeout: float = 2.0
+    warm_timeout: float = 10.0
+    max_concurrent_fetches: int = 5
+
+
+class CacheStats(BaseModel):
+    """Statistics about the image cache contents.
+
+    Attributes
+    ----------
+    channel_count : int
+        Number of cached channel images.
+    channel_missing_count : int
+        Number of channel .missing markers.
+    video_count : int
+        Number of cached video images.
+    video_missing_count : int
+        Number of video .missing markers.
+    total_size_bytes : int
+        Total disk usage for all cached images.
+    oldest_file : datetime | None
+        Modification time of the oldest cached file.
+    newest_file : datetime | None
+        Modification time of the newest cached file.
+    """
+
+    channel_count: int
+    channel_missing_count: int
+    video_count: int
+    video_missing_count: int
+    total_size_bytes: int
+    oldest_file: datetime | None
+    newest_file: datetime | None
+
+
+class WarmResult(BaseModel):
+    """Result of a cache-warming operation.
+
+    Attributes
+    ----------
+    downloaded : int
+        Number of images successfully downloaded.
+    skipped : int
+        Number of images already cached (skipped).
+    failed : int
+        Number of images that failed to download.
+    no_url : int
+        Number of entities with no thumbnail URL.
+    total : int
+        Total number of entities processed.
+    """
+
+    downloaded: int
+    skipped: int
+    failed: int
+    no_url: int
+    total: int
+
+
+# ╔══════════════════════════════════════════════════════════════════════╗
+# ║  ImageCacheService                                                  ║
+# ╚══════════════════════════════════════════════════════════════════════╝
+
+
+class ImageCacheService:
+    """Proxy service that caches YouTube thumbnail images locally.
+
+    The service stores images on the local filesystem with atomic writes,
+    detects content types via magic bytes, and serves SVG placeholders
+    when an image is unavailable.
+
+    Parameters
+    ----------
+    config : ImageCacheConfig
+        Cache configuration including directory paths and timeouts.
+    """
+
+    def __init__(self, config: ImageCacheConfig) -> None:
+        self._config = config
+        self._semaphore = asyncio.Semaphore(config.max_concurrent_fetches)
+        self._passthrough = False
+        self.ensure_directories()
+
+    # ------------------------------------------------------------------
+    # Directory management (FR-030)
+    # ------------------------------------------------------------------
+
+    def ensure_directories(self) -> None:
+        """Create cache directories if they do not exist.
+
+        If directory creation fails, the service falls back to passthrough
+        mode where every request returns a placeholder.
+        """
+        try:
+            self._config.channels_dir.mkdir(parents=True, exist_ok=True)
+            self._config.videos_dir.mkdir(parents=True, exist_ok=True)
+            logger.debug(
+                "Image cache directories ready: channels=%s, videos=%s",
+                self._config.channels_dir,
+                self._config.videos_dir,
+            )
+        except OSError:
+            logger.error(
+                "Failed to create image cache directories; "
+                "falling back to passthrough mode",
+                exc_info=True,
+            )
+            self._passthrough = True
+
+    # ------------------------------------------------------------------
+    # Placeholder generation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _serve_placeholder(entity_type: str) -> Response:
+        """Return an SVG placeholder response.
+
+        Parameters
+        ----------
+        entity_type : str
+            Either ``"channel"`` or ``"video"``.
+
+        Returns
+        -------
+        Response
+            SVG placeholder with appropriate headers.
+        """
+        svg_bytes = (
+            _CHANNEL_PLACEHOLDER_SVG
+            if entity_type == "channel"
+            else _VIDEO_PLACEHOLDER_SVG
+        )
+        return Response(
+            content=svg_bytes,
+            media_type="image/svg+xml",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_PLACEHOLDER,
+                "X-Cache": "PLACEHOLDER",
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Content-type detection via magic bytes
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _detect_content_type(file_path: Path) -> str:
+        """Detect image content type by reading magic bytes.
+
+        Parameters
+        ----------
+        file_path : Path
+            Path to the image file on disk.
+
+        Returns
+        -------
+        str
+            MIME type string (``image/jpeg``, ``image/png``, ``image/webp``,
+            or ``image/jpeg`` as fallback).
+        """
+        try:
+            with file_path.open("rb") as f:
+                header = f.read(12)
+        except OSError:
+            return "image/jpeg"
+
+        if header[:2] == b"\xff\xd8":
+            return "image/jpeg"
+        if header[:4] == b"\x89PNG":
+            return "image/png"
+        if header[:4] == b"RIFF" and header[8:12] == b"WEBP":
+            return "image/webp"
+        return "image/jpeg"
+
+    # ------------------------------------------------------------------
+    # Fetch pipeline
+    # ------------------------------------------------------------------
+
+    async def _fetch_and_cache(
+        self,
+        url: str,
+        cache_path: Path,
+        timeout: float,
+    ) -> tuple[bool, str | None]:
+        """Fetch an image from *url* and write it to *cache_path* atomically.
+
+        Parameters
+        ----------
+        url : str
+            Remote image URL to fetch.
+        cache_path : Path
+            Local path where the image should be stored.
+        timeout : float
+            HTTP request timeout in seconds.
+
+        Returns
+        -------
+        tuple[bool, str | None]
+            ``(True, None)`` on success, or ``(False, reason)`` on failure.
+        """
+        async with self._semaphore:
+            try:
+                async with httpx.AsyncClient(
+                    follow_redirects=True,
+                    timeout=timeout,
+                ) as client:
+                    response = await client.get(url)
+            except httpx.TimeoutException:
+                logger.warning("Timeout fetching image: %s", url)
+                return False, "timeout"
+            except httpx.HTTPError as exc:
+                logger.warning("HTTP error fetching image %s: %s", url, exc)
+                return False, f"http_error: {exc}"
+
+        status_code = response.status_code
+
+        # 404 / 410 → create .missing marker (FR-006)
+        if status_code in (404, 410):
+            logger.info("Image not found (%d) at %s; creating .missing marker", status_code, url)
+            self._create_missing_marker(cache_path)
+            return False, f"not_found_{status_code}"
+
+        # 429 / 5xx → transient failure, do NOT create .missing
+        if status_code == 429 or status_code >= 500:
+            logger.warning(
+                "Transient error %d fetching image %s; no .missing marker",
+                status_code,
+                url,
+            )
+            return False, f"server_error_{status_code}"
+
+        # Non-200 → generic failure
+        if status_code != 200:
+            logger.warning("Unexpected status %d fetching image %s", status_code, url)
+            return False, f"unexpected_status_{status_code}"
+
+        # Validate Content-Type contains "image/"
+        content_type = response.headers.get("content-type", "")
+        if "image/" not in content_type:
+            logger.warning(
+                "Non-image content-type '%s' from %s", content_type, url
+            )
+            return False, f"invalid_content_type: {content_type}"
+
+        body = response.content
+
+        # Validate body size (FR-025, FR-029)
+        if len(body) < _MIN_IMAGE_BYTES:
+            logger.warning(
+                "Image too small (%d bytes) from %s", len(body), url
+            )
+            return False, f"too_small_{len(body)}"
+
+        if len(body) > _MAX_IMAGE_BYTES:
+            logger.warning(
+                "Image too large (%d bytes) from %s", len(body), url
+            )
+            return False, f"too_large_{len(body)}"
+
+        # Atomic write: temp file → rename (POSIX atomic rename)
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = cache_path.with_name(
+                f".{cache_path.stem}.tmp.{uuid4()}"
+            )
+            tmp_path.write_bytes(body)
+            tmp_path.rename(cache_path)
+            logger.info("Cached image: %s (%d bytes)", cache_path, len(body))
+            return True, None
+        except OSError:
+            logger.error(
+                "Disk error writing cached image to %s",
+                cache_path,
+                exc_info=True,
+            )
+            return False, "disk_error"
+
+    # ------------------------------------------------------------------
+    # Cache state management
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_cache_path(
+        entity_type: str,
+        entity_id: str,
+        quality: str | None = None,
+        *,
+        channels_dir: Path | None = None,
+        videos_dir: Path | None = None,
+    ) -> Path:
+        """Compute the on-disk cache path for an entity image.
+
+        Parameters
+        ----------
+        entity_type : str
+            ``"channel"`` or ``"video"``.
+        entity_id : str
+            Entity identifier (channel ID or video ID).
+        quality : str | None
+            Quality suffix for video thumbnails (e.g. ``"hqdefault"``).
+        channels_dir : Path | None
+            Override channels directory (used internally).
+        videos_dir : Path | None
+            Override videos directory (used internally).
+
+        Returns
+        -------
+        Path
+            Absolute path where the image should be cached.
+        """
+        if entity_type == "channel":
+            assert channels_dir is not None
+            return channels_dir / f"{entity_id}.jpg"
+        else:
+            assert videos_dir is not None
+            prefix = entity_id[:2] if len(entity_id) >= 2 else entity_id
+            q = quality or "hqdefault"
+            return videos_dir / prefix / f"{entity_id}_{q}.jpg"
+
+    def _resolve_cache_path(
+        self,
+        entity_type: str,
+        entity_id: str,
+        quality: str | None = None,
+    ) -> Path:
+        """Resolve cache path using the service's configured directories.
+
+        Parameters
+        ----------
+        entity_type : str
+            ``"channel"`` or ``"video"``.
+        entity_id : str
+            Entity identifier.
+        quality : str | None
+            Quality suffix for video thumbnails.
+
+        Returns
+        -------
+        Path
+            Absolute path where the image should be cached.
+        """
+        return self._get_cache_path(
+            entity_type,
+            entity_id,
+            quality,
+            channels_dir=self._config.channels_dir,
+            videos_dir=self._config.videos_dir,
+        )
+
+    @staticmethod
+    def _get_missing_path(cache_path: Path) -> Path:
+        """Get the ``.missing`` marker path for a given cache path.
+
+        Parameters
+        ----------
+        cache_path : Path
+            The image cache path (e.g. ``channels/UCxxx.jpg``).
+
+        Returns
+        -------
+        Path
+            Corresponding ``.missing`` marker path.
+        """
+        return cache_path.with_suffix(".missing")
+
+    def _create_missing_marker(self, cache_path: Path) -> None:
+        """Create a zero-byte ``.missing`` marker file.
+
+        Parameters
+        ----------
+        cache_path : Path
+            The image cache path whose marker to create.
+        """
+        missing_path = self._get_missing_path(cache_path)
+        try:
+            missing_path.parent.mkdir(parents=True, exist_ok=True)
+            missing_path.touch()
+        except OSError:
+            logger.error(
+                "Failed to create .missing marker at %s",
+                missing_path,
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _check_cache(cache_path: Path) -> str | None:
+        """Check whether a cached image file exists and is valid.
+
+        If the file exists but is smaller than the minimum size threshold,
+        it is considered corrupted and is deleted.
+
+        Parameters
+        ----------
+        cache_path : Path
+            Path to the cached image file.
+
+        Returns
+        -------
+        str | None
+            ``"HIT"`` if a valid cached file exists, ``None`` otherwise.
+        """
+        if not cache_path.is_file():
+            return None
+        if cache_path.stat().st_size < _MIN_IMAGE_BYTES:
+            logger.warning(
+                "Corrupted cache file (too small), deleting: %s", cache_path
+            )
+            try:
+                cache_path.unlink()
+            except OSError:
+                pass
+            return None
+        return "HIT"
+
+    @staticmethod
+    def _check_missing(cache_path: Path) -> bool:
+        """Check whether a ``.missing`` marker exists for the given cache path.
+
+        Parameters
+        ----------
+        cache_path : Path
+            The image cache path to check.
+
+        Returns
+        -------
+        bool
+            ``True`` if a ``.missing`` marker is present.
+        """
+        return cache_path.with_suffix(".missing").is_file()
+
+    # ------------------------------------------------------------------
+    # Serve a cached file as a Response
+    # ------------------------------------------------------------------
+
+    def _serve_cached_file(self, cache_path: Path, cache_status: str) -> Response:
+        """Serve a cached image file as a Starlette ``Response``.
+
+        Parameters
+        ----------
+        cache_path : Path
+            Path to the cached image on disk.
+        cache_status : str
+            Value for the ``X-Cache`` response header (e.g. ``"HIT"`` or
+            ``"MISS"``).
+
+        Returns
+        -------
+        Response
+            Image response with correct Content-Type, Cache-Control, and
+            X-Cache headers.
+        """
+        content_type = self._detect_content_type(cache_path)
+        body = cache_path.read_bytes()
+        return Response(
+            content=body,
+            media_type=content_type,
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": cache_status,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Public API: get_channel_image (T006)
+    # ------------------------------------------------------------------
+
+    async def get_channel_image(
+        self,
+        session: AsyncSession,
+        channel_id: str,
+    ) -> Response:
+        """Serve a channel thumbnail image, fetching and caching on miss.
+
+        Flow:
+        1. Check local cache (HIT -> serve with 7-day immutable).
+        2. Check ``.missing`` marker -> serve placeholder.
+        3. Look up ``thumbnail_url`` via DB query.
+        4. If channel not found or URL is NULL -> serve placeholder.
+        5. Fetch and cache.
+        6. On success -> serve cached file (X-Cache: MISS).
+        7. On failure -> serve placeholder (X-Cache: PLACEHOLDER).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session for looking up the channel's thumbnail URL.
+        channel_id : str
+            YouTube channel ID (24 characters, starts with UC).
+
+        Returns
+        -------
+        Response
+            Image response (JPEG/PNG/WebP) or SVG placeholder.
+        """
+        if self._passthrough:
+            return self._serve_placeholder("channel")
+
+        cache_path = self._resolve_cache_path("channel", channel_id)
+
+        # 1. Cache HIT
+        cache_status = self._check_cache(cache_path)
+        if cache_status == "HIT":
+            logger.debug("Cache HIT for channel image: %s", channel_id)
+            return self._serve_cached_file(cache_path, "HIT")
+
+        # 2. .missing marker
+        if self._check_missing(cache_path):
+            logger.debug(
+                "Missing marker found for channel image: %s", channel_id
+            )
+            return self._serve_placeholder("channel")
+
+        # 3. Look up thumbnail_url from DB
+        result = await session.execute(
+            select(ChannelDB.thumbnail_url).where(
+                ChannelDB.channel_id == channel_id
+            )
+        )
+        row = result.first()
+
+        # 4. Channel not found or no thumbnail URL
+        if row is None or row[0] is None:
+            logger.info(
+                "No thumbnail URL for channel %s; serving placeholder",
+                channel_id,
+            )
+            return self._serve_placeholder("channel")
+
+        thumbnail_url: str = row[0]
+
+        # 5. Fetch and cache
+        success, reason = await self._fetch_and_cache(
+            url=thumbnail_url,
+            cache_path=cache_path,
+            timeout=self._config.on_demand_timeout,
+        )
+
+        # 6. Success → serve cached file
+        if success:
+            return self._serve_cached_file(cache_path, "MISS")
+
+        # 7. Failure → placeholder
+        logger.info(
+            "Failed to fetch channel image for %s (%s); serving placeholder",
+            channel_id,
+            reason,
+        )
+        return self._serve_placeholder("channel")
+
+    # ------------------------------------------------------------------
+    # Public API: get_video_image (T013)
+    # ------------------------------------------------------------------
+
+    async def get_video_image(
+        self,
+        video_id: str,
+        quality: str = "mqdefault",
+    ) -> Response:
+        """Serve a video thumbnail image, fetching and caching on miss.
+
+        Video thumbnails use deterministic URLs based on the video ID and
+        quality level, so no database lookup is required (FR-008).
+
+        Cache paths use two-character prefix sharding (FR-020):
+        ``{videos_dir}/{video_id[:2]}/{video_id}_{quality}.jpg``
+
+        Flow:
+        1. Check local cache (HIT -> serve with 7-day immutable).
+        2. Check ``.missing`` marker -> serve placeholder.
+        3. Build deterministic YouTube thumbnail URL.
+        4. Fetch and cache.
+        5. On success -> serve cached file (X-Cache: MISS).
+        6. On failure -> serve placeholder (X-Cache: PLACEHOLDER).
+
+        Parameters
+        ----------
+        video_id : str
+            YouTube video ID (11 characters, alphanumeric plus ``-`` and
+            ``_``).
+        quality : str
+            Thumbnail quality level (default ``"mqdefault"``). Must be a
+            valid ``ImageQuality`` enum value.
+
+        Returns
+        -------
+        Response
+            Image response (JPEG/PNG/WebP) or SVG placeholder.
+        """
+        if self._passthrough:
+            return self._serve_placeholder("video")
+
+        cache_path = self._resolve_cache_path("video", video_id, quality)
+
+        # 1. Cache HIT
+        cache_status = self._check_cache(cache_path)
+        if cache_status == "HIT":
+            logger.debug("Cache HIT for video image: %s (%s)", video_id, quality)
+            return self._serve_cached_file(cache_path, "HIT")
+
+        # 2. .missing marker
+        if self._check_missing(cache_path):
+            logger.debug(
+                "Missing marker found for video image: %s (%s)",
+                video_id,
+                quality,
+            )
+            return self._serve_placeholder("video")
+
+        # 3. Deterministic YouTube thumbnail URL (FR-008)
+        thumbnail_url = f"https://i.ytimg.com/vi/{video_id}/{quality}.jpg"
+
+        # 4. Fetch and cache
+        success, reason = await self._fetch_and_cache(
+            url=thumbnail_url,
+            cache_path=cache_path,
+            timeout=self._config.on_demand_timeout,
+        )
+
+        # 5. Success -> serve cached file
+        if success:
+            return self._serve_cached_file(cache_path, "MISS")
+
+        # 6. Failure -> placeholder
+        logger.info(
+            "Failed to fetch video image for %s/%s (%s); serving placeholder",
+            video_id,
+            quality,
+            reason,
+        )
+        return self._serve_placeholder("video")
+
+    # ------------------------------------------------------------------
+    # Exponential backoff helper for 429 responses
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _backoff_on_429(
+        attempt: int,
+        *,
+        initial_wait: float = 60.0,
+        multiplier: float = 2.0,
+        max_wait: float = 300.0,
+        progress_callback: Callable[[str, str], None] | None = None,
+    ) -> None:
+        """Sleep with exponential backoff after a 429 response.
+
+        Parameters
+        ----------
+        attempt : int
+            Zero-based retry attempt number.
+        initial_wait : float
+            Initial backoff duration in seconds (default 60).
+        multiplier : float
+            Backoff multiplier (default 2x).
+        max_wait : float
+            Maximum backoff duration in seconds (default 300).
+        progress_callback : Callable[[str, str], None] | None
+            Optional callback for reporting backoff status.
+        """
+        wait = min(initial_wait * (multiplier ** attempt), max_wait)
+        if progress_callback is not None:
+            progress_callback(
+                "__backoff__",
+                f"429 backoff {wait:.0f}s (attempt {attempt + 1}/3)",
+            )
+        logger.warning(
+            "429 rate-limited — backing off %.0fs (attempt %d/3)",
+            wait,
+            attempt + 1,
+        )
+        await asyncio.sleep(wait)
+
+    # ------------------------------------------------------------------
+    # Internal: fetch with retry for warm operations
+    # ------------------------------------------------------------------
+
+    async def _fetch_with_warm_retry(
+        self,
+        url: str,
+        cache_path: Path,
+        *,
+        progress_callback: Callable[[str, str], None] | None = None,
+    ) -> tuple[bool, str | None]:
+        """Fetch an image with warm timeout and 429 exponential backoff.
+
+        Parameters
+        ----------
+        url : str
+            Remote image URL.
+        cache_path : Path
+            Local cache path.
+        progress_callback : Callable[[str, str], None] | None
+            Optional progress callback.
+
+        Returns
+        -------
+        tuple[bool, str | None]
+            ``(True, None)`` on success, ``(False, reason)`` on failure.
+        """
+        max_retries = 3
+        reason: str | None = None
+        for attempt in range(max_retries):
+            success, reason = await self._fetch_and_cache(
+                url=url,
+                cache_path=cache_path,
+                timeout=self._config.warm_timeout,
+            )
+            if success:
+                return True, None
+            # Retry on 429 only
+            if reason is not None and reason.startswith("server_error_429"):
+                if attempt < max_retries - 1:
+                    await self._backoff_on_429(
+                        attempt,
+                        progress_callback=progress_callback,
+                    )
+                    continue
+            # Non-retryable failure
+            return False, reason
+        return False, reason
+
+    # ------------------------------------------------------------------
+    # Public API: warm_channels (T018)
+    # ------------------------------------------------------------------
+
+    async def warm_channels(
+        self,
+        session: AsyncSession,
+        *,
+        delay: float = 0.5,
+        limit: int | None = None,
+        dry_run: bool = False,
+        progress_callback: Callable[[str, str], None] | None = None,
+    ) -> WarmResult:
+        """Pre-download channel avatar images that are not yet cached.
+
+        Queries all channels from the database and downloads missing
+        thumbnails with rate limiting and exponential backoff on 429.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session for querying channel thumbnail URLs.
+        delay : float
+            Seconds to sleep between successive downloads (default 0.5).
+        limit : int | None
+            Maximum number of images to download.  ``None`` means unlimited.
+        dry_run : bool
+            If ``True``, count what *would* be downloaded without fetching.
+        progress_callback : Callable[[str, str], None] | None
+            Optional ``(entity_id, status)`` callback for CLI progress.
+
+        Returns
+        -------
+        WarmResult
+            Counts of downloaded / skipped / failed / no_url / total.
+        """
+        downloaded = 0
+        skipped = 0
+        failed = 0
+        no_url = 0
+
+        # Query all channels
+        result = await session.execute(
+            select(ChannelDB.channel_id, ChannelDB.thumbnail_url)
+        )
+        rows = result.all()
+        total = len(rows)
+
+        for row in rows:
+            channel_id: str = row[0]
+            thumbnail_url: str | None = row[1]
+
+            # No URL -> count and skip
+            if thumbnail_url is None:
+                no_url += 1
+                if progress_callback is not None:
+                    progress_callback(channel_id, "no_url")
+                continue
+
+            cache_path = self._resolve_cache_path("channel", channel_id)
+            missing_path = self._get_missing_path(cache_path)
+
+            # Check if already cached (valid .jpg >= 1 KB)
+            cache_status = self._check_cache(cache_path)
+            if cache_status == "HIT":
+                skipped += 1
+                if progress_callback is not None:
+                    progress_callback(channel_id, "skipped")
+                continue
+
+            # In dry-run mode, count as "to download" but don't fetch
+            if dry_run:
+                downloaded += 1  # counts as "would download"
+                if progress_callback is not None:
+                    progress_callback(channel_id, "dry_run")
+                continue
+
+            # Check limit
+            if limit is not None and downloaded >= limit:
+                # Remaining channels count as skipped
+                skipped += 1
+                if progress_callback is not None:
+                    progress_callback(channel_id, "limit_reached")
+                continue
+
+            # Remove .missing marker before re-attempt
+            if missing_path.is_file():
+                try:
+                    missing_path.unlink()
+                except OSError:
+                    pass
+
+            # Fetch with retry
+            success, reason = await self._fetch_with_warm_retry(
+                url=thumbnail_url,
+                cache_path=cache_path,
+                progress_callback=progress_callback,
+            )
+
+            if success:
+                downloaded += 1
+                if progress_callback is not None:
+                    progress_callback(channel_id, "downloaded")
+            else:
+                failed += 1
+                if progress_callback is not None:
+                    progress_callback(channel_id, f"failed:{reason}")
+
+            # Rate limiting between fetches
+            if delay > 0:
+                await asyncio.sleep(delay)
+
+        return WarmResult(
+            downloaded=downloaded,
+            skipped=skipped,
+            failed=failed,
+            no_url=no_url,
+            total=total,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API: warm_videos (T018)
+    # ------------------------------------------------------------------
+
+    async def warm_videos(
+        self,
+        session: AsyncSession,
+        *,
+        quality: str = "mqdefault",
+        delay: float = 0.5,
+        limit: int | None = None,
+        dry_run: bool = False,
+        progress_callback: Callable[[str, str], None] | None = None,
+    ) -> WarmResult:
+        """Pre-download video thumbnail images that are not yet cached.
+
+        Queries video IDs from the database in 1,000-row batches and
+        downloads missing thumbnails using deterministic YouTube URLs.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session for querying video IDs.
+        quality : str
+            Thumbnail quality level (default ``"mqdefault"``).
+        delay : float
+            Seconds to sleep between successive downloads (default 0.5).
+        limit : int | None
+            Maximum number of images to download.  ``None`` means unlimited.
+        dry_run : bool
+            If ``True``, count what *would* be downloaded without fetching.
+        progress_callback : Callable[[str, str], None] | None
+            Optional ``(entity_id, status)`` callback for CLI progress.
+
+        Returns
+        -------
+        WarmResult
+            Counts of downloaded / skipped / failed / no_url / total.
+        """
+        downloaded = 0
+        skipped = 0
+        failed = 0
+        # no_url is always 0 for videos (deterministic URLs)
+        no_url = 0
+
+        # Count total videos for reporting
+        count_result = await session.execute(
+            select(func.count()).select_from(VideoDB)
+        )
+        total = count_result.scalar_one()
+
+        # Stream video IDs in 1,000-row batches
+        batch_size = 1000
+        offset = 0
+
+        while True:
+            result = await session.execute(
+                select(VideoDB.video_id)
+                .order_by(VideoDB.video_id)
+                .offset(offset)
+                .limit(batch_size)
+            )
+            batch = result.scalars().all()
+            if not batch:
+                break
+
+            for video_id in batch:
+                cache_path = self._resolve_cache_path(
+                    "video", video_id, quality
+                )
+                missing_path = self._get_missing_path(cache_path)
+
+                # Check if already cached
+                cache_status = self._check_cache(cache_path)
+                if cache_status == "HIT":
+                    skipped += 1
+                    if progress_callback is not None:
+                        progress_callback(video_id, "skipped")
+                    continue
+
+                # Dry-run: count as "would download"
+                if dry_run:
+                    downloaded += 1
+                    if progress_callback is not None:
+                        progress_callback(video_id, "dry_run")
+                    continue
+
+                # Check download limit
+                if limit is not None and downloaded >= limit:
+                    skipped += 1
+                    if progress_callback is not None:
+                        progress_callback(video_id, "limit_reached")
+                    continue
+
+                # Remove .missing marker before re-attempt
+                if missing_path.is_file():
+                    try:
+                        missing_path.unlink()
+                    except OSError:
+                        pass
+
+                # Deterministic URL
+                thumbnail_url = (
+                    f"https://i.ytimg.com/vi/{video_id}/{quality}.jpg"
+                )
+
+                # Fetch with retry
+                success, reason = await self._fetch_with_warm_retry(
+                    url=thumbnail_url,
+                    cache_path=cache_path,
+                    progress_callback=progress_callback,
+                )
+
+                if success:
+                    downloaded += 1
+                    if progress_callback is not None:
+                        progress_callback(video_id, "downloaded")
+                else:
+                    failed += 1
+                    if progress_callback is not None:
+                        progress_callback(video_id, f"failed:{reason}")
+
+                # Rate limiting between fetches
+                if delay > 0:
+                    await asyncio.sleep(delay)
+
+            offset += batch_size
+
+        return WarmResult(
+            downloaded=downloaded,
+            skipped=skipped,
+            failed=failed,
+            no_url=no_url,
+            total=total,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API: get_stats (T024)
+    # ------------------------------------------------------------------
+
+    async def get_stats(self) -> CacheStats:
+        """Compute statistics about the image cache contents.
+
+        Scans the channels and videos cache directories for ``.jpg`` image
+        files and ``.missing`` marker files, counting entries and summing
+        file sizes.
+
+        Returns
+        -------
+        CacheStats
+            Aggregated cache statistics including counts, total size, and
+            oldest/newest file modification times.
+        """
+        channel_count = 0
+        channel_missing_count = 0
+        video_count = 0
+        video_missing_count = 0
+        total_size_bytes = 0
+        oldest_mtime: float | None = None
+        newest_mtime: float | None = None
+
+        def _update_mtime(mtime: float) -> None:
+            nonlocal oldest_mtime, newest_mtime
+            if oldest_mtime is None or mtime < oldest_mtime:
+                oldest_mtime = mtime
+            if newest_mtime is None or mtime > newest_mtime:
+                newest_mtime = mtime
+
+        # Scan channels directory
+        channels_dir = self._config.channels_dir
+        if channels_dir.is_dir():
+            for path in channels_dir.glob("*.jpg"):
+                if path.is_file():
+                    channel_count += 1
+                    stat = path.stat()
+                    total_size_bytes += stat.st_size
+                    _update_mtime(stat.st_mtime)
+            for path in channels_dir.glob("*.missing"):
+                if path.is_file():
+                    channel_missing_count += 1
+
+        # Scan videos directory (recursive due to sharding)
+        videos_dir = self._config.videos_dir
+        if videos_dir.is_dir():
+            for path in videos_dir.rglob("*.jpg"):
+                if path.is_file():
+                    video_count += 1
+                    stat = path.stat()
+                    total_size_bytes += stat.st_size
+                    _update_mtime(stat.st_mtime)
+            for path in videos_dir.rglob("*.missing"):
+                if path.is_file():
+                    video_missing_count += 1
+
+        oldest_file = (
+            datetime.fromtimestamp(oldest_mtime) if oldest_mtime is not None else None
+        )
+        newest_file = (
+            datetime.fromtimestamp(newest_mtime) if newest_mtime is not None else None
+        )
+
+        logger.info(
+            "Cache stats: channels=%d (+%d missing), videos=%d (+%d missing), "
+            "total_size=%d bytes",
+            channel_count,
+            channel_missing_count,
+            video_count,
+            video_missing_count,
+            total_size_bytes,
+        )
+
+        return CacheStats(
+            channel_count=channel_count,
+            channel_missing_count=channel_missing_count,
+            video_count=video_count,
+            video_missing_count=video_missing_count,
+            total_size_bytes=total_size_bytes,
+            oldest_file=oldest_file,
+            newest_file=newest_file,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API: purge (T025)
+    # ------------------------------------------------------------------
+
+    async def purge(self, type_: str) -> int:
+        """Delete cached image files and missing markers by type.
+
+        Removes all ``.jpg`` image files and ``.missing`` marker files from
+        the specified cache directory(ies).  The directories themselves are
+        preserved.
+
+        Parameters
+        ----------
+        type_ : str
+            Which cache to purge: ``"channels"``, ``"videos"``, or
+            ``"all"``.
+
+        Returns
+        -------
+        int
+            Total bytes freed (sum of deleted file sizes).
+        """
+        bytes_freed = 0
+
+        if type_ in ("channels", "all"):
+            bytes_freed += self._purge_directory(
+                self._config.channels_dir, recursive=False
+            )
+
+        if type_ in ("videos", "all"):
+            bytes_freed += self._purge_directory(
+                self._config.videos_dir, recursive=True
+            )
+
+        logger.info(
+            "Purge complete (type=%s): freed %d bytes", type_, bytes_freed
+        )
+        return bytes_freed
+
+    def _purge_directory(self, directory: Path, *, recursive: bool) -> int:
+        """Delete all .jpg and .missing files in a directory.
+
+        Parameters
+        ----------
+        directory : Path
+            Directory to purge.
+        recursive : bool
+            If ``True``, use ``rglob`` to scan subdirectories.
+
+        Returns
+        -------
+        int
+            Total bytes freed.
+        """
+        bytes_freed = 0
+        if not directory.is_dir():
+            return bytes_freed
+
+        glob_fn = directory.rglob if recursive else directory.glob
+
+        for pattern in ("*.jpg", "*.missing"):
+            for path in glob_fn(pattern):
+                if not path.is_file():
+                    continue
+                try:
+                    size = path.stat().st_size
+                    path.unlink()
+                    bytes_freed += size
+                except OSError:
+                    logger.warning(
+                        "Failed to delete cached file: %s",
+                        path,
+                        exc_info=True,
+                    )
+
+        return bytes_freed
+
+    async def count_unavailable_cached(
+        self, session: AsyncSession, type_: str
+    ) -> int:
+        """Count cached images belonging to unavailable content.
+
+        Queries the database for channels or videos whose
+        ``availability_status`` is not ``'available'`` and checks whether
+        a corresponding cached image exists on disk.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session for querying availability status.
+        type_ : str
+            Which cache to check: ``"channels"``, ``"videos"``, or
+            ``"all"``.
+
+        Returns
+        -------
+        int
+            Number of cached images that belong to unavailable content.
+        """
+        count = 0
+
+        if type_ in ("channels", "all"):
+            result = await session.execute(
+                select(ChannelDB.channel_id).where(
+                    ChannelDB.availability_status != "available"
+                )
+            )
+            for row in result.all():
+                channel_id: str = row[0]
+                cache_path = self._resolve_cache_path("channel", channel_id)
+                if cache_path.is_file():
+                    count += 1
+
+        if type_ in ("videos", "all"):
+            result = await session.execute(
+                select(VideoDB.video_id).where(
+                    VideoDB.availability_status != "available"
+                )
+            )
+            for row in result.all():
+                video_id: str = row[0]
+                cache_path = self._resolve_cache_path("video", video_id)
+                if cache_path.is_file():
+                    count += 1
+
+        return count
+
+    # ------------------------------------------------------------------
+    # Public API: invalidate_channel (T028)
+    # ------------------------------------------------------------------
+
+    async def invalidate_channel(self, channel_id: str) -> None:
+        """Invalidate a channel's cached avatar image.
+
+        Deletes the cached ``.jpg`` file and/or ``.missing`` marker for the
+        given channel.  This is a no-op if neither file exists.
+
+        Video thumbnails are never invalidated (FR-018).
+
+        Parameters
+        ----------
+        channel_id : str
+            YouTube channel ID whose cached avatar should be removed.
+        """
+        cache_path = self._resolve_cache_path("channel", channel_id)
+        missing_path = self._get_missing_path(cache_path)
+
+        deleted = False
+
+        if cache_path.is_file():
+            try:
+                cache_path.unlink()
+                deleted = True
+                logger.info(
+                    "Invalidated cached channel image: %s", channel_id
+                )
+            except OSError:
+                logger.error(
+                    "Failed to delete cached channel image for %s",
+                    channel_id,
+                    exc_info=True,
+                )
+
+        if missing_path.is_file():
+            try:
+                missing_path.unlink()
+                deleted = True
+                logger.info(
+                    "Removed .missing marker for channel: %s", channel_id
+                )
+            except OSError:
+                logger.error(
+                    "Failed to delete .missing marker for channel %s",
+                    channel_id,
+                    exc_info=True,
+                )
+
+        if not deleted:
+            logger.debug(
+                "No cached image or .missing marker to invalidate "
+                "for channel: %s",
+                channel_id,
+            )

--- a/tests/integration/api/test_images_integration.py
+++ b/tests/integration/api/test_images_integration.py
@@ -1,0 +1,538 @@
+"""
+Integration tests for image cache proxy endpoints.
+
+Tests end-to-end image caching behavior including cold cache, warm cache,
+sharding, quality variants, and preservation guarantees.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from chronovista.api.main import app
+from chronovista.services.image_cache import (
+    ImageCacheConfig,
+    ImageCacheService,
+    _CACHE_CONTROL_HIT,
+)
+from tests.factories.channel_factory import ChannelTestData
+from tests.factories.video_factory import VideoTestData
+
+# CRITICAL: This line ensures async tests work with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+async def async_client() -> AsyncGenerator[AsyncClient, None]:
+    """Create async test client for FastAPI testing."""
+    from collections.abc import AsyncGenerator
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from chronovista.api.deps import get_db
+
+    # Mock database dependency
+    async def mock_get_db() -> AsyncGenerator[AsyncSession, None]:
+        mock_session = AsyncMock(spec=AsyncSession)
+        yield mock_session
+
+    # Override the dependency
+    app.dependency_overrides[get_db] = mock_get_db
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        # Clean up the override
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def image_cache_config(tmp_path: Path) -> ImageCacheConfig:
+    """Create test image cache configuration."""
+    cache_dir = tmp_path / "cache"
+    return ImageCacheConfig(
+        cache_dir=cache_dir,
+        channels_dir=cache_dir / "images" / "channels",
+        videos_dir=cache_dir / "images" / "videos",
+        on_demand_timeout=2.0,
+        warm_timeout=10.0,
+        max_concurrent_fetches=5,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T017: Video Integration Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestVideoImageIntegration:
+    """End-to-end integration tests for video thumbnail caching."""
+
+    async def test_cold_cache_fetch_warm_cache_serve(
+        self, tmp_path: Path, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test cold cache → fetch → warm cache → serve from cache flow."""
+        service = ImageCacheService(config=image_cache_config)
+        video_id = VideoTestData.VALID_VIDEO_IDS[0]
+        quality = "mqdefault"
+
+        # Verify cache is cold (no file exists)
+        prefix = video_id[:2]
+        cache_path = image_cache_config.videos_dir / prefix / f"{video_id}_{quality}.jpg"
+        assert not cache_path.exists()
+
+        # Mock successful fetch
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = valid_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            # First request: cold cache (MISS)
+            response1 = await service.get_video_image(
+                video_id=video_id,
+                quality=quality,
+            )
+
+        assert response1.status_code == 200
+        assert response1.headers["X-Cache"] == "MISS"
+        assert cache_path.exists()
+        assert cache_path.read_bytes() == valid_image
+
+        # Second request: warm cache (HIT, no network call)
+        response2 = await service.get_video_image(
+            video_id=video_id,
+            quality=quality,
+        )
+
+        assert response2.status_code == 200
+        assert response2.headers["X-Cache"] == "HIT"
+        assert response2.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+
+    async def test_prefix_sharding_creates_correct_subdirectories(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test prefix sharding creates correct subdirectories for videos."""
+        service = ImageCacheService(config=image_cache_config)
+
+        # Test with different video IDs to verify sharding
+        test_cases = [
+            ("dQw4w9WgXcQ", "dQ"),  # Rick Astley
+            ("9bZkp7q19f0", "9b"),  # Tech video
+            ("abcdefghijk", "ab"),  # Test ID
+        ]
+
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = valid_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            for video_id, expected_prefix in test_cases:
+                # Fetch the image
+                await service.get_video_image(
+                    video_id=video_id,
+                    quality="mqdefault",
+                )
+
+                # Verify the sharded directory was created
+                shard_dir = image_cache_config.videos_dir / expected_prefix
+                assert shard_dir.exists()
+                assert shard_dir.is_dir()
+
+                # Verify the file is in the correct location
+                cache_path = shard_dir / f"{video_id}_mqdefault.jpg"
+                assert cache_path.exists()
+
+    async def test_quality_variants_cached_as_separate_files(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test different quality variants are cached as separate files."""
+        service = ImageCacheService(config=image_cache_config)
+        video_id = VideoTestData.VALID_VIDEO_IDS[1]
+        qualities = ["default", "mqdefault", "hqdefault"]
+
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = valid_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            # Fetch each quality variant
+            for quality in qualities:
+                response = await service.get_video_image(
+                    video_id=video_id,
+                    quality=quality,
+                )
+                assert response.status_code == 200
+
+        # Verify all quality variants are cached separately
+        prefix = video_id[:2]
+        shard_dir = image_cache_config.videos_dir / prefix
+
+        for quality in qualities:
+            cache_path = shard_dir / f"{video_id}_{quality}.jpg"
+            assert cache_path.exists()
+            assert cache_path.read_bytes() == valid_image
+
+    async def test_deterministic_url_construction_no_db_query(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test video thumbnails use deterministic URLs without DB queries."""
+        service = ImageCacheService(config=image_cache_config)
+        video_id = VideoTestData.VALID_VIDEO_IDS[2]
+        quality = "hqdefault"
+
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = valid_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            # Fetch the image
+            response = await service.get_video_image(
+                video_id=video_id,
+                quality=quality,
+            )
+
+            # Verify the URL was constructed deterministically
+            mock_client.get.assert_called_once()
+            called_url = mock_client.get.call_args[0][0]
+            expected_url = f"https://i.ytimg.com/vi/{video_id}/{quality}.jpg"
+            assert called_url == expected_url
+
+        assert response.status_code == 200
+        assert response.headers["X-Cache"] == "MISS"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T023: US6 Integration Preservation Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestImagePreservationIntegration:
+    """End-to-end tests for image preservation after availability changes."""
+
+    async def test_end_to_end_cache_then_mark_unavailable_still_serves(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test end-to-end: cache image → mark entity unavailable → request image → verify still served.
+
+        This is the complete integration test for US6: image preservation
+        guarantee. Even after an entity becomes unavailable, its cached
+        image continues to be served.
+        """
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Step 1: Cache the image
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(valid_image)
+
+        # Step 2: Verify image is served (cache HIT)
+        mock_db_session = AsyncMock()
+        response1 = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response1.status_code == 200
+        assert response1.headers["X-Cache"] == "HIT"
+        assert response1.body == valid_image
+
+        # Step 3: Simulate availability_status change
+        # (In reality this would be a DB update, but the cache service
+        # doesn't query availability_status, so it has no effect on serving)
+
+        # Step 4: Request image again - should still be served from cache
+        response2 = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response2.status_code == 200
+        assert response2.headers["X-Cache"] == "HIT"
+        assert response2.body == valid_image
+
+        # Database should never be queried (cache hits)
+        mock_db_session.execute.assert_not_called()
+
+    async def test_video_preservation_after_deletion(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test video thumbnail preservation after video deletion.
+
+        Video thumbnails are even more resilient because they don't require
+        DB queries at all - they use deterministic URLs.
+        """
+        service = ImageCacheService(config=image_cache_config)
+        video_id = VideoTestData.VALID_VIDEO_IDS[0]
+        quality = "mqdefault"
+
+        # Step 1: Cache the video thumbnail
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        prefix = video_id[:2]
+        video_dir = image_cache_config.videos_dir / prefix
+        video_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = video_dir / f"{video_id}_{quality}.jpg"
+        cache_path.write_bytes(valid_image)
+
+        # Step 2: Verify thumbnail is served (cache HIT)
+        response1 = await service.get_video_image(
+            video_id=video_id,
+            quality=quality,
+        )
+
+        assert response1.status_code == 200
+        assert response1.headers["X-Cache"] == "HIT"
+        assert response1.body == valid_image
+
+        # Step 3: Simulate video deletion
+        # (The cache service doesn't check video status, so deletion has no effect)
+
+        # Step 4: Request thumbnail again - should still be served from cache
+        response2 = await service.get_video_image(
+            video_id=video_id,
+            quality=quality,
+        )
+
+        assert response2.status_code == 200
+        assert response2.headers["X-Cache"] == "HIT"
+        assert response2.body == valid_image
+
+    async def test_channel_preservation_across_multiple_availability_states(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test channel image remains cached through various availability states."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[1]
+
+        # Cache the channel image
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(valid_image)
+
+        mock_db_session = AsyncMock()
+
+        # Simulate various availability states (in reality these would be DB updates)
+        # The cache service doesn't check these, so it continues serving the image
+        availability_states = [
+            "available",
+            "private",
+            "deleted",
+            "terminated",
+            "copyright",
+            "tos_violation",
+            "unavailable",
+        ]
+
+        for _ in availability_states:
+            response = await service.get_channel_image(
+                session=mock_db_session,
+                channel_id=channel_id,
+            )
+
+            # Image should always be served from cache
+            assert response.status_code == 200
+            assert response.headers["X-Cache"] == "HIT"
+            assert response.body == valid_image
+
+        # Database should never be queried (all cache hits)
+        mock_db_session.execute.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T012: Channel Image Integration Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestChannelImageIntegration:
+    """End-to-end integration tests for channel avatar caching."""
+
+    async def test_cold_cache_fetch_warm_cache_serve(
+        self, tmp_path: Path, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test cold cache → fetch → warm cache → serve from cache flow."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Verify cache is cold (no file exists)
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        assert not cache_path.exists()
+
+        # Mock database query for thumbnail_url
+        mock_db_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.first.return_value = ("https://example.com/thumbnail.jpg",)
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        # Mock successful HTTP fetch
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = valid_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            # First request: cold cache (MISS)
+            response1 = await service.get_channel_image(
+                session=mock_db_session,
+                channel_id=channel_id,
+            )
+
+        assert response1.status_code == 200
+        assert response1.headers["X-Cache"] == "MISS"
+        assert cache_path.exists()
+        assert cache_path.read_bytes() == valid_image
+
+        # Second request: warm cache (HIT, no network call)
+        response2 = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response2.status_code == 200
+        assert response2.headers["X-Cache"] == "HIT"
+        assert response2.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+
+    async def test_cache_hit_response_time_under_50ms(
+        self, tmp_path: Path, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test cache hit response completes in under 50ms (NFR-003 timing assertion)."""
+        import time
+
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[1]
+
+        # Pre-populate cache
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(valid_image)
+
+        mock_db_session = AsyncMock()
+
+        # Measure cache hit response time
+        start_time = time.monotonic()
+        response = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+        elapsed_ms = (time.monotonic() - start_time) * 1000
+
+        assert response.status_code == 200
+        assert response.headers["X-Cache"] == "HIT"
+        assert elapsed_ms < 50.0, f"Cache hit took {elapsed_ms:.2f}ms, expected < 50ms"
+
+    async def test_proper_x_cache_headers(
+        self, tmp_path: Path, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test proper X-Cache headers: MISS on first request, HIT on second."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[2]
+
+        # Mock database query
+        mock_db_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.first.return_value = ("https://example.com/thumb.jpg",)
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        # Mock HTTP response
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = valid_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            # First request: MISS
+            response1 = await service.get_channel_image(
+                session=mock_db_session,
+                channel_id=channel_id,
+            )
+
+        assert response1.headers["X-Cache"] == "MISS"
+
+        # Second request: HIT
+        response2 = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response2.headers["X-Cache"] == "HIT"
+
+    async def test_cache_control_header_for_real_images(
+        self, tmp_path: Path, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test Cache-Control header: public, max-age=604800, immutable for real images."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[3]
+
+        # Pre-populate cache
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(valid_image)
+
+        mock_db_session = AsyncMock()
+
+        response = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "public, max-age=604800, immutable"

--- a/tests/unit/api/routers/test_images.py
+++ b/tests/unit/api/routers/test_images.py
@@ -1,0 +1,683 @@
+"""
+Unit tests for image cache proxy API endpoints.
+
+Tests the FastAPI channel image endpoint including cache behavior,
+placeholder serving, and error handling.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from chronovista.api.main import app
+from chronovista.services.image_cache import (
+    _CACHE_CONTROL_HIT,
+    _CACHE_CONTROL_PLACEHOLDER,
+    _CHANNEL_PLACEHOLDER_SVG,
+)
+from tests.factories.channel_factory import ChannelTestData
+
+# CRITICAL: This line ensures async tests work with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+async def async_client() -> AsyncGenerator[AsyncClient, None]:
+    """Create async test client for FastAPI testing."""
+    from collections.abc import AsyncGenerator
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from chronovista.api.deps import get_db
+
+    # Mock database dependency
+    async def mock_get_db() -> AsyncGenerator[AsyncSession, None]:
+        mock_session = AsyncMock(spec=AsyncSession)
+        yield mock_session
+
+    # Override the dependency
+    app.dependency_overrides[get_db] = mock_get_db
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        # Clean up the override
+        app.dependency_overrides.clear()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Channel Image Endpoint Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestChannelImageEndpoint:
+    """Tests for GET /api/v1/images/channels/{channel_id} endpoint."""
+
+    async def test_cache_hit_returns_image_with_hit_header(
+        self, async_client: AsyncClient, tmp_path: Path
+    ) -> None:
+        """Test cache HIT returns image bytes with X-Cache: HIT header."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Mock the image cache service to return a HIT response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "HIT",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "image/jpeg"
+        assert response.headers["X-Cache"] == "HIT"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+        assert len(response.content) > 1024
+
+    async def test_cache_miss_fetches_and_returns_with_miss_header(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test cache MISS fetches, caches, returns with X-Cache: MISS."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[1]
+
+        # Mock the image cache service to return a MISS response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "MISS",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "image/jpeg"
+        assert response.headers["X-Cache"] == "MISS"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+
+    async def test_placeholder_on_failure_with_placeholder_header(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test placeholder served on failure with X-Cache: PLACEHOLDER."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[2]
+
+        # Mock the image cache service to return a PLACEHOLDER response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=_CHANNEL_PLACEHOLDER_SVG,
+            media_type="image/svg+xml",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_PLACEHOLDER,
+                "X-Cache": "PLACEHOLDER",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "image/svg+xml"
+        assert response.headers["X-Cache"] == "PLACEHOLDER"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_PLACEHOLDER
+        assert response.content == _CHANNEL_PLACEHOLDER_SVG
+
+    async def test_placeholder_on_null_thumbnail_url(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test placeholder served when channel has NULL thumbnail_url."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[3]
+
+        # Mock the image cache service to return a PLACEHOLDER response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=_CHANNEL_PLACEHOLDER_SVG,
+            media_type="image/svg+xml",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_PLACEHOLDER,
+                "X-Cache": "PLACEHOLDER",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "image/svg+xml"
+        assert response.headers["X-Cache"] == "PLACEHOLDER"
+
+    async def test_invalid_channel_id_format_returns_422(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test invalid channel_id format returns 422 response."""
+        # Too short
+        response = await async_client.get("/api/v1/images/channels/UCxxx")
+        assert response.status_code == 422
+
+        # Too long
+        response = await async_client.get(
+            "/api/v1/images/channels/UCxxx123456789012345678901234567890"
+        )
+        assert response.status_code == 422
+
+        # Wrong prefix
+        response = await async_client.get(
+            "/api/v1/images/channels/XXxxx12345678901234567890"
+        )
+        assert response.status_code == 422
+
+        # Special characters
+        response = await async_client.get(
+            "/api/v1/images/channels/UC@@@12345678901234567890"
+        )
+        assert response.status_code == 422
+
+    async def test_cache_control_header_7_day_for_real_images(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test Cache-Control header is 7-day immutable for real images."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[4]
+
+        # Mock HIT response (real image)
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "HIT",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "public, max-age=604800, immutable"
+
+    async def test_cache_control_header_1_hour_for_placeholders(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test Cache-Control header is 1-hour for placeholders."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Mock PLACEHOLDER response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=_CHANNEL_PLACEHOLDER_SVG,
+            media_type="image/svg+xml",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_PLACEHOLDER,
+                "X-Cache": "PLACEHOLDER",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        assert response.status_code == 200
+        assert response.headers["Cache-Control"] == "public, max-age=3600"
+
+    async def test_endpoint_is_public_no_auth_required(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test endpoint is public and works without authentication."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[1]
+
+        # Mock response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=_CHANNEL_PLACEHOLDER_SVG,
+            media_type="image/svg+xml",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_PLACEHOLDER,
+                "X-Cache": "PLACEHOLDER",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            # No auth headers
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        assert response.status_code == 200
+
+    async def test_endpoint_accepts_only_get_method(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test endpoint only accepts GET method."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[2]
+
+        # POST should not be allowed
+        response = await async_client.post(f"/api/v1/images/channels/{channel_id}")
+        assert response.status_code == 405
+
+        # PUT should not be allowed
+        response = await async_client.put(f"/api/v1/images/channels/{channel_id}")
+        assert response.status_code == 405
+
+        # DELETE should not be allowed
+        response = await async_client.delete(f"/api/v1/images/channels/{channel_id}")
+        assert response.status_code == 405
+
+    async def test_endpoint_handles_png_images(self, async_client: AsyncClient) -> None:
+        """Test endpoint serves PNG images with correct content type."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[3]
+
+        # Mock PNG response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\x89PNG\r\n\x1a\n" + b"\x00" * 2048,
+            media_type="image/png",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "HIT",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "image/png"
+
+    async def test_endpoint_handles_webp_images(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test endpoint serves WebP images with correct content type."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[4]
+
+        # Mock WebP response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 2048,
+            media_type="image/webp",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "HIT",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "image/webp"
+
+    async def test_concurrent_requests_handled_correctly(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test multiple concurrent requests handled correctly."""
+        import asyncio
+
+        channel_ids = ChannelTestData.VALID_CHANNEL_IDS
+
+        # Mock responses
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "HIT",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            # Make 5 concurrent requests
+            responses = await asyncio.gather(
+                *[
+                    async_client.get(f"/api/v1/images/channels/{channel_id}")
+                    for channel_id in channel_ids
+                ]
+            )
+
+        # All should succeed
+        for response in responses:
+            assert response.status_code == 200
+            assert response.headers["X-Cache"] == "HIT"
+
+    async def test_endpoint_path_matches_openapi_spec(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test endpoint path matches OpenAPI specification."""
+        # Get OpenAPI spec
+        response = await async_client.get("/openapi.json")
+        assert response.status_code == 200
+        openapi_spec = response.json()
+
+        # Check that endpoint is documented
+        assert "/api/v1/images/channels/{channel_id}" in openapi_spec["paths"]
+
+        endpoint_spec = openapi_spec["paths"]["/api/v1/images/channels/{channel_id}"]
+        assert "get" in endpoint_spec
+
+        # Check parameters
+        get_spec = endpoint_spec["get"]
+        assert "parameters" in get_spec
+
+        # Verify channel_id parameter
+        channel_id_param = next(
+            (p for p in get_spec["parameters"] if p["name"] == "channel_id"),
+            None,
+        )
+        assert channel_id_param is not None
+        assert channel_id_param["in"] == "path"
+        assert channel_id_param["required"] is True
+        assert channel_id_param["schema"]["minLength"] == 24
+        assert channel_id_param["schema"]["maxLength"] == 24
+
+    async def test_response_does_not_include_api_envelope(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test response is raw binary, not wrapped in ApiResponse."""
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Mock response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "HIT",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_channel_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(
+                f"/api/v1/images/channels/{channel_id}"
+            )
+
+        # Response should be raw binary, not JSON
+        assert response.status_code == 200
+        assert "application/json" not in response.headers.get("Content-Type", "")
+        assert "image/" in response.headers.get("Content-Type", "")
+
+        # Should not be parseable as JSON
+        with pytest.raises(Exception):
+            response.json()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Video Image Endpoint Tests (T015)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestVideoImageEndpoint:
+    """Tests for GET /api/v1/images/videos/{video_id} endpoint."""
+
+    async def test_cache_hit_returns_image_with_hit_header(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test cache HIT returns image bytes with X-Cache: HIT header."""
+        from tests.factories.video_factory import VideoTestData
+
+        video_id = VideoTestData.VALID_VIDEO_IDS[0]
+
+        # Mock the image cache service to return a HIT response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "HIT",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_video_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(f"/api/v1/images/videos/{video_id}")
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "image/jpeg"
+        assert response.headers["X-Cache"] == "HIT"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+        assert len(response.content) > 1024
+
+    async def test_cache_miss_with_deterministic_url(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test cache MISS uses deterministic YouTube URL construction."""
+        from tests.factories.video_factory import VideoTestData
+
+        video_id = VideoTestData.VALID_VIDEO_IDS[1]
+
+        # Mock the image cache service to return a MISS response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "MISS",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_video_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(f"/api/v1/images/videos/{video_id}")
+
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "image/jpeg"
+        assert response.headers["X-Cache"] == "MISS"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+
+    async def test_quality_parameter_default_mqdefault(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test quality parameter defaults to mqdefault when not specified."""
+        from tests.factories.video_factory import VideoTestData
+
+        video_id = VideoTestData.VALID_VIDEO_IDS[2]
+
+        # Mock to capture the quality parameter passed
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "HIT",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_video_image",
+            return_value=mock_response,
+        ) as mock_service:
+            # No quality parameter
+            response = await async_client.get(f"/api/v1/images/videos/{video_id}")
+
+            # Verify the service was called with default quality
+            mock_service.assert_called_once()
+            call_kwargs = mock_service.call_args[1]
+            assert call_kwargs["video_id"] == video_id
+            assert call_kwargs["quality"] == "mqdefault"
+
+        assert response.status_code == 200
+
+    async def test_quality_parameter_variations(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test various quality parameter values work correctly."""
+        from tests.factories.video_factory import VideoTestData
+
+        video_id = VideoTestData.VALID_VIDEO_IDS[3]
+        qualities = ["default", "mqdefault", "hqdefault", "sddefault", "maxresdefault"]
+
+        for quality in qualities:
+            # Mock response
+            from starlette.responses import Response
+
+            mock_response = Response(
+                content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+                media_type="image/jpeg",
+                headers={
+                    "Cache-Control": _CACHE_CONTROL_HIT,
+                    "X-Cache": "HIT",
+                },
+            )
+
+            with patch(
+                "chronovista.api.routers.images._image_cache_service.get_video_image",
+                return_value=mock_response,
+            ) as mock_service:
+                response = await async_client.get(
+                    f"/api/v1/images/videos/{video_id}?quality={quality}"
+                )
+
+                # Verify service called with correct quality
+                mock_service.assert_called_once()
+                call_kwargs = mock_service.call_args[1]
+                assert call_kwargs["quality"] == quality
+
+            assert response.status_code == 200
+
+    async def test_invalid_video_id_returns_422(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test invalid video_id format returns 422 response."""
+        # Too short
+        response = await async_client.get("/api/v1/images/videos/short")
+        assert response.status_code == 422
+
+        # Too long
+        response = await async_client.get("/api/v1/images/videos/toolongvideoid123")
+        assert response.status_code == 422
+
+        # Special characters
+        response = await async_client.get("/api/v1/images/videos/abc@def#hij")
+        assert response.status_code == 422
+
+    async def test_invalid_quality_parameter_returns_422(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test invalid quality parameter returns 422 response."""
+        from tests.factories.video_factory import VideoTestData
+
+        video_id = VideoTestData.VALID_VIDEO_IDS[0]
+
+        # Invalid quality value
+        response = await async_client.get(
+            f"/api/v1/images/videos/{video_id}?quality=invalid"
+        )
+        assert response.status_code == 422
+
+        response_data = response.json()
+        assert "detail" in response_data
+        assert "Invalid quality" in response_data["detail"]
+
+    async def test_sharded_directory_creation(self, async_client: AsyncClient) -> None:
+        """Test video thumbnails use sharded directory structure."""
+        from tests.factories.video_factory import VideoTestData
+
+        video_id = VideoTestData.VALID_VIDEO_IDS[4]  # "abcdefghijk"
+
+        # Mock response
+        from starlette.responses import Response
+
+        mock_response = Response(
+            content=b"\xff\xd8\xff\xe0" + b"\x00" * 2048,
+            media_type="image/jpeg",
+            headers={
+                "Cache-Control": _CACHE_CONTROL_HIT,
+                "X-Cache": "HIT",
+            },
+        )
+
+        with patch(
+            "chronovista.api.routers.images._image_cache_service.get_video_image",
+            return_value=mock_response,
+        ):
+            response = await async_client.get(f"/api/v1/images/videos/{video_id}")
+
+        assert response.status_code == 200
+        # The sharding is handled in the service layer, so we just verify it works

--- a/tests/unit/cli/commands/test_cache.py
+++ b/tests/unit/cli/commands/test_cache.py
@@ -1,0 +1,996 @@
+"""
+Unit tests for cache CLI commands.
+
+Comprehensive test coverage for the `chronovista cache warm` command
+including dry-run mode, type filtering, quality selection, limit/delay
+parameters, exit codes, and error handling.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from chronovista.cli.commands import cache as cache_module
+from chronovista.models.enums import ImageQuality
+from chronovista.services.image_cache import CacheStats, WarmResult
+
+# Create test apps that wrap each command
+test_warm_app = typer.Typer()
+test_warm_app.command(name="warm")(cache_module.warm)
+
+test_status_app = typer.Typer()
+test_status_app.command(name="status")(cache_module.status)
+
+test_purge_app = typer.Typer()
+test_purge_app.command(name="purge")(cache_module.purge)
+
+runner = CliRunner()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def mock_db_session():
+    """Create a mock database session."""
+    session = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def mock_image_cache_service():
+    """Create a mock ImageCacheService."""
+    service = MagicMock()
+
+    # Mock warm_channels method
+    async def mock_warm_channels(*args, **kwargs):
+        return WarmResult(
+            downloaded=10,
+            skipped=5,
+            failed=0,
+            no_url=2,
+            total=17,
+        )
+
+    service.warm_channels = AsyncMock(side_effect=mock_warm_channels)
+
+    # Mock warm_videos method
+    async def mock_warm_videos(*args, **kwargs):
+        return WarmResult(
+            downloaded=50,
+            skipped=25,
+            failed=0,
+            no_url=0,
+            total=75,
+        )
+
+    service.warm_videos = AsyncMock(side_effect=mock_warm_videos)
+
+    return service
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T021: CLI Warm Command Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCacheWarmCommand:
+    """Unit tests for the `cache warm` CLI command."""
+
+    def test_warm_dry_run_shows_counts_without_downloading(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test `warm --dry-run` shows counts without downloading."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, ["--dry-run"])
+
+        assert result.exit_code == 0
+        output = result.output if result.output else result.stdout
+        assert "Dry run" in output or "dry" in output.lower()
+
+        # Verify service methods were called with dry_run=True
+        mock_image_cache_service.warm_channels.assert_called_once()
+        call_kwargs = mock_image_cache_service.warm_channels.call_args.kwargs
+        assert call_kwargs["dry_run"] is True
+
+        mock_image_cache_service.warm_videos.assert_called_once()
+        call_kwargs = mock_image_cache_service.warm_videos.call_args.kwargs
+        assert call_kwargs["dry_run"] is True
+
+    def test_warm_type_channels_only_warms_channels(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test `warm --type channels` only warms channels."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [ "--type", "channels"])
+
+        assert result.exit_code == 0
+
+        # Verify only channels were warmed
+        mock_image_cache_service.warm_channels.assert_called_once()
+        mock_image_cache_service.warm_videos.assert_not_called()
+
+    def test_warm_type_videos_only_warms_videos(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test `warm --type videos` only warms videos."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [ "--type", "videos"])
+
+        assert result.exit_code == 0
+
+        # Verify only videos were warmed
+        mock_image_cache_service.warm_videos.assert_called_once()
+        mock_image_cache_service.warm_channels.assert_not_called()
+
+    def test_warm_type_all_warms_both(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test `warm --type all` warms both channels and videos."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [ "--type", "all"])
+
+        assert result.exit_code == 0
+
+        # Verify both channels and videos were warmed
+        mock_image_cache_service.warm_channels.assert_called_once()
+        mock_image_cache_service.warm_videos.assert_called_once()
+
+    def test_warm_limit_passes_limit_to_service(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test `warm --limit 5` passes limit to service."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [ "--limit", "5"])
+
+        assert result.exit_code == 0
+
+        # Verify limit was passed to both service methods
+        call_kwargs = mock_image_cache_service.warm_channels.call_args.kwargs
+        assert call_kwargs["limit"] == 5
+
+        call_kwargs = mock_image_cache_service.warm_videos.call_args.kwargs
+        assert call_kwargs["limit"] == 5
+
+    def test_warm_delay_passes_delay_to_service(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test `warm --delay 1.0` passes delay to service."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [ "--delay", "1.0"])
+
+        assert result.exit_code == 0
+
+        # Verify delay was passed to both service methods
+        call_kwargs = mock_image_cache_service.warm_channels.call_args.kwargs
+        assert call_kwargs["delay"] == 1.0
+
+        call_kwargs = mock_image_cache_service.warm_videos.call_args.kwargs
+        assert call_kwargs["delay"] == 1.0
+
+    def test_warm_type_invalid_exits_with_code_2(self):
+        """Test `warm --type invalid` exits with code 2."""
+        result = runner.invoke(test_warm_app, [ "--type", "invalid"])
+
+        assert result.exit_code == 2
+        # Rich console output goes to output, not stdout
+        output = result.output if result.output else result.stdout
+        assert "Invalid --type" in output or "invalid" in output.lower()
+
+    def test_warm_quality_invalid_exits_with_code_2(self):
+        """Test `warm --quality invalid` exits with code 2."""
+        result = runner.invoke(test_warm_app, [ "--quality", "invalid"])
+
+        assert result.exit_code == 2
+        # Rich console output goes to output, not stdout
+        output = result.output if result.output else result.stdout
+        assert "Invalid --quality" in output or "invalid" in output.lower()
+
+    def test_warm_with_failed_downloads_exits_with_code_1(
+        self, mock_db_session
+    ):
+        """Test `warm` with failed downloads exits with code 1."""
+
+        # Create service that reports failures
+        service_with_failures = MagicMock()
+
+        async def mock_warm_channels_with_failures(*args, **kwargs):
+            return WarmResult(
+                downloaded=5,
+                skipped=3,
+                failed=2,  # Some failures
+                no_url=1,
+                total=11,
+            )
+
+        service_with_failures.warm_channels = AsyncMock(
+            side_effect=mock_warm_channels_with_failures
+        )
+
+        async def mock_warm_videos_with_failures(*args, **kwargs):
+            return WarmResult(
+                downloaded=10,
+                skipped=5,
+                failed=3,  # Some failures
+                no_url=0,
+                total=18,
+            )
+
+        service_with_failures.warm_videos = AsyncMock(
+            side_effect=mock_warm_videos_with_failures
+        )
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service_with_failures,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [])
+
+        assert result.exit_code == 1
+
+    def test_warm_with_all_successes_exits_with_code_0(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test `warm` with all successes exits with code 0."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [])
+
+        assert result.exit_code == 0
+
+    def test_warm_null_thumbnail_url_reported_as_no_url(
+        self, mock_db_session
+    ):
+        """Test NULL thumbnail_url channels reported as no_url in summary."""
+
+        # Create service that reports no_url entries
+        service_with_no_urls = MagicMock()
+
+        async def mock_warm_channels_with_no_urls(*args, **kwargs):
+            return WarmResult(
+                downloaded=5,
+                skipped=3,
+                failed=0,
+                no_url=10,  # Some channels have no URL
+                total=18,
+            )
+
+        service_with_no_urls.warm_channels = AsyncMock(
+            side_effect=mock_warm_channels_with_no_urls
+        )
+
+        async def mock_warm_videos_no_op(*args, **kwargs):
+            return WarmResult(
+                downloaded=0,
+                skipped=0,
+                failed=0,
+                no_url=0,
+                total=0,
+            )
+
+        service_with_no_urls.warm_videos = AsyncMock(
+            side_effect=mock_warm_videos_no_op
+        )
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service_with_no_urls,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [ "--type", "channels"])
+
+        assert result.exit_code == 0
+        # The summary table should include the No URL column with value 10
+        output = result.output if result.output else result.stdout
+        assert "10" in output  # The no_url count should appear in output
+
+    def test_warm_default_quality_is_mqdefault(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test default quality for video thumbnails is mqdefault."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [ "--type", "videos"])
+
+        assert result.exit_code == 0
+
+        # Verify quality passed to service is mqdefault
+        call_kwargs = mock_image_cache_service.warm_videos.call_args.kwargs
+        assert call_kwargs["quality"] == "mqdefault"
+
+    def test_warm_quality_hqdefault(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test `warm --quality hqdefault` passes correct quality to service."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(
+                    test_warm_app, ["--type", "videos", "--quality", "hqdefault"]
+                )
+
+        assert result.exit_code == 0
+
+        # Verify quality passed to service is hqdefault
+        call_kwargs = mock_image_cache_service.warm_videos.call_args.kwargs
+        assert call_kwargs["quality"] == "hqdefault"
+
+    def test_warm_default_type_is_all(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test default --type is 'all' (both channels and videos)."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [])
+
+        assert result.exit_code == 0
+
+        # Verify both channels and videos were warmed (default is "all")
+        mock_image_cache_service.warm_channels.assert_called_once()
+        mock_image_cache_service.warm_videos.assert_called_once()
+
+    def test_warm_default_delay_is_0_5(
+        self, mock_db_session, mock_image_cache_service
+    ):
+        """Test default --delay is 0.5 seconds."""
+
+        async def mock_get_session(*args, **kwargs):
+            yield mock_db_session
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=mock_image_cache_service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_warm_app, [])
+
+        assert result.exit_code == 0
+
+        # Verify delay passed to service is 0.5
+        call_kwargs = mock_image_cache_service.warm_channels.call_args.kwargs
+        assert call_kwargs["delay"] == 0.5
+
+        call_kwargs = mock_image_cache_service.warm_videos.call_args.kwargs
+        assert call_kwargs["delay"] == 0.5
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T024: CLI Status Command Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCacheStatusCommand:
+    """Unit tests for the `cache status` CLI command."""
+
+    def test_status_displays_cache_stats(self):
+        """Test `status` displays cache statistics in table format."""
+        # Create mock service with realistic stats
+        service = MagicMock()
+
+        async def mock_get_stats():
+            return CacheStats(
+                channel_count=150,
+                channel_missing_count=5,
+                video_count=2500,
+                video_missing_count=12,
+                total_size_bytes=500_000_000,  # 500 MB
+                oldest_file=datetime(2023, 1, 15, tzinfo=timezone.utc),
+                newest_file=datetime(2024, 12, 20, tzinfo=timezone.utc),
+            )
+
+        service.get_stats = AsyncMock(side_effect=mock_get_stats)
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            result = runner.invoke(test_status_app, [])
+
+        assert result.exit_code == 0
+        output = result.output if result.output else result.stdout
+
+        # Verify cache stats appear in output
+        assert "150" in output  # channel_count
+        assert "2,500" in output or "2500" in output  # video_count (may have comma)
+        assert "476" in output or "500" in output  # size in MB (approx)
+
+    def test_status_displays_missing_markers_count(self):
+        """Test `status` displays missing marker counts in table."""
+        service = MagicMock()
+
+        async def mock_get_stats():
+            return CacheStats(
+                channel_count=100,
+                channel_missing_count=8,
+                video_count=1000,
+                video_missing_count=25,
+                total_size_bytes=100_000_000,
+                oldest_file=datetime(2023, 6, 1, tzinfo=timezone.utc),
+                newest_file=datetime(2024, 11, 30, tzinfo=timezone.utc),
+            )
+
+        service.get_stats = AsyncMock(side_effect=mock_get_stats)
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            result = runner.invoke(test_status_app, [])
+
+        assert result.exit_code == 0
+        output = result.output if result.output else result.stdout
+
+        # Verify missing counts appear
+        assert "8" in output  # channel_missing_count
+        assert "25" in output  # video_missing_count
+
+    def test_status_displays_cache_directory_path(self):
+        """Test `status` displays cache directory path."""
+        service = MagicMock()
+
+        async def mock_get_stats():
+            return CacheStats(
+                channel_count=50,
+                channel_missing_count=2,
+                video_count=500,
+                video_missing_count=3,
+                total_size_bytes=50_000_000,
+                oldest_file=datetime(2023, 3, 10, tzinfo=timezone.utc),
+                newest_file=datetime(2024, 10, 15, tzinfo=timezone.utc),
+            )
+
+        service.get_stats = AsyncMock(side_effect=mock_get_stats)
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            result = runner.invoke(test_status_app, [])
+
+        assert result.exit_code == 0
+        output = result.output if result.output else result.stdout
+
+        # Verify cache directory is shown
+        assert "Cache directory:" in output or "cache" in output.lower()
+
+    def test_status_displays_file_dates(self):
+        """Test `status` displays oldest and newest file dates."""
+        service = MagicMock()
+
+        async def mock_get_stats():
+            return CacheStats(
+                channel_count=75,
+                channel_missing_count=1,
+                video_count=800,
+                video_missing_count=5,
+                total_size_bytes=75_000_000,
+                oldest_file=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                newest_file=datetime(2024, 12, 31, tzinfo=timezone.utc),
+            )
+
+        service.get_stats = AsyncMock(side_effect=mock_get_stats)
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            result = runner.invoke(test_status_app, [])
+
+        assert result.exit_code == 0
+        output = result.output if result.output else result.stdout
+
+        # Verify file dates appear
+        assert "2023-01-01" in output  # oldest_file
+        assert "2024-12-31" in output  # newest_file
+
+    def test_status_exits_with_code_0(self):
+        """Test `status` exits with code 0 on success."""
+        service = MagicMock()
+
+        async def mock_get_stats():
+            return CacheStats(
+                channel_count=10,
+                channel_missing_count=0,
+                video_count=100,
+                video_missing_count=0,
+                total_size_bytes=10_000_000,
+                oldest_file=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                newest_file=datetime(2024, 12, 1, tzinfo=timezone.utc),
+            )
+
+        service.get_stats = AsyncMock(side_effect=mock_get_stats)
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            result = runner.invoke(test_status_app, [])
+
+        assert result.exit_code == 0
+
+    def test_status_empty_cache_displays_zero_counts(self):
+        """Test `status` with empty cache shows all zero counts."""
+        service = MagicMock()
+
+        async def mock_get_stats():
+            return CacheStats(
+                channel_count=0,
+                channel_missing_count=0,
+                video_count=0,
+                video_missing_count=0,
+                total_size_bytes=0,
+                oldest_file=None,
+                newest_file=None,
+            )
+
+        service.get_stats = AsyncMock(side_effect=mock_get_stats)
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            result = runner.invoke(test_status_app, [])
+
+        assert result.exit_code == 0
+        output = result.output if result.output else result.stdout
+
+        # Verify zeros appear (multiple times for different columns)
+        # Count occurrences to ensure we're seeing the table data
+        zero_count = output.count("0")
+        assert zero_count >= 4  # At least 4 zeros for cached + missing columns
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T025: CLI Purge Command Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCachePurgeCommand:
+    """Unit tests for the `cache purge` CLI command."""
+
+    def test_purge_with_force_skips_confirmation(self):
+        """Test `purge --force` bypasses confirmation prompt."""
+        service = MagicMock()
+
+        async def mock_count_unavailable(*args, **kwargs):
+            return 0
+
+        async def mock_purge(*args, **kwargs):
+            return 50_000_000  # 50 MB freed
+
+        service.count_unavailable_cached = AsyncMock(
+            side_effect=mock_count_unavailable
+        )
+        service.purge = AsyncMock(side_effect=mock_purge)
+
+        async def mock_get_session(*args, **kwargs):
+            yield AsyncMock()
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_purge_app, ["--force"])
+
+        assert result.exit_code == 0
+        output = result.output if result.output else result.stdout
+
+        # Verify no confirmation prompt appeared
+        assert "Are you sure" not in output
+        # Verify purge was called
+        service.purge.assert_called_once()
+
+    def test_purge_default_type_is_all(self):
+        """Test default purge type is 'all'."""
+        service = MagicMock()
+
+        async def mock_count_unavailable(*args, **kwargs):
+            return 0
+
+        async def mock_purge(*args, **kwargs):
+            return 100_000_000  # 100 MB freed
+
+        service.count_unavailable_cached = AsyncMock(
+            side_effect=mock_count_unavailable
+        )
+        service.purge = AsyncMock(side_effect=mock_purge)
+
+        async def mock_get_session(*args, **kwargs):
+            yield AsyncMock()
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_purge_app, ["--force"])
+
+        assert result.exit_code == 0
+
+        # Verify purge was called with type_="all"
+        call_kwargs = service.purge.call_args.kwargs
+        assert call_kwargs["type_"] == "all"
+
+    def test_purge_type_channels_only(self):
+        """Test `purge --type channels` only purges channels."""
+        service = MagicMock()
+
+        async def mock_count_unavailable(*args, **kwargs):
+            return 0
+
+        async def mock_purge(*args, **kwargs):
+            return 25_000_000  # 25 MB freed
+
+        service.count_unavailable_cached = AsyncMock(
+            side_effect=mock_count_unavailable
+        )
+        service.purge = AsyncMock(side_effect=mock_purge)
+
+        async def mock_get_session(*args, **kwargs):
+            yield AsyncMock()
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(
+                    test_purge_app, ["--type", "channels", "--force"]
+                )
+
+        assert result.exit_code == 0
+
+        # Verify purge was called with type_="channels"
+        call_kwargs = service.purge.call_args.kwargs
+        assert call_kwargs["type_"] == "channels"
+
+    def test_purge_type_videos_only(self):
+        """Test `purge --type videos` only purges videos."""
+        service = MagicMock()
+
+        async def mock_count_unavailable(*args, **kwargs):
+            return 0
+
+        async def mock_purge(*args, **kwargs):
+            return 10_000_000  # 10 MB freed
+
+        service.count_unavailable_cached = AsyncMock(
+            side_effect=mock_count_unavailable
+        )
+        service.purge = AsyncMock(side_effect=mock_purge)
+
+        async def mock_get_session(*args, **kwargs):
+            yield AsyncMock()
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_purge_app, ["--type", "videos", "--force"])
+
+        assert result.exit_code == 0
+
+        # Verify purge was called with type_="videos"
+        call_kwargs = service.purge.call_args.kwargs
+        assert call_kwargs["type_"] == "videos"
+
+    def test_purge_type_invalid_exits_2(self):
+        """Test `purge --type invalid` exits with code 2."""
+        result = runner.invoke(test_purge_app, ["--type", "invalid", "--force"])
+
+        assert result.exit_code == 2
+        output = result.output if result.output else result.stdout
+        assert "Invalid --type" in output or "invalid" in output.lower()
+
+    def test_purge_reports_bytes_freed(self):
+        """Test `purge` reports freed bytes in human-readable format."""
+        service = MagicMock()
+
+        async def mock_count_unavailable(*args, **kwargs):
+            return 0
+
+        async def mock_purge(*args, **kwargs):
+            return 150_000_000  # 150 MB freed
+
+        service.count_unavailable_cached = AsyncMock(
+            side_effect=mock_count_unavailable
+        )
+        service.purge = AsyncMock(side_effect=mock_purge)
+
+        async def mock_get_session(*args, **kwargs):
+            yield AsyncMock()
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_purge_app, ["--force"])
+
+        assert result.exit_code == 0
+        output = result.output if result.output else result.stdout
+
+        # Verify freed size is shown (should be ~143 MB)
+        assert "MB" in output or "freed" in output.lower()
+
+    def test_purge_confirmation_prompt_y(self):
+        """Test purge proceeds when user confirms with 'y'."""
+        service = MagicMock()
+
+        async def mock_count_unavailable(*args, **kwargs):
+            return 0
+
+        async def mock_purge(*args, **kwargs):
+            return 50_000_000  # 50 MB freed
+
+        service.count_unavailable_cached = AsyncMock(
+            side_effect=mock_count_unavailable
+        )
+        service.purge = AsyncMock(side_effect=mock_purge)
+
+        async def mock_get_session(*args, **kwargs):
+            yield AsyncMock()
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                # Simulate user typing "y" at the confirmation prompt
+                result = runner.invoke(test_purge_app, [], input="y\n")
+
+        assert result.exit_code == 0
+        # Verify purge was actually called
+        service.purge.assert_called_once()
+
+    def test_purge_confirmation_prompt_n_exits_1(self):
+        """Test purge cancels with exit code 1 when user responds 'n'."""
+        service = MagicMock()
+
+        async def mock_count_unavailable(*args, **kwargs):
+            return 0
+
+        async def mock_purge(*args, **kwargs):
+            return 50_000_000
+
+        service.count_unavailable_cached = AsyncMock(
+            side_effect=mock_count_unavailable
+        )
+        service.purge = AsyncMock(side_effect=mock_purge)
+
+        async def mock_get_session(*args, **kwargs):
+            yield AsyncMock()
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                # Simulate user typing "n" at the confirmation prompt
+                result = runner.invoke(test_purge_app, [], input="n\n")
+
+        assert result.exit_code == 1
+        output = result.output if result.output else result.stdout
+        assert "cancelled" in output.lower() or "canceled" in output.lower()
+        # Verify purge was NOT called
+        service.purge.assert_not_called()
+
+    def test_purge_unavailable_content_warning(self):
+        """Test purge displays warning about unavailable content."""
+        service = MagicMock()
+
+        async def mock_count_unavailable(*args, **kwargs):
+            return 15  # 15 cached images from unavailable content
+
+        async def mock_purge(*args, **kwargs):
+            return 50_000_000
+
+        service.count_unavailable_cached = AsyncMock(
+            side_effect=mock_count_unavailable
+        )
+        service.purge = AsyncMock(side_effect=mock_purge)
+
+        async def mock_get_session(*args, **kwargs):
+            yield AsyncMock()
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_purge_app, ["--force"])
+
+        assert result.exit_code == 0
+        output = result.output if result.output else result.stdout
+
+        # Verify warning about unavailable content
+        assert "15" in output  # count of unavailable images
+        assert "Warning" in output or "warning" in output.lower()
+        assert (
+            "unavailable" in output.lower() or "CANNOT be re-downloaded" in output
+        )
+
+    def test_purge_exits_0_on_success(self):
+        """Test `purge` exits with code 0 on successful completion."""
+        service = MagicMock()
+
+        async def mock_count_unavailable(*args, **kwargs):
+            return 0
+
+        async def mock_purge(*args, **kwargs):
+            return 75_000_000  # 75 MB freed
+
+        service.count_unavailable_cached = AsyncMock(
+            side_effect=mock_count_unavailable
+        )
+        service.purge = AsyncMock(side_effect=mock_purge)
+
+        async def mock_get_session(*args, **kwargs):
+            yield AsyncMock()
+
+        with patch(
+            "chronovista.cli.commands.cache._build_cache_service",
+            return_value=service,
+        ):
+            with patch(
+                "chronovista.cli.commands.cache.db_manager.get_session",
+                side_effect=mock_get_session,
+            ):
+                result = runner.invoke(test_purge_app, ["--force"])
+
+        assert result.exit_code == 0

--- a/tests/unit/services/test_image_cache.py
+++ b/tests/unit/services/test_image_cache.py
@@ -1,0 +1,1109 @@
+"""
+Unit tests for ImageCacheService.
+
+Tests the core image caching infrastructure including directory management,
+fetch pipeline, cache state management, and placeholder generation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from chronovista.services.image_cache import (
+    ImageCacheConfig,
+    ImageCacheService,
+    _CACHE_CONTROL_HIT,
+    _CACHE_CONTROL_PLACEHOLDER,
+    _CHANNEL_PLACEHOLDER_SVG,
+    _MAX_IMAGE_BYTES,
+    _MIN_IMAGE_BYTES,
+    _VIDEO_PLACEHOLDER_SVG,
+)
+from tests.factories.channel_factory import ChannelTestData
+
+# CRITICAL: This line ensures async tests work with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def image_cache_config(tmp_path: Path) -> ImageCacheConfig:
+    """Create test image cache configuration."""
+    cache_dir = tmp_path / "cache"
+    return ImageCacheConfig(
+        cache_dir=cache_dir,
+        channels_dir=cache_dir / "images" / "channels",
+        videos_dir=cache_dir / "images" / "videos",
+        on_demand_timeout=2.0,
+        warm_timeout=10.0,
+        max_concurrent_fetches=5,
+    )
+
+
+@pytest.fixture
+def mock_db_session() -> AsyncMock:
+    """Create mock database session."""
+    session = AsyncMock(spec=AsyncSession)
+    return session
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T004a: Directory Management Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDirectoryManagement:
+    """Tests for directory creation and passthrough mode."""
+
+    def test_ensure_directories_creates_channels_dir(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test ensure_directories creates channels directory."""
+        service = ImageCacheService(config=image_cache_config)
+
+        assert image_cache_config.channels_dir.exists()
+        assert image_cache_config.channels_dir.is_dir()
+        assert service._passthrough is False
+
+    def test_ensure_directories_creates_videos_dir(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test ensure_directories creates videos directory."""
+        service = ImageCacheService(config=image_cache_config)
+
+        assert image_cache_config.videos_dir.exists()
+        assert image_cache_config.videos_dir.is_dir()
+        assert service._passthrough is False
+
+    def test_ensure_directories_passthrough_on_failure(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test passthrough mode when directory creation fails."""
+        # Make the parent directory read-only to cause mkdir to fail
+        with patch.object(Path, "mkdir", side_effect=OSError("Permission denied")):
+            service = ImageCacheService(config=image_cache_config)
+
+            # Service should be in passthrough mode
+            assert service._passthrough is True
+
+    def test_passthrough_mode_returns_placeholder_for_channel(
+        self, image_cache_config: ImageCacheConfig, mock_db_session: AsyncMock
+    ) -> None:
+        """Test passthrough mode returns placeholder without attempting fetch."""
+        # Force passthrough mode
+        with patch.object(Path, "mkdir", side_effect=OSError("Permission denied")):
+            service = ImageCacheService(config=image_cache_config)
+
+        # Should return placeholder immediately
+        async def run_test() -> None:
+            response = await service.get_channel_image(
+                session=mock_db_session,
+                channel_id=ChannelTestData.VALID_CHANNEL_IDS[0],
+            )
+
+            assert response.status_code == 200
+            assert response.media_type == "image/svg+xml"
+            assert response.body == _CHANNEL_PLACEHOLDER_SVG
+            assert response.headers["X-Cache"] == "PLACEHOLDER"
+            assert response.headers["Cache-Control"] == _CACHE_CONTROL_PLACEHOLDER
+
+            # Database should never be queried in passthrough mode
+            mock_db_session.execute.assert_not_called()
+
+        asyncio.run(run_test())
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Placeholder Generation Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestPlaceholderGeneration:
+    """Tests for SVG placeholder generation."""
+
+    def test_serve_placeholder_channel(self) -> None:
+        """Test placeholder serving for channel returns correct SVG."""
+        response = ImageCacheService._serve_placeholder("channel")
+
+        assert response.status_code == 200
+        assert response.media_type == "image/svg+xml"
+        assert response.body == _CHANNEL_PLACEHOLDER_SVG
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_PLACEHOLDER
+        assert response.headers["X-Cache"] == "PLACEHOLDER"
+
+    def test_serve_placeholder_video(self) -> None:
+        """Test placeholder serving for video returns correct SVG."""
+        response = ImageCacheService._serve_placeholder("video")
+
+        assert response.status_code == 200
+        assert response.media_type == "image/svg+xml"
+        assert response.body == _VIDEO_PLACEHOLDER_SVG
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_PLACEHOLDER
+        assert response.headers["X-Cache"] == "PLACEHOLDER"
+
+    def test_placeholder_svg_contains_valid_xml(self) -> None:
+        """Test placeholder SVG contains valid XML structure."""
+        # Channel placeholder
+        channel_svg = _CHANNEL_PLACEHOLDER_SVG.decode("utf-8")
+        assert channel_svg.startswith("<svg")
+        assert "xmlns=" in channel_svg
+        assert channel_svg.endswith("</svg>")
+
+        # Video placeholder
+        video_svg = _VIDEO_PLACEHOLDER_SVG.decode("utf-8")
+        assert video_svg.startswith("<svg")
+        assert "xmlns=" in video_svg
+        assert video_svg.endswith("</svg>")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T004b: Content-Type Detection Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestContentTypeDetection:
+    """Tests for magic byte content-type detection."""
+
+    def test_detect_content_type_jpeg(self, tmp_path: Path) -> None:
+        """Test JPEG detection via magic bytes."""
+        test_file = tmp_path / "test.jpg"
+        test_file.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+
+        content_type = ImageCacheService._detect_content_type(test_file)
+        assert content_type == "image/jpeg"
+
+    def test_detect_content_type_png(self, tmp_path: Path) -> None:
+        """Test PNG detection via magic bytes."""
+        test_file = tmp_path / "test.png"
+        test_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        content_type = ImageCacheService._detect_content_type(test_file)
+        assert content_type == "image/png"
+
+    def test_detect_content_type_webp(self, tmp_path: Path) -> None:
+        """Test WebP detection via magic bytes."""
+        test_file = tmp_path / "test.webp"
+        test_file.write_bytes(b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 100)
+
+        content_type = ImageCacheService._detect_content_type(test_file)
+        assert content_type == "image/webp"
+
+    def test_detect_content_type_fallback(self, tmp_path: Path) -> None:
+        """Test fallback to image/jpeg for unknown formats."""
+        test_file = tmp_path / "test.bin"
+        test_file.write_bytes(b"UNKNOWN" + b"\x00" * 100)
+
+        content_type = ImageCacheService._detect_content_type(test_file)
+        assert content_type == "image/jpeg"
+
+    def test_detect_content_type_oserror_fallback(self, tmp_path: Path) -> None:
+        """Test fallback when file cannot be read."""
+        nonexistent_file = tmp_path / "nonexistent.jpg"
+
+        content_type = ImageCacheService._detect_content_type(nonexistent_file)
+        assert content_type == "image/jpeg"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T004b: Fetch Pipeline Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestFetchPipeline:
+    """Tests for image fetching and caching pipeline."""
+
+    async def test_fetch_and_cache_success(
+        self, image_cache_config: ImageCacheConfig, tmp_path: Path
+    ) -> None:
+        """Test successful fetch caches file atomically."""
+        service = ImageCacheService(config=image_cache_config)
+        cache_path = tmp_path / "test.jpg"
+
+        # Create valid image bytes (JPEG magic + sufficient size)
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+
+        # Mock httpx response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = valid_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            success, reason = await service._fetch_and_cache(
+                url="https://example.com/image.jpg",
+                cache_path=cache_path,
+                timeout=2.0,
+            )
+
+        assert success is True
+        assert reason is None
+        assert cache_path.exists()
+        assert cache_path.read_bytes() == valid_image
+
+    async def test_fetch_and_cache_validates_content_type(
+        self, image_cache_config: ImageCacheConfig, tmp_path: Path
+    ) -> None:
+        """Test validation rejects non-image content types."""
+        service = ImageCacheService(config=image_cache_config)
+        cache_path = tmp_path / "test.jpg"
+
+        # Mock response with wrong content type
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.content = b"<html>Not an image</html>"
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            success, reason = await service._fetch_and_cache(
+                url="https://example.com/page.html",
+                cache_path=cache_path,
+                timeout=2.0,
+            )
+
+        assert success is False
+        assert reason is not None
+        assert "invalid_content_type" in reason
+        assert not cache_path.exists()
+
+    async def test_fetch_and_cache_validates_too_small(
+        self, image_cache_config: ImageCacheConfig, tmp_path: Path
+    ) -> None:
+        """Test validation rejects images smaller than 1024 bytes."""
+        service = ImageCacheService(config=image_cache_config)
+        cache_path = tmp_path / "test.jpg"
+
+        # Create too-small image (< 1024 bytes)
+        small_image = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = small_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            success, reason = await service._fetch_and_cache(
+                url="https://example.com/small.jpg",
+                cache_path=cache_path,
+                timeout=2.0,
+            )
+
+        assert success is False
+        assert reason is not None
+        assert "too_small" in reason
+        assert not cache_path.exists()
+
+    async def test_fetch_and_cache_validates_too_large(
+        self, image_cache_config: ImageCacheConfig, tmp_path: Path
+    ) -> None:
+        """Test validation rejects images larger than 5MB."""
+        service = ImageCacheService(config=image_cache_config)
+        cache_path = tmp_path / "test.jpg"
+
+        # Create too-large image (> 5MB)
+        large_image = b"\xff\xd8\xff\xe0" + b"\x00" * (_MAX_IMAGE_BYTES + 1000)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = large_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            success, reason = await service._fetch_and_cache(
+                url="https://example.com/huge.jpg",
+                cache_path=cache_path,
+                timeout=2.0,
+            )
+
+        assert success is False
+        assert reason is not None
+        assert "too_large" in reason
+        assert not cache_path.exists()
+
+    async def test_fetch_and_cache_semaphore_limiting(
+        self, image_cache_config: ImageCacheConfig, tmp_path: Path
+    ) -> None:
+        """Test semaphore limits concurrent fetches."""
+        # Set low concurrent limit
+        image_cache_config.max_concurrent_fetches = 2
+        service = ImageCacheService(config=image_cache_config)
+
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = valid_image
+
+        fetch_count = 0
+        max_concurrent = 0
+        current_concurrent = 0
+
+        async def mock_get(url: str) -> Mock:
+            nonlocal fetch_count, max_concurrent, current_concurrent
+            current_concurrent += 1
+            fetch_count += 1
+            max_concurrent = max(max_concurrent, current_concurrent)
+            await asyncio.sleep(0.01)  # Simulate network delay
+            current_concurrent -= 1
+            return mock_response
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get = mock_get
+            mock_client_cls.return_value = mock_client
+
+            # Start 5 concurrent fetches
+            tasks = [
+                service._fetch_and_cache(
+                    url=f"https://example.com/image{i}.jpg",
+                    cache_path=tmp_path / f"image{i}.jpg",
+                    timeout=2.0,
+                )
+                for i in range(5)
+            ]
+
+            results = await asyncio.gather(*tasks)
+
+        # All should succeed
+        assert all(success for success, _ in results)
+
+        # Semaphore should limit to max 2 concurrent
+        assert max_concurrent <= 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T004c: Cache State Management Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCacheStateManagement:
+    """Tests for .missing marker creation and cache validation."""
+
+    async def test_missing_marker_created_on_404(
+        self, image_cache_config: ImageCacheConfig, tmp_path: Path
+    ) -> None:
+        """Test .missing marker created on 404 response."""
+        service = ImageCacheService(config=image_cache_config)
+        cache_path = tmp_path / "test.jpg"
+
+        mock_response = Mock()
+        mock_response.status_code = 404
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            success, reason = await service._fetch_and_cache(
+                url="https://example.com/missing.jpg",
+                cache_path=cache_path,
+                timeout=2.0,
+            )
+
+        assert success is False
+        assert reason is not None and "not_found_404" in reason
+
+        # .missing marker should exist
+        missing_path = cache_path.with_suffix(".missing")
+        assert missing_path.exists()
+
+    async def test_missing_marker_created_on_410(
+        self, image_cache_config: ImageCacheConfig, tmp_path: Path
+    ) -> None:
+        """Test .missing marker created on 410 response."""
+        service = ImageCacheService(config=image_cache_config)
+        cache_path = tmp_path / "test.jpg"
+
+        mock_response = Mock()
+        mock_response.status_code = 410
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            success, reason = await service._fetch_and_cache(
+                url="https://example.com/gone.jpg",
+                cache_path=cache_path,
+                timeout=2.0,
+            )
+
+        assert success is False
+        assert reason is not None and "not_found_410" in reason
+
+        # .missing marker should exist
+        missing_path = cache_path.with_suffix(".missing")
+        assert missing_path.exists()
+
+    async def test_no_missing_marker_on_429(
+        self, image_cache_config: ImageCacheConfig, tmp_path: Path
+    ) -> None:
+        """Test NO .missing marker on 429 (transient error)."""
+        service = ImageCacheService(config=image_cache_config)
+        cache_path = tmp_path / "test.jpg"
+
+        mock_response = Mock()
+        mock_response.status_code = 429
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            success, reason = await service._fetch_and_cache(
+                url="https://example.com/rate_limited.jpg",
+                cache_path=cache_path,
+                timeout=2.0,
+            )
+
+        assert success is False
+        assert reason is not None and "server_error_429" in reason
+
+        # NO .missing marker should exist
+        missing_path = cache_path.with_suffix(".missing")
+        assert not missing_path.exists()
+
+    async def test_no_missing_marker_on_5xx(
+        self, image_cache_config: ImageCacheConfig, tmp_path: Path
+    ) -> None:
+        """Test NO .missing marker on 5xx (transient error)."""
+        service = ImageCacheService(config=image_cache_config)
+        cache_path = tmp_path / "test.jpg"
+
+        mock_response = Mock()
+        mock_response.status_code = 503
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            success, reason = await service._fetch_and_cache(
+                url="https://example.com/server_error.jpg",
+                cache_path=cache_path,
+                timeout=2.0,
+            )
+
+        assert success is False
+        assert reason is not None and "server_error_503" in reason
+
+        # NO .missing marker should exist
+        missing_path = cache_path.with_suffix(".missing")
+        assert not missing_path.exists()
+
+    def test_check_cache_hit_for_valid_file(self, tmp_path: Path) -> None:
+        """Test _check_cache returns HIT for valid cached files."""
+        cache_path = tmp_path / "test.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+
+        result = ImageCacheService._check_cache(cache_path)
+        assert result == "HIT"
+
+    def test_check_cache_deletes_corrupted_file(self, tmp_path: Path) -> None:
+        """Test _check_cache deletes corrupted files (<1024 bytes)."""
+        cache_path = tmp_path / "corrupted.jpg"
+        cache_path.write_bytes(b"\x00" * 512)  # Too small
+
+        result = ImageCacheService._check_cache(cache_path)
+        assert result is None
+        assert not cache_path.exists()
+
+    def test_check_cache_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        """Test _check_cache returns None when file doesn't exist."""
+        cache_path = tmp_path / "nonexistent.jpg"
+
+        result = ImageCacheService._check_cache(cache_path)
+        assert result is None
+
+    def test_check_missing_returns_true_when_marker_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """Test _check_missing returns True when .missing marker exists."""
+        cache_path = tmp_path / "test.jpg"
+        missing_path = cache_path.with_suffix(".missing")
+        missing_path.touch()
+
+        result = ImageCacheService._check_missing(cache_path)
+        assert result is True
+
+    def test_check_missing_returns_false_when_marker_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """Test _check_missing returns False when no marker exists."""
+        cache_path = tmp_path / "test.jpg"
+
+        result = ImageCacheService._check_missing(cache_path)
+        assert result is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T006: get_channel_image() Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGetChannelImage:
+    """Tests for get_channel_image() public API."""
+
+    async def test_cache_hit_path(
+        self, image_cache_config: ImageCacheConfig, mock_db_session: AsyncMock
+    ) -> None:
+        """Test cache HIT path returns image with X-Cache: HIT."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Create cached file
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+
+        response = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response.status_code == 200
+        assert response.media_type == "image/jpeg"
+        assert response.headers["X-Cache"] == "HIT"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+
+        # Database should not be queried on cache hit
+        mock_db_session.execute.assert_not_called()
+
+    async def test_cache_miss_fetch_success(
+        self, image_cache_config: ImageCacheConfig, mock_db_session: AsyncMock
+    ) -> None:
+        """Test cache MISS path fetches and returns with X-Cache: MISS."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[1]
+        thumbnail_url = "https://example.com/thumbnail.jpg"
+
+        # Mock DB query to return thumbnail URL
+        mock_result = MagicMock()
+        mock_row = (thumbnail_url,)
+        mock_result.first.return_value = mock_row
+        mock_db_session.execute.return_value = mock_result
+
+        # Mock successful fetch
+        valid_image = b"\xff\xd8\xff\xe0" + b"\x00" * 2048
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/jpeg"}
+        mock_response.content = valid_image
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            response = await service.get_channel_image(
+                session=mock_db_session,
+                channel_id=channel_id,
+            )
+
+        assert response.status_code == 200
+        assert response.media_type == "image/jpeg"
+        assert response.headers["X-Cache"] == "MISS"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+
+        # Database should be queried
+        mock_db_session.execute.assert_called_once()
+
+    async def test_placeholder_on_fetch_failure(
+        self, image_cache_config: ImageCacheConfig, mock_db_session: AsyncMock
+    ) -> None:
+        """Test PLACEHOLDER path when fetch fails."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[2]
+        thumbnail_url = "https://example.com/thumbnail.jpg"
+
+        # Mock DB query
+        mock_result = MagicMock()
+        mock_row = (thumbnail_url,)
+        mock_result.first.return_value = mock_row
+        mock_db_session.execute.return_value = mock_result
+
+        # Mock failed fetch (timeout)
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.get.side_effect = httpx.TimeoutException("Timeout")
+            mock_client_cls.return_value = mock_client
+
+            response = await service.get_channel_image(
+                session=mock_db_session,
+                channel_id=channel_id,
+            )
+
+        assert response.status_code == 200
+        assert response.media_type == "image/svg+xml"
+        assert response.body == _CHANNEL_PLACEHOLDER_SVG
+        assert response.headers["X-Cache"] == "PLACEHOLDER"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_PLACEHOLDER
+
+    async def test_placeholder_on_null_thumbnail_url(
+        self, image_cache_config: ImageCacheConfig, mock_db_session: AsyncMock
+    ) -> None:
+        """Test placeholder returned when thumbnail_url is NULL."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[3]
+
+        # Mock DB query to return NULL thumbnail URL
+        mock_result = MagicMock()
+        mock_row = (None,)
+        mock_result.first.return_value = mock_row
+        mock_db_session.execute.return_value = mock_result
+
+        response = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response.status_code == 200
+        assert response.media_type == "image/svg+xml"
+        assert response.body == _CHANNEL_PLACEHOLDER_SVG
+        assert response.headers["X-Cache"] == "PLACEHOLDER"
+
+    async def test_placeholder_on_channel_not_found(
+        self, image_cache_config: ImageCacheConfig, mock_db_session: AsyncMock
+    ) -> None:
+        """Test placeholder returned when channel not found in DB."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[4]
+
+        # Mock DB query to return no results
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_db_session.execute.return_value = mock_result
+
+        response = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response.status_code == 200
+        assert response.media_type == "image/svg+xml"
+        assert response.body == _CHANNEL_PLACEHOLDER_SVG
+        assert response.headers["X-Cache"] == "PLACEHOLDER"
+
+    async def test_missing_marker_returns_placeholder_immediately(
+        self, image_cache_config: ImageCacheConfig, mock_db_session: AsyncMock
+    ) -> None:
+        """Test .missing marker causes immediate placeholder return."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Create .missing marker
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        missing_path = cache_path.with_suffix(".missing")
+        missing_path.parent.mkdir(parents=True, exist_ok=True)
+        missing_path.touch()
+
+        response = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response.status_code == 200
+        assert response.media_type == "image/svg+xml"
+        assert response.body == _CHANNEL_PLACEHOLDER_SVG
+        assert response.headers["X-Cache"] == "PLACEHOLDER"
+
+        # Database should not be queried when .missing marker exists
+        mock_db_session.execute.assert_not_called()
+
+    async def test_serve_cached_file_with_correct_content_type(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test _serve_cached_file detects and serves correct content type."""
+        service = ImageCacheService(config=image_cache_config)
+
+        # Create PNG file
+        cache_path = image_cache_config.channels_dir / "test.png"
+        cache_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 2048)
+
+        response = service._serve_cached_file(cache_path, "HIT")
+
+        assert response.status_code == 200
+        assert response.media_type == "image/png"
+        assert response.headers["X-Cache"] == "HIT"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T022: US6 Preservation Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestImagePreservation:
+    """Tests for image preservation guarantees (US6).
+
+    The image cache service serves cached images regardless of entity
+    availability_status. This ensures that deleted/unavailable content
+    continues to show cached thumbnails.
+    """
+
+    async def test_get_channel_image_serves_cached_regardless_of_status(
+        self, image_cache_config: ImageCacheConfig, mock_db_session: AsyncMock
+    ) -> None:
+        """Test get_channel_image() serves cached avatar regardless of channel availability_status.
+
+        The cache service does not check availability_status - it only checks
+        for cached files. This is a behavioral guarantee that cached images
+        are preserved even after entities become unavailable.
+        """
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Create cached file
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+
+        # Service should serve from cache without checking availability_status
+        response = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+
+        assert response.status_code == 200
+        assert response.media_type == "image/jpeg"
+        assert response.headers["X-Cache"] == "HIT"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+
+        # Database should NOT be queried on cache hit (no availability check)
+        mock_db_session.execute.assert_not_called()
+
+    async def test_get_video_image_serves_cached_regardless_of_status(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test get_video_image() serves cached thumbnail regardless of video status.
+
+        Video thumbnails are deterministic and do not require DB queries,
+        so availability_status is never checked. Cached images are always
+        served if present.
+        """
+        from tests.factories.video_factory import VideoTestData
+
+        service = ImageCacheService(config=image_cache_config)
+        video_id = VideoTestData.VALID_VIDEO_IDS[0]
+        quality = "mqdefault"
+
+        # Create cached file in sharded directory
+        prefix = video_id[:2]
+        video_dir = image_cache_config.videos_dir / prefix
+        video_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = video_dir / f"{video_id}_{quality}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+
+        # Service should serve from cache (no DB query for videos)
+        response = await service.get_video_image(
+            video_id=video_id,
+            quality=quality,
+        )
+
+        assert response.status_code == 200
+        assert response.media_type == "image/jpeg"
+        assert response.headers["X-Cache"] == "HIT"
+        assert response.headers["Cache-Control"] == _CACHE_CONTROL_HIT
+
+    async def test_no_cache_invalidation_on_availability_changes(
+        self, image_cache_config: ImageCacheConfig, mock_db_session: AsyncMock
+    ) -> None:
+        """Test that cache is NOT invalidated when availability_status changes.
+
+        This is a behavioral test confirming that the image cache service
+        has no mechanism to invalidate cache based on availability_status.
+        Once an image is cached, it remains cached indefinitely.
+        """
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[1]
+
+        # Create cached file
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+
+        # First request: cache hit
+        response1 = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+        assert response1.headers["X-Cache"] == "HIT"
+
+        # Simulate availability_status change (in reality this would be a DB update,
+        # but the cache service doesn't query availability_status, so it has no effect)
+
+        # Second request: still cache hit (no invalidation)
+        response2 = await service.get_channel_image(
+            session=mock_db_session,
+            channel_id=channel_id,
+        )
+        assert response2.headers["X-Cache"] == "HIT"
+
+        # Cache file should still exist
+        assert cache_path.exists()
+
+        # Database should never be queried (cache hits)
+        mock_db_session.execute.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T030: Cache Invalidation Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCacheInvalidation:
+    """Tests for cache invalidation via invalidate_channel() method.
+
+    The image cache service provides selective invalidation for channel
+    thumbnails when thumbnail_url changes. Video thumbnails are never
+    invalidated (FR-018).
+    """
+
+    async def test_invalidation_deletes_cached_file(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test invalidate_channel() deletes existing .jpg cache file."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Create cached file
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+        assert cache_path.exists()
+
+        # Invalidate
+        await service.invalidate_channel(channel_id)
+
+        # File should be deleted
+        assert not cache_path.exists()
+
+    async def test_invalidation_deletes_missing_marker(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test invalidate_channel() deletes existing .missing marker."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[1]
+
+        # Create .missing marker
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        missing_path = cache_path.with_suffix(".missing")
+        missing_path.touch()
+        assert missing_path.exists()
+
+        # Invalidate
+        await service.invalidate_channel(channel_id)
+
+        # Marker should be deleted
+        assert not missing_path.exists()
+
+    async def test_invalidation_deletes_both_jpg_and_missing(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test invalidate_channel() deletes both .jpg and .missing when both exist."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[2]
+
+        # Create both .jpg and .missing
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+        missing_path = cache_path.with_suffix(".missing")
+        missing_path.touch()
+        assert cache_path.exists()
+        assert missing_path.exists()
+
+        # Invalidate
+        await service.invalidate_channel(channel_id)
+
+        # Both should be deleted
+        assert not cache_path.exists()
+        assert not missing_path.exists()
+
+    async def test_invalidation_noop_when_neither_exists(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test invalidate_channel() is a no-op when no cached files exist.
+
+        This verifies the method handles the case gracefully when there's
+        nothing to invalidate, logging debug but not raising errors.
+        """
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[3]
+
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        missing_path = cache_path.with_suffix(".missing")
+        assert not cache_path.exists()
+        assert not missing_path.exists()
+
+        # Should not raise any errors
+        await service.invalidate_channel(channel_id)
+
+        # Still should not exist (no-op)
+        assert not cache_path.exists()
+        assert not missing_path.exists()
+
+    async def test_null_to_url_preserves_cache(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test NULL → non-NULL thumbnail_url does NOT invalidate cache.
+
+        This is a conceptual test documenting that when old URL is NULL and
+        new URL is non-NULL, no invalidation should happen. The enrichment
+        hook or service calling code is responsible for this logic, not the
+        invalidate_channel() method itself.
+
+        This test verifies the service provides invalidation as a tool, but
+        does NOT automatically invalidate on NULL → URL transitions.
+        """
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Create cached file (simulating old state with NULL URL that somehow
+        # got a cached placeholder or previous image)
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+        assert cache_path.exists()
+
+        # Simulate NULL → URL transition:
+        # The caller (enrichment hook) should recognize this case and NOT call
+        # invalidate_channel() because the old URL was NULL (no old image to
+        # invalidate).
+
+        # Verify cache still exists (because we didn't call invalidate)
+        assert cache_path.exists()
+
+        # This documents that invalidate_channel() is a manual tool - it
+        # doesn't auto-detect NULL → URL transitions.
+
+    async def test_url_to_null_preserves_cache(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test non-NULL → NULL thumbnail_url does NOT invalidate cache.
+
+        This is a conceptual test documenting that when old URL is non-NULL
+        and new URL is NULL, no invalidation should happen. The enrichment
+        hook should preserve the cached image from the old URL even when the
+        new metadata shows NULL.
+
+        This supports FR-006 (image preservation for deleted content).
+        """
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[1]
+
+        # Create cached file (from old non-NULL URL)
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+        assert cache_path.exists()
+
+        # Simulate URL → NULL transition:
+        # The caller (enrichment hook) should recognize this case and NOT call
+        # invalidate_channel() to preserve the cached image from the old URL.
+
+        # Verify cache still exists (because we didn't call invalidate)
+        assert cache_path.exists()
+
+        # This documents preservation behavior: old cached images are kept
+        # even when new metadata shows NULL URL (deleted/unavailable content).
+
+    async def test_video_thumbnails_not_invalidated(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test that there is NO invalidate_video() method on the service.
+
+        Video thumbnails are deterministic and immutable (FR-018), so they
+        should never be invalidated. This test verifies the service does NOT
+        provide an invalidate_video() method.
+        """
+        service = ImageCacheService(config=image_cache_config)
+
+        # Verify no invalidate_video method exists
+        assert not hasattr(service, "invalidate_video")
+
+        # Only invalidate_channel should exist
+        assert hasattr(service, "invalidate_channel")
+
+    async def test_invalidation_handles_disk_errors_gracefully(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test invalidate_channel() logs errors but does not raise on disk failures."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[4]
+
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+
+        # Mock unlink to raise OSError
+        with patch.object(Path, "unlink", side_effect=OSError("Disk error")):
+            # Should not raise - errors are logged
+            await service.invalidate_channel(channel_id)
+
+            # File still exists (deletion failed)
+            assert cache_path.exists()
+
+    async def test_multiple_invalidations_idempotent(
+        self, image_cache_config: ImageCacheConfig
+    ) -> None:
+        """Test that calling invalidate_channel() multiple times is safe and idempotent."""
+        service = ImageCacheService(config=image_cache_config)
+        channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
+
+        # Create cached file
+        cache_path = image_cache_config.channels_dir / f"{channel_id}.jpg"
+        cache_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 2048)
+
+        # First invalidation
+        await service.invalidate_channel(channel_id)
+        assert not cache_path.exists()
+
+        # Second invalidation (should be no-op)
+        await service.invalidate_channel(channel_id)
+        assert not cache_path.exists()
+
+        # Third invalidation (still no-op)
+        await service.invalidate_channel(channel_id)
+        assert not cache_path.exists()


### PR DESCRIPTION
## Summary

- Add backend image proxy that locally caches YouTube channel avatars and video thumbnails, eliminating 429 rate-limit errors from YouTube CDN
- New `ImageCacheService` with async fetch, atomic writes, magic-byte content type detection, `.missing` markers, and SVG placeholder fallbacks
- Two proxy endpoints: `GET /api/v1/images/channels/{channel_id}` and `GET /api/v1/images/videos/{video_id}?quality=mqdefault`
- CLI commands: `cache warm` (pre-warm with Rich Progress), `cache status` (stats table), `cache purge` (selective cleanup)
- Enrichment invalidation hook: auto-deletes cached avatar when channel `thumbnail_url` changes
- Frontend: all YouTube CDN image URLs replaced with backend proxy URLs across ChannelCard, ChannelDetailPage, VideoCard, VideoDetailPage, and PlaylistVideoCard
- Video thumbnails added to VideoCard (`mqdefault`), VideoDetailPage (`sddefault`), and PlaylistVideoCard (`mqdefault`)
- Fix: Wayback page parser now extracts `channel_id` from pre-2020 archive pages via `data-channel-external-id` and `<a>` anchor tag fallbacks

## Test plan

- [ ] 108 new backend tests pass (45 service + 22 router + 31 CLI + 10 integration)
- [ ] 94 new frontend tests pass across 4 component test files
- [ ] 96 page parser tests pass (4 new for channel_id fallback extraction)
- [ ] `mypy --strict` passes on all test files (0 errors)
- [ ] TypeScript strict mode passes (0 errors)
- [ ] `chronovista cache warm --type channels --limit 5` fetches and caches channel avatars
- [ ] `chronovista cache status` displays cache statistics table
- [ ] `chronovista cache purge --type videos --force` clears video thumbnail cache
- [ ] Channel and video images render via proxy URLs in the frontend
- [ ] Placeholder SVG displays when image is unavailable