### PR TITLE
feat(tags): add tag normalization schema and core service (Feature 028a)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive user guide and API reference
 - Architecture documentation
 
+## [0.31.0] - 2026-02-22
+
+### Added
+- **Feature 028a: Tag Normalization Schema & Core Service (ADR-003 Phase 1)**
+  - 5 new tables: `named_entities`, `entity_aliases`, `canonical_tags`, `tag_aliases`, `tag_operation_logs` with UUIDv7 PKs, 15 indexes, all CHECK/UNIQUE/cascade constraints
+  - 9-step `TagNormalizationService.normalize()` pipeline with three-tier selective diacritic stripping (8 safe Tier 1 marks stripped, Tier 2/3 preserved)
+  - `selective_strip_diacritics()` standalone utility for reuse in future phases
+  - `select_canonical_form()` with `str.istitle()` preference, frequency tiebreaker, alphabetical `min()` deterministic tiebreaker
+  - 6 new `(str, Enum)` types: `EntityType` (8), `EntityAliasType` (6), `TagStatus` (3), `CreationMethod` (4), `DiscoveryMethod` (5), `TagOperationType` (5)
+  - Pydantic V2 Base/Create/Update/Full models for all 4 main entities with state invariant validators (FR-027, FR-028)
+  - 4 new repositories inheriting `BaseSQLAlchemyRepository` with ORM model aliasing
+  - 5 factory-boy factories for test data generation
+
+### Technical
+- 189 new tests (71 service + 28 schema + 66 model + 24 repository)
+- Hypothesis property-based tests (500 examples each) for idempotency and Tier 1 absence invariants
+- 98% coverage across all new modules; 5,183 total tests with 0 regressions
+- mypy strict compliance (0 errors)
+- New dependency: `uuid_utils` v0.14.1
+
 ## [0.30.0] - 2026-02-19
 
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -4683,6 +4683,38 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "uuid-utils"
+version = "0.14.1"
+description = "Fast, drop-in replacement for Python's uuid module, powered by Rust."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:93a3b5dc798a54a1feb693f2d1cb4cf08258c32ff05ae4929b5f0a2ca624a4f0"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ccd65a4b8e83af23eae5e56d88034b2fe7264f465d3e830845f10d1591b81741"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b56b0cacd81583834820588378e432b0696186683b813058b707aedc1e16c4b1"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb3cf14de789097320a3c56bfdfdd51b1225d11d67298afbedee7e84e3837c96"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e0854a90d67f4b0cc6e54773deb8be618f4c9bad98d3326f081423b5d14fae"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce6743ba194de3910b5feb1a62590cd2587e33a73ab6af8a01b642ceb5055862"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:043fb58fde6cf1620a6c066382f04f87a8e74feb0f95a585e4ed46f5d44af57b"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c915d53f22945e55fe0d3d3b0b87fd965a57f5fd15666fd92d6593a73b1dd297"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0972488e3f9b449e83f006ead5a0e0a33ad4a13e4462e865b7c286ab7d7566a3"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1c238812ae0c8ffe77d8d447a32c6dfd058ea4631246b08b5a71df586ff08531"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bec8f8ef627af86abf8298e7ec50926627e29b34fa907fcfbedb45aaa72bca43"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-win32.whl", hash = "sha256:b54d6aa6252d96bac1fdbc80d26ba71bad9f220b2724d692ad2f2310c22ef523"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-win_amd64.whl", hash = "sha256:fc27638c2ce267a0ce3e06828aff786f91367f093c80625ee21dad0208e0f5ba"},
+    {file = "uuid_utils-0.14.1-cp39-abi3-win_arm64.whl", hash = "sha256:b04cb49b42afbc4ff8dbc60cf054930afc479d6f4dd7f1ec3bbe5dbfdde06b7a"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b197cd5424cf89fb019ca7f53641d05bfe34b1879614bed111c9c313b5574cd8"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:12c65020ba6cb6abe1d57fcbfc2d0ea0506c67049ee031714057f5caf0f9bc9c"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b5d2ad28063d422ccc2c28d46471d47b61a58de885d35113a8f18cb547e25bf"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da2234387b45fde40b0fedfee64a0ba591caeea9c48c7698ab6e2d85c7991533"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50fffc2827348c1e48972eed3d1c698959e63f9d030aa5dd82ba451113158a62"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dbe718765f70f5b7f9b7f66b6a937802941b1cc56bcf642ce0274169741e01"},
+    {file = "uuid_utils-0.14.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:258186964039a8e36db10810c1ece879d229b01331e09e9030bc5dcabe231bd2"},
+    {file = "uuid_utils-0.14.1.tar.gz", hash = "sha256:9bfc95f64af80ccf129c604fb6b8ca66c6f256451e32bc4570f760e4309c9b69"},
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.27.1"
 description = "The lightning-fast ASGI server."
@@ -5280,4 +5312,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "f3a5a78ed5af87a1fb1dbf7f1bbd1a9dc05e6b2b104e5687acc21964122d6d5c"
+content-hash = "3e7aa480fdfe0dfb59b3098a51e6356653e796b4a6cd6c118646588ceed1c33f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.30.0"
+version = "0.31.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]
@@ -47,6 +47,7 @@ youtube-transcript-api = "^1.2.2"
 fastapi = "^0.109.0"
 uvicorn = {extras = ["standard"], version = "^0.27.0"}
 beautifulsoup4 = "^4.12.0"
+uuid-utils = "^0.14.1"
 
 [tool.poetry.group.recovery]
 optional = true

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/db/migrations/versions/028a_add_tag_normalization_tables.py
+++ b/src/chronovista/db/migrations/versions/028a_add_tag_normalization_tables.py
@@ -1,0 +1,522 @@
+"""add_tag_normalization_tables
+
+Revision ID: f9b5c8d6e3a1
+Revises: e8a4f5c9d7b2
+Create Date: 2026-02-22 14:00:00.000000
+
+This migration implements the tag normalization schema for Feature 028
+(Tag Normalization Schema). It creates five new tables to support
+conservative tag normalization, entity extraction, and operation logging.
+
+New Tables:
+1. named_entities - Named entities extracted from tags (people, places, orgs, etc.)
+2. entity_aliases - Alternative names/variations for named entities
+3. canonical_tags - Canonical tag forms with normalization
+4. tag_aliases - Raw tag forms mapped to canonical tags
+5. tag_operation_logs - Audit log for tag management operations
+
+Key Features:
+- UUIDv7 primary keys for all new tables
+- Conservative normalization (case/accent/hashtag folding only)
+- Entity linking with confidence scores
+- Tag merge/split operation tracking with rollback support
+- Comprehensive CHECK constraints for data integrity
+- 15 performance indexes including partial indexes
+
+Related: Feature 028 (Tag Normalization Schema), Tasks T005-T006
+Architecture: ADR-003 Tag Normalization
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+# revision identifiers, used by Alembic.
+revision = "f9b5c8d6e3a1"
+down_revision = "e8a4f5c9d7b2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """
+    Create tag normalization tables with all constraints and indexes.
+
+    Creates tables in FK dependency order:
+    1. named_entities (no FK dependencies)
+    2. entity_aliases, canonical_tags (FK to named_entities)
+    3. tag_aliases, tag_operation_logs (FK to canonical_tags or none)
+    """
+    # =========================================================================
+    # TABLE 1: named_entities (no FK dependencies)
+    # =========================================================================
+    op.create_table(
+        "named_entities",
+        sa.Column("id", UUID(as_uuid=True), nullable=False, primary_key=True),
+        sa.Column("canonical_name", sa.String(500), nullable=False),
+        sa.Column("canonical_name_normalized", sa.String(500), nullable=False),
+        sa.Column("entity_type", sa.String(50), nullable=False),
+        sa.Column("entity_subtype", sa.String(100), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "external_ids",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("mention_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("video_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("channel_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "discovery_method",
+            sa.String(30),
+            nullable=False,
+            server_default=sa.text("'manual'"),
+        ),
+        sa.Column("confidence", sa.Float(), nullable=False, server_default=sa.text("1.0")),
+        sa.Column("status", sa.String(20), nullable=False, server_default=sa.text("'active'")),
+        sa.Column("merged_into_id", UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_named_entities"),
+        sa.ForeignKeyConstraint(
+            ["merged_into_id"],
+            ["named_entities.id"],
+            name="fk_named_entities_merged_into",
+        ),
+        sa.UniqueConstraint(
+            "canonical_name_normalized",
+            "entity_type",
+            name="uq_named_entity_canonical",
+        ),
+        sa.CheckConstraint(
+            "entity_type IN ('person', 'organization', 'place', 'event', 'work', 'technical_term')",
+            name="chk_entity_type_valid",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'merged', 'deprecated')",
+            name="chk_entity_status_valid",
+        ),
+        sa.CheckConstraint(
+            "discovery_method IN ('manual', 'spacy_ner', 'tag_bootstrap', 'llm_extraction', 'user_created')",
+            name="chk_entity_discovery_method_valid",
+        ),
+        sa.CheckConstraint(
+            "confidence >= 0.0 AND confidence <= 1.0",
+            name="chk_entity_confidence_range",
+        ),
+    )
+
+    # =========================================================================
+    # TABLE 2: entity_aliases (FK to named_entities)
+    # =========================================================================
+    op.create_table(
+        "entity_aliases",
+        sa.Column("id", UUID(as_uuid=True), nullable=False, primary_key=True),
+        sa.Column("entity_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("alias_name", sa.String(500), nullable=False),
+        sa.Column("alias_name_normalized", sa.String(500), nullable=False),
+        sa.Column(
+            "alias_type",
+            sa.String(30),
+            nullable=False,
+            server_default=sa.text("'name_variant'"),
+        ),
+        sa.Column("occurrence_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "first_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_entity_aliases"),
+        sa.ForeignKeyConstraint(
+            ["entity_id"],
+            ["named_entities.id"],
+            name="fk_entity_aliases_entity",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "alias_name_normalized",
+            "entity_id",
+            name="uq_entity_alias_name",
+        ),
+        sa.CheckConstraint(
+            "alias_type IN ('name_variant', 'abbreviation', 'nickname', 'asr_error', 'translated_name', 'former_name')",
+            name="chk_alias_type_valid",
+        ),
+    )
+
+    # =========================================================================
+    # TABLE 3: canonical_tags (FK to named_entities)
+    # =========================================================================
+    op.create_table(
+        "canonical_tags",
+        sa.Column("id", UUID(as_uuid=True), nullable=False, primary_key=True),
+        sa.Column("canonical_form", sa.String(500), nullable=False),
+        sa.Column("normalized_form", sa.String(500), nullable=False, unique=True),
+        sa.Column("alias_count", sa.Integer(), nullable=False, server_default=sa.text("1")),
+        sa.Column("video_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("entity_type", sa.String(50), nullable=True),
+        sa.Column("entity_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("status", sa.String(20), nullable=False, server_default=sa.text("'active'")),
+        sa.Column("merged_into_id", UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_canonical_tags"),
+        sa.ForeignKeyConstraint(
+            ["entity_id"],
+            ["named_entities.id"],
+            name="fk_canonical_tags_entity",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["merged_into_id"],
+            ["canonical_tags.id"],
+            name="fk_canonical_tags_merged_into",
+        ),
+        sa.CheckConstraint(
+            "entity_type IN ('person', 'organization', 'place', 'event', 'work', 'technical_term', 'topic', 'descriptor') OR entity_type IS NULL",
+            name="chk_canonical_tag_entity_type_valid",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'merged', 'deprecated')",
+            name="chk_canonical_tag_status_valid",
+        ),
+        sa.CheckConstraint(
+            "alias_count >= 1",
+            name="chk_canonical_tag_alias_count_positive",
+        ),
+        sa.CheckConstraint(
+            "video_count >= 0",
+            name="chk_canonical_tag_video_count_non_negative",
+        ),
+        sa.CheckConstraint(
+            "canonical_form != ''",
+            name="chk_canonical_tag_canonical_form_not_empty",
+        ),
+    )
+
+    # =========================================================================
+    # TABLE 4: tag_aliases (FK to canonical_tags)
+    # =========================================================================
+    op.create_table(
+        "tag_aliases",
+        sa.Column("id", UUID(as_uuid=True), nullable=False, primary_key=True),
+        sa.Column("raw_form", sa.String(500), nullable=False, unique=True),
+        sa.Column("normalized_form", sa.String(500), nullable=False),
+        sa.Column("canonical_tag_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "creation_method",
+            sa.String(30),
+            nullable=False,
+            server_default=sa.text("'auto_normalize'"),
+        ),
+        sa.Column(
+            "normalization_version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "occurrence_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "first_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_tag_aliases"),
+        sa.ForeignKeyConstraint(
+            ["canonical_tag_id"],
+            ["canonical_tags.id"],
+            name="fk_tag_aliases_canonical_tag",
+            ondelete="CASCADE",
+        ),
+        sa.CheckConstraint(
+            "creation_method IN ('auto_normalize', 'manual_merge', 'backfill', 'api_create')",
+            name="chk_tag_alias_creation_method_valid",
+        ),
+        sa.CheckConstraint(
+            "occurrence_count >= 1",
+            name="chk_tag_alias_occurrence_count_positive",
+        ),
+    )
+
+    # =========================================================================
+    # TABLE 5: tag_operation_logs (no FK dependencies, just plain UUID column)
+    # =========================================================================
+    op.create_table(
+        "tag_operation_logs",
+        sa.Column("id", UUID(as_uuid=True), nullable=False, primary_key=True),
+        sa.Column("operation_type", sa.String(30), nullable=False),
+        sa.Column(
+            "source_canonical_ids",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("target_canonical_id", UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "affected_alias_ids",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column(
+            "performed_by",
+            sa.String(100),
+            nullable=False,
+            server_default=sa.text("'system'"),
+        ),
+        sa.Column(
+            "performed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "rollback_data",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("rolled_back", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("rolled_back_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id", name="pk_tag_operation_logs"),
+        sa.CheckConstraint(
+            "operation_type IN ('merge', 'split', 'rename', 'delete', 'create')",
+            name="chk_tag_operation_type_valid",
+        ),
+    )
+
+    # =========================================================================
+    # INDEXES (15 total)
+    # =========================================================================
+
+    # Index 1: canonical_tags - video count descending (hot tags)
+    op.create_index(
+        "idx_canonical_tags_video_count_desc",
+        "canonical_tags",
+        [sa.text("video_count DESC")],
+        unique=False,
+    )
+
+    # Index 2: canonical_tags - canonical form pattern ops (LIKE queries)
+    op.create_index(
+        "idx_canonical_tags_canonical_pattern",
+        "canonical_tags",
+        ["canonical_form"],
+        unique=False,
+        postgresql_ops={"canonical_form": "varchar_pattern_ops"},
+    )
+
+    # Index 3: canonical_tags - entity_id (partial index WHERE NOT NULL)
+    op.create_index(
+        "idx_canonical_tags_entity_id",
+        "canonical_tags",
+        ["entity_id"],
+        unique=False,
+        postgresql_where=sa.text("entity_id IS NOT NULL"),
+    )
+
+    # Index 4: canonical_tags - normalized form for active tags (partial)
+    op.create_index(
+        "idx_canonical_tags_active_normalized",
+        "canonical_tags",
+        ["normalized_form"],
+        unique=False,
+        postgresql_where=sa.text("status = 'active'"),
+    )
+
+    # Index 5: tag_aliases - normalized form
+    op.create_index(
+        "idx_tag_aliases_normalized",
+        "tag_aliases",
+        ["normalized_form"],
+        unique=False,
+    )
+
+    # Index 6: tag_aliases - canonical_tag_id
+    op.create_index(
+        "idx_tag_aliases_canonical_id",
+        "tag_aliases",
+        ["canonical_tag_id"],
+        unique=False,
+    )
+
+    # Index 7: tag_aliases - raw form pattern ops (LIKE queries)
+    op.create_index(
+        "idx_tag_aliases_raw_pattern",
+        "tag_aliases",
+        ["raw_form"],
+        unique=False,
+        postgresql_ops={"raw_form": "varchar_pattern_ops"},
+    )
+
+    # Index 8: named_entities - normalized name
+    op.create_index(
+        "idx_named_entities_normalized",
+        "named_entities",
+        ["canonical_name_normalized"],
+        unique=False,
+    )
+
+    # Index 9: named_entities - entity type
+    op.create_index(
+        "idx_named_entities_type",
+        "named_entities",
+        ["entity_type"],
+        unique=False,
+    )
+
+    # Index 10: named_entities - status
+    op.create_index(
+        "idx_named_entities_status",
+        "named_entities",
+        ["status"],
+        unique=False,
+    )
+
+    # Index 11: entity_aliases - normalized name
+    op.create_index(
+        "idx_entity_aliases_normalized",
+        "entity_aliases",
+        ["alias_name_normalized"],
+        unique=False,
+    )
+
+    # Index 12: entity_aliases - entity_id
+    op.create_index(
+        "idx_entity_aliases_entity_id",
+        "entity_aliases",
+        ["entity_id"],
+        unique=False,
+    )
+
+    # Index 13: entity_aliases - alias type
+    op.create_index(
+        "idx_entity_aliases_type",
+        "entity_aliases",
+        ["alias_type"],
+        unique=False,
+    )
+
+    # Index 14: tag_operation_logs - performed_at
+    op.create_index(
+        "idx_tag_operation_logs_performed_at",
+        "tag_operation_logs",
+        ["performed_at"],
+        unique=False,
+    )
+
+    # Index 15: video_tags - tag (NEW index on EXISTING table)
+    # Use IF NOT EXISTS because this index may already exist from prior operations
+    op.execute("CREATE INDEX IF NOT EXISTS idx_video_tags_tag ON video_tags (tag)")
+
+
+def downgrade() -> None:
+    """
+    Drop tag normalization tables and all associated indexes.
+
+    WARNING: This will permanently delete all tag normalization data including:
+    - All canonical tags and their aliases
+    - All named entities and their aliases
+    - All tag operation history and rollback data
+    - Statistics and confidence scores
+
+    Ensure you have backups if this data is needed.
+
+    Drop order is reverse of creation to respect FK constraints.
+    """
+    # =========================================================================
+    # DROP INDEXES (reverse order)
+    # =========================================================================
+
+    # Drop new index on existing video_tags table first
+    # Use IF EXISTS because the index may have pre-existed this migration
+    op.execute("DROP INDEX IF EXISTS idx_video_tags_tag")
+
+    # Drop tag_operation_logs indexes
+    op.drop_index("idx_tag_operation_logs_performed_at", table_name="tag_operation_logs")
+
+    # Drop entity_aliases indexes
+    op.drop_index("idx_entity_aliases_type", table_name="entity_aliases")
+    op.drop_index("idx_entity_aliases_entity_id", table_name="entity_aliases")
+    op.drop_index("idx_entity_aliases_normalized", table_name="entity_aliases")
+
+    # Drop named_entities indexes
+    op.drop_index("idx_named_entities_status", table_name="named_entities")
+    op.drop_index("idx_named_entities_type", table_name="named_entities")
+    op.drop_index("idx_named_entities_normalized", table_name="named_entities")
+
+    # Drop tag_aliases indexes
+    op.drop_index("idx_tag_aliases_raw_pattern", table_name="tag_aliases")
+    op.drop_index("idx_tag_aliases_canonical_id", table_name="tag_aliases")
+    op.drop_index("idx_tag_aliases_normalized", table_name="tag_aliases")
+
+    # Drop canonical_tags indexes
+    op.drop_index("idx_canonical_tags_active_normalized", table_name="canonical_tags")
+    op.drop_index("idx_canonical_tags_entity_id", table_name="canonical_tags")
+    op.drop_index("idx_canonical_tags_canonical_pattern", table_name="canonical_tags")
+    op.drop_index("idx_canonical_tags_video_count_desc", table_name="canonical_tags")
+
+    # =========================================================================
+    # DROP TABLES (reverse FK dependency order)
+    # =========================================================================
+
+    # Drop tables with no FK dependencies or that depend on others
+    op.drop_table("tag_operation_logs")
+    op.drop_table("tag_aliases")
+
+    # Drop tables that depend on named_entities
+    op.drop_table("canonical_tags")
+    op.drop_table("entity_aliases")
+
+    # Drop base table
+    op.drop_table("named_entities")

--- a/src/chronovista/models/__init__.py
+++ b/src/chronovista/models/__init__.py
@@ -172,6 +172,30 @@ from .transcript_segment import (
     TranscriptSegment,
     TranscriptSegmentResponse,
 )
+from .canonical_tag import (
+    CanonicalTag,
+    CanonicalTagBase,
+    CanonicalTagCreate,
+    CanonicalTagUpdate,
+)
+from .tag_alias import (
+    TagAlias,
+    TagAliasBase,
+    TagAliasCreate,
+    TagAliasUpdate,
+)
+from .named_entity import (
+    NamedEntity,
+    NamedEntityBase,
+    NamedEntityCreate,
+    NamedEntityUpdate,
+)
+from .entity_alias import (
+    EntityAlias,
+    EntityAliasBase,
+    EntityAliasCreate,
+    EntityAliasUpdate,
+)
 
 __all__ = [
     # YouTube API Response Models (FR-005, FR-006, FR-007)
@@ -325,6 +349,26 @@ __all__ = [
     "EnrichmentReport",
     "EnrichmentSummary",
     "EnrichmentDetail",
+    # Canonical Tags (Feature 028 - Tag Normalization)
+    "CanonicalTag",
+    "CanonicalTagCreate",
+    "CanonicalTagUpdate",
+    "CanonicalTagBase",
+    # Tag Aliases (Feature 028 - Tag Normalization)
+    "TagAlias",
+    "TagAliasCreate",
+    "TagAliasUpdate",
+    "TagAliasBase",
+    # Named Entities (Feature 028 - Tag Normalization)
+    "NamedEntity",
+    "NamedEntityCreate",
+    "NamedEntityUpdate",
+    "NamedEntityBase",
+    # Entity Aliases (Feature 028 - Tag Normalization)
+    "EntityAlias",
+    "EntityAliasCreate",
+    "EntityAliasUpdate",
+    "EntityAliasBase",
     # Utility functions
     "get_model_count",
 ]

--- a/src/chronovista/models/canonical_tag.py
+++ b/src/chronovista/models/canonical_tag.py
@@ -1,0 +1,124 @@
+"""
+Canonical tag models for tag normalization.
+
+Defines Pydantic models for canonical tags that represent the normalized,
+deduplicated form of video tags with lifecycle management and merge tracking.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .enums import EntityType, TagStatus
+
+
+class CanonicalTagBase(BaseModel):
+    """Base model for canonical tag data."""
+
+    canonical_form: str = Field(
+        ..., min_length=1, max_length=500, description="Display form of the tag"
+    )
+    normalized_form: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Machine key (lowercased, accent-folded)",
+    )
+    entity_type: Optional[EntityType] = Field(
+        default=None, description="Entity type classification (nullable)"
+    )
+    status: TagStatus = Field(
+        default=TagStatus.ACTIVE, description="Lifecycle status of the canonical tag"
+    )
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class CanonicalTagCreate(CanonicalTagBase):
+    """Model for creating canonical tags."""
+
+    alias_count: int = Field(default=1, ge=0, description="Number of known aliases")
+    video_count: int = Field(
+        default=0, ge=0, description="Number of videos using this tag"
+    )
+    entity_id: Optional[uuid.UUID] = Field(
+        default=None, description="Link to named entity"
+    )
+    merged_into_id: Optional[uuid.UUID] = Field(
+        default=None, description="Target tag ID if merged"
+    )
+
+    @model_validator(mode="after")
+    def merged_status_requires_target(self) -> CanonicalTagCreate:
+        """Validate that merged status has a merge target (FR-027)."""
+        if self.status == TagStatus.MERGED and self.merged_into_id is None:
+            raise ValueError(
+                "merged_into_id is required when status is 'merged'"
+            )
+        return self
+
+
+class CanonicalTagUpdate(BaseModel):
+    """Model for updating canonical tags (PATCH-style, all fields optional)."""
+
+    canonical_form: Optional[str] = Field(
+        default=None, min_length=1, max_length=500
+    )
+    normalized_form: Optional[str] = Field(
+        default=None, min_length=1, max_length=500
+    )
+    entity_type: Optional[EntityType] = None
+    status: Optional[TagStatus] = None
+    alias_count: Optional[int] = Field(default=None, ge=0)
+    video_count: Optional[int] = Field(default=None, ge=0)
+    entity_id: Optional[uuid.UUID] = None
+    merged_into_id: Optional[uuid.UUID] = None
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class CanonicalTag(CanonicalTagBase):
+    """Full canonical tag model with timestamps and identifiers."""
+
+    id: uuid.UUID = Field(..., description="Canonical tag UUID (UUIDv7)")
+    alias_count: int = Field(..., ge=0, description="Number of known aliases")
+    video_count: int = Field(
+        ..., ge=0, description="Number of videos using this tag"
+    )
+    entity_id: Optional[uuid.UUID] = Field(
+        default=None, description="Link to named entity"
+    )
+    merged_into_id: Optional[uuid.UUID] = Field(
+        default=None, description="Target tag ID if merged"
+    )
+    created_at: datetime = Field(..., description="When the record was created")
+    updated_at: datetime = Field(..., description="When the record was last updated")
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        validate_assignment=True,
+    )
+
+    @model_validator(mode="after")
+    def merged_status_requires_target(self) -> CanonicalTag:
+        """Validate that merged status has a merge target (FR-027)."""
+        if self.status == TagStatus.MERGED and self.merged_into_id is None:
+            raise ValueError(
+                "merged_into_id is required when status is 'merged'"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def no_self_merge(self) -> CanonicalTag:
+        """Validate that a tag cannot be merged into itself (FR-028)."""
+        if self.merged_into_id is not None and self.merged_into_id == self.id:
+            raise ValueError("A canonical tag cannot be merged into itself")
+        return self

--- a/src/chronovista/models/entity_alias.py
+++ b/src/chronovista/models/entity_alias.py
@@ -1,0 +1,88 @@
+"""
+Entity alias models for named entity resolution.
+
+Defines Pydantic models for entity aliases that map alternative names
+(variants, abbreviations, nicknames, etc.) to their canonical named entities.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .enums import EntityAliasType
+
+
+class EntityAliasBase(BaseModel):
+    """Base model for entity alias data."""
+
+    alias_name: str = Field(
+        ..., min_length=1, max_length=500, description="Alternative name text"
+    )
+    alias_name_normalized: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Normalized alias name for matching",
+    )
+    alias_type: EntityAliasType = Field(
+        default=EntityAliasType.NAME_VARIANT,
+        description="Type of alias relationship",
+    )
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class EntityAliasCreate(EntityAliasBase):
+    """Model for creating entity aliases."""
+
+    entity_id: uuid.UUID = Field(
+        ..., description="FK to named_entity this alias belongs to"
+    )
+    occurrence_count: int = Field(
+        default=0, ge=0, description="How many times this alias was seen"
+    )
+
+
+class EntityAliasUpdate(BaseModel):
+    """Model for updating entity aliases (PATCH-style, all fields optional)."""
+
+    alias_name: Optional[str] = Field(default=None, min_length=1, max_length=500)
+    alias_name_normalized: Optional[str] = Field(
+        default=None, min_length=1, max_length=500
+    )
+    alias_type: Optional[EntityAliasType] = None
+    entity_id: Optional[uuid.UUID] = None
+    occurrence_count: Optional[int] = Field(default=None, ge=0)
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class EntityAlias(EntityAliasBase):
+    """Full entity alias model with timestamps and identifiers."""
+
+    id: uuid.UUID = Field(..., description="Entity alias UUID (UUIDv7)")
+    entity_id: uuid.UUID = Field(
+        ..., description="FK to named_entity this alias belongs to"
+    )
+    occurrence_count: int = Field(
+        ..., ge=0, description="How many times this alias was seen"
+    )
+    first_seen_at: datetime = Field(
+        ..., description="When this alias was first encountered"
+    )
+    last_seen_at: datetime = Field(
+        ..., description="When this alias was last encountered"
+    )
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        validate_assignment=True,
+    )

--- a/src/chronovista/models/enums.py
+++ b/src/chronovista/models/enums.py
@@ -232,3 +232,64 @@ class LanguageCode(str, Enum):
             "ar": ["ar", "ar-SA", "ar-EG"],
         }
         return variants_map.get(base_language, [base_language])
+
+
+class EntityType(str, Enum):
+    """Types of named entities extracted from tags."""
+
+    PERSON = "person"
+    ORGANIZATION = "organization"
+    PLACE = "place"
+    EVENT = "event"
+    WORK = "work"
+    TECHNICAL_TERM = "technical_term"
+    TOPIC = "topic"
+    DESCRIPTOR = "descriptor"
+
+
+class EntityAliasType(str, Enum):
+    """Types of alias relationships between entity names."""
+
+    NAME_VARIANT = "name_variant"
+    ABBREVIATION = "abbreviation"
+    NICKNAME = "nickname"
+    ASR_ERROR = "asr_error"
+    TRANSLATED_NAME = "translated_name"
+    FORMER_NAME = "former_name"
+
+
+class TagStatus(str, Enum):
+    """Lifecycle status of a canonical tag."""
+
+    ACTIVE = "active"
+    MERGED = "merged"
+    DEPRECATED = "deprecated"
+
+
+class CreationMethod(str, Enum):
+    """Methods by which a canonical tag was created."""
+
+    AUTO_NORMALIZE = "auto_normalize"
+    MANUAL_MERGE = "manual_merge"
+    BACKFILL = "backfill"
+    API_CREATE = "api_create"
+
+
+class DiscoveryMethod(str, Enum):
+    """Methods by which a tag was originally discovered."""
+
+    MANUAL = "manual"
+    SPACY_NER = "spacy_ner"
+    TAG_BOOTSTRAP = "tag_bootstrap"
+    LLM_EXTRACTION = "llm_extraction"
+    USER_CREATED = "user_created"
+
+
+class TagOperationType(str, Enum):
+    """Types of operations recorded in the tag operation log."""
+
+    MERGE = "merge"
+    SPLIT = "split"
+    RENAME = "rename"
+    DELETE = "delete"
+    CREATE = "create"

--- a/src/chronovista/models/named_entity.py
+++ b/src/chronovista/models/named_entity.py
@@ -1,0 +1,176 @@
+"""
+Named entity models for entity extraction and management.
+
+Defines Pydantic models for named entities discovered from tags and transcripts,
+supporting entity resolution, merge tracking, and confidence scoring.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .enums import DiscoveryMethod, EntityType, TagStatus
+
+
+class NamedEntityBase(BaseModel):
+    """Base model for named entity data."""
+
+    canonical_name: str = Field(
+        ..., min_length=1, max_length=500, description="Display name of the entity"
+    )
+    canonical_name_normalized: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Normalized name for matching",
+    )
+    entity_type: EntityType = Field(
+        ..., description="Entity type classification (required, not nullable)"
+    )
+    discovery_method: DiscoveryMethod = Field(
+        default=DiscoveryMethod.MANUAL,
+        description="How this entity was discovered",
+    )
+    status: TagStatus = Field(
+        default=TagStatus.ACTIVE, description="Lifecycle status of the entity"
+    )
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class NamedEntityCreate(NamedEntityBase):
+    """Model for creating named entities."""
+
+    entity_subtype: Optional[str] = Field(
+        default=None, max_length=255, description="Finer-grained subtype"
+    )
+    description: Optional[str] = Field(
+        default=None, description="Human-readable description"
+    )
+    external_ids: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="External identifiers (Wikidata QID, MusicBrainz, etc.)",
+    )
+    confidence: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description="Confidence score between 0.0 and 1.0",
+    )
+    merged_into_id: Optional[uuid.UUID] = Field(
+        default=None, description="Target entity ID if merged"
+    )
+
+    @field_validator("confidence")
+    @classmethod
+    def validate_confidence_range(cls, v: float) -> float:
+        """Validate confidence is within valid range."""
+        if v < 0.0 or v > 1.0:
+            raise ValueError("Confidence must be between 0.0 and 1.0")
+        return v
+
+    @model_validator(mode="after")
+    def merged_status_requires_target(self) -> NamedEntityCreate:
+        """Validate that merged status has a merge target (FR-027)."""
+        if self.status == TagStatus.MERGED and self.merged_into_id is None:
+            raise ValueError(
+                "merged_into_id is required when status is 'merged'"
+            )
+        return self
+
+
+class NamedEntityUpdate(BaseModel):
+    """Model for updating named entities (PATCH-style, all fields optional)."""
+
+    canonical_name: Optional[str] = Field(
+        default=None, min_length=1, max_length=500
+    )
+    canonical_name_normalized: Optional[str] = Field(
+        default=None, min_length=1, max_length=500
+    )
+    entity_type: Optional[EntityType] = None
+    discovery_method: Optional[DiscoveryMethod] = None
+    status: Optional[TagStatus] = None
+    entity_subtype: Optional[str] = Field(default=None, max_length=255)
+    description: Optional[str] = None
+    external_ids: Optional[Dict[str, Any]] = None
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    merged_into_id: Optional[uuid.UUID] = None
+    mention_count: Optional[int] = Field(default=None, ge=0)
+    video_count: Optional[int] = Field(default=None, ge=0)
+    channel_count: Optional[int] = Field(default=None, ge=0)
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class NamedEntity(NamedEntityBase):
+    """Full named entity model with timestamps and identifiers."""
+
+    id: uuid.UUID = Field(..., description="Named entity UUID (UUIDv7)")
+    entity_subtype: Optional[str] = Field(
+        default=None, max_length=255, description="Finer-grained subtype"
+    )
+    description: Optional[str] = Field(
+        default=None, description="Human-readable description"
+    )
+    external_ids: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="External identifiers (Wikidata QID, MusicBrainz, etc.)",
+    )
+    mention_count: int = Field(
+        ..., ge=0, description="Total mentions across all sources"
+    )
+    video_count: int = Field(
+        ..., ge=0, description="Number of videos referencing this entity"
+    )
+    channel_count: int = Field(
+        ..., ge=0, description="Number of channels referencing this entity"
+    )
+    confidence: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Confidence score between 0.0 and 1.0",
+    )
+    merged_into_id: Optional[uuid.UUID] = Field(
+        default=None, description="Target entity ID if merged"
+    )
+    created_at: datetime = Field(..., description="When the record was created")
+    updated_at: datetime = Field(..., description="When the record was last updated")
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        validate_assignment=True,
+    )
+
+    @field_validator("confidence")
+    @classmethod
+    def validate_confidence_range(cls, v: float) -> float:
+        """Validate confidence is within valid range."""
+        if v < 0.0 or v > 1.0:
+            raise ValueError("Confidence must be between 0.0 and 1.0")
+        return v
+
+    @model_validator(mode="after")
+    def merged_status_requires_target(self) -> NamedEntity:
+        """Validate that merged status has a merge target (FR-027)."""
+        if self.status == TagStatus.MERGED and self.merged_into_id is None:
+            raise ValueError(
+                "merged_into_id is required when status is 'merged'"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def no_self_merge(self) -> NamedEntity:
+        """Validate that an entity cannot be merged into itself (FR-028)."""
+        if self.merged_into_id is not None and self.merged_into_id == self.id:
+            raise ValueError("A named entity cannot be merged into itself")
+        return self

--- a/src/chronovista/models/tag_alias.py
+++ b/src/chronovista/models/tag_alias.py
@@ -1,0 +1,96 @@
+"""
+Tag alias models for tag normalization.
+
+Defines Pydantic models for tag aliases that map raw tag forms (as they appear
+in YouTube data) to their canonical normalized representations.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .enums import CreationMethod
+
+
+class TagAliasBase(BaseModel):
+    """Base model for tag alias data."""
+
+    raw_form: str = Field(
+        ..., min_length=1, max_length=500, description="Original tag text as seen"
+    )
+    normalized_form: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Normalized form for matching",
+    )
+    creation_method: CreationMethod = Field(
+        default=CreationMethod.AUTO_NORMALIZE,
+        description="How this alias was created",
+    )
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class TagAliasCreate(TagAliasBase):
+    """Model for creating tag aliases."""
+
+    canonical_tag_id: uuid.UUID = Field(
+        ..., description="FK to canonical_tag this alias resolves to"
+    )
+    normalization_version: int = Field(
+        default=1, ge=1, description="Version of the normalization algorithm"
+    )
+    occurrence_count: int = Field(
+        default=1, ge=0, description="How many times this raw form was seen"
+    )
+
+
+class TagAliasUpdate(BaseModel):
+    """Model for updating tag aliases (PATCH-style, all fields optional)."""
+
+    raw_form: Optional[str] = Field(default=None, min_length=1, max_length=500)
+    normalized_form: Optional[str] = Field(
+        default=None, min_length=1, max_length=500
+    )
+    canonical_tag_id: Optional[uuid.UUID] = None
+    creation_method: Optional[CreationMethod] = None
+    normalization_version: Optional[int] = Field(default=None, ge=1)
+    occurrence_count: Optional[int] = Field(default=None, ge=0)
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class TagAlias(TagAliasBase):
+    """Full tag alias model with timestamps and identifiers."""
+
+    id: uuid.UUID = Field(..., description="Tag alias UUID (UUIDv7)")
+    canonical_tag_id: uuid.UUID = Field(
+        ..., description="FK to canonical_tag this alias resolves to"
+    )
+    normalization_version: int = Field(
+        ..., ge=1, description="Version of the normalization algorithm"
+    )
+    occurrence_count: int = Field(
+        ..., ge=0, description="How many times this raw form was seen"
+    )
+    first_seen_at: datetime = Field(
+        ..., description="When this raw form was first encountered"
+    )
+    last_seen_at: datetime = Field(
+        ..., description="When this raw form was last encountered"
+    )
+    created_at: datetime = Field(..., description="When the record was created")
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        validate_assignment=True,
+    )

--- a/src/chronovista/repositories/__init__.py
+++ b/src/chronovista/repositories/__init__.py
@@ -6,10 +6,14 @@ the Repository pattern for clean separation of domain logic and data persistence
 """
 
 from .base import BaseRepository, BaseSQLAlchemyRepository, IdType
+from .canonical_tag_repository import CanonicalTagRepository
 from .channel_repository import ChannelRepository
 from .channel_topic_repository import ChannelTopicRepository
+from .entity_alias_repository import EntityAliasRepository
+from .named_entity_repository import NamedEntityRepository
 from .playlist_membership_repository import PlaylistMembershipRepository
 from .playlist_repository import PlaylistRepository
+from .tag_alias_repository import TagAliasRepository
 from .topic_category_repository import TopicCategoryRepository
 from .transcript_segment_repository import TranscriptSegmentRepository
 from .user_language_preference_repository import UserLanguagePreferenceRepository
@@ -25,10 +29,14 @@ __all__ = [
     "BaseRepository",
     "BaseSQLAlchemyRepository",
     "IdType",
+    "CanonicalTagRepository",
     "ChannelRepository",
     "ChannelTopicRepository",
+    "EntityAliasRepository",
+    "NamedEntityRepository",
     "PlaylistMembershipRepository",
     "PlaylistRepository",
+    "TagAliasRepository",
     "TopicCategoryRepository",
     "TranscriptSegmentRepository",
     "UserLanguagePreferenceRepository",

--- a/src/chronovista/repositories/canonical_tag_repository.py
+++ b/src/chronovista/repositories/canonical_tag_repository.py
@@ -1,0 +1,49 @@
+"""
+Canonical tag repository for tag normalization management.
+
+Handles CRUD operations for canonical tags that represent the normalized,
+deduplicated form of video tags with lifecycle management and merge tracking.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import CanonicalTag as CanonicalTagDB
+from chronovista.models.canonical_tag import CanonicalTagCreate, CanonicalTagUpdate
+from chronovista.repositories.base import BaseSQLAlchemyRepository
+
+
+class CanonicalTagRepository(
+    BaseSQLAlchemyRepository[
+        CanonicalTagDB,
+        CanonicalTagCreate,
+        CanonicalTagUpdate,
+        uuid.UUID,
+    ]
+):
+    """Repository for canonical tag CRUD operations."""
+
+    def __init__(self) -> None:
+        """Initialize repository with CanonicalTag model."""
+        super().__init__(CanonicalTagDB)
+
+    async def get(
+        self, session: AsyncSession, id: uuid.UUID
+    ) -> Optional[CanonicalTagDB]:
+        """Get canonical tag by UUID primary key."""
+        result = await session.execute(
+            select(CanonicalTagDB).where(CanonicalTagDB.id == id)
+        )
+        return result.scalar_one_or_none()
+
+    async def exists(self, session: AsyncSession, id: uuid.UUID) -> bool:
+        """Check if canonical tag exists by UUID primary key."""
+        result = await session.execute(
+            select(CanonicalTagDB.id).where(CanonicalTagDB.id == id)
+        )
+        return result.first() is not None

--- a/src/chronovista/repositories/entity_alias_repository.py
+++ b/src/chronovista/repositories/entity_alias_repository.py
@@ -1,0 +1,49 @@
+"""
+Entity alias repository for named entity resolution.
+
+Handles CRUD operations for entity aliases that map alternative names
+(variants, abbreviations, nicknames, etc.) to their canonical named entities.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import EntityAlias as EntityAliasDB
+from chronovista.models.entity_alias import EntityAliasCreate, EntityAliasUpdate
+from chronovista.repositories.base import BaseSQLAlchemyRepository
+
+
+class EntityAliasRepository(
+    BaseSQLAlchemyRepository[
+        EntityAliasDB,
+        EntityAliasCreate,
+        EntityAliasUpdate,
+        uuid.UUID,
+    ]
+):
+    """Repository for entity alias CRUD operations."""
+
+    def __init__(self) -> None:
+        """Initialize repository with EntityAlias model."""
+        super().__init__(EntityAliasDB)
+
+    async def get(
+        self, session: AsyncSession, id: uuid.UUID
+    ) -> Optional[EntityAliasDB]:
+        """Get entity alias by UUID primary key."""
+        result = await session.execute(
+            select(EntityAliasDB).where(EntityAliasDB.id == id)
+        )
+        return result.scalar_one_or_none()
+
+    async def exists(self, session: AsyncSession, id: uuid.UUID) -> bool:
+        """Check if entity alias exists by UUID primary key."""
+        result = await session.execute(
+            select(EntityAliasDB.id).where(EntityAliasDB.id == id)
+        )
+        return result.first() is not None

--- a/src/chronovista/repositories/named_entity_repository.py
+++ b/src/chronovista/repositories/named_entity_repository.py
@@ -1,0 +1,49 @@
+"""
+Named entity repository for entity extraction and management.
+
+Handles CRUD operations for named entities discovered from tags and transcripts,
+supporting entity resolution, merge tracking, and confidence scoring.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import NamedEntity as NamedEntityDB
+from chronovista.models.named_entity import NamedEntityCreate, NamedEntityUpdate
+from chronovista.repositories.base import BaseSQLAlchemyRepository
+
+
+class NamedEntityRepository(
+    BaseSQLAlchemyRepository[
+        NamedEntityDB,
+        NamedEntityCreate,
+        NamedEntityUpdate,
+        uuid.UUID,
+    ]
+):
+    """Repository for named entity CRUD operations."""
+
+    def __init__(self) -> None:
+        """Initialize repository with NamedEntity model."""
+        super().__init__(NamedEntityDB)
+
+    async def get(
+        self, session: AsyncSession, id: uuid.UUID
+    ) -> Optional[NamedEntityDB]:
+        """Get named entity by UUID primary key."""
+        result = await session.execute(
+            select(NamedEntityDB).where(NamedEntityDB.id == id)
+        )
+        return result.scalar_one_or_none()
+
+    async def exists(self, session: AsyncSession, id: uuid.UUID) -> bool:
+        """Check if named entity exists by UUID primary key."""
+        result = await session.execute(
+            select(NamedEntityDB.id).where(NamedEntityDB.id == id)
+        )
+        return result.first() is not None

--- a/src/chronovista/repositories/tag_alias_repository.py
+++ b/src/chronovista/repositories/tag_alias_repository.py
@@ -1,0 +1,49 @@
+"""
+Tag alias repository for tag normalization management.
+
+Handles CRUD operations for tag aliases that map raw tag forms (as they appear
+in YouTube data) to their canonical normalized representations.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import TagAlias as TagAliasDB
+from chronovista.models.tag_alias import TagAliasCreate, TagAliasUpdate
+from chronovista.repositories.base import BaseSQLAlchemyRepository
+
+
+class TagAliasRepository(
+    BaseSQLAlchemyRepository[
+        TagAliasDB,
+        TagAliasCreate,
+        TagAliasUpdate,
+        uuid.UUID,
+    ]
+):
+    """Repository for tag alias CRUD operations."""
+
+    def __init__(self) -> None:
+        """Initialize repository with TagAlias model."""
+        super().__init__(TagAliasDB)
+
+    async def get(
+        self, session: AsyncSession, id: uuid.UUID
+    ) -> Optional[TagAliasDB]:
+        """Get tag alias by UUID primary key."""
+        result = await session.execute(
+            select(TagAliasDB).where(TagAliasDB.id == id)
+        )
+        return result.scalar_one_or_none()
+
+    async def exists(self, session: AsyncSession, id: uuid.UUID) -> bool:
+        """Check if tag alias exists by UUID primary key."""
+        result = await session.execute(
+            select(TagAliasDB.id).where(TagAliasDB.id == id)
+        )
+        return result.first() is not None

--- a/src/chronovista/services/tag_normalization.py
+++ b/src/chronovista/services/tag_normalization.py
@@ -1,0 +1,231 @@
+"""
+Tag Normalization Service for canonical tag resolution.
+
+This module implements a 9-step normalization pipeline that produces a stable
+canonical form for YouTube video tags.  The pipeline is pure (no I/O, no
+database) and idempotent: ``normalize(normalize(x)) == normalize(x)``.
+
+Diacritic handling is *selective* — only the eight Tier 1 combining marks
+that are safe to strip are removed.  Tier 2 marks (tilde, cedilla, ogonek,
+horn, dot above, ring above, caron) and all Tier 3 marks survive.
+
+References
+----------
+- FR-002: Empty / whitespace-only input returns ``None``
+- FR-006: ``selective_strip_diacritics`` exposed as standalone utility
+- FR-007: Idempotency guarantee
+- FR-008: Pure function — no I/O, no database
+- T003: TagNormalizationService implementation task
+"""
+
+from __future__ import annotations
+
+import logging
+import unicodedata
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tier 1 — SAFE_TO_STRIP combining marks (8 total)
+# These are common Latin diacritics whose removal does *not* change the
+# linguistic identity of the base character for tag-matching purposes.
+# ---------------------------------------------------------------------------
+SAFE_TO_STRIP: frozenset[str] = frozenset(
+    {
+        "\u0300",  # COMBINING GRAVE ACCENT
+        "\u0301",  # COMBINING ACUTE ACCENT
+        "\u0302",  # COMBINING CIRCUMFLEX ACCENT
+        "\u0304",  # COMBINING MACRON
+        "\u0306",  # COMBINING BREVE
+        "\u0308",  # COMBINING DIAERESIS
+        "\u030B",  # COMBINING DOUBLE ACUTE ACCENT
+        "\u030F",  # COMBINING DOUBLE GRAVE ACCENT
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Zero-width characters to strip (Step 5)
+# ---------------------------------------------------------------------------
+_ZERO_WIDTH_CHARS: frozenset[str] = frozenset(
+    {
+        "\u200B",  # ZERO WIDTH SPACE
+        "\u200C",  # ZERO WIDTH NON-JOINER
+        "\u200D",  # ZERO WIDTH JOINER
+        "\uFEFF",  # ZERO WIDTH NO-BREAK SPACE / BOM
+    }
+)
+
+
+def selective_strip_diacritics(text: str) -> str:
+    """
+    Strip only Tier 1 combining marks from *text*, preserving all others.
+
+    The function decomposes to NFKD, walks each character, removes only
+    the eight marks listed in ``SAFE_TO_STRIP``, and recomposes to NFC.
+
+    Parameters
+    ----------
+    text : str
+        The input string (arbitrary Unicode).
+
+    Returns
+    -------
+    str
+        The string with Tier 1 diacritics removed and NFC-recomposed.
+
+    Examples
+    --------
+    >>> selective_strip_diacritics("München")
+    'Munchen'
+
+    >>> selective_strip_diacritics("año")
+    'año'
+    """
+    decomposed = unicodedata.normalize("NFKD", text)
+    filtered = "".join(ch for ch in decomposed if ch not in SAFE_TO_STRIP)
+    return unicodedata.normalize("NFC", filtered)
+
+
+class TagNormalizationService:
+    """
+    Service that normalizes raw YouTube tags into canonical form.
+
+    The 9-step pipeline is executed in strict order:
+
+    1. Strip leading/trailing whitespace
+    2. Strip a single leading ``#`` character
+    3. Replace non-breaking spaces (U+00A0) and tabs with regular space
+    4. Collapse multiple spaces to a single space
+    5. Strip zero-width characters (U+200B, U+200C, U+200D, U+FEFF)
+    6. NFKD decompose
+    7. Strip Tier 1 combining marks only (selective)
+    8. NFC recompose
+    9. Casefold
+
+    The result is ``None`` when the output would be an empty string.
+    """
+
+    def normalize(self, raw_tag: str) -> str | None:
+        """
+        Run the full 9-step normalization pipeline on *raw_tag*.
+
+        Parameters
+        ----------
+        raw_tag : str
+            The raw tag value as it appears on a YouTube video.
+
+        Returns
+        -------
+        str | None
+            The canonical form, or ``None`` if the result is empty after
+            all normalization steps.
+
+        Examples
+        --------
+        >>> svc = TagNormalizationService()
+        >>> svc.normalize("#MÉXICO")
+        'mexico'
+
+        >>> svc.normalize("  ")
+        None
+        """
+        # Step 1: Strip leading/trailing whitespace
+        text = raw_tag.strip()
+
+        # Step 2: Strip SINGLE leading '#' character
+        if text.startswith("#"):
+            text = text[1:]
+
+        # Step 3: Replace non-breaking spaces and tabs with regular space
+        text = text.replace("\u00A0", " ").replace("\t", " ")
+
+        # Step 4: Collapse multiple spaces to single space
+        parts = text.split()
+        text = " ".join(parts)
+
+        # Step 5: Strip zero-width characters
+        text = "".join(ch for ch in text if ch not in _ZERO_WIDTH_CHARS)
+
+        # Step 6: NFKD decompose
+        text = unicodedata.normalize("NFKD", text)
+
+        # Step 7: Strip Tier 1 combining marks only
+        text = "".join(ch for ch in text if ch not in SAFE_TO_STRIP)
+
+        # Step 8: NFC recompose
+        text = unicodedata.normalize("NFC", text)
+
+        # Step 9: Casefold
+        text = text.casefold()
+
+        # Final cleanup: Collapse any multiple spaces that may have been
+        # introduced during normalization (e.g., from NFKD decomposition of
+        # spacing diacritics like U+00B8 SPACING CEDILLA → space + combining mark),
+        # and strip any leading/trailing whitespace
+        parts = text.split()
+        text = " ".join(parts)
+
+        # FR-002: Return None for empty results
+        return text if text else None
+
+    def select_canonical_form(self, forms: list[tuple[str, int]]) -> str:
+        """
+        Select the canonical form from a list of raw forms and their counts.
+
+        Implements the FR-009 algorithm:
+        1. Filter for title case forms (using ``str.istitle()``)
+        2. If title case forms exist: pick the one with highest occurrence count
+        3. If NO title case forms exist: pick the one with highest occurrence count from ALL forms
+        4. If occurrence counts are tied at any step: use alphabetical ``min()`` as deterministic tiebreaker
+
+        Parameters
+        ----------
+        forms : list[tuple[str, int]]
+            A list of ``(raw_form, occurrence_count)`` tuples.  Must not be empty.
+
+        Returns
+        -------
+        str
+            The selected canonical form.
+
+        Raises
+        ------
+        ValueError
+            If *forms* is empty.
+
+        Examples
+        --------
+        >>> svc = TagNormalizationService()
+        >>> svc.select_canonical_form([("MEXICO", 203), ("Mexico", 412), ("mexico", 156)])
+        'Mexico'
+
+        >>> svc.select_canonical_form([("Mexico", 200), ("México", 200)])
+        'Mexico'
+
+        >>> svc.select_canonical_form([("MEXICO", 500), ("mexico", 300)])
+        'MEXICO'
+        """
+        if not forms:
+            raise ValueError("Cannot select canonical form from empty list")
+
+        # Single-element case
+        if len(forms) == 1:
+            return forms[0][0]
+
+        # Step 1: Filter for title case forms
+        title_case_forms = [(form, count) for form, count in forms if form.istitle()]
+
+        # Step 2: Determine the candidate pool
+        if title_case_forms:
+            candidates = title_case_forms
+        else:
+            candidates = forms
+
+        # Step 3: Find the maximum occurrence count
+        max_count = max(count for _, count in candidates)
+
+        # Step 4: Get all forms with the maximum count
+        max_forms = [form for form, count in candidates if count == max_count]
+
+        # Step 5: Use alphabetical min as tiebreaker
+        return min(max_forms)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -145,6 +145,57 @@ from .transcript_segment_factory import (
     create_transcript_segment_create,
     create_transcript_segment_response,
 )
+from .canonical_tag_factory import (
+    CanonicalTagBaseFactory,
+    CanonicalTagCreateFactory,
+    CanonicalTagFactory,
+    CanonicalTagTestData,
+    CanonicalTagUpdateFactory,
+    create_canonical_tag,
+    create_canonical_tag_base,
+    create_canonical_tag_create,
+    create_canonical_tag_update,
+)
+from .tag_alias_factory import (
+    TagAliasBaseFactory,
+    TagAliasCreateFactory,
+    TagAliasFactory,
+    TagAliasTestData,
+    TagAliasUpdateFactory,
+    create_tag_alias,
+    create_tag_alias_base,
+    create_tag_alias_create,
+    create_tag_alias_update,
+)
+from .named_entity_factory import (
+    NamedEntityBaseFactory,
+    NamedEntityCreateFactory,
+    NamedEntityFactory,
+    NamedEntityTestData,
+    NamedEntityUpdateFactory,
+    create_named_entity,
+    create_named_entity_base,
+    create_named_entity_create,
+    create_named_entity_update,
+)
+from .entity_alias_factory import (
+    EntityAliasBaseFactory,
+    EntityAliasCreateFactory,
+    EntityAliasFactory,
+    EntityAliasTestData,
+    EntityAliasUpdateFactory,
+    create_entity_alias,
+    create_entity_alias_base,
+    create_entity_alias_create,
+    create_entity_alias_update,
+)
+from .tag_operation_log_factory import (
+    TagOperationLogFactory,
+    TagOperationLogTestData,
+    create_merge_operation_log,
+    create_split_operation_log,
+    create_tag_operation_log,
+)
 
 __all__ = [
     # VideoTag factories
@@ -275,4 +326,50 @@ __all__ = [
     "create_transcript_segment_response",
     "create_batch_transcript_segments",
     "create_corrected_transcript_segment",
+    # CanonicalTag factories
+    "CanonicalTagBaseFactory",
+    "CanonicalTagCreateFactory",
+    "CanonicalTagUpdateFactory",
+    "CanonicalTagFactory",
+    "CanonicalTagTestData",
+    "create_canonical_tag",
+    "create_canonical_tag_base",
+    "create_canonical_tag_create",
+    "create_canonical_tag_update",
+    # TagAlias factories
+    "TagAliasBaseFactory",
+    "TagAliasCreateFactory",
+    "TagAliasUpdateFactory",
+    "TagAliasFactory",
+    "TagAliasTestData",
+    "create_tag_alias",
+    "create_tag_alias_base",
+    "create_tag_alias_create",
+    "create_tag_alias_update",
+    # NamedEntity factories
+    "NamedEntityBaseFactory",
+    "NamedEntityCreateFactory",
+    "NamedEntityUpdateFactory",
+    "NamedEntityFactory",
+    "NamedEntityTestData",
+    "create_named_entity",
+    "create_named_entity_base",
+    "create_named_entity_create",
+    "create_named_entity_update",
+    # EntityAlias factories
+    "EntityAliasBaseFactory",
+    "EntityAliasCreateFactory",
+    "EntityAliasUpdateFactory",
+    "EntityAliasFactory",
+    "EntityAliasTestData",
+    "create_entity_alias",
+    "create_entity_alias_base",
+    "create_entity_alias_create",
+    "create_entity_alias_update",
+    # TagOperationLog factories
+    "TagOperationLogFactory",
+    "TagOperationLogTestData",
+    "create_tag_operation_log",
+    "create_merge_operation_log",
+    "create_split_operation_log",
 ]

--- a/tests/factories/canonical_tag_factory.py
+++ b/tests/factories/canonical_tag_factory.py
@@ -1,0 +1,175 @@
+"""
+Factory for CanonicalTag Pydantic models using factory_boy.
+
+Provides reusable test data factories for all CanonicalTag model variants
+with sensible defaults and easy customization.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import factory
+from factory import LazyFunction, Sequence
+from uuid_utils import uuid7
+
+
+def _uuid7() -> uuid.UUID:
+    """Generate a UUIDv7 as a standard uuid.UUID for Pydantic compatibility."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+from chronovista.models.canonical_tag import (
+    CanonicalTag,
+    CanonicalTagBase,
+    CanonicalTagCreate,
+    CanonicalTagUpdate,
+)
+from chronovista.models.enums import TagStatus
+
+
+class CanonicalTagBaseFactory(factory.Factory[CanonicalTagBase]):
+    """Factory for CanonicalTagBase models."""
+
+    class Meta:
+        model = CanonicalTagBase
+
+    canonical_form: Any = Sequence(lambda n: f"Tag {n}")
+    normalized_form: Any = Sequence(lambda n: f"tag {n}")
+    entity_type: Any = LazyFunction(lambda: None)
+    status: Any = LazyFunction(lambda: TagStatus.ACTIVE)
+
+
+class CanonicalTagCreateFactory(factory.Factory[CanonicalTagCreate]):
+    """Factory for CanonicalTagCreate models."""
+
+    class Meta:
+        model = CanonicalTagCreate
+
+    canonical_form: Any = Sequence(lambda n: f"Tag {n}")
+    normalized_form: Any = Sequence(lambda n: f"tag {n}")
+    entity_type: Any = LazyFunction(lambda: None)
+    status: Any = LazyFunction(lambda: TagStatus.ACTIVE)
+    alias_count: Any = LazyFunction(lambda: 1)
+    video_count: Any = LazyFunction(lambda: 0)
+    entity_id: Any = LazyFunction(lambda: None)
+    merged_into_id: Any = LazyFunction(lambda: None)
+
+
+class CanonicalTagUpdateFactory(factory.Factory[CanonicalTagUpdate]):
+    """Factory for CanonicalTagUpdate models.
+
+    Note: This factory respects the model's default values (None for all fields).
+    For Update models, the default behavior should be an empty update (all None),
+    with values only generated when explicitly requested.
+    """
+
+    class Meta:
+        model = CanonicalTagUpdate
+
+    # No default values - respects model defaults (None for all fields)
+
+
+class CanonicalTagFactory(factory.Factory[CanonicalTag]):
+    """Factory for full CanonicalTag models with all fields."""
+
+    class Meta:
+        model = CanonicalTag
+
+    id: Any = LazyFunction(_uuid7)
+    canonical_form: Any = Sequence(lambda n: f"Tag {n}")
+    normalized_form: Any = Sequence(lambda n: f"tag {n}")
+    entity_type: Any = LazyFunction(lambda: None)
+    status: Any = LazyFunction(lambda: TagStatus.ACTIVE)
+    alias_count: Any = LazyFunction(lambda: 1)
+    video_count: Any = LazyFunction(lambda: 0)
+    entity_id: Any = LazyFunction(lambda: None)
+    merged_into_id: Any = LazyFunction(lambda: None)
+    created_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+    updated_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+
+
+# Convenience factory methods
+def create_canonical_tag(**kwargs: Any) -> CanonicalTag:
+    """Create a CanonicalTag with keyword arguments."""
+    result = CanonicalTagFactory.build(**kwargs)
+    assert isinstance(result, CanonicalTag)
+    return result
+
+
+def create_canonical_tag_base(**kwargs: Any) -> CanonicalTagBase:
+    """Create a CanonicalTagBase with keyword arguments."""
+    result = CanonicalTagBaseFactory.build(**kwargs)
+    assert isinstance(result, CanonicalTagBase)
+    return result
+
+
+def create_canonical_tag_create(**kwargs: Any) -> CanonicalTagCreate:
+    """Create a CanonicalTagCreate with keyword arguments."""
+    result = CanonicalTagCreateFactory.build(**kwargs)
+    assert isinstance(result, CanonicalTagCreate)
+    return result
+
+
+def create_canonical_tag_update(**kwargs: Any) -> CanonicalTagUpdate:
+    """Create a CanonicalTagUpdate with keyword arguments."""
+    result = CanonicalTagUpdateFactory.build(**kwargs)
+    assert isinstance(result, CanonicalTagUpdate)
+    return result
+
+
+# Common test data patterns
+class CanonicalTagTestData:
+    """Common test data patterns for CanonicalTag models."""
+
+    VALID_CANONICAL_FORMS = [
+        "Python",
+        "Machine Learning",
+        "New York City",
+        "Google",
+        "Tutorial",
+        "A",  # Minimum length
+    ]
+
+    VALID_NORMALIZED_FORMS = [
+        "python",
+        "machine learning",
+        "new york city",
+        "google",
+        "tutorial",
+        "a",
+    ]
+
+    VALID_STATUSES = [
+        TagStatus.ACTIVE,
+        TagStatus.MERGED,
+        TagStatus.DEPRECATED,
+    ]
+
+    INVALID_CANONICAL_FORMS = [
+        "",  # Empty
+        "x" * 501,  # Too long (max is 500)
+    ]
+
+    @classmethod
+    def valid_canonical_tag_data(cls) -> dict[str, Any]:
+        """Get valid canonical tag data."""
+        return {
+            "canonical_form": cls.VALID_CANONICAL_FORMS[0],
+            "normalized_form": cls.VALID_NORMALIZED_FORMS[0],
+            "entity_type": None,
+            "status": TagStatus.ACTIVE,
+        }
+
+    @classmethod
+    def minimal_canonical_tag_data(cls) -> dict[str, Any]:
+        """Get minimal valid canonical tag data."""
+        return {
+            "canonical_form": "Python",
+            "normalized_form": "python",
+        }

--- a/tests/factories/entity_alias_factory.py
+++ b/tests/factories/entity_alias_factory.py
@@ -1,0 +1,168 @@
+"""
+Factory for EntityAlias Pydantic models using factory_boy.
+
+Provides reusable test data factories for all EntityAlias model variants
+with sensible defaults and easy customization.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import factory
+from factory import LazyFunction, Sequence
+from uuid_utils import uuid7
+
+
+def _uuid7() -> uuid.UUID:
+    """Generate a UUIDv7 as a standard uuid.UUID for Pydantic compatibility."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+from chronovista.models.entity_alias import (
+    EntityAlias,
+    EntityAliasBase,
+    EntityAliasCreate,
+    EntityAliasUpdate,
+)
+from chronovista.models.enums import EntityAliasType
+
+
+class EntityAliasBaseFactory(factory.Factory[EntityAliasBase]):
+    """Factory for EntityAliasBase models."""
+
+    class Meta:
+        model = EntityAliasBase
+
+    alias_name: Any = Sequence(lambda n: f"Alias {n}")
+    alias_name_normalized: Any = Sequence(lambda n: f"alias {n}")
+    alias_type: Any = LazyFunction(lambda: EntityAliasType.NAME_VARIANT)
+
+
+class EntityAliasCreateFactory(factory.Factory[EntityAliasCreate]):
+    """Factory for EntityAliasCreate models."""
+
+    class Meta:
+        model = EntityAliasCreate
+
+    alias_name: Any = Sequence(lambda n: f"Alias {n}")
+    alias_name_normalized: Any = Sequence(lambda n: f"alias {n}")
+    alias_type: Any = LazyFunction(lambda: EntityAliasType.NAME_VARIANT)
+    entity_id: Any = LazyFunction(_uuid7)
+    occurrence_count: Any = LazyFunction(lambda: 0)
+
+
+class EntityAliasUpdateFactory(factory.Factory[EntityAliasUpdate]):
+    """Factory for EntityAliasUpdate models.
+
+    Note: This factory respects the model's default values (None for all fields).
+    For Update models, the default behavior should be an empty update (all None),
+    with values only generated when explicitly requested.
+    """
+
+    class Meta:
+        model = EntityAliasUpdate
+
+    # No default values - respects model defaults (None for all fields)
+
+
+class EntityAliasFactory(factory.Factory[EntityAlias]):
+    """Factory for full EntityAlias models with all fields."""
+
+    class Meta:
+        model = EntityAlias
+
+    id: Any = LazyFunction(_uuid7)
+    alias_name: Any = Sequence(lambda n: f"Alias {n}")
+    alias_name_normalized: Any = Sequence(lambda n: f"alias {n}")
+    alias_type: Any = LazyFunction(lambda: EntityAliasType.NAME_VARIANT)
+    entity_id: Any = LazyFunction(_uuid7)
+    occurrence_count: Any = LazyFunction(lambda: 0)
+    first_seen_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+    last_seen_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+
+
+# Convenience factory methods
+def create_entity_alias(**kwargs: Any) -> EntityAlias:
+    """Create an EntityAlias with keyword arguments."""
+    result = EntityAliasFactory.build(**kwargs)
+    assert isinstance(result, EntityAlias)
+    return result
+
+
+def create_entity_alias_base(**kwargs: Any) -> EntityAliasBase:
+    """Create an EntityAliasBase with keyword arguments."""
+    result = EntityAliasBaseFactory.build(**kwargs)
+    assert isinstance(result, EntityAliasBase)
+    return result
+
+
+def create_entity_alias_create(**kwargs: Any) -> EntityAliasCreate:
+    """Create an EntityAliasCreate with keyword arguments."""
+    result = EntityAliasCreateFactory.build(**kwargs)
+    assert isinstance(result, EntityAliasCreate)
+    return result
+
+
+def create_entity_alias_update(**kwargs: Any) -> EntityAliasUpdate:
+    """Create an EntityAliasUpdate with keyword arguments."""
+    result = EntityAliasUpdateFactory.build(**kwargs)
+    assert isinstance(result, EntityAliasUpdate)
+    return result
+
+
+# Common test data patterns
+class EntityAliasTestData:
+    """Common test data patterns for EntityAlias models."""
+
+    VALID_ALIAS_NAMES = [
+        "Elon",
+        "E. Musk",
+        "SpaceX CEO",
+        "Tesla CEO",
+        "Mr. Musk",
+    ]
+
+    VALID_ALIAS_NAMES_NORMALIZED = [
+        "elon",
+        "e. musk",
+        "spacex ceo",
+        "tesla ceo",
+        "mr. musk",
+    ]
+
+    VALID_ALIAS_TYPES = [
+        EntityAliasType.NAME_VARIANT,
+        EntityAliasType.ABBREVIATION,
+        EntityAliasType.NICKNAME,
+        EntityAliasType.ASR_ERROR,
+        EntityAliasType.TRANSLATED_NAME,
+        EntityAliasType.FORMER_NAME,
+    ]
+
+    INVALID_ALIAS_NAMES = [
+        "",  # Empty
+        "x" * 501,  # Too long (max is 500)
+    ]
+
+    @classmethod
+    def valid_entity_alias_data(cls) -> dict[str, Any]:
+        """Get valid entity alias data."""
+        return {
+            "alias_name": cls.VALID_ALIAS_NAMES[0],
+            "alias_name_normalized": cls.VALID_ALIAS_NAMES_NORMALIZED[0],
+            "alias_type": EntityAliasType.NAME_VARIANT,
+        }
+
+    @classmethod
+    def minimal_entity_alias_data(cls) -> dict[str, Any]:
+        """Get minimal valid entity alias data."""
+        return {
+            "alias_name": "Elon",
+            "alias_name_normalized": "elon",
+        }

--- a/tests/factories/named_entity_factory.py
+++ b/tests/factories/named_entity_factory.py
@@ -1,0 +1,202 @@
+"""
+Factory for NamedEntity Pydantic models using factory_boy.
+
+Provides reusable test data factories for all NamedEntity model variants
+with sensible defaults and easy customization.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import factory
+from factory import LazyFunction, Sequence
+from uuid_utils import uuid7
+
+
+def _uuid7() -> uuid.UUID:
+    """Generate a UUIDv7 as a standard uuid.UUID for Pydantic compatibility."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+from chronovista.models.enums import DiscoveryMethod, EntityType, TagStatus
+from chronovista.models.named_entity import (
+    NamedEntity,
+    NamedEntityBase,
+    NamedEntityCreate,
+    NamedEntityUpdate,
+)
+
+
+class NamedEntityBaseFactory(factory.Factory[NamedEntityBase]):
+    """Factory for NamedEntityBase models."""
+
+    class Meta:
+        model = NamedEntityBase
+
+    canonical_name: Any = Sequence(lambda n: f"Entity {n}")
+    canonical_name_normalized: Any = Sequence(lambda n: f"entity {n}")
+    entity_type: Any = LazyFunction(lambda: EntityType.PERSON)
+    discovery_method: Any = LazyFunction(lambda: DiscoveryMethod.MANUAL)
+    status: Any = LazyFunction(lambda: TagStatus.ACTIVE)
+
+
+class NamedEntityCreateFactory(factory.Factory[NamedEntityCreate]):
+    """Factory for NamedEntityCreate models."""
+
+    class Meta:
+        model = NamedEntityCreate
+
+    canonical_name: Any = Sequence(lambda n: f"Entity {n}")
+    canonical_name_normalized: Any = Sequence(lambda n: f"entity {n}")
+    entity_type: Any = LazyFunction(lambda: EntityType.PERSON)
+    discovery_method: Any = LazyFunction(lambda: DiscoveryMethod.MANUAL)
+    status: Any = LazyFunction(lambda: TagStatus.ACTIVE)
+    entity_subtype: Any = LazyFunction(lambda: None)
+    description: Any = LazyFunction(lambda: None)
+    external_ids: Any = LazyFunction(dict)
+    confidence: Any = LazyFunction(lambda: 1.0)
+    merged_into_id: Any = LazyFunction(lambda: None)
+
+
+class NamedEntityUpdateFactory(factory.Factory[NamedEntityUpdate]):
+    """Factory for NamedEntityUpdate models.
+
+    Note: This factory respects the model's default values (None for all fields).
+    For Update models, the default behavior should be an empty update (all None),
+    with values only generated when explicitly requested.
+    """
+
+    class Meta:
+        model = NamedEntityUpdate
+
+    # No default values - respects model defaults (None for all fields)
+
+
+class NamedEntityFactory(factory.Factory[NamedEntity]):
+    """Factory for full NamedEntity models with all fields."""
+
+    class Meta:
+        model = NamedEntity
+
+    id: Any = LazyFunction(_uuid7)
+    canonical_name: Any = Sequence(lambda n: f"Entity {n}")
+    canonical_name_normalized: Any = Sequence(lambda n: f"entity {n}")
+    entity_type: Any = LazyFunction(lambda: EntityType.PERSON)
+    discovery_method: Any = LazyFunction(lambda: DiscoveryMethod.MANUAL)
+    status: Any = LazyFunction(lambda: TagStatus.ACTIVE)
+    entity_subtype: Any = LazyFunction(lambda: None)
+    description: Any = LazyFunction(lambda: None)
+    external_ids: Any = LazyFunction(dict)
+    mention_count: Any = LazyFunction(lambda: 0)
+    video_count: Any = LazyFunction(lambda: 0)
+    channel_count: Any = LazyFunction(lambda: 0)
+    confidence: Any = LazyFunction(lambda: 1.0)
+    merged_into_id: Any = LazyFunction(lambda: None)
+    created_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+    updated_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+
+
+# Convenience factory methods
+def create_named_entity(**kwargs: Any) -> NamedEntity:
+    """Create a NamedEntity with keyword arguments."""
+    result = NamedEntityFactory.build(**kwargs)
+    assert isinstance(result, NamedEntity)
+    return result
+
+
+def create_named_entity_base(**kwargs: Any) -> NamedEntityBase:
+    """Create a NamedEntityBase with keyword arguments."""
+    result = NamedEntityBaseFactory.build(**kwargs)
+    assert isinstance(result, NamedEntityBase)
+    return result
+
+
+def create_named_entity_create(**kwargs: Any) -> NamedEntityCreate:
+    """Create a NamedEntityCreate with keyword arguments."""
+    result = NamedEntityCreateFactory.build(**kwargs)
+    assert isinstance(result, NamedEntityCreate)
+    return result
+
+
+def create_named_entity_update(**kwargs: Any) -> NamedEntityUpdate:
+    """Create a NamedEntityUpdate with keyword arguments."""
+    result = NamedEntityUpdateFactory.build(**kwargs)
+    assert isinstance(result, NamedEntityUpdate)
+    return result
+
+
+# Common test data patterns
+class NamedEntityTestData:
+    """Common test data patterns for NamedEntity models."""
+
+    VALID_CANONICAL_NAMES = [
+        "Elon Musk",
+        "Google",
+        "New York City",
+        "PyCon",
+        "Python",
+        "machine learning",
+    ]
+
+    VALID_CANONICAL_NAMES_NORMALIZED = [
+        "elon musk",
+        "google",
+        "new york city",
+        "pycon",
+        "python",
+        "machine learning",
+    ]
+
+    VALID_ENTITY_TYPES = [
+        EntityType.PERSON,
+        EntityType.ORGANIZATION,
+        EntityType.PLACE,
+        EntityType.EVENT,
+        EntityType.WORK,
+        EntityType.TECHNICAL_TERM,
+    ]
+
+    VALID_DISCOVERY_METHODS = [
+        DiscoveryMethod.MANUAL,
+        DiscoveryMethod.SPACY_NER,
+        DiscoveryMethod.TAG_BOOTSTRAP,
+        DiscoveryMethod.LLM_EXTRACTION,
+        DiscoveryMethod.USER_CREATED,
+    ]
+
+    VALID_STATUSES = [
+        TagStatus.ACTIVE,
+        TagStatus.MERGED,
+        TagStatus.DEPRECATED,
+    ]
+
+    INVALID_CANONICAL_NAMES = [
+        "",  # Empty
+        "x" * 501,  # Too long (max is 500)
+    ]
+
+    @classmethod
+    def valid_named_entity_data(cls) -> dict[str, Any]:
+        """Get valid named entity data."""
+        return {
+            "canonical_name": cls.VALID_CANONICAL_NAMES[0],
+            "canonical_name_normalized": cls.VALID_CANONICAL_NAMES_NORMALIZED[0],
+            "entity_type": EntityType.PERSON,
+            "discovery_method": DiscoveryMethod.MANUAL,
+            "status": TagStatus.ACTIVE,
+        }
+
+    @classmethod
+    def minimal_named_entity_data(cls) -> dict[str, Any]:
+        """Get minimal valid named entity data."""
+        return {
+            "canonical_name": "Elon Musk",
+            "canonical_name_normalized": "elon musk",
+            "entity_type": EntityType.PERSON,
+        }

--- a/tests/factories/tag_alias_factory.py
+++ b/tests/factories/tag_alias_factory.py
@@ -1,0 +1,173 @@
+"""
+Factory for TagAlias Pydantic models using factory_boy.
+
+Provides reusable test data factories for all TagAlias model variants
+with sensible defaults and easy customization.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import factory
+from factory import LazyFunction, Sequence
+from uuid_utils import uuid7
+
+
+def _uuid7() -> uuid.UUID:
+    """Generate a UUIDv7 as a standard uuid.UUID for Pydantic compatibility."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+from chronovista.models.enums import CreationMethod
+from chronovista.models.tag_alias import (
+    TagAlias,
+    TagAliasBase,
+    TagAliasCreate,
+    TagAliasUpdate,
+)
+
+
+class TagAliasBaseFactory(factory.Factory[TagAliasBase]):
+    """Factory for TagAliasBase models."""
+
+    class Meta:
+        model = TagAliasBase
+
+    raw_form: Any = Sequence(lambda n: f"raw_tag_{n}")
+    normalized_form: Any = Sequence(lambda n: f"raw_tag_{n}")
+    creation_method: Any = LazyFunction(lambda: CreationMethod.AUTO_NORMALIZE)
+
+
+class TagAliasCreateFactory(factory.Factory[TagAliasCreate]):
+    """Factory for TagAliasCreate models."""
+
+    class Meta:
+        model = TagAliasCreate
+
+    raw_form: Any = Sequence(lambda n: f"raw_tag_{n}")
+    normalized_form: Any = Sequence(lambda n: f"raw_tag_{n}")
+    creation_method: Any = LazyFunction(lambda: CreationMethod.AUTO_NORMALIZE)
+    canonical_tag_id: Any = LazyFunction(_uuid7)
+    normalization_version: Any = LazyFunction(lambda: 1)
+    occurrence_count: Any = LazyFunction(lambda: 1)
+
+
+class TagAliasUpdateFactory(factory.Factory[TagAliasUpdate]):
+    """Factory for TagAliasUpdate models.
+
+    Note: This factory respects the model's default values (None for all fields).
+    For Update models, the default behavior should be an empty update (all None),
+    with values only generated when explicitly requested.
+    """
+
+    class Meta:
+        model = TagAliasUpdate
+
+    # No default values - respects model defaults (None for all fields)
+
+
+class TagAliasFactory(factory.Factory[TagAlias]):
+    """Factory for full TagAlias models with all fields."""
+
+    class Meta:
+        model = TagAlias
+
+    id: Any = LazyFunction(_uuid7)
+    raw_form: Any = Sequence(lambda n: f"raw_tag_{n}")
+    normalized_form: Any = Sequence(lambda n: f"raw_tag_{n}")
+    creation_method: Any = LazyFunction(lambda: CreationMethod.AUTO_NORMALIZE)
+    canonical_tag_id: Any = LazyFunction(_uuid7)
+    normalization_version: Any = LazyFunction(lambda: 1)
+    occurrence_count: Any = LazyFunction(lambda: 1)
+    first_seen_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+    last_seen_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+    created_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+
+
+# Convenience factory methods
+def create_tag_alias(**kwargs: Any) -> TagAlias:
+    """Create a TagAlias with keyword arguments."""
+    result = TagAliasFactory.build(**kwargs)
+    assert isinstance(result, TagAlias)
+    return result
+
+
+def create_tag_alias_base(**kwargs: Any) -> TagAliasBase:
+    """Create a TagAliasBase with keyword arguments."""
+    result = TagAliasBaseFactory.build(**kwargs)
+    assert isinstance(result, TagAliasBase)
+    return result
+
+
+def create_tag_alias_create(**kwargs: Any) -> TagAliasCreate:
+    """Create a TagAliasCreate with keyword arguments."""
+    result = TagAliasCreateFactory.build(**kwargs)
+    assert isinstance(result, TagAliasCreate)
+    return result
+
+
+def create_tag_alias_update(**kwargs: Any) -> TagAliasUpdate:
+    """Create a TagAliasUpdate with keyword arguments."""
+    result = TagAliasUpdateFactory.build(**kwargs)
+    assert isinstance(result, TagAliasUpdate)
+    return result
+
+
+# Common test data patterns
+class TagAliasTestData:
+    """Common test data patterns for TagAlias models."""
+
+    VALID_RAW_FORMS = [
+        "Python",
+        "#python",
+        "PYTHON",
+        "python3",
+        "Machine Learning",
+        "#MachineLearning",
+    ]
+
+    VALID_NORMALIZED_FORMS = [
+        "python",
+        "python",
+        "python",
+        "python3",
+        "machine learning",
+        "machinelearning",
+    ]
+
+    VALID_CREATION_METHODS = [
+        CreationMethod.AUTO_NORMALIZE,
+        CreationMethod.MANUAL_MERGE,
+        CreationMethod.BACKFILL,
+        CreationMethod.API_CREATE,
+    ]
+
+    INVALID_RAW_FORMS = [
+        "",  # Empty
+        "x" * 501,  # Too long (max is 500)
+    ]
+
+    @classmethod
+    def valid_tag_alias_data(cls) -> dict[str, Any]:
+        """Get valid tag alias data."""
+        return {
+            "raw_form": cls.VALID_RAW_FORMS[0],
+            "normalized_form": cls.VALID_NORMALIZED_FORMS[0],
+            "creation_method": CreationMethod.AUTO_NORMALIZE,
+        }
+
+    @classmethod
+    def minimal_tag_alias_data(cls) -> dict[str, Any]:
+        """Get minimal valid tag alias data."""
+        return {
+            "raw_form": "Python",
+            "normalized_form": "python",
+        }

--- a/tests/factories/tag_operation_log_factory.py
+++ b/tests/factories/tag_operation_log_factory.py
@@ -1,0 +1,164 @@
+"""
+Factory for TagOperationLog ORM model using factory_boy.
+
+Provides reusable test data factories for TagOperationLog instances
+with sensible defaults and easy customization.
+
+Note: TagOperationLog does not have a separate Pydantic model, so this
+factory targets the SQLAlchemy ORM model directly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import factory
+from factory import LazyFunction
+from uuid_utils import uuid7
+
+from chronovista.db.models import TagOperationLog
+
+
+class TagOperationLogFactory(factory.Factory[TagOperationLog]):
+    """Factory for TagOperationLog ORM models."""
+
+    class Meta:
+        model = TagOperationLog
+        exclude = ["_skip_session"]
+
+    # Exclude from SQLAlchemy session management — these are in-memory only
+    _skip_session: Any = True
+
+    id: Any = LazyFunction(uuid7)
+    operation_type: Any = LazyFunction(lambda: "create")
+    source_canonical_ids: Any = LazyFunction(list)
+    target_canonical_id: Any = LazyFunction(lambda: None)
+    affected_alias_ids: Any = LazyFunction(list)
+    reason: Any = LazyFunction(lambda: None)
+    performed_by: Any = LazyFunction(lambda: "system")
+    performed_at: Any = LazyFunction(
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+    )
+    rollback_data: Any = LazyFunction(dict)
+    rolled_back: Any = LazyFunction(lambda: False)
+    rolled_back_at: Any = LazyFunction(lambda: None)
+
+
+# Convenience factory methods
+def create_tag_operation_log(**kwargs: Any) -> TagOperationLog:
+    """Create a TagOperationLog with keyword arguments."""
+    result = TagOperationLogFactory.build(**kwargs)
+    assert isinstance(result, TagOperationLog)
+    return result
+
+
+def create_merge_operation_log(**kwargs: Any) -> TagOperationLog:
+    """Create a TagOperationLog for a merge operation.
+
+    Parameters
+    ----------
+    **kwargs : Any
+        Override any TagOperationLog fields.
+
+    Returns
+    -------
+    TagOperationLog
+        A TagOperationLog instance configured for a merge operation.
+    """
+    source_id = uuid7()
+    target_id = uuid7()
+    alias_id = uuid7()
+    defaults: Dict[str, Any] = {
+        "operation_type": "merge",
+        "source_canonical_ids": [str(source_id)],
+        "target_canonical_id": target_id,
+        "affected_alias_ids": [str(alias_id)],
+        "reason": "Duplicate tags identified during normalization",
+        "performed_by": "system",
+    }
+    defaults.update(kwargs)
+    result = TagOperationLogFactory.build(**defaults)
+    assert isinstance(result, TagOperationLog)
+    return result
+
+
+def create_split_operation_log(**kwargs: Any) -> TagOperationLog:
+    """Create a TagOperationLog for a split operation.
+
+    Parameters
+    ----------
+    **kwargs : Any
+        Override any TagOperationLog fields.
+
+    Returns
+    -------
+    TagOperationLog
+        A TagOperationLog instance configured for a split operation.
+    """
+    source_id = uuid7()
+    defaults: Dict[str, Any] = {
+        "operation_type": "split",
+        "source_canonical_ids": [str(source_id)],
+        "reason": "Tag split into more specific variants",
+        "performed_by": "admin",
+    }
+    defaults.update(kwargs)
+    result = TagOperationLogFactory.build(**defaults)
+    assert isinstance(result, TagOperationLog)
+    return result
+
+
+# Common test data patterns
+class TagOperationLogTestData:
+    """Common test data patterns for TagOperationLog models."""
+
+    VALID_OPERATION_TYPES = [
+        "merge",
+        "split",
+        "rename",
+        "delete",
+        "create",
+    ]
+
+    VALID_PERFORMED_BY = [
+        "system",
+        "admin",
+        "user_123",
+        "backfill_script",
+    ]
+
+    @classmethod
+    def valid_operation_log_data(cls) -> Dict[str, Any]:
+        """Get valid tag operation log data."""
+        return {
+            "operation_type": "create",
+            "source_canonical_ids": [],
+            "target_canonical_id": None,
+            "affected_alias_ids": [],
+            "reason": None,
+            "performed_by": "system",
+            "rollback_data": {},
+            "rolled_back": False,
+            "rolled_back_at": None,
+        }
+
+    @classmethod
+    def merge_operation_data(cls) -> Dict[str, Any]:
+        """Get data for a merge operation."""
+        source_id = uuid7()
+        target_id = uuid7()
+        return {
+            "operation_type": "merge",
+            "source_canonical_ids": [str(source_id)],
+            "target_canonical_id": target_id,
+            "affected_alias_ids": [],
+            "reason": "Duplicate canonical tags",
+            "performed_by": "system",
+            "rollback_data": {
+                "original_canonical_form": "Python3",
+                "original_normalized_form": "python3",
+            },
+            "rolled_back": False,
+            "rolled_back_at": None,
+        }

--- a/tests/integration/db/test_tag_normalization_schema.py
+++ b/tests/integration/db/test_tag_normalization_schema.py
@@ -1,0 +1,1066 @@
+"""
+Tests for Feature 028 schema: tag normalization tables and constraints.
+
+This test suite validates that the Alembic migration (028a_add_tag_normalization_tables)
+correctly creates all 5 tables with proper constraints, foreign keys, indexes, and
+cascade behaviors. These tests introspect the database catalog directly.
+
+Changes Validated (US2: T006b):
+1. AS-1: Five tables created in FK dependency order
+2. AS-2: CHECK constraints reject invalid classification values
+3. AS-3: UNIQUE constraints reject duplicate normalized_form
+4. AS-4: Cascade delete from canonical_tag removes tag_aliases
+5. AS-5: Delete named_entity sets canonical_tag.entity_id to NULL
+6. AS-6: Migration downgrade drops all 5 tables cleanly (documented only)
+7. AS-7: Partial index exists on canonical_tags
+8. AS-8: video_tags.tag index exists
+
+Related: Feature 028 (Tag Normalization Schema), Tasks T005-T006
+Architecture: ADR-003 Tag Normalization
+Migration: 028a_add_tag_normalization_tables (f9b5c8d6e3a1)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.db.models import (
+    CanonicalTag,
+    EntityAlias,
+    NamedEntity,
+    TagAlias,
+    TagOperationLog,
+    Video,
+    VideoTag,
+)
+
+# CRITICAL: This line ensures async tests work with coverage
+# Note: This applies to ALL tests in the module, including sync tests
+# For sync tests, we explicitly mark them with @pytest.mark.asyncio(False)
+pytestmark = pytest.mark.asyncio
+
+
+def get_table_names_sync(connection: Any) -> list[str]:
+    """
+    Get all table names from database using synchronous connection.
+
+    Parameters
+    ----------
+    connection : Any
+        SQLAlchemy synchronous connection
+
+    Returns
+    -------
+    list[str]
+        List of table names in the database
+    """
+    inspector = inspect(connection)
+    return cast(list[str], inspector.get_table_names())
+
+
+def get_indexes_sync(connection: Any, table_name: str) -> list[dict[str, Any]]:
+    """
+    Get indexes for a table using synchronous connection.
+
+    Parameters
+    ----------
+    connection : Any
+        SQLAlchemy synchronous connection
+    table_name : str
+        Name of the table to inspect
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        List of index metadata dictionaries
+    """
+    inspector = inspect(connection)
+    return cast(list[dict[str, Any]], inspector.get_indexes(table_name))
+
+
+class TestTableCreation:
+    """AS-1: Verify migration creates 5 tables in FK dependency order."""
+
+    async def test_five_tables_exist(self, db_session: AsyncSession) -> None:
+        """Verify all 5 tag normalization tables exist after migration."""
+        # Execute inspection in sync context
+        connection = await db_session.connection()
+        table_names = await connection.run_sync(get_table_names_sync)
+
+        expected_tables = [
+            "named_entities",
+            "entity_aliases",
+            "canonical_tags",
+            "tag_aliases",
+            "tag_operation_logs",
+        ]
+
+        for table in expected_tables:
+            assert table in table_names, f"Table {table} not found in database"
+
+    async def test_tables_can_be_queried(self, db_session: AsyncSession) -> None:
+        """Verify all 5 tables can be queried without errors."""
+        # Test each table by executing a simple query
+        await db_session.execute(text("SELECT COUNT(*) FROM named_entities"))
+        await db_session.execute(text("SELECT COUNT(*) FROM entity_aliases"))
+        await db_session.execute(text("SELECT COUNT(*) FROM canonical_tags"))
+        await db_session.execute(text("SELECT COUNT(*) FROM tag_aliases"))
+        await db_session.execute(text("SELECT COUNT(*) FROM tag_operation_logs"))
+
+
+class TestCheckConstraints:
+    """AS-2: Verify CHECK constraints reject invalid values."""
+
+    async def test_named_entity_invalid_entity_type(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify named_entities.entity_type CHECK constraint rejects invalid values."""
+        entity = NamedEntity(
+            id=uuid7(),
+            canonical_name="Test Person",
+            canonical_name_normalized="test person",
+            entity_type="invalid_type",  # Invalid value
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "chk_entity_type_valid" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_named_entity_invalid_status(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify named_entities.status CHECK constraint rejects invalid values."""
+        entity = NamedEntity(
+            id=uuid7(),
+            canonical_name="Test Person",
+            canonical_name_normalized="test person",
+            entity_type="person",
+            discovery_method="manual",
+            confidence=1.0,
+            status="invalid_status",  # Invalid value
+        )
+        db_session.add(entity)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "chk_entity_status_valid" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_named_entity_invalid_discovery_method(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify named_entities.discovery_method CHECK constraint rejects invalid values."""
+        entity = NamedEntity(
+            id=uuid7(),
+            canonical_name="Test Person",
+            canonical_name_normalized="test person",
+            entity_type="person",
+            discovery_method="invalid_method",  # Invalid value
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "chk_entity_discovery_method_valid" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_named_entity_confidence_out_of_range(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify named_entities.confidence CHECK constraint rejects values outside [0.0, 1.0]."""
+        entity = NamedEntity(
+            id=uuid7(),
+            canonical_name="Test Person",
+            canonical_name_normalized="test person",
+            entity_type="person",
+            discovery_method="manual",
+            confidence=1.5,  # Invalid: > 1.0
+            status="active",
+        )
+        db_session.add(entity)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "chk_entity_confidence_range" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_canonical_tag_invalid_status(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify canonical_tags.status CHECK constraint rejects invalid values."""
+        tag = CanonicalTag(
+            id=uuid7(),
+            canonical_form="Python Programming",
+            normalized_form="python programming",
+            alias_count=1,
+            video_count=0,
+            status="invalid_status",  # Invalid value
+        )
+        db_session.add(tag)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "chk_canonical_tag_status_valid" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_canonical_tag_invalid_entity_type(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify canonical_tags.entity_type CHECK constraint rejects invalid values."""
+        tag = CanonicalTag(
+            id=uuid7(),
+            canonical_form="Test Tag",
+            normalized_form="test tag",
+            alias_count=1,
+            video_count=0,
+            entity_type="invalid_entity_type",  # Invalid value
+            status="active",
+        )
+        db_session.add(tag)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "chk_canonical_tag_entity_type_valid" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_tag_operation_log_invalid_operation_type(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify tag_operation_logs.operation_type CHECK constraint rejects invalid values."""
+        operation = TagOperationLog(
+            id=uuid7(),
+            operation_type="invalid_operation",  # Invalid value
+            performed_by="system",
+        )
+        db_session.add(operation)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "chk_tag_operation_type_valid" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_entity_alias_invalid_alias_type(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify entity_aliases.alias_type CHECK constraint rejects invalid values."""
+        # First create parent entity
+        entity = NamedEntity(
+            id=uuid7(),
+            canonical_name="Test Person",
+            canonical_name_normalized="test person",
+            entity_type="person",
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity)
+        await db_session.flush()
+
+        # Try to create alias with invalid type
+        alias = EntityAlias(
+            id=uuid7(),
+            entity_id=entity.id,
+            alias_name="Test Alias",
+            alias_name_normalized="test alias",
+            alias_type="invalid_alias_type",  # Invalid value
+        )
+        db_session.add(alias)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "chk_alias_type_valid" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_tag_alias_invalid_creation_method(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify tag_aliases.creation_method CHECK constraint rejects invalid values."""
+        # First create canonical tag
+        canonical_tag = CanonicalTag(
+            id=uuid7(),
+            canonical_form="Python",
+            normalized_form="python",
+            alias_count=1,
+            video_count=0,
+            status="active",
+        )
+        db_session.add(canonical_tag)
+        await db_session.flush()
+
+        # Try to create alias with invalid creation_method
+        alias = TagAlias(
+            id=uuid7(),
+            raw_form="#Python",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag.id,
+            creation_method="invalid_method",  # Invalid value
+        )
+        db_session.add(alias)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "chk_tag_alias_creation_method_valid" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+
+class TestUniqueConstraints:
+    """AS-3: Verify UNIQUE constraints reject duplicates."""
+
+    async def test_canonical_tag_duplicate_normalized_form(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify canonical_tags.normalized_form UNIQUE constraint rejects duplicates."""
+        # Insert first tag
+        tag1 = CanonicalTag(
+            id=uuid7(),
+            canonical_form="Python Programming",
+            normalized_form="python programming",
+            alias_count=1,
+            video_count=0,
+            status="active",
+        )
+        db_session.add(tag1)
+        await db_session.flush()
+
+        # Try to insert second tag with same normalized_form
+        tag2 = CanonicalTag(
+            id=uuid7(),
+            canonical_form="PYTHON Programming",  # Different canonical
+            normalized_form="python programming",  # Same normalized
+            alias_count=1,
+            video_count=0,
+            status="active",
+        )
+        db_session.add(tag2)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "normalized_form" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_tag_alias_duplicate_raw_form(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify tag_aliases.raw_form UNIQUE constraint rejects duplicates."""
+        # Create two canonical tags separately to avoid batch insert UUID issues
+        tag1_id = uuid7()
+        tag1 = CanonicalTag(
+            id=tag1_id,
+            canonical_form="Python",
+            normalized_form="python",
+            alias_count=1,
+            video_count=0,
+            status="active",
+        )
+        db_session.add(tag1)
+        await db_session.flush()
+
+        tag2_id = uuid7()
+        tag2 = CanonicalTag(
+            id=tag2_id,
+            canonical_form="JavaScript",
+            normalized_form="javascript",
+            alias_count=1,
+            video_count=0,
+            status="active",
+        )
+        db_session.add(tag2)
+        await db_session.flush()
+
+        # Create first alias
+        alias1 = TagAlias(
+            id=uuid7(),
+            raw_form="#Python",
+            normalized_form="python",
+            canonical_tag_id=tag1_id,
+        )
+        db_session.add(alias1)
+        await db_session.flush()
+
+        # Try to create second alias with same raw_form but different canonical tag
+        alias2 = TagAlias(
+            id=uuid7(),
+            raw_form="#Python",  # Same raw form
+            normalized_form="python",
+            canonical_tag_id=tag2_id,  # Different canonical tag
+        )
+        db_session.add(alias2)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "raw_form" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_named_entity_duplicate_canonical_name_and_type(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify named_entities UNIQUE constraint on (canonical_name_normalized, entity_type)."""
+        # Insert first entity
+        entity1 = NamedEntity(
+            id=uuid7(),
+            canonical_name="Mexico City",
+            canonical_name_normalized="mexico city",
+            entity_type="place",
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity1)
+        await db_session.flush()
+
+        # Try to insert duplicate with same normalized name and type
+        entity2 = NamedEntity(
+            id=uuid7(),
+            canonical_name="MEXICO CITY",  # Different case
+            canonical_name_normalized="mexico city",  # Same normalized
+            entity_type="place",  # Same type
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity2)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "uq_named_entity_canonical" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_entity_alias_duplicate_alias_name_and_entity(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify entity_aliases UNIQUE constraint on (alias_name_normalized, entity_id)."""
+        # Create parent entity
+        entity = NamedEntity(
+            id=uuid7(),
+            canonical_name="Python",
+            canonical_name_normalized="python",
+            entity_type="technical_term",
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity)
+        await db_session.flush()
+
+        # Create first alias
+        alias1 = EntityAlias(
+            id=uuid7(),
+            entity_id=entity.id,
+            alias_name="python3",
+            alias_name_normalized="python3",
+            alias_type="abbreviation",
+        )
+        db_session.add(alias1)
+        await db_session.flush()
+
+        # Try to create duplicate alias
+        alias2 = EntityAlias(
+            id=uuid7(),
+            entity_id=entity.id,
+            alias_name="PYTHON3",  # Different case
+            alias_name_normalized="python3",  # Same normalized
+            alias_type="abbreviation",
+        )
+        db_session.add(alias2)
+
+        with pytest.raises(IntegrityError) as exc_info:
+            await db_session.flush()
+
+        assert "uq_entity_alias_name" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+
+class TestCascadeDelete:
+    """AS-4: Verify cascade delete from canonical_tag removes tag_aliases."""
+
+    async def test_delete_canonical_tag_cascades_to_aliases(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify deleting canonical_tag cascades to tag_aliases (CASCADE)."""
+        # Create canonical tag
+        canonical_tag_id = uuid7()
+        canonical_tag = CanonicalTag(
+            id=canonical_tag_id,
+            canonical_form="Python",
+            normalized_form="python",
+            alias_count=3,
+            video_count=0,
+            status="active",
+        )
+        db_session.add(canonical_tag)
+        await db_session.flush()
+
+        # Create multiple aliases separately to avoid batch insert UUID issues
+        alias1 = TagAlias(
+            id=uuid7(),
+            raw_form="#Python",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag_id,
+        )
+        db_session.add(alias1)
+        await db_session.flush()
+
+        alias2 = TagAlias(
+            id=uuid7(),
+            raw_form="python programming",
+            normalized_form="python programming",
+            canonical_tag_id=canonical_tag_id,
+        )
+        db_session.add(alias2)
+        await db_session.flush()
+
+        alias3 = TagAlias(
+            id=uuid7(),
+            raw_form="PYTHON",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag_id,
+        )
+        db_session.add(alias3)
+        await db_session.flush()
+
+        # Verify aliases exist
+        result = await db_session.execute(
+            text("SELECT COUNT(*) FROM tag_aliases WHERE canonical_tag_id = :tag_id"),
+            {"tag_id": canonical_tag_id},
+        )
+        count = result.scalar()
+        assert count == 3
+
+        # Delete canonical tag
+        await db_session.delete(canonical_tag)
+        await db_session.flush()
+
+        # Verify aliases were cascade deleted
+        result = await db_session.execute(
+            text("SELECT COUNT(*) FROM tag_aliases WHERE canonical_tag_id = :tag_id"),
+            {"tag_id": canonical_tag_id},
+        )
+        count = result.scalar()
+        assert count == 0
+
+    async def test_delete_named_entity_cascades_to_entity_aliases(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify deleting named_entity cascades to entity_aliases (CASCADE)."""
+        # Create named entity
+        entity_id = uuid7()
+        entity = NamedEntity(
+            id=entity_id,
+            canonical_name="Mexico",
+            canonical_name_normalized="mexico",
+            entity_type="place",
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity)
+        await db_session.flush()
+
+        # Create entity aliases separately to avoid batch insert UUID issues
+        alias1 = EntityAlias(
+            id=uuid7(),
+            entity_id=entity_id,
+            alias_name="México",
+            alias_name_normalized="mexico",
+            alias_type="name_variant",
+        )
+        db_session.add(alias1)
+        await db_session.flush()
+
+        alias2 = EntityAlias(
+            id=uuid7(),
+            entity_id=entity_id,
+            alias_name="MX",
+            alias_name_normalized="mx",
+            alias_type="abbreviation",
+        )
+        db_session.add(alias2)
+        await db_session.flush()
+
+        # Verify aliases exist
+        result = await db_session.execute(
+            text("SELECT COUNT(*) FROM entity_aliases WHERE entity_id = :entity_id"),
+            {"entity_id": entity_id},
+        )
+        count = result.scalar()
+        assert count == 2
+
+        # Delete entity
+        await db_session.delete(entity)
+        await db_session.flush()
+
+        # Verify aliases were cascade deleted
+        result = await db_session.execute(
+            text("SELECT COUNT(*) FROM entity_aliases WHERE entity_id = :entity_id"),
+            {"entity_id": entity_id},
+        )
+        count = result.scalar()
+        assert count == 0
+
+
+class TestSetNullBehavior:
+    """AS-5: Verify delete named_entity sets canonical_tag.entity_id to NULL."""
+
+    async def test_delete_named_entity_sets_canonical_tag_entity_id_to_null(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify deleting named_entity sets canonical_tag.entity_id to NULL (SET NULL)."""
+        # Create named entity
+        entity = NamedEntity(
+            id=uuid7(),
+            canonical_name="Python Language",
+            canonical_name_normalized="python language",
+            entity_type="technical_term",
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity)
+        await db_session.flush()
+
+        # Create canonical tag linked to entity
+        canonical_tag = CanonicalTag(
+            id=uuid7(),
+            canonical_form="Python",
+            normalized_form="python",
+            alias_count=1,
+            video_count=0,
+            entity_type="technical_term",
+            entity_id=entity.id,  # Link to entity
+            status="active",
+        )
+        db_session.add(canonical_tag)
+        await db_session.flush()
+
+        # Verify entity_id is set
+        assert canonical_tag.entity_id == entity.id
+
+        # Delete entity
+        await db_session.delete(entity)
+        await db_session.flush()
+
+        # Refresh canonical tag to see updated value
+        await db_session.refresh(canonical_tag)
+
+        # Verify entity_id is now NULL (SET NULL behavior)
+        assert canonical_tag.entity_id is None
+
+    async def test_canonical_tag_survives_entity_deletion(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Verify canonical_tag record itself is NOT deleted when entity is deleted."""
+        # Create named entity
+        entity = NamedEntity(
+            id=uuid7(),
+            canonical_name="JavaScript",
+            canonical_name_normalized="javascript",
+            entity_type="technical_term",
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity)
+        await db_session.flush()
+
+        # Create canonical tag linked to entity
+        canonical_tag = CanonicalTag(
+            id=uuid7(),
+            canonical_form="JavaScript",
+            normalized_form="javascript",
+            alias_count=1,
+            video_count=0,
+            entity_type="technical_term",
+            entity_id=entity.id,
+            status="active",
+        )
+        db_session.add(canonical_tag)
+        await db_session.flush()
+
+        canonical_tag_id = canonical_tag.id
+
+        # Delete entity
+        await db_session.delete(entity)
+        await db_session.flush()
+
+        # Verify canonical_tag still exists
+        result = await db_session.execute(
+            text("SELECT COUNT(*) FROM canonical_tags WHERE id = :tag_id"),
+            {"tag_id": canonical_tag_id},
+        )
+        count = result.scalar()
+        assert count == 1
+
+
+class TestIndexExistence:
+    """
+    AS-7 & AS-8: Verify partial and regular indexes exist.
+
+    NOTE: These tests are SKIPPED because the test database is created using
+    Base.metadata.create_all() which creates ORM models but does NOT run
+    Alembic migrations. The indexes defined in migration 028a are NOT created
+    by the ORM metadata.
+
+    To properly test indexes, we would need to:
+    1. Run Alembic migrations in the test database setup
+    2. OR verify the migration SQL contains the index creation DDL (done in T006a)
+
+    Since migration SQL validation is covered in T006a, and integration tests
+    use ORM-created schema (not migration-created), we document the expected
+    indexes here but skip actual database checks.
+    """
+
+    async def test_canonical_tags_active_normalized_partial_index_documented(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Document that idx_canonical_tags_active_normalized partial index should exist.
+
+        This index is created by migration 028a:
+        - Index name: idx_canonical_tags_active_normalized
+        - Table: canonical_tags
+        - Column: normalized_form
+        - Partial: WHERE status = 'active'
+        - Purpose: Speed up lookups of active canonical tags
+        """
+        # Test passes by documentation - actual index check would require migration
+        pytest.skip("Index tests require migration-created schema, not ORM schema")
+
+    async def test_video_tags_tag_index_documented(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Document that idx_video_tags_tag index should exist.
+
+        This index is created by migration 028a:
+        - Index name: idx_video_tags_tag
+        - Table: video_tags (existing table)
+        - Column: tag
+        - Purpose: Speed up tag lookups for normalization joins
+        """
+        # Test passes by documentation - actual index check would require migration
+        pytest.skip("Index tests require migration-created schema, not ORM schema")
+
+    async def test_canonical_tags_video_count_desc_index_documented(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Document that idx_canonical_tags_video_count_desc index should exist.
+
+        This index is created by migration 028a:
+        - Index name: idx_canonical_tags_video_count_desc
+        - Table: canonical_tags
+        - Column: video_count DESC
+        - Purpose: Speed up "hot tags" queries (most popular tags)
+        """
+        # Test passes by documentation - actual index check would require migration
+        pytest.skip("Index tests require migration-created schema, not ORM schema")
+
+
+class TestMigrationDowngrade:
+    """
+    AS-6: Document migration downgrade behavior.
+
+    NOTE: We do NOT run actual downgrade in tests to avoid data loss.
+    This test class documents the expected downgrade behavior.
+
+    The downgrade SQL in migration f9b5c8d6e3a1 performs:
+    1. Drop all 15 indexes (including idx_video_tags_tag)
+    2. Drop tables in reverse FK dependency order:
+       - tag_operation_logs (no FKs to others)
+       - tag_aliases (FK to canonical_tags)
+       - canonical_tags (FK to named_entities)
+       - entity_aliases (FK to named_entities)
+       - named_entities (base table)
+
+    This ensures clean removal without FK constraint violations.
+
+    WARNING: Downgrade permanently deletes:
+    - All canonical tags and their aliases
+    - All named entities and their aliases
+    - All tag operation history and rollback data
+    - Statistics and confidence scores
+    """
+
+    @pytest.mark.asyncio(False)  # Override module-level marker for this sync test
+    def test_downgrade_documentation(self) -> None:
+        """Document expected downgrade behavior (no actual downgrade executed)."""
+        expected_drop_order = [
+            "tag_operation_logs",
+            "tag_aliases",
+            "canonical_tags",
+            "entity_aliases",
+            "named_entities",
+        ]
+
+        # This is a documentation test - it always passes
+        # Actual downgrade testing would require separate test database
+        # and Alembic commands, which are out of scope for schema tests
+        assert len(expected_drop_order) == 5
+        assert "named_entities" in expected_drop_order
+
+
+class TestSchemaIntegration:
+    """Integration tests validating schema works correctly with data."""
+
+    async def test_create_complete_tag_hierarchy(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test creating a complete tag hierarchy with entity linking."""
+        # Create named entity
+        entity_id = uuid7()
+        entity = NamedEntity(
+            id=entity_id,
+            canonical_name="Python",
+            canonical_name_normalized="python",
+            entity_type="technical_term",
+            entity_subtype="programming_language",
+            description="Python programming language",
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+        )
+        db_session.add(entity)
+        await db_session.flush()
+
+        # Create entity alias
+        entity_alias = EntityAlias(
+            id=uuid7(),
+            entity_id=entity_id,
+            alias_name="Python3",
+            alias_name_normalized="python3",
+            alias_type="abbreviation",
+        )
+        db_session.add(entity_alias)
+        await db_session.flush()
+
+        # Create canonical tag linked to entity
+        canonical_tag_id = uuid7()
+        canonical_tag = CanonicalTag(
+            id=canonical_tag_id,
+            canonical_form="Python",
+            normalized_form="python",
+            alias_count=2,
+            video_count=0,
+            entity_type="technical_term",
+            entity_id=entity_id,
+            status="active",
+        )
+        db_session.add(canonical_tag)
+        await db_session.flush()
+
+        # Create tag aliases separately to avoid batch insert UUID issues
+        tag_alias1 = TagAlias(
+            id=uuid7(),
+            raw_form="#Python",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag_id,
+            creation_method="auto_normalize",
+        )
+        db_session.add(tag_alias1)
+        await db_session.flush()
+
+        tag_alias2 = TagAlias(
+            id=uuid7(),
+            raw_form="PYTHON",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag_id,
+            creation_method="auto_normalize",
+        )
+        db_session.add(tag_alias2)
+        await db_session.flush()
+
+        # Create operation log
+        operation = TagOperationLog(
+            id=uuid7(),
+            operation_type="create",
+            target_canonical_id=canonical_tag_id,
+            reason="Initial tag creation",
+            performed_by="test_user",
+        )
+        db_session.add(operation)
+        await db_session.flush()
+
+        # Verify record counts via raw SQL instead of relationship loading
+        # (relationship loading can fail if not properly configured)
+        result = await db_session.execute(
+            text("SELECT COUNT(*) FROM entity_aliases WHERE entity_id = :entity_id"),
+            {"entity_id": entity_id},
+        )
+        entity_alias_count = result.scalar()
+        assert entity_alias_count == 1
+
+        result = await db_session.execute(
+            text("SELECT COUNT(*) FROM tag_aliases WHERE canonical_tag_id = :tag_id"),
+            {"tag_id": canonical_tag_id},
+        )
+        tag_alias_count = result.scalar()
+        assert tag_alias_count == 2
+
+        # Verify entity linking via raw SQL (avoid ORM refresh issues)
+        result = await db_session.execute(
+            text("SELECT entity_id FROM canonical_tags WHERE id = :tag_id"),
+            {"tag_id": canonical_tag_id},
+        )
+        stored_entity_id = result.scalar()
+        # Compare UUID values as strings to avoid type representation issues
+        assert str(stored_entity_id) == str(entity_id)
+
+    async def test_tag_merge_operation_log(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test logging a tag merge operation with rollback data."""
+        # Create two tags to merge separately
+        tag1_id = uuid7()
+        tag1 = CanonicalTag(
+            id=tag1_id,
+            canonical_form="Python",
+            normalized_form="python",
+            alias_count=1,
+            video_count=5,
+            status="active",
+        )
+        db_session.add(tag1)
+        await db_session.flush()
+
+        tag2_id = uuid7()
+        tag2 = CanonicalTag(
+            id=tag2_id,
+            canonical_form="python programming",
+            normalized_form="python programming",
+            alias_count=1,
+            video_count=3,
+            status="active",
+        )
+        db_session.add(tag2)
+        await db_session.flush()
+
+        # Create merge operation log
+        operation = TagOperationLog(
+            id=uuid7(),
+            operation_type="merge",
+            source_canonical_ids=[str(tag2_id)],
+            target_canonical_id=tag1_id,
+            affected_alias_ids=[],
+            reason="Merge duplicate tag variations",
+            performed_by="admin",
+            rollback_data={
+                "source_tag": str(tag2_id),
+                "source_normalized_form": tag2.normalized_form,
+                "source_video_count": tag2.video_count,
+            },
+        )
+        db_session.add(operation)
+        await db_session.flush()
+
+        # Verify operation logged correctly
+        assert operation.operation_type == "merge"
+        assert operation.target_canonical_id == tag1_id
+        assert operation.rolled_back is False
+        assert operation.rollback_data["source_tag"] == str(tag2_id)
+
+    async def test_default_values_applied(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test that default values are correctly applied on insert."""
+        # Create minimal canonical tag (testing defaults)
+        tag = CanonicalTag(
+            id=uuid7(),
+            canonical_form="Test Tag",
+            normalized_form="test tag",
+        )
+        db_session.add(tag)
+        await db_session.flush()
+
+        await db_session.refresh(tag)
+
+        # Verify defaults
+        assert tag.alias_count == 1  # Default from server_default
+        assert tag.video_count == 0  # Default from server_default
+        assert tag.status == "active"  # Default from server_default
+        assert tag.created_at is not None
+        assert tag.updated_at is not None
+
+    async def test_jsonb_fields_store_complex_data(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test that JSONB fields correctly store and retrieve complex data."""
+        # Create named entity with external_ids
+        entity = NamedEntity(
+            id=uuid7(),
+            canonical_name="Google",
+            canonical_name_normalized="google",
+            entity_type="organization",
+            discovery_method="manual",
+            confidence=1.0,
+            status="active",
+            external_ids={
+                "wikidata": "Q95",
+                "wikipedia": "Google",
+                "crunchbase": "google",
+            },
+        )
+        db_session.add(entity)
+        await db_session.flush()
+
+        await db_session.refresh(entity)
+
+        # Verify JSONB data
+        assert entity.external_ids["wikidata"] == "Q95"
+        assert entity.external_ids["wikipedia"] == "Google"
+        assert len(entity.external_ids) == 3
+
+    async def test_timestamp_fields_populated(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test that timestamp fields are automatically populated."""
+        # Create tag alias
+        canonical_tag = CanonicalTag(
+            id=uuid7(),
+            canonical_form="Test",
+            normalized_form="test",
+        )
+        db_session.add(canonical_tag)
+        await db_session.flush()
+
+        alias = TagAlias(
+            id=uuid7(),
+            raw_form="#Test",
+            normalized_form="test",
+            canonical_tag_id=canonical_tag.id,
+        )
+        db_session.add(alias)
+        await db_session.flush()
+
+        await db_session.refresh(alias)
+
+        # Verify timestamps
+        assert alias.first_seen_at is not None
+        assert alias.last_seen_at is not None
+        assert alias.created_at is not None
+        assert alias.first_seen_at <= alias.created_at

--- a/tests/unit/models/test_tag_normalization_models.py
+++ b/tests/unit/models/test_tag_normalization_models.py
@@ -1,0 +1,725 @@
+"""
+Tests for tag normalization Pydantic models.
+
+Tests validation, serialization, and model validators for canonical tags,
+tag aliases, named entities, and entity aliases using factory patterns.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+from uuid_utils import uuid7
+
+from chronovista.db.models import (
+    CanonicalTag as CanonicalTagDB,
+    EntityAlias as EntityAliasDB,
+    NamedEntity as NamedEntityDB,
+    TagAlias as TagAliasDB,
+)
+from chronovista.models.canonical_tag import (
+    CanonicalTag,
+    CanonicalTagBase,
+    CanonicalTagCreate,
+    CanonicalTagUpdate,
+)
+from chronovista.models.entity_alias import (
+    EntityAlias,
+    EntityAliasBase,
+    EntityAliasCreate,
+    EntityAliasUpdate,
+)
+from chronovista.models.enums import (
+    CreationMethod,
+    DiscoveryMethod,
+    EntityAliasType,
+    EntityType,
+    TagStatus,
+)
+from chronovista.models.named_entity import (
+    NamedEntity,
+    NamedEntityBase,
+    NamedEntityCreate,
+    NamedEntityUpdate,
+)
+from chronovista.models.tag_alias import (
+    TagAlias,
+    TagAliasBase,
+    TagAliasCreate,
+    TagAliasUpdate,
+)
+from tests.factories import (
+    CanonicalTagBaseFactory,
+    CanonicalTagCreateFactory,
+    CanonicalTagFactory,
+    CanonicalTagTestData,
+    CanonicalTagUpdateFactory,
+    EntityAliasBaseFactory,
+    EntityAliasCreateFactory,
+    EntityAliasFactory,
+    EntityAliasTestData,
+    EntityAliasUpdateFactory,
+    NamedEntityBaseFactory,
+    NamedEntityCreateFactory,
+    NamedEntityFactory,
+    NamedEntityTestData,
+    NamedEntityUpdateFactory,
+    TagAliasBaseFactory,
+    TagAliasCreateFactory,
+    TagAliasFactory,
+    TagAliasTestData,
+    TagAliasUpdateFactory,
+)
+
+
+class TestCanonicalTagModels:
+    """Test CanonicalTag Pydantic models."""
+
+    def test_create_canonical_tag_base_valid(self) -> None:
+        """Test creating valid CanonicalTagBase with keyword arguments."""
+        tag = CanonicalTagBaseFactory.build(
+            canonical_form="Python",
+            normalized_form="python",
+            entity_type=None,
+            status=TagStatus.ACTIVE,
+        )
+
+        assert tag.canonical_form == "Python"
+        assert tag.normalized_form == "python"
+        assert tag.entity_type is None
+        assert tag.status == TagStatus.ACTIVE
+
+    def test_create_canonical_tag_create_valid(self) -> None:
+        """Test creating valid CanonicalTagCreate with all fields."""
+        tag = CanonicalTagCreateFactory.build(
+            canonical_form="Machine Learning",
+            normalized_form="machine learning",
+            entity_type=EntityType.TECHNICAL_TERM,
+            status=TagStatus.ACTIVE,
+            alias_count=3,
+            video_count=10,
+        )
+
+        assert tag.canonical_form == "Machine Learning"
+        assert tag.normalized_form == "machine learning"
+        assert tag.entity_type == EntityType.TECHNICAL_TERM
+        assert tag.status == TagStatus.ACTIVE
+        assert tag.alias_count == 3
+        assert tag.video_count == 10
+
+    def test_canonical_tag_create_defaults(self) -> None:
+        """Test CanonicalTagCreate default values (FR-025)."""
+        tag = CanonicalTagCreate(
+            canonical_form="Python",
+            normalized_form="python",
+        )
+
+        assert tag.alias_count == 1
+        assert tag.video_count == 0
+        assert tag.entity_type is None
+        assert tag.status == TagStatus.ACTIVE
+        assert tag.entity_id is None
+        assert tag.merged_into_id is None
+
+    def test_canonical_tag_full_with_all_fields(self) -> None:
+        """Test creating full CanonicalTag with all fields."""
+        tag_id = uuid.UUID(bytes=uuid7().bytes)
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+        tag = CanonicalTagFactory.build(
+            id=tag_id,
+            canonical_form="Python",
+            normalized_form="python",
+            entity_type=EntityType.TECHNICAL_TERM,
+            status=TagStatus.ACTIVE,
+            alias_count=5,
+            video_count=100,
+            entity_id=entity_id,
+            merged_into_id=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        assert tag.id == tag_id
+        assert tag.canonical_form == "Python"
+        assert tag.normalized_form == "python"
+        assert tag.entity_type == EntityType.TECHNICAL_TERM
+        assert tag.status == TagStatus.ACTIVE
+        assert tag.alias_count == 5
+        assert tag.video_count == 100
+        assert tag.entity_id == entity_id
+        assert tag.merged_into_id is None
+        assert tag.created_at == now
+        assert tag.updated_at == now
+
+    def test_canonical_tag_classification_enum_types(self) -> None:
+        """Test classification fields use enum types (FR-025)."""
+        tag = CanonicalTagCreateFactory.build(
+            entity_type=EntityType.PERSON,
+            status=TagStatus.MERGED,
+            merged_into_id=uuid.UUID(bytes=uuid7().bytes),
+        )
+
+        # Verify that entity_type is an EntityType enum
+        assert isinstance(tag.entity_type, EntityType)
+        assert tag.entity_type == EntityType.PERSON
+
+        # Verify that status is a TagStatus enum
+        assert isinstance(tag.status, TagStatus)
+        assert tag.status == TagStatus.MERGED
+
+    def test_canonical_tag_model_dump_serialization(self) -> None:
+        """Test model_dump() serialization of classification fields (US3 AS-3)."""
+        tag = CanonicalTagCreateFactory.build(
+            canonical_form="Python",
+            normalized_form="python",
+            entity_type=EntityType.TECHNICAL_TERM,
+            status=TagStatus.ACTIVE,
+        )
+
+        data = tag.model_dump()
+
+        # Enums should serialize to their string values
+        assert data["entity_type"] == "technical_term"
+        assert data["status"] == "active"
+        assert data["canonical_form"] == "Python"
+        assert data["normalized_form"] == "python"
+
+    def test_canonical_tag_merged_status_requires_target(self) -> None:
+        """Test merged status requires merged_into_id (FR-027)."""
+        with pytest.raises(ValidationError, match="merged_into_id is required"):
+            CanonicalTagCreate(
+                canonical_form="OldTag",
+                normalized_form="oldtag",
+                status=TagStatus.MERGED,
+                merged_into_id=None,
+            )
+
+    def test_canonical_tag_merged_with_target_succeeds(self) -> None:
+        """Test merged status with merged_into_id succeeds (FR-027)."""
+        target_id = uuid.UUID(bytes=uuid7().bytes)
+        tag = CanonicalTagCreate(
+            canonical_form="OldTag",
+            normalized_form="oldtag",
+            status=TagStatus.MERGED,
+            merged_into_id=target_id,
+        )
+
+        assert tag.status == TagStatus.MERGED
+        assert tag.merged_into_id == target_id
+
+    def test_canonical_tag_no_self_merge(self) -> None:
+        """Test tag cannot be merged into itself (FR-028)."""
+        tag_id = uuid.UUID(bytes=uuid7().bytes)
+
+        with pytest.raises(ValidationError, match="cannot be merged into itself"):
+            CanonicalTag(
+                id=tag_id,
+                canonical_form="SelfMerge",
+                normalized_form="selfmerge",
+                status=TagStatus.MERGED,
+                merged_into_id=tag_id,  # Same as id - should fail
+                alias_count=1,
+                video_count=0,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+
+    def test_canonical_tag_update_partial_fields(self) -> None:
+        """Test CanonicalTagUpdate with partial fields."""
+        update = CanonicalTagUpdate(
+            canonical_form="Updated Tag",
+            status=TagStatus.DEPRECATED,
+        )
+
+        assert update.canonical_form == "Updated Tag"
+        assert update.status == TagStatus.DEPRECATED
+        # Other fields should remain None
+        assert update.normalized_form is None
+        assert update.entity_type is None
+        assert update.alias_count is None
+        assert update.video_count is None
+
+    @pytest.mark.parametrize("invalid_form", CanonicalTagTestData.INVALID_CANONICAL_FORMS)
+    def test_canonical_form_validation_invalid(self, invalid_form: str) -> None:
+        """Test canonical_form validation with invalid inputs."""
+        with pytest.raises(ValidationError):
+            CanonicalTagBaseFactory.build(canonical_form=invalid_form)
+
+    @pytest.mark.parametrize("valid_form", CanonicalTagTestData.VALID_CANONICAL_FORMS)
+    def test_canonical_form_validation_valid(self, valid_form: str) -> None:
+        """Test canonical_form validation with valid inputs."""
+        tag = CanonicalTagBaseFactory.build(canonical_form=valid_form)
+        assert tag.canonical_form == valid_form
+
+
+class TestTagAliasModels:
+    """Test TagAlias Pydantic models."""
+
+    def test_create_tag_alias_base_valid(self) -> None:
+        """Test creating valid TagAliasBase."""
+        alias = TagAliasBaseFactory.build(
+            raw_form="Python",
+            normalized_form="python",
+            creation_method=CreationMethod.AUTO_NORMALIZE,
+        )
+
+        assert alias.raw_form == "Python"
+        assert alias.normalized_form == "python"
+        assert alias.creation_method == CreationMethod.AUTO_NORMALIZE
+
+    def test_tag_alias_create_defaults(self) -> None:
+        """Test TagAliasCreate default values."""
+        canonical_tag_id = uuid.UUID(bytes=uuid7().bytes)
+        alias = TagAliasCreate(
+            raw_form="PYTHON",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag_id,
+        )
+
+        # Verify defaults
+        assert alias.creation_method == CreationMethod.AUTO_NORMALIZE
+        assert alias.normalization_version == 1
+        assert alias.occurrence_count == 1
+
+    def test_tag_alias_normalization_version_field(self) -> None:
+        """Test normalization_version field exists and defaults to 1 (FR-030)."""
+        canonical_tag_id = uuid.UUID(bytes=uuid7().bytes)
+        alias = TagAliasCreate(
+            raw_form="#MachineLearning",
+            normalized_form="machinelearning",
+            canonical_tag_id=canonical_tag_id,
+        )
+
+        assert hasattr(alias, "normalization_version")
+        assert alias.normalization_version == 1
+
+    def test_tag_alias_full_with_all_fields(self) -> None:
+        """Test creating full TagAlias with all fields."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        canonical_tag_id = uuid.UUID(bytes=uuid7().bytes)
+        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+        alias = TagAliasFactory.build(
+            id=alias_id,
+            raw_form="#Python",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag_id,
+            creation_method=CreationMethod.MANUAL_MERGE,
+            normalization_version=2,
+            occurrence_count=50,
+            first_seen_at=now,
+            last_seen_at=now,
+            created_at=now,
+        )
+
+        assert alias.id == alias_id
+        assert alias.raw_form == "#Python"
+        assert alias.normalized_form == "python"
+        assert alias.canonical_tag_id == canonical_tag_id
+        assert alias.creation_method == CreationMethod.MANUAL_MERGE
+        assert alias.normalization_version == 2
+        assert alias.occurrence_count == 50
+        assert alias.first_seen_at == now
+        assert alias.last_seen_at == now
+        assert alias.created_at == now
+
+    def test_tag_alias_model_dump_serialization(self) -> None:
+        """Test model_dump() serialization."""
+        canonical_tag_id = uuid.UUID(bytes=uuid7().bytes)
+        alias = TagAliasCreateFactory.build(
+            raw_form="Python",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag_id,
+            creation_method=CreationMethod.BACKFILL,
+        )
+
+        data = alias.model_dump()
+
+        assert data["raw_form"] == "Python"
+        assert data["normalized_form"] == "python"
+        assert data["canonical_tag_id"] == canonical_tag_id
+        assert data["creation_method"] == "backfill"
+        assert data["normalization_version"] == 1
+        assert data["occurrence_count"] == 1
+
+    @pytest.mark.parametrize("invalid_form", TagAliasTestData.INVALID_RAW_FORMS)
+    def test_raw_form_validation_invalid(self, invalid_form: str) -> None:
+        """Test raw_form validation with invalid inputs."""
+        with pytest.raises(ValidationError):
+            TagAliasBaseFactory.build(raw_form=invalid_form)
+
+    @pytest.mark.parametrize("valid_form", TagAliasTestData.VALID_RAW_FORMS)
+    def test_raw_form_validation_valid(self, valid_form: str) -> None:
+        """Test raw_form validation with valid inputs."""
+        alias = TagAliasBaseFactory.build(raw_form=valid_form)
+        assert alias.raw_form == valid_form
+
+
+class TestNamedEntityModels:
+    """Test NamedEntity Pydantic models."""
+
+    def test_create_named_entity_base_valid(self) -> None:
+        """Test creating valid NamedEntityBase."""
+        entity = NamedEntityBaseFactory.build(
+            canonical_name="Elon Musk",
+            canonical_name_normalized="elon musk",
+            entity_type=EntityType.PERSON,
+            discovery_method=DiscoveryMethod.MANUAL,
+            status=TagStatus.ACTIVE,
+        )
+
+        assert entity.canonical_name == "Elon Musk"
+        assert entity.canonical_name_normalized == "elon musk"
+        assert entity.entity_type == EntityType.PERSON
+        assert entity.discovery_method == DiscoveryMethod.MANUAL
+        assert entity.status == TagStatus.ACTIVE
+
+    def test_named_entity_create_defaults(self) -> None:
+        """Test NamedEntityCreate default values."""
+        entity = NamedEntityCreate(
+            canonical_name="Python",
+            canonical_name_normalized="python",
+            entity_type=EntityType.TECHNICAL_TERM,
+        )
+
+        # Verify defaults
+        assert entity.discovery_method == DiscoveryMethod.MANUAL
+        assert entity.confidence == 1.0
+        assert entity.status == TagStatus.ACTIVE
+        assert entity.entity_subtype is None
+        assert entity.description is None
+        assert entity.external_ids == {}
+        assert entity.merged_into_id is None
+
+    def test_named_entity_merged_status_requires_target(self) -> None:
+        """Test merged status requires merged_into_id (FR-027)."""
+        with pytest.raises(ValidationError, match="merged_into_id is required"):
+            NamedEntityCreate(
+                canonical_name="OldEntity",
+                canonical_name_normalized="oldentity",
+                entity_type=EntityType.PERSON,
+                status=TagStatus.MERGED,
+                merged_into_id=None,
+            )
+
+    def test_named_entity_merged_with_target_succeeds(self) -> None:
+        """Test merged status with merged_into_id succeeds (FR-027)."""
+        target_id = uuid.UUID(bytes=uuid7().bytes)
+        entity = NamedEntityCreate(
+            canonical_name="OldEntity",
+            canonical_name_normalized="oldentity",
+            entity_type=EntityType.PERSON,
+            status=TagStatus.MERGED,
+            merged_into_id=target_id,
+        )
+
+        assert entity.status == TagStatus.MERGED
+        assert entity.merged_into_id == target_id
+
+    def test_named_entity_no_self_merge(self) -> None:
+        """Test entity cannot be merged into itself (FR-028)."""
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+
+        with pytest.raises(ValidationError, match="cannot be merged into itself"):
+            NamedEntity(
+                id=entity_id,
+                canonical_name="SelfMerge",
+                canonical_name_normalized="selfmerge",
+                entity_type=EntityType.PERSON,
+                discovery_method=DiscoveryMethod.MANUAL,
+                status=TagStatus.MERGED,
+                merged_into_id=entity_id,  # Same as id - should fail
+                mention_count=0,
+                video_count=0,
+                channel_count=0,
+                confidence=1.0,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+
+    def test_named_entity_confidence_out_of_range_high(self) -> None:
+        """Test confidence validation rejects values > 1.0."""
+        with pytest.raises(ValidationError):
+            NamedEntityCreate(
+                canonical_name="Test",
+                canonical_name_normalized="test",
+                entity_type=EntityType.PERSON,
+                confidence=1.5,
+            )
+
+    def test_named_entity_confidence_out_of_range_low(self) -> None:
+        """Test confidence validation rejects values < 0.0."""
+        with pytest.raises(ValidationError):
+            NamedEntityCreate(
+                canonical_name="Test",
+                canonical_name_normalized="test",
+                entity_type=EntityType.PERSON,
+                confidence=-0.1,
+            )
+
+    def test_named_entity_confidence_valid_range(self) -> None:
+        """Test confidence validation accepts valid range [0.0, 1.0]."""
+        entity = NamedEntityCreate(
+            canonical_name="Test",
+            canonical_name_normalized="test",
+            entity_type=EntityType.PERSON,
+            confidence=0.5,
+        )
+        assert entity.confidence == 0.5
+
+        entity_min = NamedEntityCreate(
+            canonical_name="Test Min",
+            canonical_name_normalized="test min",
+            entity_type=EntityType.PERSON,
+            confidence=0.0,
+        )
+        assert entity_min.confidence == 0.0
+
+        entity_max = NamedEntityCreate(
+            canonical_name="Test Max",
+            canonical_name_normalized="test max",
+            entity_type=EntityType.PERSON,
+            confidence=1.0,
+        )
+        assert entity_max.confidence == 1.0
+
+    def test_named_entity_topic_type_accepted_by_pydantic(self) -> None:
+        """Test EntityType.TOPIC is valid at Pydantic level (US3 AS-2).
+
+        Note: TOPIC is valid in the EntityType enum, but DB-level CHECK
+        constraint prevents it in named_entities table. This test verifies
+        Pydantic accepts TOPIC since it's a valid enum value.
+        """
+        entity = NamedEntityCreate(
+            canonical_name="Test Topic",
+            canonical_name_normalized="test topic",
+            entity_type=EntityType.TOPIC,
+        )
+
+        # Pydantic accepts TOPIC because it's in EntityType enum
+        assert entity.entity_type == EntityType.TOPIC
+
+    def test_named_entity_model_dump_serialization(self) -> None:
+        """Test model_dump() serialization."""
+        entity = NamedEntityCreateFactory.build(
+            canonical_name="Google",
+            canonical_name_normalized="google",
+            entity_type=EntityType.ORGANIZATION,
+            discovery_method=DiscoveryMethod.SPACY_NER,
+            status=TagStatus.ACTIVE,
+            confidence=0.95,
+        )
+
+        data = entity.model_dump()
+
+        assert data["canonical_name"] == "Google"
+        assert data["canonical_name_normalized"] == "google"
+        assert data["entity_type"] == "organization"
+        assert data["discovery_method"] == "spacy_ner"
+        assert data["status"] == "active"
+        assert data["confidence"] == 0.95
+
+    @pytest.mark.parametrize("invalid_name", NamedEntityTestData.INVALID_CANONICAL_NAMES)
+    def test_canonical_name_validation_invalid(self, invalid_name: str) -> None:
+        """Test canonical_name validation with invalid inputs."""
+        with pytest.raises(ValidationError):
+            NamedEntityBaseFactory.build(canonical_name=invalid_name)
+
+    @pytest.mark.parametrize("valid_name", NamedEntityTestData.VALID_CANONICAL_NAMES)
+    def test_canonical_name_validation_valid(self, valid_name: str) -> None:
+        """Test canonical_name validation with valid inputs."""
+        entity = NamedEntityBaseFactory.build(canonical_name=valid_name)
+        assert entity.canonical_name == valid_name
+
+
+class TestEntityAliasModels:
+    """Test EntityAlias Pydantic models."""
+
+    def test_create_entity_alias_base_valid(self) -> None:
+        """Test creating valid EntityAliasBase."""
+        alias = EntityAliasBaseFactory.build(
+            alias_name="Elon",
+            alias_name_normalized="elon",
+            alias_type=EntityAliasType.NICKNAME,
+        )
+
+        assert alias.alias_name == "Elon"
+        assert alias.alias_name_normalized == "elon"
+        assert alias.alias_type == EntityAliasType.NICKNAME
+
+    def test_entity_alias_create_with_entity_id(self) -> None:
+        """Test EntityAliasCreate with entity_id."""
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        alias = EntityAliasCreate(
+            alias_name="SpaceX CEO",
+            alias_name_normalized="spacex ceo",
+            entity_id=entity_id,
+        )
+
+        assert alias.alias_name == "SpaceX CEO"
+        assert alias.alias_name_normalized == "spacex ceo"
+        assert alias.entity_id == entity_id
+        assert alias.alias_type == EntityAliasType.NAME_VARIANT  # Default
+        assert alias.occurrence_count == 0  # Default
+
+    def test_entity_alias_type_defaults_to_name_variant(self) -> None:
+        """Test alias_type defaults to NAME_VARIANT."""
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        alias = EntityAliasCreate(
+            alias_name="Test",
+            alias_name_normalized="test",
+            entity_id=entity_id,
+        )
+
+        assert alias.alias_type == EntityAliasType.NAME_VARIANT
+
+    def test_entity_alias_full_with_all_fields(self) -> None:
+        """Test creating full EntityAlias with all fields."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+        alias = EntityAliasFactory.build(
+            id=alias_id,
+            alias_name="E. Musk",
+            alias_name_normalized="e. musk",
+            alias_type=EntityAliasType.ABBREVIATION,
+            entity_id=entity_id,
+            occurrence_count=25,
+            first_seen_at=now,
+            last_seen_at=now,
+        )
+
+        assert alias.id == alias_id
+        assert alias.alias_name == "E. Musk"
+        assert alias.alias_name_normalized == "e. musk"
+        assert alias.alias_type == EntityAliasType.ABBREVIATION
+        assert alias.entity_id == entity_id
+        assert alias.occurrence_count == 25
+        assert alias.first_seen_at == now
+        assert alias.last_seen_at == now
+
+    def test_entity_alias_model_dump_serialization(self) -> None:
+        """Test model_dump() serialization."""
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        alias = EntityAliasCreateFactory.build(
+            alias_name="Tesla CEO",
+            alias_name_normalized="tesla ceo",
+            alias_type=EntityAliasType.NICKNAME,
+            entity_id=entity_id,
+        )
+
+        data = alias.model_dump()
+
+        assert data["alias_name"] == "Tesla CEO"
+        assert data["alias_name_normalized"] == "tesla ceo"
+        assert data["alias_type"] == "nickname"
+        assert data["entity_id"] == entity_id
+        assert data["occurrence_count"] == 0
+
+    @pytest.mark.parametrize("invalid_name", EntityAliasTestData.INVALID_ALIAS_NAMES)
+    def test_alias_name_validation_invalid(self, invalid_name: str) -> None:
+        """Test alias_name validation with invalid inputs."""
+        with pytest.raises(ValidationError):
+            EntityAliasBaseFactory.build(alias_name=invalid_name)
+
+    @pytest.mark.parametrize("valid_name", EntityAliasTestData.VALID_ALIAS_NAMES)
+    def test_alias_name_validation_valid(self, valid_name: str) -> None:
+        """Test alias_name validation with valid inputs."""
+        alias = EntityAliasBaseFactory.build(alias_name=valid_name)
+        assert alias.alias_name == valid_name
+
+
+class TestUUIDv7Generation:
+    """Test UUIDv7 generation in ORM models (US3 AS-6).
+
+    Note: These tests verify that the ORM model configuration includes
+    default=uuid7 for primary keys. The actual UUID generation happens
+    when the object is persisted to the database, so we verify the
+    callable is configured, not that IDs are pre-generated.
+    """
+
+    def test_canonical_tag_has_uuid7_default(self) -> None:
+        """Test CanonicalTag ORM has uuid7 default configured."""
+        # Verify the model has the id field configured with uuid7 default
+        assert hasattr(CanonicalTagDB, "id")
+        # The ORM model should have uuid7 as the default factory
+        # When persisted to DB, it will generate UUIDv7
+        # For now, verify the model accepts manual UUIDv7 assignment
+        tag_id = uuid.UUID(bytes=uuid7().bytes)
+        tag = CanonicalTagDB(
+            id=tag_id,
+            canonical_form="Python",
+            normalized_form="python",
+            entity_type=None,
+            status="active",
+            alias_count=1,
+            video_count=0,
+        )
+        assert tag.id == tag_id
+        assert tag.id.version == 7
+
+    def test_tag_alias_has_uuid7_default(self) -> None:
+        """Test TagAlias ORM has uuid7 default configured."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        canonical_tag_id = uuid.UUID(bytes=uuid7().bytes)
+        alias = TagAliasDB(
+            id=alias_id,
+            raw_form="Python",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag_id,
+            creation_method="auto_normalize",
+            normalization_version=1,
+            occurrence_count=1,
+        )
+
+        assert alias.id == alias_id
+        assert alias.id.version == 7
+
+    def test_named_entity_has_uuid7_default(self) -> None:
+        """Test NamedEntity ORM has uuid7 default configured."""
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        entity = NamedEntityDB(
+            id=entity_id,
+            canonical_name="Elon Musk",
+            canonical_name_normalized="elon musk",
+            entity_type="person",
+            discovery_method="manual",
+            status="active",
+            mention_count=0,
+            video_count=0,
+            channel_count=0,
+            confidence=1.0,
+        )
+
+        assert entity.id == entity_id
+        assert entity.id.version == 7
+
+    def test_entity_alias_has_uuid7_default(self) -> None:
+        """Test EntityAlias ORM has uuid7 default configured."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        alias = EntityAliasDB(
+            id=alias_id,
+            alias_name="Elon",
+            alias_name_normalized="elon",
+            alias_type="nickname",
+            entity_id=entity_id,
+            occurrence_count=0,
+        )
+
+        assert alias.id == alias_id
+        assert alias.id.version == 7
+
+    def test_generated_uuids_are_unique(self) -> None:
+        """Test that generated UUIDs are unique."""
+        # Generate multiple UUIDs and verify uniqueness
+        ids = [uuid.UUID(bytes=uuid7().bytes) for _ in range(5)]
+        assert len(ids) == len(set(ids))
+        # All should be version 7
+        assert all(id.version == 7 for id in ids)

--- a/tests/unit/repositories/test_tag_normalization_repos.py
+++ b/tests/unit/repositories/test_tag_normalization_repos.py
@@ -1,0 +1,451 @@
+"""
+Tests for tag normalization repository functionality.
+
+Tests repository CRUD operations and initialization for canonical tags,
+tag aliases, named entities, and entity aliases.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.db.models import (
+    CanonicalTag as CanonicalTagDB,
+    EntityAlias as EntityAliasDB,
+    NamedEntity as NamedEntityDB,
+    TagAlias as TagAliasDB,
+)
+from chronovista.models.canonical_tag import CanonicalTagCreate
+from chronovista.models.entity_alias import EntityAliasCreate
+from chronovista.models.enums import (
+    CreationMethod,
+    DiscoveryMethod,
+    EntityAliasType,
+    EntityType,
+    TagStatus,
+)
+from chronovista.models.named_entity import NamedEntityCreate
+from chronovista.models.tag_alias import TagAliasCreate
+from chronovista.repositories.canonical_tag_repository import CanonicalTagRepository
+from chronovista.repositories.entity_alias_repository import EntityAliasRepository
+from chronovista.repositories.named_entity_repository import NamedEntityRepository
+from chronovista.repositories.tag_alias_repository import TagAliasRepository
+
+
+class TestCanonicalTagRepository:
+    """Test CanonicalTagRepository functionality."""
+
+    @pytest.fixture
+    def repository(self) -> CanonicalTagRepository:
+        """Create repository instance for testing."""
+        return CanonicalTagRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create mock async session."""
+        return MagicMock(spec=AsyncSession)
+
+    @pytest.fixture
+    def sample_canonical_tag_db(self) -> CanonicalTagDB:
+        """Create sample database canonical tag object."""
+        return CanonicalTagDB(
+            canonical_form="Python",
+            normalized_form="python",
+            entity_type="technical_term",
+            status="active",
+            alias_count=5,
+            video_count=100,
+        )
+
+    def test_repository_initialization(self, repository: CanonicalTagRepository) -> None:
+        """Test repository initialization."""
+        assert repository.model == CanonicalTagDB
+
+    def test_repository_has_crud_methods(self, repository: CanonicalTagRepository) -> None:
+        """Test that repository has standard CRUD methods."""
+        # Verify repository has expected methods from BaseSQLAlchemyRepository
+        assert hasattr(repository, "get")
+        assert hasattr(repository, "exists")
+        assert hasattr(repository, "create")
+        assert hasattr(repository, "update")
+        assert hasattr(repository, "delete")
+        assert hasattr(repository, "get_multi")
+
+    @pytest.mark.asyncio
+    async def test_get_existing_tag(
+        self,
+        repository: CanonicalTagRepository,
+        mock_session: MagicMock,
+        sample_canonical_tag_db: CanonicalTagDB,
+    ) -> None:
+        """Test getting canonical tag by UUID when it exists."""
+        tag_id = sample_canonical_tag_db.id
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_canonical_tag_db
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, tag_id)
+
+        assert result == sample_canonical_tag_db
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_tag(
+        self, repository: CanonicalTagRepository, mock_session: MagicMock
+    ) -> None:
+        """Test getting canonical tag when it doesn't exist."""
+        tag_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, tag_id)
+
+        assert result is None
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exists_true(
+        self, repository: CanonicalTagRepository, mock_session: MagicMock
+    ) -> None:
+        """Test exists returns True when tag exists."""
+        tag_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.first.return_value = (tag_id,)
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, tag_id)
+
+        assert result is True
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exists_false(
+        self, repository: CanonicalTagRepository, mock_session: MagicMock
+    ) -> None:
+        """Test exists returns False when tag doesn't exist."""
+        tag_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, tag_id)
+
+        assert result is False
+        mock_session.execute.assert_called_once()
+
+
+class TestTagAliasRepository:
+    """Test TagAliasRepository functionality."""
+
+    @pytest.fixture
+    def repository(self) -> TagAliasRepository:
+        """Create repository instance for testing."""
+        return TagAliasRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create mock async session."""
+        return MagicMock(spec=AsyncSession)
+
+    @pytest.fixture
+    def sample_tag_alias_db(self) -> TagAliasDB:
+        """Create sample database tag alias object."""
+        canonical_tag_id = uuid.UUID(bytes=uuid7().bytes)
+        return TagAliasDB(
+            raw_form="Python",
+            normalized_form="python",
+            canonical_tag_id=canonical_tag_id,
+            creation_method="auto_normalize",
+            normalization_version=1,
+            occurrence_count=10,
+        )
+
+    def test_repository_initialization(self, repository: TagAliasRepository) -> None:
+        """Test repository initialization."""
+        assert repository.model == TagAliasDB
+
+    def test_repository_has_crud_methods(self, repository: TagAliasRepository) -> None:
+        """Test that repository has standard CRUD methods."""
+        assert hasattr(repository, "get")
+        assert hasattr(repository, "exists")
+        assert hasattr(repository, "create")
+        assert hasattr(repository, "update")
+        assert hasattr(repository, "delete")
+        assert hasattr(repository, "get_multi")
+
+    @pytest.mark.asyncio
+    async def test_get_existing_alias(
+        self,
+        repository: TagAliasRepository,
+        mock_session: MagicMock,
+        sample_tag_alias_db: TagAliasDB,
+    ) -> None:
+        """Test getting tag alias by UUID when it exists."""
+        alias_id = sample_tag_alias_db.id
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_tag_alias_db
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, alias_id)
+
+        assert result == sample_tag_alias_db
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_alias(
+        self, repository: TagAliasRepository, mock_session: MagicMock
+    ) -> None:
+        """Test getting tag alias when it doesn't exist."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, alias_id)
+
+        assert result is None
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exists_true(
+        self, repository: TagAliasRepository, mock_session: MagicMock
+    ) -> None:
+        """Test exists returns True when alias exists."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.first.return_value = (alias_id,)
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, alias_id)
+
+        assert result is True
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exists_false(
+        self, repository: TagAliasRepository, mock_session: MagicMock
+    ) -> None:
+        """Test exists returns False when alias doesn't exist."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, alias_id)
+
+        assert result is False
+        mock_session.execute.assert_called_once()
+
+
+class TestNamedEntityRepository:
+    """Test NamedEntityRepository functionality."""
+
+    @pytest.fixture
+    def repository(self) -> NamedEntityRepository:
+        """Create repository instance for testing."""
+        return NamedEntityRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create mock async session."""
+        return MagicMock(spec=AsyncSession)
+
+    @pytest.fixture
+    def sample_named_entity_db(self) -> NamedEntityDB:
+        """Create sample database named entity object."""
+        return NamedEntityDB(
+            canonical_name="Elon Musk",
+            canonical_name_normalized="elon musk",
+            entity_type="person",
+            discovery_method="manual",
+            status="active",
+            mention_count=50,
+            video_count=10,
+            channel_count=3,
+            confidence=0.95,
+        )
+
+    def test_repository_initialization(self, repository: NamedEntityRepository) -> None:
+        """Test repository initialization."""
+        assert repository.model == NamedEntityDB
+
+    def test_repository_has_crud_methods(self, repository: NamedEntityRepository) -> None:
+        """Test that repository has standard CRUD methods."""
+        assert hasattr(repository, "get")
+        assert hasattr(repository, "exists")
+        assert hasattr(repository, "create")
+        assert hasattr(repository, "update")
+        assert hasattr(repository, "delete")
+        assert hasattr(repository, "get_multi")
+
+    @pytest.mark.asyncio
+    async def test_get_existing_entity(
+        self,
+        repository: NamedEntityRepository,
+        mock_session: MagicMock,
+        sample_named_entity_db: NamedEntityDB,
+    ) -> None:
+        """Test getting named entity by UUID when it exists."""
+        entity_id = sample_named_entity_db.id
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_named_entity_db
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, entity_id)
+
+        assert result == sample_named_entity_db
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_entity(
+        self, repository: NamedEntityRepository, mock_session: MagicMock
+    ) -> None:
+        """Test getting named entity when it doesn't exist."""
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, entity_id)
+
+        assert result is None
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exists_true(
+        self, repository: NamedEntityRepository, mock_session: MagicMock
+    ) -> None:
+        """Test exists returns True when entity exists."""
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.first.return_value = (entity_id,)
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, entity_id)
+
+        assert result is True
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exists_false(
+        self, repository: NamedEntityRepository, mock_session: MagicMock
+    ) -> None:
+        """Test exists returns False when entity doesn't exist."""
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, entity_id)
+
+        assert result is False
+        mock_session.execute.assert_called_once()
+
+
+class TestEntityAliasRepository:
+    """Test EntityAliasRepository functionality."""
+
+    @pytest.fixture
+    def repository(self) -> EntityAliasRepository:
+        """Create repository instance for testing."""
+        return EntityAliasRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create mock async session."""
+        return MagicMock(spec=AsyncSession)
+
+    @pytest.fixture
+    def sample_entity_alias_db(self) -> EntityAliasDB:
+        """Create sample database entity alias object."""
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        return EntityAliasDB(
+            alias_name="Elon",
+            alias_name_normalized="elon",
+            alias_type="nickname",
+            entity_id=entity_id,
+            occurrence_count=25,
+        )
+
+    def test_repository_initialization(self, repository: EntityAliasRepository) -> None:
+        """Test repository initialization."""
+        assert repository.model == EntityAliasDB
+
+    def test_repository_has_crud_methods(self, repository: EntityAliasRepository) -> None:
+        """Test that repository has standard CRUD methods."""
+        assert hasattr(repository, "get")
+        assert hasattr(repository, "exists")
+        assert hasattr(repository, "create")
+        assert hasattr(repository, "update")
+        assert hasattr(repository, "delete")
+        assert hasattr(repository, "get_multi")
+
+    @pytest.mark.asyncio
+    async def test_get_existing_alias(
+        self,
+        repository: EntityAliasRepository,
+        mock_session: MagicMock,
+        sample_entity_alias_db: EntityAliasDB,
+    ) -> None:
+        """Test getting entity alias by UUID when it exists."""
+        alias_id = sample_entity_alias_db.id
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sample_entity_alias_db
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, alias_id)
+
+        assert result == sample_entity_alias_db
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_alias(
+        self, repository: EntityAliasRepository, mock_session: MagicMock
+    ) -> None:
+        """Test getting entity alias when it doesn't exist."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, alias_id)
+
+        assert result is None
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exists_true(
+        self, repository: EntityAliasRepository, mock_session: MagicMock
+    ) -> None:
+        """Test exists returns True when alias exists."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.first.return_value = (alias_id,)
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, alias_id)
+
+        assert result is True
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exists_false(
+        self, repository: EntityAliasRepository, mock_session: MagicMock
+    ) -> None:
+        """Test exists returns False when alias doesn't exist."""
+        alias_id = uuid.UUID(bytes=uuid7().bytes)
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, alias_id)
+
+        assert result is False
+        mock_session.execute.assert_called_once()

--- a/tests/unit/services/test_tag_normalization.py
+++ b/tests/unit/services/test_tag_normalization.py
@@ -1,0 +1,481 @@
+"""
+Tests for Tag Normalization Service.
+
+Covers the 9-step normalization pipeline (``TagNormalizationService.normalize``)
+and the standalone ``selective_strip_diacritics`` utility.  Edge-case and
+idempotency tests are included; hypothesis / multilang tests live in
+separate task files (T024, T025).
+
+References
+----------
+- T004: Unit test task for tag normalization
+- FR-002: Empty / whitespace-only input returns ``None``
+- FR-006: ``selective_strip_diacritics`` standalone utility
+- FR-007: Idempotency guarantee
+- FR-008: Pure function — no I/O, no database
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from chronovista.services.tag_normalization import (
+    SAFE_TO_STRIP,
+    TagNormalizationService,
+    selective_strip_diacritics,
+)
+
+
+@pytest.fixture()
+def svc() -> TagNormalizationService:
+    """Provide a fresh ``TagNormalizationService`` instance."""
+    return TagNormalizationService()
+
+
+# =========================================================================
+# TestNormalize — 9-step pipeline
+# =========================================================================
+
+
+class TestNormalize:
+    """Tests for ``TagNormalizationService.normalize``."""
+
+    # ----- basic transformations ------------------------------------------
+
+    def test_case_folding(self, svc: TagNormalizationService) -> None:
+        """Upper-case input is case-folded to lower case."""
+        assert svc.normalize("MEXICO") == "mexico"
+
+    def test_hashtag_stripping(self, svc: TagNormalizationService) -> None:
+        """A single leading '#' is removed (accent on 'e' is Tier 1)."""
+        assert svc.normalize("#Mexico") == "mexico"
+
+    def test_tilde_preserved(self, svc: TagNormalizationService) -> None:
+        """Spanish tilde (Tier 2) survives normalization."""
+        assert svc.normalize("año") == "año"
+
+    def test_cedilla_preserved(self, svc: TagNormalizationService) -> None:
+        """French cedilla (Tier 2) survives normalization."""
+        assert svc.normalize("façade") == "façade"
+
+    def test_umlaut_stripped(self, svc: TagNormalizationService) -> None:
+        """German umlaut / diaeresis (Tier 1) is stripped."""
+        assert svc.normalize("München") == "munchen"
+
+    def test_empty_string_returns_none(self, svc: TagNormalizationService) -> None:
+        """Empty string yields ``None``."""
+        assert svc.normalize("") is None
+
+    def test_whitespace_only_returns_none(self, svc: TagNormalizationService) -> None:
+        """Whitespace-only input yields ``None``."""
+        assert svc.normalize("  ") is None
+
+    def test_composed_transformations(self, svc: TagNormalizationService) -> None:
+        """Hashtag + accent + case fold: '#MEXICO' -> 'mexico'."""
+        assert svc.normalize("#MÉXICO") == "mexico"
+
+    # ----- idempotency (FR-007) ------------------------------------------
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "MEXICO",
+            "#Mexico",
+            "año",
+            "façade",
+            "München",
+            "#MÉXICO",
+            "mex\u200bico",
+            "hello\u00A0world",
+        ],
+        ids=[
+            "upper",
+            "hashtag",
+            "tilde",
+            "cedilla",
+            "umlaut",
+            "composed",
+            "zero-width",
+            "nbsp",
+        ],
+    )
+    def test_idempotency(self, svc: TagNormalizationService, raw: str) -> None:
+        """normalize(normalize(x)) == normalize(x) for various inputs."""
+        first = svc.normalize(raw)
+        if first is None:
+            # If the first pass is None, a second pass on "" should also be None,
+            # but the contract says we pass a str — so treat None sentinel consistently.
+            assert first is None
+        else:
+            assert svc.normalize(first) == first
+
+    def test_idempotency_double_hash_converges(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """'##double' converges after two passes (output with leading '#' is not stable)."""
+        first = svc.normalize("##double")
+        assert first == "#double"
+        second = svc.normalize(first)
+        assert second == "double"
+        # Third pass is stable
+        assert svc.normalize(second) == second
+
+    # ----- edge cases: hashtag stripping ---------------------------------
+
+    def test_triple_hash_strips_one(self, svc: TagNormalizationService) -> None:
+        """'###' strips one '#' leaving '##'."""
+        assert svc.normalize("###") == "##"
+
+    def test_double_hash_tag(self, svc: TagNormalizationService) -> None:
+        """'##double' strips one '#' leaving '#double'."""
+        assert svc.normalize("##double") == "#double"
+
+    # ----- edge cases: zero-width characters -----------------------------
+
+    def test_zero_width_space_removal(self, svc: TagNormalizationService) -> None:
+        """Zero-width space (U+200B) inside a word is removed."""
+        assert svc.normalize("mex\u200bico") == "mexico"
+
+    def test_zero_width_non_joiner_removal(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """Zero-width non-joiner (U+200C) is removed."""
+        assert svc.normalize("test\u200cvalue") == "testvalue"
+
+    def test_zero_width_joiner_removal(self, svc: TagNormalizationService) -> None:
+        """Zero-width joiner (U+200D) is removed."""
+        assert svc.normalize("test\u200dvalue") == "testvalue"
+
+    def test_bom_removal(self, svc: TagNormalizationService) -> None:
+        """BOM / zero-width no-break space (U+FEFF) is removed."""
+        assert svc.normalize("\uFEFFhello") == "hello"
+
+    # ----- edge cases: whitespace normalization --------------------------
+
+    def test_non_breaking_space_normalization(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """Non-breaking space (U+00A0) is replaced with regular space."""
+        assert svc.normalize("hello\u00A0world") == "hello world"
+
+    def test_tab_normalization(self, svc: TagNormalizationService) -> None:
+        """Tab character is replaced with regular space."""
+        assert svc.normalize("hello\tworld") == "hello world"
+
+    def test_multiple_spaces_collapse(self, svc: TagNormalizationService) -> None:
+        """Multiple spaces collapse to a single space."""
+        assert svc.normalize("hello   world") == "hello world"
+
+    # ----- edge case: single Tier 1 mark only ----------------------------
+
+    def test_single_tier1_mark_returns_none(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """A string consisting only of a Tier 1 combining mark yields None."""
+        # Compose a string that is just the combining acute accent
+        assert svc.normalize("\u0301") is None
+
+
+# =========================================================================
+# TestSelectiveStripDiacritics — standalone utility (FR-006)
+# =========================================================================
+
+
+class TestSelectiveStripDiacritics:
+    """Tests for the ``selective_strip_diacritics`` standalone utility."""
+
+    # ----- Tier 1 marks removed ------------------------------------------
+
+    def test_acute_accent_removed(self) -> None:
+        """Acute accent (Tier 1) is stripped: 'é' -> 'e'."""
+        assert selective_strip_diacritics("é") == "e"
+
+    def test_grave_accent_removed(self) -> None:
+        """Grave accent (Tier 1) is stripped: 'è' -> 'e'."""
+        assert selective_strip_diacritics("è") == "e"
+
+    def test_circumflex_removed(self) -> None:
+        """Circumflex (Tier 1) is stripped: 'ê' -> 'e'."""
+        assert selective_strip_diacritics("ê") == "e"
+
+    def test_diaeresis_removed(self) -> None:
+        """Diaeresis (Tier 1) is stripped: 'ü' -> 'u'."""
+        assert selective_strip_diacritics("ü") == "u"
+
+    def test_macron_removed(self) -> None:
+        """Macron (Tier 1) is stripped: 'ā' -> 'a'."""
+        assert selective_strip_diacritics("ā") == "a"
+
+    def test_breve_removed(self) -> None:
+        """Breve (Tier 1) is stripped: 'ă' -> 'a'."""
+        assert selective_strip_diacritics("ă") == "a"
+
+    def test_double_acute_removed(self) -> None:
+        """Double acute (Tier 1) is stripped: 'ő' -> 'o'."""
+        assert selective_strip_diacritics("ő") == "o"
+
+    def test_double_grave_removed(self) -> None:
+        """Double grave (Tier 1) is stripped."""
+        # U+0200 = A with double grave -> 'A' after stripping
+        assert selective_strip_diacritics("\u0200") == "A"
+
+    # ----- Tier 2 combining marks preserved ------------------------------
+
+    def test_tilde_preserved(self) -> None:
+        """Combining tilde (Tier 2) is preserved: 'ñ' stays 'ñ'."""
+        assert selective_strip_diacritics("ñ") == "ñ"
+
+    def test_cedilla_preserved(self) -> None:
+        """Combining cedilla (Tier 2) is preserved: 'ç' stays 'ç'."""
+        assert selective_strip_diacritics("ç") == "ç"
+
+    def test_ogonek_preserved(self) -> None:
+        """Combining ogonek (Tier 2) is preserved: 'ą' stays 'ą'."""
+        assert selective_strip_diacritics("ą") == "ą"
+
+    def test_caron_preserved(self) -> None:
+        """Combining caron (Tier 2) is preserved: 'č' stays 'č'."""
+        assert selective_strip_diacritics("č") == "č"
+
+    def test_dot_above_preserved(self) -> None:
+        """Combining dot above (Tier 2) is preserved: 'ż' stays 'ż'."""
+        assert selective_strip_diacritics("ż") == "ż"
+
+    def test_ring_above_preserved(self) -> None:
+        """Combining ring above (Tier 2) is preserved: 'å' stays 'å'."""
+        assert selective_strip_diacritics("å") == "å"
+
+    # ----- Tier 2 base characters preserved ------------------------------
+
+    def test_o_stroke_preserved(self) -> None:
+        """ø (U+00F8) is a base character and survives: 'ø' stays 'ø'."""
+        assert selective_strip_diacritics("ø") == "ø"
+
+    def test_a_ring_preserved(self) -> None:
+        """å (U+00E5) survives (ring above is Tier 2)."""
+        assert selective_strip_diacritics("å") == "å"
+
+    def test_ae_ligature_preserved(self) -> None:
+        """æ (U+00E6) is a base character and survives."""
+        assert selective_strip_diacritics("æ") == "æ"
+
+    def test_l_stroke_preserved(self) -> None:
+        """ł (U+0142) is a base character and survives."""
+        assert selective_strip_diacritics("ł") == "ł"
+
+    # ----- Tier 3 marks preserved ----------------------------------------
+
+    def test_tier3_combining_marks_preserved(self) -> None:
+        """Arbitrary Tier 3 combining marks (not in Tier 1 or Tier 2) survive."""
+        # U+0325 = COMBINING RING BELOW (Tier 3)
+        text_with_ring_below = "a\u0325"
+        nfc = unicodedata.normalize("NFC", text_with_ring_below)
+        result = selective_strip_diacritics(nfc)
+        # The ring below should still be present
+        decomposed = unicodedata.normalize("NFKD", result)
+        assert "\u0325" in decomposed
+
+    # ----- mixed input ---------------------------------------------------
+
+    def test_mixed_tier1_and_tier2(self) -> None:
+        """Tier 1 is removed while Tier 2 is preserved in the same word."""
+        # 'Müñchen' has diaeresis (Tier 1) on u and tilde (Tier 2) on n
+        result = selective_strip_diacritics("Müñchen")
+        assert result == "Muñchen"
+
+
+# =========================================================================
+# TestSelectCanonicalForm — canonical form selection algorithm (FR-009)
+# =========================================================================
+
+
+class TestSelectCanonicalForm:
+    """Tests for ``TagNormalizationService.select_canonical_form``."""
+
+    # ----- US4 acceptance scenarios --------------------------------------
+
+    def test_title_case_preferred(self, svc: TagNormalizationService) -> None:
+        """Title case form is preferred when it exists."""
+        forms = [("MEXICO", 203), ("Mexico", 412), ("mexico", 156)]
+        assert svc.select_canonical_form(forms) == "Mexico"
+
+    def test_alphabetical_tiebreaker_title_case(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """When title case forms have equal count, use alphabetical min."""
+        forms = [("Mexico", 200), ("México", 200)]
+        assert svc.select_canonical_form(forms) == "Mexico"
+
+    def test_most_frequent_when_no_title_case(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """When no title case forms exist, pick most frequent."""
+        forms = [("MEXICO", 500), ("mexico", 300)]
+        assert svc.select_canonical_form(forms) == "MEXICO"
+
+    def test_low_count_tag_frequency_applies(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """Frequency rule applies regardless of absolute count."""
+        forms = [("TOPIC", 2), ("topic", 1)]
+        assert svc.select_canonical_form(forms) == "TOPIC"
+
+    def test_single_form(self, svc: TagNormalizationService) -> None:
+        """Single form is returned as-is."""
+        forms = [("hello", 1)]
+        assert svc.select_canonical_form(forms) == "hello"
+
+    # ----- edge cases ----------------------------------------------------
+
+    def test_empty_list_raises_error(self, svc: TagNormalizationService) -> None:
+        """Empty list raises ValueError."""
+        with pytest.raises(ValueError, match="Cannot select canonical form from empty list"):
+            svc.select_canonical_form([])
+
+    def test_all_equal_counts_no_title_case(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """When all forms have equal count and none are title case, use alphabetical min."""
+        forms = [("zebra", 10), ("apple", 10), ("banana", 10)]
+        assert svc.select_canonical_form(forms) == "apple"
+
+    def test_all_equal_counts_all_title_case(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """When all forms are title case with equal count, use alphabetical min."""
+        forms = [("Zebra", 10), ("Apple", 10), ("Banana", 10)]
+        assert svc.select_canonical_form(forms) == "Apple"
+
+    def test_mixed_case_prefers_title_even_if_lower_count(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """Title case is preferred even if it has lower count than non-title forms."""
+        forms = [("TOPIC", 1000), ("topic", 500), ("Topic", 50)]
+        assert svc.select_canonical_form(forms) == "Topic"
+
+    def test_multiple_title_case_picks_highest_count(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """Among multiple title case forms, pick the one with highest count."""
+        forms = [("Mexico", 100), ("México", 200), ("mexico", 500)]
+        assert svc.select_canonical_form(forms) == "México"
+
+
+# =========================================================================
+# TestMultilang* — multi-language diacritic preservation tests (T024)
+# =========================================================================
+
+
+class TestMultilangSpanish:
+    """Spanish diacritic handling tests."""
+
+    def test_tilde_preserved(self, svc: TagNormalizationService) -> None:
+        """Spanish tilde is preserved in normalization."""
+        assert svc.normalize("año") == "año"
+
+    def test_acute_stripped_tilde_preserved(
+        self, svc: TagNormalizationService
+    ) -> None:
+        """Acute accent (Tier 1) is stripped, tilde (Tier 2) preserved, casefolded."""
+        assert svc.normalize("España") == "españa"
+
+
+class TestMultilangPortuguese:
+    """Portuguese diacritic handling tests."""
+
+    def test_cedilla_preserved(self, svc: TagNormalizationService) -> None:
+        """Portuguese cedilla is preserved in normalization."""
+        assert svc.normalize("façade") == "façade"
+
+    def test_circumflex_stripped(self, svc: TagNormalizationService) -> None:
+        """Circumflex (Tier 1) is stripped from Portuguese text."""
+        assert svc.normalize("avô") == "avo"
+
+
+class TestMultilangGerman:
+    """German diacritic handling tests."""
+
+    def test_umlaut_u_stripped(self, svc: TagNormalizationService) -> None:
+        """German diaeresis/umlaut on 'ü' (Tier 1) is stripped."""
+        assert svc.normalize("München") == "munchen"
+
+    def test_umlaut_u_lowercase_stripped(self, svc: TagNormalizationService) -> None:
+        """German diaeresis on lowercase 'ü' (Tier 1) is stripped."""
+        assert svc.normalize("über") == "uber"
+
+
+class TestMultilangNordic:
+    """Nordic language diacritic handling tests."""
+
+    def test_o_stroke_preserved(self, svc: TagNormalizationService) -> None:
+        """Norwegian/Danish ø (o-stroke) is preserved as a base character."""
+        assert svc.normalize("ø") == "ø"
+
+    def test_a_ring_preserved(self, svc: TagNormalizationService) -> None:
+        """Nordic å (a-ring) is preserved (ring above is Tier 2)."""
+        assert svc.normalize("å") == "å"
+
+    def test_ae_ligature_preserved(self, svc: TagNormalizationService) -> None:
+        """Nordic æ (ae-ligature) is preserved as a base character."""
+        assert svc.normalize("æ") == "æ"
+
+
+class TestMultilangPolish:
+    """Polish diacritic handling tests."""
+
+    def test_l_stroke_preserved(self, svc: TagNormalizationService) -> None:
+        """Polish ł (l-stroke) is preserved as a base character."""
+        assert svc.normalize("ł") == "ł"
+
+
+class TestZeroFalseMerges:
+    """SC-002: Verify that semantically distinct tags remain distinct."""
+
+    def test_ano_vs_ano_different(self, svc: TagNormalizationService) -> None:
+        """Spanish 'año' and 'ano' must NOT produce the same normalized output."""
+        result_with_tilde = svc.normalize("año")
+        result_without_tilde = svc.normalize("ano")
+        assert result_with_tilde != result_without_tilde
+        assert result_with_tilde == "año"
+        assert result_without_tilde == "ano"
+
+    def test_facade_vs_facade_different(self, svc: TagNormalizationService) -> None:
+        """French 'façade' and 'facade' must remain distinct."""
+        result_with_cedilla = svc.normalize("façade")
+        result_without_cedilla = svc.normalize("facade")
+        assert result_with_cedilla != result_without_cedilla
+        assert result_with_cedilla == "façade"
+        assert result_without_cedilla == "facade"
+
+
+# =========================================================================
+# TestHypothesisProperties — property-based tests (T025)
+# =========================================================================
+
+
+class TestHypothesisProperties:
+    """Property-based tests using Hypothesis for normalization invariants."""
+
+    @given(st.text(min_size=1, max_size=100))
+    @settings(max_examples=500)
+    def test_idempotency(self, text: str) -> None:
+        """SC-003: normalize(normalize(x)) == normalize(x) for all non-empty inputs."""
+        svc = TagNormalizationService()
+        result = svc.normalize(text)
+        if result is not None:
+            assert svc.normalize(result) == result
+
+    @given(st.text(min_size=1, max_size=100))
+    @settings(max_examples=500)
+    def test_no_tier1_marks_in_output(self, text: str) -> None:
+        """US5 AS-6: Normalized output must not contain any Tier 1 combining marks."""
+        svc = TagNormalizationService()
+        result = svc.normalize(text)
+        if result is not None:
+            decomposed = unicodedata.normalize("NFD", result)
+            for char in decomposed:
+                assert char not in SAFE_TO_STRIP


### PR DESCRIPTION
## Summary

ADR-003 Phase 1: Foundational storage layer and normalization algorithm for tag grouping. Creates the schema, enums, normalization service, and all supporting infrastructure. Tables are empty after this phase — no data moves until Phase 2 (028b backfill).

- **5 new database tables** (`named_entities`, `entity_aliases`, `canonical_tags`, `tag_aliases`, `tag_operation_logs`) with UUIDv7 PKs, 15 indexes, CHECK/UNIQUE/cascade constraints
- **9-step normalization pipeline** with three-tier selective diacritic stripping (8 safe Tier 1 marks stripped; Tier 2/3 preserved for Spanish/Portuguese/Nordic/Polish)
- **6 new enums**, 4 Pydantic model files (Base/Create/Update/Full), 4 repositories, 5 factory-boy factories
- **189 tests** (98% coverage, 0 mypy errors) including hypothesis property-based tests for idempotency
- Version bump to v0.31.0

**New dependency:** `uuid_utils` v0.14.1 (UUIDv7 generation — PG 15 lacks native support)

### Key files

| Area | Files |
|------|-------|
| Migration | `db/migrations/versions/028a_add_tag_normalization_tables.py` |
| ORM models | `db/models.py` (5 new classes) |
| Enums | `models/enums.py` (6 new enums) |
| Service | `services/tag_normalization.py` |
| Pydantic | `models/canonical_tag.py`, `tag_alias.py`, `named_entity.py`, `entity_alias.py` |
| Repos | `repositories/canonical_tag_repository.py`, `tag_alias_repository.py`, `named_entity_repository.py`, `entity_alias_repository.py` |

### Architecture reference

- [ADR-003: Tag Normalization](src/chronovista/docs/architecture/003-ADR-TAG-NORMALIZATION.md) (updated to "Phase 1 Implemented")
- [Feature spec](specs/028-tag-normalization-schema/spec.md)

## Test plan

- [x] 71 normalization service tests (edge cases, multilang, hypothesis)
- [x] 28 schema integration tests (constraints, cascades, FK behavior)
- [x] 66 Pydantic model validation tests (FR-027/FR-028 invariants)
- [x] 24 repository unit tests (CRUD, initialization)
- [x] Full regression: 5,183 tests passed, 0 failures
- [x] mypy strict: 0 errors on all 9 new source files
- [x] Alembic migration: upgrade + downgrade + re-upgrade verified