### PR TITLE
feat(tags): tag normalization backfill pipeline (Feature 029)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/license-AGPL--3.0-green.svg" alt="License: AGPL-3.0">
-  <img src="https://img.shields.io/badge/tests-6,000+-brightgreen.svg" alt="Tests: 6,000+">
+  <img src="https://img.shields.io/badge/tests-7,200+-brightgreen.svg" alt="Tests: 7,200+">
   <img src="https://img.shields.io/badge/coverage-72%25-brightgreen.svg" alt="Coverage: 72%">
   <img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style: black">
 </p>
@@ -367,6 +367,7 @@ See [System Architecture](src/chronovista/docs/architecture/system-architecture.
 - [x] Video search and filtering UI
 - [x] Deleted content visibility and status tracking
 - [x] Wayback Machine video recovery
+- [x] Tag normalization (canonical grouping of 141K tags)
 - [ ] ML-powered insights
 
 

--- a/docs/api/cli/commands.md
+++ b/docs/api/cli/commands.md
@@ -52,6 +52,13 @@ Command-line interface modules.
       show_root_heading: true
       show_source: true
 
+## Tag Commands
+
+::: chronovista.cli.tag_commands
+    options:
+      show_root_heading: true
+      show_source: true
+
 ## Transcript Commands
 
 ::: chronovista.cli.transcript_commands

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive user guide and API reference
 - Architecture documentation
 
+## [0.32.0] - 2026-02-23
+
+### Added
+- **Feature 029: Tag Normalization Backfill Pipeline (ADR-003 Phase 2)**
+  - `TagBackfillService` bulk normalization pipeline processing 141,163 tags into 124,686 canonical groups
+  - `chronovista tags normalize` CLI command with `--batch-size` option and Rich progress bar
+  - `chronovista tags analyze` CLI command with `--format` (table/json) for pre-backfill preview and collision review
+  - `chronovista tags recount` CLI command with `--dry-run` for recalculating `alias_count` and `video_count`
+  - SQLAlchemy Core `INSERT ... ON CONFLICT DO NOTHING` bulk inserts with pre-generated UUIDv7 primary keys
+  - Two-pass `video_count` computation: insert with 0, then single SQL `UPDATE ... FROM (subquery JOIN)`
+  - Collision detection flagging diacritic-affected merges (e.g., México/Mexico) for manual review
+  - `KNOWN_FALSE_MERGE_PATTERNS` (5 entries: café, résumé, cliché, naïve, rapé) for analysis display labels
+  - Per-batch transaction commits (1,000 records/batch) with idempotent re-run support
+  - `get_distinct_tags_with_counts()` repository method for bulk tag extraction
+
+### Fixed
+- Tag normalization idempotency bug: `normalize("##")` → `"#"` but `normalize("#")` → `None`; changed single `#` strip to `lstrip("#")`
+
+### Technical
+- 145 new tests (37 unit + 12 integration + 17 CLI + Hypothesis property-based)
+- 5,255 total tests passing with 0 regressions
+- mypy strict compliance (0 errors)
+- No new dependencies
+
 ## [0.31.0] - 2026-02-22
 
 ### Added

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -77,6 +77,23 @@ Project-specific terminology used throughout chronovista documentation and code.
 **Stub Channel**
 :   A minimal channel record created automatically during video recovery when the recovered `channel_id` doesn't exist in the database. Satisfies foreign key constraints and is marked with `availability_status = unavailable`. Stub channels are eligible for subsequent channel recovery to fill in their metadata.
 
+## Tag Normalization Concepts
+
+**Tag Normalization**
+:   The process of grouping raw video tags into canonical forms using Unicode normalization, diacritic stripping, and case folding. For example, "México", "mexico", and "MEXICO" all normalize to the same canonical tag. Implemented as a 9-step pipeline in `TagNormalizationService`.
+
+**Canonical Tag**
+:   The preferred display form for a group of normalized tags. Selected by preference: title case (`str.istitle()`), then highest frequency, then alphabetical tiebreaker. Stored in the `canonical_tags` table with UUIDv7 primary keys.
+
+**Tag Alias**
+:   A raw tag form from `video_tags` linked to its canonical tag. Every distinct raw tag becomes exactly one alias. Stored in the `tag_aliases` table. The `video_tags` table itself is never modified — aliases provide the mapping.
+
+**Collision Candidate**
+:   A group of tags that were merged by diacritic stripping where the casefolded forms differ (e.g., "México" casefolds to "méxico" while "Mexico" casefolds to "mexico"). Flagged in `tags analyze` output for manual review. Not an error — most collisions are correct merges.
+
+**Tier 1 Diacritics**
+:   Eight combining marks that are universally safe to strip during normalization: acute, grave, circumflex, diaeresis, macron, breve, dot above, and ring above. Stripping these merges common accent variants (e.g., café/cafe) without changing letter identity.
+
 ## Technical Concepts
 
 **Development Mode**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.31.0"
+version = "0.32.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/repositories/video_tag_repository.py
+++ b/src/chronovista/repositories/video_tag_repository.py
@@ -344,3 +344,33 @@ class VideoTagRepository(
         # In a real implementation, you'd join with the videos table
         # and delete tags where video_id doesn't exist in videos
         return 0
+
+    async def get_distinct_tags_with_counts(
+        self, session: AsyncSession
+    ) -> List[Tuple[str, int]]:
+        """
+        Retrieve all distinct tags with their occurrence counts.
+
+        Returns all distinct non-NULL tags from the video_tags table,
+        grouped and ordered alphabetically by tag value.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            The database session.
+
+        Returns
+        -------
+        list[tuple[str, int]]
+            List of (tag, occurrence_count) tuples ordered by tag.
+        """
+        result = await session.execute(
+            select(
+                VideoTagDB.tag,
+                func.count(VideoTagDB.tag).label("occurrence_count"),
+            )
+            .where(VideoTagDB.tag.is_not(None))
+            .group_by(VideoTagDB.tag)
+            .order_by(VideoTagDB.tag)
+        )
+        return [(row[0], row[1]) for row in result.all()]

--- a/src/chronovista/services/tag_backfill.py
+++ b/src/chronovista/services/tag_backfill.py
@@ -1,0 +1,878 @@
+"""
+Tag normalization backfill pipeline service.
+
+This module provides the ``TagBackfillService`` that orchestrates the tag
+normalization backfill process — scanning existing ``video_tags`` rows,
+normalizing each raw tag, and populating the ``canonical_tags`` and
+``tag_aliases`` tables.
+
+References
+----------
+- FR-019: Known false-merge patterns for Tier 1 diacritic stripping
+- FR-022: Table existence check before backfill
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import Any
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import Progress
+from rich.table import Table
+from sqlalchemy import distinct, func, inspect as sa_inspect, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.db.models import CanonicalTag as CanonicalTagDB
+from chronovista.db.models import TagAlias as TagAliasDB
+from chronovista.db.models import VideoTag as VideoTagDB
+from chronovista.repositories.video_tag_repository import VideoTagRepository
+from chronovista.services.tag_normalization import TagNormalizationService
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Known Tier 1 false-merge patterns (FR-019)
+# These normalized forms merge semantically distinct words due to diacritic
+# stripping.  Reported as "known false-merge" in collision detection output.
+# ---------------------------------------------------------------------------
+KNOWN_FALSE_MERGE_PATTERNS: frozenset[str] = frozenset(
+    {
+        "cafe",  # café (French loanword) / cafe (English)
+        "resume",  # résumé (French loanword) / resume (English verb)
+        "cliche",  # cliché (French loanword) / cliche (anglicized)
+        "naive",  # naïve (French loanword) / naive (anglicized)
+        "rape",  # Rapé (cartoonist) / rape (unrelated English word)
+    }
+)
+
+
+class TagBackfillService:
+    """Orchestrates tag normalization backfill, analysis, and recount operations.
+
+    Parameters
+    ----------
+    normalization_service : TagNormalizationService
+        The service that provides the 9-step normalization pipeline and
+        canonical form selection logic.
+    """
+
+    def __init__(self, normalization_service: TagNormalizationService) -> None:
+        self._normalization_service = normalization_service
+
+    async def _check_tables_exist(self, session: AsyncSession) -> None:
+        """Check that ``canonical_tags`` and ``tag_aliases`` tables exist.
+
+        Raises ``SystemExit`` with a user-friendly message directing the user
+        to run ``alembic upgrade head`` if either table is missing (FR-022).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            An active SQLAlchemy async session used to inspect the database.
+
+        Raises
+        ------
+        SystemExit
+            If one or both required tables are missing from the database.
+        """
+
+        def _sync_check(connection) -> list[str]:  # type: ignore[no-untyped-def]
+            inspector = sa_inspect(connection)
+            tables = inspector.get_table_names()
+            missing: list[str] = []
+            if "canonical_tags" not in tables:
+                missing.append("canonical_tags")
+            if "tag_aliases" not in tables:
+                missing.append("tag_aliases")
+            return missing
+
+        conn = await session.connection()
+        missing = await conn.run_sync(_sync_check)
+        if missing:
+            table_list = ", ".join(missing)
+            raise SystemExit(
+                f"Required table(s) missing: {table_list}. "
+                f"Run 'alembic upgrade head' to create them."
+            )
+
+    # ------------------------------------------------------------------
+    # T004: Normalization and grouping
+    # ------------------------------------------------------------------
+
+    def _normalize_and_group_core(
+        self,
+        distinct_tags: dict[str, int],
+    ) -> tuple[
+        dict[str, list[tuple[str, int]]],  # groups: normalized_form -> [(raw_form, count), ...]
+        list[tuple[str, int]],  # skip_list: [(raw_form, count), ...]
+    ]:
+        """Normalize tags and group aliases by normalized form.
+
+        This is the shared helper used by both ``_normalize_and_group`` (backfill)
+        and ``run_analysis`` (Phase 3).  It performs normalization and grouping
+        but does **not** generate UUIDs or batch records.
+
+        Parameters
+        ----------
+        distinct_tags : dict[str, int]
+            Mapping of raw tag strings to their occurrence counts.
+
+        Returns
+        -------
+        tuple[dict[str, list[tuple[str, int]]], list[tuple[str, int]]]
+            A 2-tuple of:
+            - ``groups``: normalized_form -> list of (raw_form, count) tuples
+            - ``skip_list``: list of (raw_form, count) tuples that could not
+              be normalized (normalize returned ``None``)
+        """
+        groups: dict[str, list[tuple[str, int]]] = defaultdict(list)
+        skip_list: list[tuple[str, int]] = []
+
+        for raw_tag, count in distinct_tags.items():
+            normalized = self._normalization_service.normalize(raw_tag)
+            if normalized is None:
+                skip_list.append((raw_tag, count))
+                logger.debug("Skipping tag (normalizes to empty): %r", raw_tag)
+            else:
+                groups[normalized].append((raw_tag, count))
+
+        logger.info(
+            "Normalization complete: %d groups, %d skipped",
+            len(groups),
+            len(skip_list),
+        )
+        return dict(groups), skip_list
+
+    def _normalize_and_group(
+        self,
+        distinct_tags: dict[str, int],
+        execution_timestamp: datetime,
+    ) -> tuple[
+        list[dict[str, Any]],  # canonical_tags batch records
+        list[dict[str, Any]],  # tag_aliases batch records
+        list[tuple[str, int]],  # skip_list
+    ]:
+        """Normalize, group, and build batch insert records for the backfill.
+
+        Delegates to ``_normalize_and_group_core`` for the normalization step,
+        then generates UUIDv7 primary keys and assembles the batch dictionaries
+        required by ``_batch_insert_canonical_tags`` and ``_batch_insert_tag_aliases``.
+
+        Parameters
+        ----------
+        distinct_tags : dict[str, int]
+            Mapping of raw tag strings to their occurrence counts.
+        execution_timestamp : datetime
+            The timestamp to use for ``first_seen_at`` and ``last_seen_at``
+            on all tag alias records.
+
+        Returns
+        -------
+        tuple[list[dict[str, Any]], list[dict[str, Any]], list[tuple[str, int]]]
+            A 3-tuple of:
+            - ``canonical_tags_batch``: dicts ready for bulk insert into
+              ``canonical_tags``
+            - ``tag_aliases_batch``: dicts ready for bulk insert into
+              ``tag_aliases``
+            - ``skip_list``: raw tags that could not be normalized
+        """
+        groups, skip_list = self._normalize_and_group_core(distinct_tags)
+
+        canonical_tags_batch: list[dict[str, Any]] = []
+        tag_aliases_batch: list[dict[str, Any]] = []
+
+        for normalized_form, aliases in groups.items():
+            # Pre-generate a UUIDv7 for the canonical tag (convert for Pydantic compat)
+            ct_id = uuid.UUID(bytes=uuid7().bytes)
+
+            canonical_form = self._normalization_service.select_canonical_form(aliases)
+
+            canonical_tags_batch.append(
+                {
+                    "id": ct_id,
+                    "canonical_form": canonical_form,
+                    "normalized_form": normalized_form,
+                    "alias_count": len(aliases),
+                    "video_count": 0,
+                    "status": "active",
+                }
+            )
+
+            for raw_form, occ_count in aliases:
+                alias_id = uuid.UUID(bytes=uuid7().bytes)
+                tag_aliases_batch.append(
+                    {
+                        "id": alias_id,
+                        "raw_form": raw_form,
+                        "normalized_form": normalized_form,
+                        "canonical_tag_id": ct_id,
+                        "creation_method": "backfill",
+                        "normalization_version": 1,
+                        "occurrence_count": occ_count,
+                        "first_seen_at": execution_timestamp,
+                        "last_seen_at": execution_timestamp,
+                    }
+                )
+
+        logger.info(
+            "Prepared %d canonical tag records and %d tag alias records",
+            len(canonical_tags_batch),
+            len(tag_aliases_batch),
+        )
+        return canonical_tags_batch, tag_aliases_batch, skip_list
+
+    # ------------------------------------------------------------------
+    # T005: Batch insert helpers
+    # ------------------------------------------------------------------
+
+    async def _batch_insert_canonical_tags(
+        self,
+        session: AsyncSession,
+        records: list[dict[str, Any]],
+        batch_size: int,
+    ) -> tuple[int, int]:
+        """Insert canonical tag records in batches, skipping conflicts.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            An active SQLAlchemy async session.
+        records : list[dict[str, Any]]
+            List of dicts to insert into ``canonical_tags``.
+        batch_size : int
+            Number of records per batch.
+
+        Returns
+        -------
+        tuple[int, int]
+            ``(inserted, skipped)`` — the number of rows actually inserted
+            and the number skipped due to ``ON CONFLICT DO NOTHING``.
+        """
+        inserted = 0
+        skipped = 0
+
+        for i in range(0, len(records), batch_size):
+            batch = records[i : i + batch_size]
+            stmt = pg_insert(CanonicalTagDB).values(batch).on_conflict_do_nothing()
+            result = await session.execute(stmt)
+            await session.commit()
+            batch_inserted = result.rowcount
+            inserted += batch_inserted
+            skipped += len(batch) - batch_inserted
+
+        logger.info(
+            "Canonical tags: %d inserted, %d skipped (already exist)",
+            inserted,
+            skipped,
+        )
+        return inserted, skipped
+
+    async def _batch_insert_tag_aliases(
+        self,
+        session: AsyncSession,
+        records: list[dict[str, Any]],
+        batch_size: int,
+    ) -> tuple[int, int]:
+        """Insert tag alias records in batches, skipping conflicts.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            An active SQLAlchemy async session.
+        records : list[dict[str, Any]]
+            List of dicts to insert into ``tag_aliases``.
+        batch_size : int
+            Number of records per batch.
+
+        Returns
+        -------
+        tuple[int, int]
+            ``(inserted, skipped)`` — the number of rows actually inserted
+            and the number skipped due to ``ON CONFLICT DO NOTHING``.
+        """
+        inserted = 0
+        skipped = 0
+
+        for i in range(0, len(records), batch_size):
+            batch = records[i : i + batch_size]
+            stmt = pg_insert(TagAliasDB).values(batch).on_conflict_do_nothing()
+            result = await session.execute(stmt)
+            await session.commit()
+            batch_inserted = result.rowcount
+            inserted += batch_inserted
+            skipped += len(batch) - batch_inserted
+
+        logger.info(
+            "Tag aliases: %d inserted, %d skipped (already exist)",
+            inserted,
+            skipped,
+        )
+        return inserted, skipped
+
+    # ------------------------------------------------------------------
+    # T006: Video count update
+    # ------------------------------------------------------------------
+
+    async def _update_video_counts(self, session: AsyncSession) -> int:
+        """Update ``video_count`` on every canonical tag using a correlated subquery.
+
+        Joins ``tag_aliases.raw_form`` to ``video_tags.tag`` to count distinct
+        videos per canonical tag, then writes the result back.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            An active SQLAlchemy async session.
+
+        Returns
+        -------
+        int
+            The number of canonical tag rows updated.
+        """
+        subq = (
+            select(
+                TagAliasDB.canonical_tag_id,
+                func.count(distinct(VideoTagDB.video_id)).label("cnt"),
+            )
+            .join(VideoTagDB, VideoTagDB.tag == TagAliasDB.raw_form)
+            .group_by(TagAliasDB.canonical_tag_id)
+            .subquery()
+        )
+
+        stmt = (
+            update(CanonicalTagDB)
+            .where(CanonicalTagDB.id == subq.c.canonical_tag_id)
+            .values(video_count=subq.c.cnt)
+        )
+        result = await session.execute(stmt)
+        await session.commit()
+
+        logger.info("Updated video_count on %d canonical tags", result.rowcount)
+        return result.rowcount
+
+    # ------------------------------------------------------------------
+    # T007: Orchestrator
+    # ------------------------------------------------------------------
+
+    async def run_backfill(
+        self,
+        session: AsyncSession,
+        batch_size: int = 1000,
+        console: Console | None = None,
+    ) -> None:
+        """Run the full tag normalization backfill pipeline.
+
+        Scans all distinct tags in ``video_tags``, normalizes each one,
+        groups aliases under canonical forms, batch-inserts into
+        ``canonical_tags`` and ``tag_aliases``, and updates video counts.
+
+        The operation is idempotent: re-running skips rows that already
+        exist (``ON CONFLICT DO NOTHING``).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            An active SQLAlchemy async session.
+        batch_size : int, optional
+            Number of records per INSERT batch (default ``1000``).
+            Must be >= 1.
+        console : Console | None, optional
+            Rich console for output.  A default console is created if
+            ``None``.
+
+        Raises
+        ------
+        SystemExit
+            If ``batch_size < 1`` (exit code 2) or if required tables
+            are missing from the database.
+        """
+        if batch_size < 1:
+            raise SystemExit(2)
+
+        start_time = time.time()
+        _console = console or Console()
+
+        # Step 1: Verify required tables exist (FR-022)
+        await self._check_tables_exist(session)
+
+        # Step 2: Query distinct tags from video_tags
+        repo = VideoTagRepository()
+        raw_tags = await repo.get_distinct_tags_with_counts(session)
+        distinct_tags: dict[str, int] = {tag: count for tag, count in raw_tags}
+
+        logger.info("Found %d distinct tags in video_tags", len(distinct_tags))
+
+        # Step 3: Normalize, group, and prepare batch records
+        execution_timestamp = datetime.now(UTC)
+        ct_records, ta_records, skip_list = self._normalize_and_group(
+            distinct_tags, execution_timestamp
+        )
+
+        # Step 4: Batch insert with Rich progress bar
+        with Progress(console=_console) as progress:
+            task = progress.add_task(
+                "Processing distinct tags...",
+                total=len(ct_records) + len(ta_records),
+            )
+
+            ct_inserted, ct_skipped = await self._batch_insert_canonical_tags(
+                session, ct_records, batch_size
+            )
+            progress.update(task, advance=len(ct_records))
+
+            ta_inserted, ta_skipped = await self._batch_insert_tag_aliases(
+                session, ta_records, batch_size
+            )
+            progress.update(task, advance=len(ta_records))
+
+        # Step 5: Update video counts
+        updated = await self._update_video_counts(session)
+        logger.info("Updated video_count on %d canonical tags", updated)
+
+        # Step 6: Print completion summary
+        elapsed = time.time() - start_time
+
+        _console.print()
+        _console.print("[bold]── Backfill Complete ──[/bold]")
+        _console.print()
+
+        ct_line = f"Canonical tags created:    {ct_inserted:>7,}"
+        if ct_skipped > 0:
+            ct_line += f"  ({ct_skipped:,} already exist)"
+        _console.print(ct_line)
+
+        ta_line = f"Tag aliases created:      {ta_inserted:>7,}"
+        if ta_skipped > 0:
+            ta_line += f"  ({ta_skipped:,} already exist)"
+        _console.print(ta_line)
+
+        _console.print(f"Tags skipped:             {len(skip_list):>7,}")
+
+        minutes, seconds = divmod(int(elapsed), 60)
+        if minutes > 0:
+            _console.print(f"Elapsed time:            {minutes}m {seconds:02d}s")
+        else:
+            _console.print(f"Elapsed time:              {seconds}s")
+
+        # Step 7: Display skipped tags table if any
+        if skip_list:
+            skip_table = Table(title="Skipped Tags")
+            skip_table.add_column("Raw Form")
+            skip_table.add_column("Occurrences", justify="right")
+            for raw_form, count in skip_list:
+                skip_table.add_row(repr(raw_form), str(count))
+            _console.print(skip_table)
+
+    # ------------------------------------------------------------------
+    # T012: Collision detection
+    # ------------------------------------------------------------------
+
+    def _detect_collisions(
+        self,
+        groups: dict[str, list[tuple[str, int]]],
+    ) -> list[dict[str, Any]]:
+        """Detect collision candidates among normalized tag groups.
+
+        A collision occurs when a single normalized form merges raw tags
+        whose *casefolded* forms (after stripping leading ``#`` and
+        whitespace) are distinct.  This indicates the normalization
+        pipeline merged semantically different words — typically due to
+        diacritic stripping.
+
+        Parameters
+        ----------
+        groups : dict[str, list[tuple[str, int]]]
+            Mapping of normalized form to list of ``(raw_form, count)``
+            tuples, as returned by ``_normalize_and_group_core``.
+
+        Returns
+        -------
+        list[dict[str, Any]]
+            Collision candidates sorted by total occurrence count
+            descending.  Each entry has keys ``normalized_form``,
+            ``aliases`` (list of dicts with ``raw_form`` and
+            ``occurrence_count``), and ``is_known_false_merge``.
+        """
+        collisions: list[dict[str, Any]] = []
+
+        for normalized_form, aliases in groups.items():
+            if len(aliases) < 2:
+                continue
+
+            # For each raw form: strip leading #, strip whitespace, casefold
+            # (do NOT strip diacritics)
+            casefolded_set: set[str] = set()
+            for raw_form, _count in aliases:
+                cleaned = raw_form.strip()
+                if cleaned.startswith("#"):
+                    cleaned = cleaned[1:]
+                cleaned = cleaned.strip().casefold()
+                casefolded_set.add(cleaned)
+
+            # Collision only if 2+ distinct casefolded values remain
+            if len(casefolded_set) < 2:
+                continue
+
+            total_count = sum(count for _, count in aliases)
+            is_known = normalized_form in KNOWN_FALSE_MERGE_PATTERNS
+
+            collisions.append(
+                {
+                    "normalized_form": normalized_form,
+                    "aliases": [
+                        {"raw_form": rf, "occurrence_count": c}
+                        for rf, c in aliases
+                    ],
+                    "is_known_false_merge": is_known,
+                }
+            )
+
+        # Sort by total occurrence count descending
+        collisions.sort(
+            key=lambda c: sum(a["occurrence_count"] for a in c["aliases"]),
+            reverse=True,
+        )
+
+        return collisions
+
+    # ------------------------------------------------------------------
+    # T013: Analysis (read-only)
+    # ------------------------------------------------------------------
+
+    async def run_analysis(
+        self,
+        session: AsyncSession,
+        output_format: str = "table",
+        console: Console | None = None,
+    ) -> dict[str, Any] | None:
+        """Run read-only tag normalization analysis.
+
+        Queries all distinct tags, normalizes them in-memory, computes
+        summary statistics, detects collision candidates, and outputs
+        results in either Rich table or JSON format.
+
+        This method **never writes** to the database.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            An active SQLAlchemy async session (read-only usage).
+        output_format : str, optional
+            ``"table"`` for Rich console output, ``"json"`` for machine-
+            readable JSON (default ``"table"``).
+        console : Console | None, optional
+            Rich console for output.  A default console is created if
+            ``None``.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            The analysis result dict when ``output_format="json"``,
+            ``None`` when ``output_format="table"``.
+
+        Raises
+        ------
+        SystemExit
+            If required tables are missing from the database.
+        """
+        _console = console or Console()
+
+        # Step 1: Verify required tables exist (FR-022)
+        await self._check_tables_exist(session)
+
+        # Step 2: Query distinct tags from video_tags
+        repo = VideoTagRepository()
+        raw_tags = await repo.get_distinct_tags_with_counts(session)
+        distinct_tags: dict[str, int] = {tag: count for tag, count in raw_tags}
+
+        # Step 3: Normalize and group
+        groups, skip_list = self._normalize_and_group_core(distinct_tags)
+
+        # Step 4: Compute summary stats
+        total_distinct_tags = len(distinct_tags)
+        estimated_canonical_tags = len(groups)
+        skip_count = len(skip_list)
+
+        # Step 5: Select canonical forms and build top 20
+        canonical_entries: list[dict[str, Any]] = []
+        for normalized_form, aliases in groups.items():
+            canonical_form = self._normalization_service.select_canonical_form(aliases)
+            canonical_entries.append(
+                {
+                    "canonical_form": canonical_form,
+                    "normalized_form": normalized_form,
+                    "alias_count": len(aliases),
+                    "aliases": [rf for rf, _c in aliases],
+                }
+            )
+
+        # Sort by alias count descending and take top 20
+        canonical_entries.sort(key=lambda e: e["alias_count"], reverse=True)
+        top_canonical_tags = canonical_entries[:20]
+
+        # Step 6: Detect collision candidates
+        collision_candidates = self._detect_collisions(groups)
+
+        # Step 7: Build skip list
+        skipped_tags = [
+            {"raw_form": rf, "occurrence_count": c} for rf, c in skip_list
+        ]
+
+        # ---- Output ----
+
+        if output_format == "json":
+            result: dict[str, Any] = {
+                "total_distinct_tags": total_distinct_tags,
+                "estimated_canonical_tags": estimated_canonical_tags,
+                "skip_count": skip_count,
+                "top_canonical_tags": top_canonical_tags,
+                "collision_candidates": collision_candidates,
+                "skipped_tags": skipped_tags,
+            }
+            _console.print(json.dumps(result, indent=2, default=str))
+            return result
+
+        # --- Table format ---
+
+        # Summary panel
+        summary_text = (
+            f"[bold]Total distinct tags:[/bold]      {total_distinct_tags:>10,}\n"
+            f"[bold]Estimated canonical tags:[/bold]  {estimated_canonical_tags:>10,}\n"
+            f"[bold]Tags skipped:[/bold]              {skip_count:>10,}"
+        )
+        _console.print(Panel(summary_text, title="Analysis Summary", border_style="blue"))
+
+        # Top 20 canonical tags table
+        top_table = Table(title="Top 20 Canonical Tags by Alias Count")
+        top_table.add_column("Rank", style="dim", width=6)
+        top_table.add_column("Canonical Form", style="cyan", width=30)
+        top_table.add_column("Normalized Form", style="white", width=30)
+        top_table.add_column("Aliases", justify="right", width=10)
+        top_table.add_column("Alias List", style="dim", width=50)
+        for rank, entry in enumerate(top_canonical_tags, 1):
+            alias_str = ", ".join(entry["aliases"][:5])
+            if len(entry["aliases"]) > 5:
+                alias_str += f" (+{len(entry['aliases']) - 5} more)"
+            top_table.add_row(
+                str(rank),
+                entry["canonical_form"],
+                entry["normalized_form"],
+                str(entry["alias_count"]),
+                alias_str,
+            )
+        _console.print(top_table)
+
+        # Collision candidates
+        if collision_candidates:
+            collision_table = Table(title="Collision Candidates")
+            collision_table.add_column("Normalized Form", style="cyan", width=25)
+            collision_table.add_column("Aliases", style="white", width=50)
+            collision_table.add_column("Total Count", justify="right", width=12)
+            collision_table.add_column("Status", width=25)
+            for candidate in collision_candidates:
+                alias_parts = [
+                    f"{a['raw_form']} ({a['occurrence_count']:,})"
+                    for a in candidate["aliases"]
+                ]
+                alias_display = ", ".join(alias_parts)
+                total = sum(a["occurrence_count"] for a in candidate["aliases"])
+                status = (
+                    "[yellow]Known false-merge[/yellow]"
+                    if candidate["is_known_false_merge"]
+                    else ""
+                )
+                collision_table.add_row(
+                    candidate["normalized_form"],
+                    alias_display,
+                    f"{total:,}",
+                    status,
+                )
+            _console.print(collision_table)
+        else:
+            _console.print(
+                Panel(
+                    "[green]No collision candidates detected.[/green]",
+                    title="Collision Candidates",
+                    border_style="green",
+                )
+            )
+
+        # Skip list
+        if skipped_tags:
+            skip_table = Table(title="Skipped Tags")
+            skip_table.add_column("Raw Form", width=40)
+            skip_table.add_column("Occurrences", justify="right", width=12)
+            for entry in skipped_tags:
+                skip_table.add_row(repr(entry["raw_form"]), str(entry["occurrence_count"]))
+            _console.print(skip_table)
+        else:
+            _console.print(
+                Panel(
+                    "[green]No tags were skipped.[/green]",
+                    title="Skipped Tags",
+                    border_style="green",
+                )
+            )
+
+        return None
+
+    # ------------------------------------------------------------------
+    # T017: Recount utility
+    # ------------------------------------------------------------------
+
+    async def run_recount(
+        self,
+        session: AsyncSession,
+        dry_run: bool = False,
+        console: Console | None = None,
+    ) -> None:
+        """Recalculate ``alias_count`` and ``video_count`` on all canonical tags.
+
+        Computes the true counts from ``tag_aliases`` and ``video_tags`` and
+        either previews the deltas (``dry_run=True``) or writes the corrected
+        values (``dry_run=False``).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            An active SQLAlchemy async session.
+        dry_run : bool, optional
+            If ``True``, show a Rich table of count deltas without writing to
+            the database.  Default is ``False``.
+        console : Console | None, optional
+            Rich console for output.  A default console is created if
+            ``None``.
+
+        Raises
+        ------
+        SystemExit
+            If required tables are missing from the database (FR-022).
+        """
+        start_time = time.time()
+        _console = console or Console()
+
+        # Step 1: Verify required tables exist (FR-022)
+        await self._check_tables_exist(session)
+
+        # Step 2: Compute new alias_count for all canonical tags
+        alias_query = select(
+            TagAliasDB.canonical_tag_id,
+            func.count().label("new_alias_count"),
+        ).group_by(TagAliasDB.canonical_tag_id)
+        alias_rows = (await session.execute(alias_query)).all()
+        new_alias_counts: dict[uuid.UUID, int] = {
+            row.canonical_tag_id: row.new_alias_count for row in alias_rows
+        }
+
+        # Step 3: Compute new video_count for all canonical tags
+        video_query = (
+            select(
+                TagAliasDB.canonical_tag_id,
+                func.count(distinct(VideoTagDB.video_id)).label("new_video_count"),
+            )
+            .join(VideoTagDB, VideoTagDB.tag == TagAliasDB.raw_form)
+            .group_by(TagAliasDB.canonical_tag_id)
+        )
+        video_rows = (await session.execute(video_query)).all()
+        new_video_counts: dict[uuid.UUID, int] = {
+            row.canonical_tag_id: row.new_video_count for row in video_rows
+        }
+
+        # Step 4: Fetch current counts from canonical_tags
+        current_stmt = select(
+            CanonicalTagDB.id,
+            CanonicalTagDB.alias_count,
+            CanonicalTagDB.video_count,
+        )
+        current_rows = (await session.execute(current_stmt)).all()
+
+        # Step 5: Compare current vs recalculated
+        deltas: list[tuple[uuid.UUID, int, int, int, int]] = []
+        for row in current_rows:
+            ct_id = row.id
+            current_alias = row.alias_count
+            current_video = row.video_count
+            new_alias = new_alias_counts.get(ct_id, 0)
+            new_video = new_video_counts.get(ct_id, 0)
+            if current_alias != new_alias or current_video != new_video:
+                deltas.append(
+                    (ct_id, current_alias, new_alias, current_video, new_video)
+                )
+
+        if dry_run:
+            # Show Rich table with deltas only
+            if not deltas:
+                _console.print("All counts are correct.")
+            else:
+                delta_table = Table(title="Count Deltas (Dry Run)")
+                delta_table.add_column("Canonical Tag ID", style="dim")
+                delta_table.add_column("Current Alias", justify="right")
+                delta_table.add_column("New Alias", justify="right")
+                delta_table.add_column("Current Video", justify="right")
+                delta_table.add_column("New Video", justify="right")
+                for ct_id, cur_alias, new_alias, cur_video, new_video in deltas:
+                    delta_table.add_row(
+                        str(ct_id),
+                        str(cur_alias),
+                        str(new_alias),
+                        str(cur_video),
+                        str(new_video),
+                    )
+                _console.print(delta_table)
+                _console.print(f"Total with deltas: {len(deltas)}")
+            return
+
+        # Step 6: Write corrected counts (non-dry-run mode)
+        # Update alias_count via correlated subquery
+        alias_count_subq = (
+            select(
+                TagAliasDB.canonical_tag_id,
+                func.count().label("cnt"),
+            )
+            .group_by(TagAliasDB.canonical_tag_id)
+            .subquery()
+        )
+        alias_update_stmt = (
+            update(CanonicalTagDB)
+            .where(CanonicalTagDB.id == alias_count_subq.c.canonical_tag_id)
+            .values(alias_count=alias_count_subq.c.cnt)
+        )
+        await session.execute(alias_update_stmt)
+
+        # Update video_count via correlated subquery
+        video_count_subq = (
+            select(
+                TagAliasDB.canonical_tag_id,
+                func.count(distinct(VideoTagDB.video_id)).label("cnt"),
+            )
+            .join(VideoTagDB, VideoTagDB.tag == TagAliasDB.raw_form)
+            .group_by(TagAliasDB.canonical_tag_id)
+            .subquery()
+        )
+        video_update_stmt = (
+            update(CanonicalTagDB)
+            .where(CanonicalTagDB.id == video_count_subq.c.canonical_tag_id)
+            .values(video_count=video_count_subq.c.cnt)
+        )
+        await session.execute(video_update_stmt)
+        await session.commit()
+
+        # Step 7: Print summary
+        elapsed = time.time() - start_time
+        total_updated = len(deltas)
+        _console.print(f"Total updated: {total_updated}")
+
+        minutes, seconds = divmod(int(elapsed), 60)
+        if minutes > 0:
+            _console.print(f"Elapsed time: {minutes}m {seconds:02d}s")
+        else:
+            _console.print(f"Elapsed time: {seconds}s")

--- a/src/chronovista/services/tag_normalization.py
+++ b/src/chronovista/services/tag_normalization.py
@@ -93,7 +93,7 @@ class TagNormalizationService:
     The 9-step pipeline is executed in strict order:
 
     1. Strip leading/trailing whitespace
-    2. Strip a single leading ``#`` character
+    2. Strip all leading ``#`` characters
     3. Replace non-breaking spaces (U+00A0) and tabs with regular space
     4. Collapse multiple spaces to a single space
     5. Strip zero-width characters (U+200B, U+200C, U+200D, U+FEFF)
@@ -132,9 +132,8 @@ class TagNormalizationService:
         # Step 1: Strip leading/trailing whitespace
         text = raw_tag.strip()
 
-        # Step 2: Strip SINGLE leading '#' character
-        if text.startswith("#"):
-            text = text[1:]
+        # Step 2: Strip ALL leading '#' characters (for idempotency — FR-007)
+        text = text.lstrip("#")
 
         # Step 3: Replace non-breaking spaces and tabs with regular space
         text = text.replace("\u00A0", " ").replace("\t", " ")

--- a/tests/integration/cli/test_tag_normalize_commands.py
+++ b/tests/integration/cli/test_tag_normalize_commands.py
@@ -1,0 +1,459 @@
+"""
+Integration tests for `chronovista tags normalize` CLI command.
+
+These tests verify the CLI interface for the tag normalization backfill
+command, including validation, error handling, and output formatting.
+
+NOTE: These tests use synchronous fixtures and runner.invoke() to avoid
+asyncio.run() conflicts. The CLI commands themselves handle async operations
+internally via asyncio.run().
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from typer.testing import CliRunner
+
+from chronovista.cli.main import app
+
+# Test runner with environment that matches the integration test database
+TEST_DATABASE_URL = os.getenv(
+    "DATABASE_INTEGRATION_URL",
+    "postgresql+asyncpg://dev_user:dev_password@localhost:5434/chronovista_integration_test",
+)
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def patch_settings_for_integration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Patch settings to use integration test database.
+
+    The settings singleton is loaded at module import time with values from .env.
+    This fixture patches the effective_database_url property to return the
+    integration test database URL.
+    """
+    from chronovista.config import database as database_module
+    from chronovista.config import settings as settings_module
+
+    # Patch the settings object to return the test database URL
+    monkeypatch.setattr(
+        settings_module.settings,
+        "database_url",
+        TEST_DATABASE_URL,
+    )
+    monkeypatch.setattr(
+        settings_module.settings,
+        "database_dev_url",
+        TEST_DATABASE_URL,
+    )
+    monkeypatch.setattr(
+        settings_module.settings,
+        "development_mode",
+        False,
+    )
+
+    # Reset the db_manager singleton to use new settings
+    database_module.db_manager._engine = None
+    database_module.db_manager._session_factory = None
+
+
+class TestTagsNormalizeCommand:
+    """Tests for `chronovista tags normalize` command."""
+
+    def test_successful_run_output(self) -> None:
+        """Test normalize command with successful backfill execution."""
+        # Mock the database session
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            # Create async session mock
+            mock_session = AsyncMock()
+
+            # Mock get_session to yield the mock session
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            # Mock the backfill service
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_backfill",
+                new_callable=AsyncMock,
+            ) as mock_run_backfill:
+                # Mock successful backfill - it prints via console
+                mock_run_backfill.return_value = None
+
+                result = runner.invoke(app, ["tags", "normalize"])
+
+                # Command should succeed
+                assert result.exit_code == 0, f"Unexpected output: {result.output}"
+
+                # Verify run_backfill was called with expected parameters
+                mock_run_backfill.assert_called_once()
+                call_args = mock_run_backfill.call_args
+                # Verify session was passed
+                assert call_args[0][0] is mock_session
+                # Verify batch_size was passed
+                assert call_args[1]["batch_size"] == 1000  # default
+                # Verify console was passed
+                assert call_args[1]["console"] is not None
+
+    def test_rerun_output(self) -> None:
+        """Test normalize command when re-run (0 new records inserted)."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_backfill",
+                new_callable=AsyncMock,
+            ) as mock_run_backfill:
+                # Mock re-run (nothing to do)
+                mock_run_backfill.return_value = None
+
+                result = runner.invoke(app, ["tags", "normalize"])
+
+                # Command should succeed even with nothing to do
+                assert result.exit_code == 0, f"Unexpected output: {result.output}"
+                mock_run_backfill.assert_called_once()
+
+    def test_batch_size_zero_exits_2(self) -> None:
+        """Test normalize command rejects batch_size=0 with exit code 2."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_backfill",
+                new_callable=AsyncMock,
+            ) as mock_run_backfill:
+                # Mock run_backfill to raise SystemExit(2) for invalid batch_size
+                mock_run_backfill.side_effect = SystemExit(2)
+
+                result = runner.invoke(app, ["tags", "normalize", "--batch-size", "0"])
+
+                # Should exit with code 2
+                assert result.exit_code == 2
+
+    def test_batch_size_negative_exits_2(self) -> None:
+        """Test normalize command rejects negative batch_size with exit code 2."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_backfill",
+                new_callable=AsyncMock,
+            ) as mock_run_backfill:
+                # Mock run_backfill to raise SystemExit(2) for invalid batch_size
+                mock_run_backfill.side_effect = SystemExit(2)
+
+                result = runner.invoke(app, ["tags", "normalize", "--batch-size", "-1"])
+
+                # Should exit with code 2
+                assert result.exit_code == 2
+
+    def test_missing_tables_exits_1(self) -> None:
+        """Test normalize command exits with code 1 when required tables are missing."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_backfill",
+                new_callable=AsyncMock,
+            ) as mock_run_backfill:
+                # Mock run_backfill to raise SystemExit with message about missing tables
+                mock_run_backfill.side_effect = SystemExit(
+                    "Required table(s) missing: canonical_tags, tag_aliases. "
+                    "Run 'alembic upgrade head' to create them."
+                )
+
+                result = runner.invoke(app, ["tags", "normalize"])
+
+                # Should exit with code 1 (SystemExit with string message)
+                # Note: The error message from SystemExit is not captured in CLI output
+                # by the CliRunner when raised with a string argument
+                assert result.exit_code == 1
+
+    def test_custom_batch_size(self) -> None:
+        """Test normalize command with custom --batch-size parameter."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_backfill",
+                new_callable=AsyncMock,
+            ) as mock_run_backfill:
+                mock_run_backfill.return_value = None
+
+                result = runner.invoke(app, ["tags", "normalize", "--batch-size", "500"])
+
+                # Command should succeed
+                assert result.exit_code == 0, f"Unexpected output: {result.output}"
+
+                # Verify run_backfill was called with custom batch_size
+                mock_run_backfill.assert_called_once()
+                call_args = mock_run_backfill.call_args
+                assert call_args[1]["batch_size"] == 500
+
+    def test_help_flag_shows_usage(self) -> None:
+        """Test normalize command shows help text with --help flag."""
+        result = runner.invoke(app, ["tags", "normalize", "--help"])
+
+        # Should show help successfully
+        assert result.exit_code == 0
+        # Help text should mention batch-size option
+        assert "batch-size" in result.output
+        # Help text should describe the command
+        assert "normalize" in result.output.lower()
+
+    def test_exception_handling(self) -> None:
+        """Test normalize command handles unexpected exceptions gracefully."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_backfill",
+                new_callable=AsyncMock,
+            ) as mock_run_backfill:
+                # Mock unexpected exception
+                mock_run_backfill.side_effect = RuntimeError("Database connection failed")
+
+                result = runner.invoke(app, ["tags", "normalize"])
+
+                # Should exit with non-zero code
+                assert result.exit_code != 0
+
+
+class TestTagsAnalyzeCommand:
+    """Tests for `chronovista tags analyze` command."""
+
+    def test_table_format_output(self) -> None:
+        """Verify table format output contains summary stats."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_analysis",
+                new_callable=AsyncMock,
+            ) as mock_run_analysis:
+                mock_run_analysis.return_value = None
+
+                result = runner.invoke(app, ["tags", "analyze"])
+
+                assert result.exit_code == 0, f"Unexpected output: {result.output}"
+                mock_run_analysis.assert_called_once()
+                call_args = mock_run_analysis.call_args
+                assert call_args[1]["output_format"] == "table"
+
+    def test_json_format_valid(self) -> None:
+        """Verify --format json produces valid JSON with correct keys."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_analysis",
+                new_callable=AsyncMock,
+            ) as mock_run_analysis:
+                mock_run_analysis.return_value = {
+                    "total_distinct_tags": 100,
+                    "estimated_canonical_tags": 50,
+                    "skip_count": 2,
+                    "top_canonical_tags": [],
+                    "collision_candidates": [],
+                    "skipped_tags": [],
+                }
+
+                result = runner.invoke(app, ["tags", "analyze", "--format", "json"])
+
+                assert result.exit_code == 0, f"Unexpected output: {result.output}"
+                mock_run_analysis.assert_called_once()
+                call_args = mock_run_analysis.call_args
+                assert call_args[1]["output_format"] == "json"
+
+    def test_dry_run_accepted(self) -> None:
+        """Verify --dry-run is accepted without error."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_analysis",
+                new_callable=AsyncMock,
+            ) as mock_run_analysis:
+                mock_run_analysis.return_value = None
+
+                result = runner.invoke(app, ["tags", "analyze", "--dry-run"])
+
+                assert result.exit_code == 0, f"Unexpected output: {result.output}"
+                mock_run_analysis.assert_called_once()
+
+    def test_missing_tables_exits_1(self) -> None:
+        """Verify exit code 1 when tables missing."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_analysis",
+                new_callable=AsyncMock,
+            ) as mock_run_analysis:
+                mock_run_analysis.side_effect = SystemExit(
+                    "Required table(s) missing: canonical_tags, tag_aliases. "
+                    "Run 'alembic upgrade head' to create them."
+                )
+
+                result = runner.invoke(app, ["tags", "analyze"])
+
+                assert result.exit_code == 1
+
+    def test_help_flag(self) -> None:
+        """Verify --help shows expected usage text."""
+        result = runner.invoke(app, ["tags", "analyze", "--help"])
+
+        assert result.exit_code == 0
+        assert "analyze" in result.output.lower()
+        assert "--format" in result.output
+        assert "--dry-run" in result.output
+
+
+class TestTagsRecountCommand:
+    """Tests for `chronovista tags recount` command."""
+
+    def test_normal_mode_output(self) -> None:
+        """Test recount command with successful execution."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_recount",
+                new_callable=AsyncMock,
+            ) as mock_run_recount:
+                mock_run_recount.return_value = None
+
+                result = runner.invoke(app, ["tags", "recount"])
+
+                # Command should succeed
+                assert result.exit_code == 0, f"Unexpected output: {result.output}"
+
+                # Verify run_recount was called with expected parameters
+                mock_run_recount.assert_called_once()
+                call_args = mock_run_recount.call_args
+                # Verify session was passed
+                assert call_args[0][0] is mock_session
+                # Verify dry_run was False (default)
+                assert call_args[1]["dry_run"] is False
+                # Verify console was passed
+                assert call_args[1]["console"] is not None
+
+    def test_dry_run_output(self) -> None:
+        """Test recount command with --dry-run flag."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_recount",
+                new_callable=AsyncMock,
+            ) as mock_run_recount:
+                mock_run_recount.return_value = None
+
+                result = runner.invoke(app, ["tags", "recount", "--dry-run"])
+
+                # Command should succeed
+                assert result.exit_code == 0, f"Unexpected output: {result.output}"
+
+                # Verify run_recount was called with dry_run=True
+                mock_run_recount.assert_called_once()
+                call_args = mock_run_recount.call_args
+                assert call_args[1]["dry_run"] is True
+
+    def test_missing_tables_exits_1(self) -> None:
+        """Test recount command exits with code 1 when tables missing."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db_manager:
+            mock_session = AsyncMock()
+
+            async def mock_get_session(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+                yield mock_session
+
+            mock_db_manager.get_session.return_value = mock_get_session()
+
+            with patch(
+                "chronovista.services.tag_backfill.TagBackfillService.run_recount",
+                new_callable=AsyncMock,
+            ) as mock_run_recount:
+                mock_run_recount.side_effect = SystemExit(
+                    "Required table(s) missing: canonical_tags, tag_aliases. "
+                    "Run 'alembic upgrade head' to create them."
+                )
+
+                result = runner.invoke(app, ["tags", "recount"])
+
+                # Should exit with code 1 (SystemExit with string message)
+                assert result.exit_code == 1
+
+    def test_help_flag(self) -> None:
+        """Verify --help shows expected usage text."""
+        result = runner.invoke(app, ["tags", "recount", "--help"])
+
+        assert result.exit_code == 0
+        assert "recount" in result.output.lower()
+        assert "--dry-run" in result.output

--- a/tests/integration/services/test_tag_backfill_integration.py
+++ b/tests/integration/services/test_tag_backfill_integration.py
@@ -1,0 +1,950 @@
+"""
+Integration tests for tag backfill pipeline.
+
+This test suite validates the full tag normalization backfill process against
+a real database. It verifies that the SQL operations work correctly end-to-end,
+including:
+
+1. Reading distinct tags from video_tags table
+2. Normalizing and grouping tags
+3. Batch inserting into canonical_tags and tag_aliases
+4. Updating video counts via JOIN query
+5. Idempotent re-run behavior (ON CONFLICT DO NOTHING)
+6. video_tags table remains unchanged (SC-007)
+7. tag_operation_logs remains empty (FR-013)
+
+Related: Feature 028 (Tag Normalization Schema), Phase 2 (US1/US2 - T004-T011)
+Architecture: ADR-003 Tag Normalization
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import UTC, datetime
+from typing import cast
+
+import pytest
+from rich.console import Console
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.db.models import (
+    CanonicalTag as CanonicalTagDB,
+    Channel as ChannelDB,
+    TagAlias as TagAliasDB,
+    TagOperationLog as TagOperationLogDB,
+    Video as VideoDB,
+    VideoTag as VideoTagDB,
+)
+from chronovista.services.tag_backfill import TagBackfillService
+from chronovista.services.tag_normalization import TagNormalizationService
+
+# CRITICAL: This line ensures async tests work with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# Test Fixtures and Helpers
+# =============================================================================
+
+
+@pytest.fixture
+async def seeded_session(db_session: AsyncSession) -> AsyncSession:
+    """
+    Provide a database session pre-seeded with test data.
+
+    Seeds:
+    - 1 channel
+    - 3 videos
+    - Multiple video tags with various case/hashtag variants
+
+    Returns
+    -------
+    AsyncSession
+        Database session with seeded test data
+    """
+    # Seed a channel (required FK for videos)
+    channel = ChannelDB(
+        channel_id="UCtest123",
+        title="Test Channel",
+        description="Test channel for integration tests",
+        is_subscribed=False,
+    )
+    db_session.add(channel)
+    await db_session.flush()
+
+    # Seed videos (required FK for video_tags)
+    videos = [
+        VideoDB(
+            video_id="vid001",
+            channel_id="UCtest123",
+            title="Test Video 1",
+            description="Test description",
+            upload_date=datetime(2023, 1, 1, tzinfo=UTC),
+            duration=300,
+            made_for_kids=False,
+            self_declared_made_for_kids=False,
+        ),
+        VideoDB(
+            video_id="vid002",
+            channel_id="UCtest123",
+            title="Test Video 2",
+            description="Test description",
+            upload_date=datetime(2023, 1, 2, tzinfo=UTC),
+            duration=400,
+            made_for_kids=False,
+            self_declared_made_for_kids=False,
+        ),
+        VideoDB(
+            video_id="vid003",
+            channel_id="UCtest123",
+            title="Test Video 3",
+            description="Test description",
+            upload_date=datetime(2023, 1, 3, tzinfo=UTC),
+            duration=500,
+            made_for_kids=False,
+            self_declared_made_for_kids=False,
+        ),
+    ]
+    for video in videos:
+        db_session.add(video)
+    await db_session.flush()
+
+    # Seed video tags with various case/hashtag variants
+    # "Python" tag group: Python, python, PYTHON, #Python (4 variants, 3 videos)
+    video_tags = [
+        VideoTagDB(video_id="vid001", tag="Python", tag_order=1),
+        VideoTagDB(video_id="vid001", tag="Machine Learning", tag_order=2),
+        VideoTagDB(video_id="vid002", tag="python", tag_order=1),
+        VideoTagDB(video_id="vid002", tag="AI", tag_order=2),
+        VideoTagDB(video_id="vid003", tag="PYTHON", tag_order=1),
+        VideoTagDB(video_id="vid003", tag="#Python", tag_order=2),
+        VideoTagDB(video_id="vid003", tag="machine learning", tag_order=3),
+    ]
+    for video_tag in video_tags:
+        db_session.add(video_tag)
+    await db_session.flush()
+
+    await db_session.commit()
+    return db_session
+
+
+@pytest.fixture
+def backfill_service() -> TagBackfillService:
+    """
+    Provide a TagBackfillService instance for testing.
+
+    Returns
+    -------
+    TagBackfillService
+        Service instance with normalization service
+    """
+    normalization_service = TagNormalizationService()
+    return TagBackfillService(normalization_service)
+
+
+@pytest.fixture
+def silent_console() -> Console:
+    """
+    Provide a Rich Console that outputs to a StringIO buffer.
+
+    This silences console output in tests while still allowing the service
+    to execute its Rich formatting code.
+
+    Returns
+    -------
+    Console
+        Rich console instance writing to in-memory buffer
+    """
+    return Console(file=io.StringIO())
+
+
+# =============================================================================
+# Test Class: Full Backfill Pipeline
+# =============================================================================
+
+
+class TestFullBackfillPipeline:
+    """Test the complete backfill pipeline on seeded data."""
+
+    async def test_full_backfill_on_seeded_data(
+        self,
+        seeded_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Run full backfill and verify correct canonical_tags and tag_aliases creation.
+
+        Validates:
+        - canonical_tags has expected row count (3 groups: python, machine learning, ai)
+        - tag_aliases has expected row count (7 raw tags)
+        - Canonical form selection is correct (title case preference)
+        - alias_count values are correct
+        - normalized_form values are correct
+        """
+        # Run backfill
+        await backfill_service.run_backfill(
+            session=seeded_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Verify canonical_tags count (3 distinct normalized forms)
+        # Expected groups:
+        # 1. python (from Python, python, PYTHON, #Python)
+        # 2. machine learning (from Machine Learning, machine learning)
+        # 3. ai (from AI)
+        result = await seeded_session.execute(select(func.count()).select_from(CanonicalTagDB))
+        canonical_count = result.scalar()
+        assert canonical_count == 3, f"Expected 3 canonical tags, got {canonical_count}"
+
+        # Verify tag_aliases count (7 raw tags)
+        result = await seeded_session.execute(select(func.count()).select_from(TagAliasDB))
+        alias_count = result.scalar()
+        assert alias_count == 7, f"Expected 7 tag aliases, got {alias_count}"
+
+        # Verify canonical form selection (title case preference with alphabetical tiebreaker)
+        # "Python" tag group: has 2 title case forms ("Python", "#Python") both with count=1
+        # Alphabetical min tiebreaker selects "#Python" (# < P in ASCII)
+        result = await seeded_session.execute(
+            select(CanonicalTagDB.canonical_form, CanonicalTagDB.normalized_form)
+            .where(CanonicalTagDB.normalized_form == "python")
+        )
+        row = result.first()
+        assert row is not None
+        canonical_form, normalized_form = row
+        assert canonical_form == "#Python", f"Expected '#Python', got '{canonical_form}'"
+        assert normalized_form == "python"
+
+        # Verify "Machine Learning" tag group (title case preference)
+        result = await seeded_session.execute(
+            select(CanonicalTagDB.canonical_form, CanonicalTagDB.normalized_form)
+            .where(CanonicalTagDB.normalized_form == "machine learning")
+        )
+        row = result.first()
+        assert row is not None
+        canonical_form, normalized_form = row
+        assert canonical_form == "Machine Learning"
+        assert normalized_form == "machine learning"
+
+        # Verify "AI" tag group (only one variant, no title case alternative)
+        result = await seeded_session.execute(
+            select(CanonicalTagDB.canonical_form, CanonicalTagDB.normalized_form)
+            .where(CanonicalTagDB.normalized_form == "ai")
+        )
+        row = result.first()
+        assert row is not None
+        canonical_form, normalized_form = row
+        assert canonical_form == "AI"
+        assert normalized_form == "ai"
+
+        # Verify alias_count values
+        result = await seeded_session.execute(
+            select(CanonicalTagDB.canonical_form, CanonicalTagDB.alias_count)
+            .order_by(CanonicalTagDB.canonical_form)
+        )
+        alias_counts = {row[0]: row[1] for row in result.all()}
+        assert alias_counts["#Python"] == 4  # Python, python, PYTHON, #Python
+        assert alias_counts["Machine Learning"] == 2  # Machine Learning, machine learning
+        assert alias_counts["AI"] == 1
+
+        # Verify normalized_form values in tag_aliases match canonical_tags
+        result = await seeded_session.execute(
+            select(TagAliasDB.raw_form, TagAliasDB.normalized_form)
+        )
+        alias_mappings = {row[0]: row[1] for row in result.all()}
+        assert alias_mappings["Python"] == "python"
+        assert alias_mappings["python"] == "python"
+        assert alias_mappings["PYTHON"] == "python"
+        assert alias_mappings["#Python"] == "python"
+        assert alias_mappings["Machine Learning"] == "machine learning"
+        assert alias_mappings["machine learning"] == "machine learning"
+        assert alias_mappings["AI"] == "ai"
+
+
+# =============================================================================
+# Test Class: Idempotent Re-Run
+# =============================================================================
+
+
+class TestIdempotentRerun:
+    """Test that re-running backfill is idempotent (ON CONFLICT DO NOTHING)."""
+
+    async def test_idempotent_rerun(
+        self,
+        seeded_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Run backfill twice and verify second run creates no new records.
+
+        Validates:
+        - Second run creates 0 new canonical tags
+        - Second run creates 0 new tag aliases
+        - Existing records are not modified
+        """
+        # Run backfill first time
+        await backfill_service.run_backfill(
+            session=seeded_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Count records after first run
+        result = await seeded_session.execute(select(func.count()).select_from(CanonicalTagDB))
+        canonical_count_1 = result.scalar()
+        result = await seeded_session.execute(select(func.count()).select_from(TagAliasDB))
+        alias_count_1 = result.scalar()
+
+        # Capture canonical_forms and normalized_forms before second run
+        result = await seeded_session.execute(
+            select(CanonicalTagDB.canonical_form, CanonicalTagDB.normalized_form)
+            .order_by(CanonicalTagDB.canonical_form)
+        )
+        canonical_forms_before = {row[0]: row[1] for row in result.all()}
+
+        # Run backfill second time
+        await backfill_service.run_backfill(
+            session=seeded_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Count records after second run
+        result = await seeded_session.execute(select(func.count()).select_from(CanonicalTagDB))
+        canonical_count_2 = result.scalar()
+        result = await seeded_session.execute(select(func.count()).select_from(TagAliasDB))
+        alias_count_2 = result.scalar()
+
+        # Verify no new records created
+        assert canonical_count_2 == canonical_count_1, (
+            f"Second run created new canonical tags: {canonical_count_1} -> {canonical_count_2}"
+        )
+        assert alias_count_2 == alias_count_1, (
+            f"Second run created new tag aliases: {alias_count_1} -> {alias_count_2}"
+        )
+
+        # Verify canonical_forms unchanged
+        result = await seeded_session.execute(
+            select(CanonicalTagDB.canonical_form, CanonicalTagDB.normalized_form)
+            .order_by(CanonicalTagDB.canonical_form)
+        )
+        canonical_forms_after = {row[0]: row[1] for row in result.all()}
+        assert canonical_forms_after == canonical_forms_before, (
+            "Canonical forms changed after second run"
+        )
+
+
+# =============================================================================
+# Test Class: Video Count Correctness
+# =============================================================================
+
+
+class TestVideoCountCorrectness:
+    """Test that video_count is correctly computed via JOIN query."""
+
+    async def test_video_count_correctness(
+        self,
+        seeded_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Verify video_count on canonical tags matches actual video count.
+
+        The seeded data has:
+        - "python" variants on 3 videos (vid001, vid002, vid003)
+        - "machine learning" variants on 2 videos (vid001, vid003)
+        - "ai" on 1 video (vid002)
+        """
+        # Run backfill
+        await backfill_service.run_backfill(
+            session=seeded_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Verify video_count for "python" (3 videos)
+        result = await seeded_session.execute(
+            select(CanonicalTagDB.video_count)
+            .where(CanonicalTagDB.normalized_form == "python")
+        )
+        video_count = result.scalar()
+        assert video_count == 3, f"Expected 3 videos for 'python', got {video_count}"
+
+        # Verify video_count for "machine learning" (2 videos)
+        result = await seeded_session.execute(
+            select(CanonicalTagDB.video_count)
+            .where(CanonicalTagDB.normalized_form == "machine learning")
+        )
+        video_count = result.scalar()
+        assert video_count == 2, f"Expected 2 videos for 'machine learning', got {video_count}"
+
+        # Verify video_count for "ai" (1 video)
+        result = await seeded_session.execute(
+            select(CanonicalTagDB.video_count)
+            .where(CanonicalTagDB.normalized_form == "ai")
+        )
+        video_count = result.scalar()
+        assert video_count == 1, f"Expected 1 video for 'ai', got {video_count}"
+
+
+# =============================================================================
+# Test Class: Timestamp Fields
+# =============================================================================
+
+
+class TestTimestampFields:
+    """Test that timestamp fields are set correctly on tag aliases."""
+
+    async def test_first_seen_last_seen_timestamps(
+        self,
+        seeded_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Verify first_seen_at and last_seen_at are set to execution timestamp.
+
+        Both fields should be set to the same timestamp (the backfill execution time).
+        """
+        # Capture timestamp before backfill
+        before_timestamp = datetime.now(UTC)
+
+        # Run backfill
+        await backfill_service.run_backfill(
+            session=seeded_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Capture timestamp after backfill
+        after_timestamp = datetime.now(UTC)
+
+        # Verify all tag aliases have first_seen_at and last_seen_at set
+        result = await seeded_session.execute(
+            select(TagAliasDB.raw_form, TagAliasDB.first_seen_at, TagAliasDB.last_seen_at)
+        )
+        for raw_form, first_seen, last_seen in result.all():
+            assert first_seen is not None, f"first_seen_at is NULL for '{raw_form}'"
+            assert last_seen is not None, f"last_seen_at is NULL for '{raw_form}'"
+
+            # Verify timestamps are within expected range
+            assert before_timestamp <= first_seen <= after_timestamp, (
+                f"first_seen_at for '{raw_form}' is outside expected range"
+            )
+            assert before_timestamp <= last_seen <= after_timestamp, (
+                f"last_seen_at for '{raw_form}' is outside expected range"
+            )
+
+            # For backfill, first_seen_at should equal last_seen_at
+            assert first_seen == last_seen, (
+                f"first_seen_at != last_seen_at for '{raw_form}'"
+            )
+
+
+# =============================================================================
+# Test Class: Tag Operation Logs
+# =============================================================================
+
+
+class TestTagOperationLogs:
+    """Test that tag_operation_logs remains empty after backfill (FR-013)."""
+
+    async def test_no_tag_operation_logs_created(
+        self,
+        seeded_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Verify tag_operation_logs table has 0 rows after backfill.
+
+        FR-013 specifies that backfill does NOT create audit log entries.
+        """
+        # Run backfill
+        await backfill_service.run_backfill(
+            session=seeded_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Verify tag_operation_logs is empty
+        result = await seeded_session.execute(
+            select(func.count()).select_from(TagOperationLogDB)
+        )
+        log_count = result.scalar()
+        assert log_count == 0, f"Expected 0 operation logs, got {log_count}"
+
+
+# =============================================================================
+# Test Class: Video Tags Unchanged
+# =============================================================================
+
+
+class TestVideoTagsUnchanged:
+    """Test that video_tags table remains unchanged after backfill (SC-007)."""
+
+    async def test_video_tags_unchanged(
+        self,
+        seeded_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Count rows and content of video_tags before and after backfill.
+
+        Validates SC-007: video_tags table is read-only for backfill.
+        """
+        # Count rows before backfill
+        result = await seeded_session.execute(
+            select(func.count()).select_from(VideoTagDB)
+        )
+        count_before = result.scalar()
+
+        # Capture all video_tags content before backfill
+        result = await seeded_session.execute(
+            select(VideoTagDB.video_id, VideoTagDB.tag, VideoTagDB.tag_order)
+            .order_by(VideoTagDB.video_id, VideoTagDB.tag)
+        )
+        video_tags_before = [(row[0], row[1], row[2]) for row in result.all()]
+
+        # Run backfill
+        await backfill_service.run_backfill(
+            session=seeded_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Count rows after backfill
+        result = await seeded_session.execute(
+            select(func.count()).select_from(VideoTagDB)
+        )
+        count_after = result.scalar()
+
+        # Capture all video_tags content after backfill
+        result = await seeded_session.execute(
+            select(VideoTagDB.video_id, VideoTagDB.tag, VideoTagDB.tag_order)
+            .order_by(VideoTagDB.video_id, VideoTagDB.tag)
+        )
+        video_tags_after = [(row[0], row[1], row[2]) for row in result.all()]
+
+        # Verify count unchanged
+        assert count_after == count_before, (
+            f"video_tags row count changed: {count_before} -> {count_after}"
+        )
+
+        # Verify content unchanged
+        assert video_tags_after == video_tags_before, (
+            "video_tags content changed after backfill"
+        )
+
+
+# =============================================================================
+# Test Class: Large Canonical Group
+# =============================================================================
+
+
+class TestLargeCanonicalGroup:
+    """Test handling of a large canonical group with 50+ variants."""
+
+    async def test_large_canonical_group(
+        self,
+        db_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Seed 50+ case/hashtag variants of a single tag and verify single canonical tag.
+
+        Validates:
+        - Single canonical_tags row with correct alias_count
+        - All variants mapped to the same canonical tag
+        """
+        # Seed a channel and video
+        channel = ChannelDB(
+            channel_id="UCtest456",
+            title="Test Channel",
+            description="Test channel",
+            is_subscribed=False,
+        )
+        db_session.add(channel)
+        await db_session.flush()
+
+        video = VideoDB(
+            video_id="vid999",
+            channel_id="UCtest456",
+            title="Test Video",
+            description="Test description",
+            upload_date=datetime(2023, 1, 1, tzinfo=UTC),
+            duration=300,
+            made_for_kids=False,
+            self_declared_made_for_kids=False,
+        )
+        db_session.add(video)
+        await db_session.flush()
+
+        # Create 50+ variants of "Python" tag (only case/hashtag variations, no suffixes)
+        # All these normalize to "python"
+        variants = [
+            "Python",
+            "python",
+            "PYTHON",
+            "#Python",
+            "#python",
+            "#PYTHON",
+            "PyThOn",
+            "pYtHoN",
+            "pYThOn",
+            "#PyThOn",
+            "#pYtHoN",
+            "PYTHON ",  # with trailing space (will be stripped)
+            "  python",  # with leading space (will be stripped)
+            "Python  ",  # with trailing spaces
+            "  Python  ",  # with both
+            "#pYThOn",
+            "#PYTHON ",
+            "pyThon",
+            "PYthon",
+            "PytHon",
+            "PythoN",
+            "pythOn",
+            "pythoN",
+            "PYTHon",
+            "PYTHOn",
+            "PYThoN",
+            "PyTHon",
+            "PyTHOn",
+            "PyThoN",
+            "pYTHon",
+            "pYTHOn",
+            "pYThoN",
+            "pYtHon",
+            "pYtHOn",
+            "pYthoN",
+            "pyTHon",
+            "pyTHOn",
+            "pyThoN",
+            "pytHon",
+            "pytHOn",
+            "pythoN",
+            "#PYTHON",
+            "##Python",  # double hashtag (first one stripped)
+            "###python",  # triple hashtag
+        ]
+
+        # Insert video tags (deduplicate in advance to avoid PK violations)
+        seen_tags = set()
+        unique_variants = []
+        for i, variant in enumerate(variants):
+            if variant not in seen_tags:
+                video_tag = VideoTagDB(video_id="vid999", tag=variant, tag_order=i)
+                db_session.add(video_tag)
+                seen_tags.add(variant)
+                unique_variants.append(variant)
+
+        await db_session.flush()
+        await db_session.commit()
+
+        # Verify we have at least 40 unique variants
+        assert len(unique_variants) >= 40, (
+            f"Expected at least 40 unique variants, got {len(unique_variants)}"
+        )
+
+        # Debug: Check that video_tags were actually inserted
+        result = await db_session.execute(
+            select(func.count()).select_from(VideoTagDB)
+            .where(VideoTagDB.video_id == "vid999")
+        )
+        video_tag_count = result.scalar()
+
+        # Run backfill
+        await backfill_service.run_backfill(
+            session=db_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Count how many of our unique variants normalize to "python"
+        normalization_service = TagNormalizationService()
+        python_variants = [
+            v for v in unique_variants
+            if normalization_service.normalize(v) == "python"
+        ]
+        expected_count = len(python_variants)
+
+        # Debug: Check what canonical tags were actually created
+        result = await db_session.execute(
+            select(CanonicalTagDB.normalized_form, CanonicalTagDB.canonical_form, CanonicalTagDB.alias_count)
+        )
+        all_canonical_tags = [(row[0], row[1], row[2]) for row in result.all()]
+
+        # Get the "python" canonical tag
+        result = await db_session.execute(
+            select(CanonicalTagDB.canonical_form, CanonicalTagDB.alias_count)
+            .where(CanonicalTagDB.normalized_form == "python")
+        )
+        row = result.first()
+
+        assert row is not None, (
+            f"Expected 'python' canonical tag to exist. "
+            f"Unique variants: {len(unique_variants)}, "
+            f"Python variants: {expected_count}, "
+            f"Video tags inserted: {video_tag_count}, "
+            f"All canonical tags: {all_canonical_tags}"
+        )
+
+        canonical_form, alias_count = row
+        assert alias_count == expected_count, (
+            f"Expected alias_count {expected_count}, got {alias_count}"
+        )
+        # Verify we have a large group (>= 40 variants)
+        assert alias_count >= 40, f"Expected at least 40 aliases, got {alias_count}"
+
+
+# =============================================================================
+# Test Class: Interrupted Then Resumed
+# =============================================================================
+
+
+class TestInterruptedThenResumed:
+    """Test that backfill can be interrupted and resumed safely."""
+
+    async def test_interrupted_then_resumed(
+        self,
+        seeded_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Run backfill with small batch_size, then run full backfill again.
+
+        Validates ON CONFLICT fills the gap from interrupted run.
+        """
+        # Run backfill with very small batch size (simulates partial run)
+        await backfill_service.run_backfill(
+            session=seeded_session,
+            batch_size=2,
+            console=silent_console,
+        )
+
+        # Count records after partial run
+        result = await seeded_session.execute(select(func.count()).select_from(CanonicalTagDB))
+        canonical_count_1 = result.scalar()
+        result = await seeded_session.execute(select(func.count()).select_from(TagAliasDB))
+        alias_count_1 = result.scalar()
+
+        # Run full backfill with normal batch size
+        await backfill_service.run_backfill(
+            session=seeded_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Count records after full run
+        result = await seeded_session.execute(select(func.count()).select_from(CanonicalTagDB))
+        canonical_count_2 = result.scalar()
+        result = await seeded_session.execute(select(func.count()).select_from(TagAliasDB))
+        alias_count_2 = result.scalar()
+
+        # Verify all records exist (ON CONFLICT filled gaps)
+        assert canonical_count_2 == 3, f"Expected 3 canonical tags, got {canonical_count_2}"
+        assert alias_count_2 == 7, f"Expected 7 tag aliases, got {alias_count_2}"
+
+        # Verify at least some records were added in the second run
+        # (unless the first run completed, which is unlikely with batch_size=2)
+        assert canonical_count_1 is not None, "canonical_count_1 should not be None"
+        assert alias_count_1 is not None, "alias_count_1 should not be None"
+        assert canonical_count_2 >= canonical_count_1
+        assert alias_count_2 >= alias_count_1
+
+
+# =============================================================================
+# Test Class: Edge Cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    async def test_empty_video_tags_table(
+        self,
+        db_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Run backfill on empty video_tags table.
+
+        Should complete successfully without errors.
+        """
+        # Run backfill on empty database
+        await backfill_service.run_backfill(
+            session=db_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Verify no records created
+        result = await db_session.execute(select(func.count()).select_from(CanonicalTagDB))
+        canonical_count = result.scalar()
+        assert canonical_count == 0
+
+        result = await db_session.execute(select(func.count()).select_from(TagAliasDB))
+        alias_count = result.scalar()
+        assert alias_count == 0
+
+    async def test_tags_that_normalize_to_empty(
+        self,
+        db_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Test tags that normalize to empty string (should be skipped).
+
+        Examples: "   ", "#", "###", whitespace-only strings
+
+        Note: "###" normalizes to "##" (only first # is stripped), not empty.
+        """
+        # Seed a channel and video
+        channel = ChannelDB(
+            channel_id="UCtest789",
+            title="Test Channel",
+            description="Test channel",
+            is_subscribed=False,
+        )
+        db_session.add(channel)
+        await db_session.flush()
+
+        video = VideoDB(
+            video_id="vid888",
+            channel_id="UCtest789",
+            title="Test Video",
+            description="Test description",
+            upload_date=datetime(2023, 1, 1, tzinfo=UTC),
+            duration=300,
+            made_for_kids=False,
+            self_declared_made_for_kids=False,
+        )
+        db_session.add(video)
+        await db_session.flush()
+
+        # Add tags that normalize to empty (truly empty after normalization)
+        empty_tags = [
+            VideoTagDB(video_id="vid888", tag="   ", tag_order=1),  # whitespace only
+            VideoTagDB(video_id="vid888", tag="#", tag_order=2),  # just hashtag
+            VideoTagDB(video_id="vid888", tag="\t\n", tag_order=4),  # whitespace chars
+        ]
+        for video_tag in empty_tags:
+            db_session.add(video_tag)
+        await db_session.flush()
+
+        # Also add one valid tag
+        valid_tag = VideoTagDB(video_id="vid888", tag="ValidTag", tag_order=5)
+        db_session.add(valid_tag)
+        await db_session.flush()
+
+        await db_session.commit()
+
+        # Run backfill
+        await backfill_service.run_backfill(
+            session=db_session,
+            batch_size=1000,
+            console=silent_console,
+        )
+
+        # Verify only the valid tag created canonical_tags and tag_aliases
+        result = await db_session.execute(select(func.count()).select_from(CanonicalTagDB))
+        canonical_count = result.scalar()
+        assert canonical_count == 1, f"Expected 1 canonical tag, got {canonical_count}"
+
+        result = await db_session.execute(select(func.count()).select_from(TagAliasDB))
+        alias_count = result.scalar()
+        assert alias_count == 1, f"Expected 1 tag alias, got {alias_count}"
+
+        # Verify the canonical tag is for "ValidTag"
+        result = await db_session.execute(
+            select(CanonicalTagDB.canonical_form)
+        )
+        canonical_forms = [row[0] for row in result.all()]
+        assert "ValidTag" in canonical_forms
+
+    async def test_batch_size_validation(
+        self,
+        db_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Test that batch_size < 1 raises SystemExit with code 2.
+        """
+        with pytest.raises(SystemExit) as exc_info:
+            await backfill_service.run_backfill(
+                session=db_session,
+                batch_size=0,  # Invalid
+                console=silent_console,
+            )
+        assert exc_info.value.code == 2
+
+    async def test_missing_tables_raises_system_exit(
+        self,
+        db_session: AsyncSession,
+        backfill_service: TagBackfillService,
+        silent_console: Console,
+    ) -> None:
+        """
+        Test that missing tables (canonical_tags, tag_aliases) raises SystemExit.
+
+        This test drops the tables temporarily, runs backfill, then recreates them.
+        """
+        # Drop canonical_tags and tag_aliases tables
+        await db_session.execute(text("DROP TABLE IF EXISTS tag_aliases CASCADE"))
+        await db_session.execute(text("DROP TABLE IF EXISTS canonical_tags CASCADE"))
+        await db_session.commit()
+
+        # Try to run backfill (should raise SystemExit)
+        with pytest.raises(SystemExit) as exc_info:
+            await backfill_service.run_backfill(
+                session=db_session,
+                batch_size=1000,
+                console=silent_console,
+            )
+
+        # Verify error message mentions missing tables
+        assert "canonical_tags" in str(exc_info.value) or "tag_aliases" in str(exc_info.value)
+
+        # Recreate tables for cleanup (conftest will drop all tables anyway)
+        # This prevents FK constraint violations in cleanup
+        await db_session.execute(
+            text("""
+                CREATE TABLE IF NOT EXISTS canonical_tags (
+                    id UUID PRIMARY KEY,
+                    canonical_form VARCHAR(500) NOT NULL,
+                    normalized_form VARCHAR(500) NOT NULL UNIQUE,
+                    alias_count INTEGER NOT NULL DEFAULT 1,
+                    video_count INTEGER NOT NULL DEFAULT 0,
+                    status VARCHAR(20) NOT NULL DEFAULT 'active'
+                )
+            """)
+        )
+        await db_session.execute(
+            text("""
+                CREATE TABLE IF NOT EXISTS tag_aliases (
+                    id UUID PRIMARY KEY,
+                    raw_form VARCHAR(500) NOT NULL UNIQUE,
+                    normalized_form VARCHAR(500) NOT NULL,
+                    canonical_tag_id UUID NOT NULL,
+                    creation_method VARCHAR(30) NOT NULL DEFAULT 'auto_normalize',
+                    normalization_version INTEGER NOT NULL DEFAULT 1,
+                    occurrence_count INTEGER NOT NULL DEFAULT 1,
+                    first_seen_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                    last_seen_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                    created_at TIMESTAMP WITH TIME ZONE NOT NULL
+                )
+            """)
+        )
+        await db_session.commit()

--- a/tests/unit/services/test_tag_backfill.py
+++ b/tests/unit/services/test_tag_backfill.py
@@ -1,0 +1,1057 @@
+"""
+Tests for Tag Backfill Service.
+
+Comprehensive unit tests for the ``TagBackfillService`` orchestrator that
+manages the tag normalization backfill pipeline.  All database operations
+are mocked — these are unit tests, not integration tests.
+
+References
+----------
+- T009: Unit test task for tag backfill service
+- TagBackfillService implementation in src/chronovista/services/tag_backfill.py
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from chronovista.services.tag_backfill import (
+    KNOWN_FALSE_MERGE_PATTERNS,
+    TagBackfillService,
+)
+from chronovista.services.tag_normalization import TagNormalizationService
+
+
+@pytest.fixture
+def normalization_service() -> TagNormalizationService:
+    """Use the REAL normalization service (it's pure, no I/O)."""
+    return TagNormalizationService()
+
+
+@pytest.fixture
+def service(normalization_service: TagNormalizationService) -> TagBackfillService:
+    """Provide a fresh ``TagBackfillService`` instance."""
+    return TagBackfillService(normalization_service)
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    """Provide a mock async database session."""
+    return AsyncMock()
+
+
+# =========================================================================
+# TestNormalizeAndGroupCore — core normalization and grouping
+# =========================================================================
+
+
+class TestNormalizeAndGroupCore:
+    """Tests for ``_normalize_and_group_core`` method."""
+
+    @pytest.mark.asyncio
+    async def test_groups_by_normalized_form(
+        self, service: TagBackfillService
+    ) -> None:
+        """Pass multiple raw forms that normalize to the same form — verify single group."""
+        distinct_tags = {"Python": 10, "python": 5, "#Python": 3}
+        groups, skip_list = service._normalize_and_group_core(distinct_tags)
+
+        # All three should normalize to "python"
+        assert "python" in groups
+        assert len(groups) == 1
+        assert len(groups["python"]) == 3
+
+        # Verify the raw forms and counts are preserved
+        raw_forms = {form for form, count in groups["python"]}
+        assert raw_forms == {"Python", "python", "#Python"}
+
+        # Verify counts
+        counts_by_form = {form: count for form, count in groups["python"]}
+        assert counts_by_form["Python"] == 10
+        assert counts_by_form["python"] == 5
+        assert counts_by_form["#Python"] == 3
+
+        # No skips
+        assert len(skip_list) == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_normalizing_tags(
+        self, service: TagBackfillService
+    ) -> None:
+        """Pass tags that normalize to empty (None) — verify skip_list."""
+        distinct_tags = {"#": 3, "": 0, "  ": 5}
+        groups, skip_list = service._normalize_and_group_core(distinct_tags)
+
+        # No groups should be created
+        assert len(groups) == 0
+
+        # All should be skipped
+        assert len(skip_list) == 3
+        skipped_forms = {form for form, count in skip_list}
+        assert skipped_forms == {"#", "", "  "}
+
+        # Verify counts
+        counts_by_form = {form: count for form, count in skip_list}
+        assert counts_by_form["#"] == 3
+        assert counts_by_form[""] == 0
+        assert counts_by_form["  "] == 5
+
+    @pytest.mark.asyncio
+    async def test_mixed_tags(self, service: TagBackfillService) -> None:
+        """Mix of normalizable and non-normalizable tags — verify partition."""
+        distinct_tags = {
+            "Python": 10,
+            "python": 5,
+            "#": 3,
+            "Java": 8,
+            "": 0,
+        }
+        groups, skip_list = service._normalize_and_group_core(distinct_tags)
+
+        # Two groups: "python" and "java"
+        assert len(groups) == 2
+        assert "python" in groups
+        assert "java" in groups
+
+        # Python group has 2 aliases
+        assert len(groups["python"]) == 2
+        python_forms = {form for form, count in groups["python"]}
+        assert python_forms == {"Python", "python"}
+
+        # Java group has 1 alias
+        assert len(groups["java"]) == 1
+        assert groups["java"][0] == ("Java", 8)
+
+        # Two skipped
+        assert len(skip_list) == 2
+        skipped_forms = {form for form, count in skip_list}
+        assert skipped_forms == {"#", ""}
+
+    @pytest.mark.asyncio
+    async def test_empty_input(self, service: TagBackfillService) -> None:
+        """Empty dict returns empty groups and empty skip_list."""
+        distinct_tags: dict[str, int] = {}
+        groups, skip_list = service._normalize_and_group_core(distinct_tags)
+
+        assert len(groups) == 0
+        assert len(skip_list) == 0
+
+    @pytest.mark.asyncio
+    async def test_diacritic_grouping(self, service: TagBackfillService) -> None:
+        """Tags with Tier 1 diacritics normalize to same form."""
+        distinct_tags = {"café": 80, "cafe": 45, "CAFE": 20}
+        groups, skip_list = service._normalize_and_group_core(distinct_tags)
+
+        # All normalize to "cafe" (Tier 1 acute accent stripped)
+        assert len(groups) == 1
+        assert "cafe" in groups
+        assert len(groups["cafe"]) == 3
+
+        # Verify all raw forms are present
+        raw_forms = {form for form, count in groups["cafe"]}
+        assert raw_forms == {"café", "cafe", "CAFE"}
+
+        # Verify counts
+        counts_by_form = {form: count for form, count in groups["cafe"]}
+        assert counts_by_form["café"] == 80
+        assert counts_by_form["cafe"] == 45
+        assert counts_by_form["CAFE"] == 20
+
+        # No skips
+        assert len(skip_list) == 0
+
+
+# =========================================================================
+# TestNormalizeAndGroup — full method with UUID generation
+# =========================================================================
+
+
+class TestNormalizeAndGroup:
+    """Tests for ``_normalize_and_group`` method (with UUID generation)."""
+
+    @pytest.mark.asyncio
+    async def test_generates_uuid7_ids(self, service: TagBackfillService) -> None:
+        """Verify all IDs in batch records are valid UUIDs."""
+        distinct_tags = {"Python": 10, "Java": 5}
+        execution_timestamp = datetime.now(UTC)
+
+        ct_records, ta_records, skip_list = service._normalize_and_group(
+            distinct_tags, execution_timestamp
+        )
+
+        # Verify canonical tag IDs are UUIDs
+        for record in ct_records:
+            assert isinstance(record["id"], uuid.UUID)
+
+        # Verify tag alias IDs are UUIDs
+        for record in ta_records:
+            assert isinstance(record["id"], uuid.UUID)
+            assert isinstance(record["canonical_tag_id"], uuid.UUID)
+
+    @pytest.mark.asyncio
+    async def test_canonical_form_selection(self, service: TagBackfillService) -> None:
+        """Verify select_canonical_form is called with correct aliases list."""
+        distinct_tags = {"Python": 100, "python": 50, "PYTHON": 25}
+        execution_timestamp = datetime.now(UTC)
+
+        ct_records, ta_records, skip_list = service._normalize_and_group(
+            distinct_tags, execution_timestamp
+        )
+
+        # Should be 1 canonical tag
+        assert len(ct_records) == 1
+
+        # Canonical form should be "Python" (title case with highest count)
+        assert ct_records[0]["canonical_form"] == "Python"
+        assert ct_records[0]["normalized_form"] == "python"
+
+    @pytest.mark.asyncio
+    async def test_batch_record_fields(self, service: TagBackfillService) -> None:
+        """Verify canonical_tags records have correct keys and types."""
+        distinct_tags = {"Python": 10}
+        execution_timestamp = datetime.now(UTC)
+
+        ct_records, ta_records, skip_list = service._normalize_and_group(
+            distinct_tags, execution_timestamp
+        )
+
+        assert len(ct_records) == 1
+        record = ct_records[0]
+
+        # Verify all required keys are present
+        assert set(record.keys()) == {
+            "id",
+            "canonical_form",
+            "normalized_form",
+            "alias_count",
+            "video_count",
+            "status",
+        }
+
+        # Verify types
+        assert isinstance(record["id"], uuid.UUID)
+        assert isinstance(record["canonical_form"], str)
+        assert isinstance(record["normalized_form"], str)
+        assert isinstance(record["alias_count"], int)
+        assert isinstance(record["video_count"], int)
+        assert isinstance(record["status"], str)
+
+        # Verify values
+        assert record["canonical_form"] == "Python"
+        assert record["normalized_form"] == "python"
+        assert record["alias_count"] == 1
+        assert record["video_count"] == 0
+        assert record["status"] == "active"
+
+    @pytest.mark.asyncio
+    async def test_alias_record_fields(self, service: TagBackfillService) -> None:
+        """Verify tag_aliases records have correct keys and types."""
+        distinct_tags = {"Python": 10}
+        execution_timestamp = datetime.now(UTC)
+
+        ct_records, ta_records, skip_list = service._normalize_and_group(
+            distinct_tags, execution_timestamp
+        )
+
+        assert len(ta_records) == 1
+        record = ta_records[0]
+
+        # Verify all required keys are present
+        assert set(record.keys()) == {
+            "id",
+            "raw_form",
+            "normalized_form",
+            "canonical_tag_id",
+            "creation_method",
+            "normalization_version",
+            "occurrence_count",
+            "first_seen_at",
+            "last_seen_at",
+        }
+
+        # Verify types
+        assert isinstance(record["id"], uuid.UUID)
+        assert isinstance(record["raw_form"], str)
+        assert isinstance(record["normalized_form"], str)
+        assert isinstance(record["canonical_tag_id"], uuid.UUID)
+        assert isinstance(record["creation_method"], str)
+        assert isinstance(record["normalization_version"], int)
+        assert isinstance(record["occurrence_count"], int)
+        assert isinstance(record["first_seen_at"], datetime)
+        assert isinstance(record["last_seen_at"], datetime)
+
+        # Verify values
+        assert record["raw_form"] == "Python"
+        assert record["normalized_form"] == "python"
+        assert record["creation_method"] == "backfill"
+        assert record["normalization_version"] == 1
+        assert record["occurrence_count"] == 10
+
+    @pytest.mark.asyncio
+    async def test_execution_timestamp_used(self, service: TagBackfillService) -> None:
+        """Verify first_seen_at and last_seen_at both match execution_timestamp."""
+        distinct_tags = {"Python": 10}
+        execution_timestamp = datetime(2023, 5, 15, 10, 30, 45, tzinfo=UTC)
+
+        ct_records, ta_records, skip_list = service._normalize_and_group(
+            distinct_tags, execution_timestamp
+        )
+
+        assert len(ta_records) == 1
+        record = ta_records[0]
+
+        assert record["first_seen_at"] == execution_timestamp
+        assert record["last_seen_at"] == execution_timestamp
+
+    @pytest.mark.asyncio
+    async def test_alias_count_matches_group_size(
+        self, service: TagBackfillService
+    ) -> None:
+        """Verify alias_count on canonical tag equals number of aliases."""
+        distinct_tags = {"Python": 100, "python": 50, "PYTHON": 25}
+        execution_timestamp = datetime.now(UTC)
+
+        ct_records, ta_records, skip_list = service._normalize_and_group(
+            distinct_tags, execution_timestamp
+        )
+
+        # Should be 1 canonical tag with 3 aliases
+        assert len(ct_records) == 1
+        assert ct_records[0]["alias_count"] == 3
+
+        # Should be 3 tag aliases
+        assert len(ta_records) == 3
+
+    @pytest.mark.asyncio
+    async def test_varchar_500_boundary_casefold(
+        self, service: TagBackfillService
+    ) -> None:
+        """Test a tag at VARCHAR(500) boundary where casefold expansion increases length."""
+        # Create a string at the boundary with German ß (expands to ss)
+        # 499 chars + ß (1 char) = 500 chars, but casefold → 501 chars
+        base_str = "a" * 499
+        tag_with_eszett = base_str + "ß"  # 500 chars
+
+        distinct_tags = {tag_with_eszett: 1}
+        execution_timestamp = datetime.now(UTC)
+
+        # This should NOT raise an exception in the service
+        # (the DB will enforce the length constraint)
+        ct_records, ta_records, skip_list = service._normalize_and_group(
+            distinct_tags, execution_timestamp
+        )
+
+        # Verify the normalization happened
+        assert len(ta_records) == 1
+        assert ta_records[0]["raw_form"] == tag_with_eszett
+
+        # The normalized form will be 501 chars (499 a's + ss)
+        normalized = ta_records[0]["normalized_form"]
+        assert normalized == base_str + "ss"
+        assert len(normalized) == 501
+
+
+# =========================================================================
+# TestBatchSizeValidation — batch_size validation in run_backfill
+# =========================================================================
+
+
+class TestBatchSizeValidation:
+    """Tests for batch_size validation in ``run_backfill``."""
+
+    @pytest.mark.asyncio
+    async def test_batch_size_zero_raises_system_exit_2(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """batch_size=0 raises SystemExit with code 2."""
+        with pytest.raises(SystemExit) as exc_info:
+            await service.run_backfill(mock_session, batch_size=0)
+        assert exc_info.value.code == 2
+
+    @pytest.mark.asyncio
+    async def test_batch_size_negative_raises_system_exit_2(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """batch_size=-1 raises SystemExit with code 2."""
+        with pytest.raises(SystemExit) as exc_info:
+            await service.run_backfill(mock_session, batch_size=-1)
+        assert exc_info.value.code == 2
+
+    @pytest.mark.asyncio
+    async def test_batch_size_one_succeeds(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """batch_size=1 does NOT raise (mock the rest of the pipeline)."""
+        # Mock table existence check
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = []  # no missing tables
+
+        # Mock repository get_distinct_tags_with_counts
+        with patch(
+            "chronovista.services.tag_backfill.VideoTagRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_distinct_tags_with_counts.return_value = []
+
+            # Mock session.execute for batch inserts
+            mock_result = MagicMock()
+            mock_result.rowcount = 0
+            mock_session.execute.return_value = mock_result
+
+            # Should NOT raise
+            await service.run_backfill(mock_session, batch_size=1)
+
+
+# =========================================================================
+# TestCheckTablesExist — table existence validation
+# =========================================================================
+
+
+class TestCheckTablesExist:
+    """Tests for ``_check_tables_exist`` method."""
+
+    @pytest.mark.asyncio
+    async def test_both_tables_present_succeeds(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """No exception when both tables exist."""
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = []  # no missing tables
+
+        # Should not raise
+        await service._check_tables_exist(mock_session)
+
+    @pytest.mark.asyncio
+    async def test_missing_canonical_tags_raises(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """SystemExit when canonical_tags missing."""
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = ["canonical_tags"]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await service._check_tables_exist(mock_session)
+
+        # Verify error message
+        assert "canonical_tags" in str(exc_info.value)
+        assert "alembic upgrade head" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_missing_tag_aliases_raises(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """SystemExit when tag_aliases missing."""
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = ["tag_aliases"]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await service._check_tables_exist(mock_session)
+
+        # Verify error message
+        assert "tag_aliases" in str(exc_info.value)
+        assert "alembic upgrade head" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_both_missing_raises(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """SystemExit when both missing, message includes both names."""
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = ["canonical_tags", "tag_aliases"]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await service._check_tables_exist(mock_session)
+
+        # Verify both table names are in the error message
+        error_msg = str(exc_info.value)
+        assert "canonical_tags" in error_msg
+        assert "tag_aliases" in error_msg
+        assert "alembic upgrade head" in error_msg
+
+
+# =========================================================================
+# TestKnownFalseMergePatterns — verify constant
+# =========================================================================
+
+
+class TestKnownFalseMergePatterns:
+    """Tests for KNOWN_FALSE_MERGE_PATTERNS constant."""
+
+    def test_has_exactly_five_entries(self) -> None:
+        """Verify KNOWN_FALSE_MERGE_PATTERNS has exactly 5 entries."""
+        assert len(KNOWN_FALSE_MERGE_PATTERNS) == 5
+
+    def test_contains_expected_patterns(self) -> None:
+        """Verify the expected false-merge patterns are present."""
+        expected = {"cafe", "resume", "cliche", "naive", "rape"}
+        assert KNOWN_FALSE_MERGE_PATTERNS == expected
+
+    def test_is_frozenset(self) -> None:
+        """Verify KNOWN_FALSE_MERGE_PATTERNS is immutable (frozenset)."""
+        assert isinstance(KNOWN_FALSE_MERGE_PATTERNS, frozenset)
+
+
+# =========================================================================
+# TestDetectCollisions — collision detection (T012)
+# =========================================================================
+
+
+class TestDetectCollisions:
+    """Tests for ``_detect_collisions`` method."""
+
+    def test_cafe_collision(self, service: TagBackfillService) -> None:
+        """Diacritic collision: cafe/cafe → detected, is_known_false_merge=True."""
+        groups = {"cafe": [("cafe", 89), ("cafe", 45)]}
+        # Actually use distinct diacritic forms
+        groups = {"cafe": [("cafe\u0301", 89), ("cafe", 45)]}
+        result = service._detect_collisions(groups)
+
+        assert len(result) == 1
+        assert result[0]["normalized_form"] == "cafe"
+        assert result[0]["is_known_false_merge"] is True
+        assert len(result[0]["aliases"]) == 2
+
+    def test_case_hashtag_not_collision(self, service: TagBackfillService) -> None:
+        """Case and hashtag variations are NOT collisions (casefold collapses them)."""
+        groups = {
+            "mexico": [
+                ("Mexico", 50),
+                ("MEXICO", 30),
+                ("#mexico", 10),
+            ]
+        }
+        result = service._detect_collisions(groups)
+
+        # After strip #, strip whitespace, casefold: all become "mexico"
+        assert len(result) == 0
+
+    def test_empty_groups(self, service: TagBackfillService) -> None:
+        """Empty groups dict returns empty collision list."""
+        result = service._detect_collisions({})
+        assert result == []
+
+    def test_single_alias_no_collision(self, service: TagBackfillService) -> None:
+        """Groups with only 1 alias cannot be collisions."""
+        groups = {
+            "python": [("Python", 100)],
+            "java": [("Java", 80)],
+        }
+        result = service._detect_collisions(groups)
+        assert result == []
+
+    def test_known_false_merge_flag(self, service: TagBackfillService) -> None:
+        """Verify each of the 5 known patterns gets flagged."""
+        groups = {
+            "cafe": [("cafe", 10), ("\u0063\u0061\u0066\u00e9", 5)],  # cafe vs cafe
+            "resume": [("resume", 10), ("r\u00e9sum\u00e9", 5)],  # resume vs resume
+            "cliche": [("cliche", 10), ("clich\u00e9", 5)],  # cliche vs cliche
+            "naive": [("naive", 10), ("na\u00efve", 5)],  # naive vs naive
+            "rape": [("rape", 10), ("Rap\u00e9", 5)],  # rape vs Rapé
+        }
+        result = service._detect_collisions(groups)
+
+        # All 5 should be detected and flagged as known false-merges
+        assert len(result) == 5
+        for collision in result:
+            assert collision["is_known_false_merge"] is True
+
+    def test_sort_by_occurrence_descending(self, service: TagBackfillService) -> None:
+        """Multiple collisions sorted by total occurrence count descending."""
+        groups = {
+            "cafe": [("cafe", 10), ("caf\u00e9", 5)],  # total 15
+            "resume": [("resume", 100), ("r\u00e9sum\u00e9", 50)],  # total 150
+            "naive": [("naive", 30), ("na\u00efve", 20)],  # total 50
+        }
+        result = service._detect_collisions(groups)
+
+        assert len(result) == 3
+        # Should be sorted: resume (150) > naive (50) > cafe (15)
+        assert result[0]["normalized_form"] == "resume"
+        assert result[1]["normalized_form"] == "naive"
+        assert result[2]["normalized_form"] == "cafe"
+
+
+# =========================================================================
+# TestRunAnalysis — analysis output (T013)
+# =========================================================================
+
+
+class TestRunAnalysis:
+    """Tests for ``run_analysis`` method."""
+
+    @pytest.mark.asyncio
+    async def test_json_output_schema(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """Verify JSON output has all required keys."""
+        # Mock table existence check
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = []  # no missing tables
+
+        # Mock repository
+        with patch(
+            "chronovista.services.tag_backfill.VideoTagRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            mock_repo.get_distinct_tags_with_counts.return_value = [
+                ("Python", 100),
+                ("python", 50),
+                ("#Python", 25),
+                ("Java", 80),
+                ("#", 3),
+            ]
+
+            mock_console = MagicMock()
+            result = await service.run_analysis(
+                mock_session, output_format="json", console=mock_console
+            )
+
+        # Verify result is a dict with correct keys
+        assert result is not None
+        assert isinstance(result, dict)
+        required_keys = {
+            "total_distinct_tags",
+            "estimated_canonical_tags",
+            "skip_count",
+            "top_canonical_tags",
+            "collision_candidates",
+            "skipped_tags",
+        }
+        assert set(result.keys()) == required_keys
+
+        # Verify types
+        assert isinstance(result["total_distinct_tags"], int)
+        assert isinstance(result["estimated_canonical_tags"], int)
+        assert isinstance(result["skip_count"], int)
+        assert isinstance(result["top_canonical_tags"], list)
+        assert isinstance(result["collision_candidates"], list)
+        assert isinstance(result["skipped_tags"], list)
+
+        # Verify values
+        assert result["total_distinct_tags"] == 5
+        assert result["estimated_canonical_tags"] == 2  # python, java
+        assert result["skip_count"] == 1  # "#"
+
+        # Verify top canonical tags schema
+        for entry in result["top_canonical_tags"]:
+            assert "canonical_form" in entry
+            assert "normalized_form" in entry
+            assert "alias_count" in entry
+            assert "aliases" in entry
+
+        # Verify skipped tags schema
+        assert len(result["skipped_tags"]) == 1
+        assert result["skipped_tags"][0]["raw_form"] == "#"
+        assert result["skipped_tags"][0]["occurrence_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_top_20_with_fewer_groups(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """When <20 groups exist, return all of them."""
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = []
+
+        with patch(
+            "chronovista.services.tag_backfill.VideoTagRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            # Only 3 distinct tags → 3 groups
+            mock_repo.get_distinct_tags_with_counts.return_value = [
+                ("Python", 100),
+                ("Java", 80),
+                ("Go", 60),
+            ]
+
+            mock_console = MagicMock()
+            result = await service.run_analysis(
+                mock_session, output_format="json", console=mock_console
+            )
+
+        assert result is not None
+        assert len(result["top_canonical_tags"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_deterministic_output(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """Run twice with same data, verify identical results."""
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = []
+
+        tag_data = [
+            ("Python", 100),
+            ("python", 50),
+            ("Java", 80),
+            ("java", 40),
+            ("Go", 60),
+        ]
+
+        results = []
+        for _ in range(2):
+            with patch(
+                "chronovista.services.tag_backfill.VideoTagRepository"
+            ) as mock_repo_class:
+                mock_repo = AsyncMock()
+                mock_repo_class.return_value = mock_repo
+                mock_repo.get_distinct_tags_with_counts.return_value = tag_data
+
+                mock_console = MagicMock()
+                result = await service.run_analysis(
+                    mock_session, output_format="json", console=mock_console
+                )
+                results.append(result)
+
+        # Both runs should produce identical results
+        assert results[0] == results[1]
+
+    @pytest.mark.asyncio
+    async def test_table_format_output(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """Verify table format renders output and returns None."""
+        import io
+        from rich.console import Console
+
+        # Mock table existence check
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = []  # no missing tables
+
+        # Mock repository with test data
+        with patch(
+            "chronovista.services.tag_backfill.VideoTagRepository"
+        ) as mock_repo_class:
+            mock_repo = AsyncMock()
+            mock_repo_class.return_value = mock_repo
+            # Include collision candidate and skip list items
+            mock_repo.get_distinct_tags_with_counts.return_value = [
+                ("Python", 100),
+                ("python", 50),
+                ("#Python", 25),
+                ("Java", 80),
+                ("café", 80),
+                ("cafe", 45),
+                ("CAFE", 20),
+                ("#", 3),
+            ]
+
+            # Capture console output
+            output = io.StringIO()
+            test_console = Console(file=output, width=120)
+            result = await service.run_analysis(
+                mock_session, output_format="table", console=test_console
+            )
+
+        # Verify table format returns None (unlike JSON which returns dict)
+        assert result is None
+
+        # Verify output contains expected sections
+        printed = output.getvalue()
+
+        # Check for summary section
+        assert "Analysis Summary" in printed or "distinct" in printed.lower()
+
+        # Check for top canonical tags section
+        assert "Top 20" in printed or "Canonical Tags" in printed
+
+        # Check for collision candidates section (should have cafe/café collision)
+        assert "Collision Candidates" in printed or "collision" in printed.lower()
+
+        # Check for expected tag names in output
+        assert "Python" in printed or "python" in printed
+        assert "Java" in printed or "java" in printed
+
+        # Check that skipped tags section is present (for "#")
+        assert "Skipped" in printed or "skipped" in printed.lower()
+
+
+# =========================================================================
+# TestRunRecount — recount utility (T017)
+# =========================================================================
+
+
+class TestRunRecount:
+    """Tests for ``run_recount`` method."""
+
+    def _mock_tables_exist(self, mock_session: AsyncMock) -> None:
+        """Set up mock so _check_tables_exist succeeds."""
+        mock_conn = AsyncMock()
+        mock_session.connection.return_value = mock_conn
+        mock_conn.run_sync.return_value = []  # no missing tables
+
+    @pytest.mark.asyncio
+    async def test_recount_with_correct_counts(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """When counts are already correct, no updates needed."""
+        self._mock_tables_exist(mock_session)
+
+        ct_id_1 = uuid.uuid4()
+        ct_id_2 = uuid.uuid4()
+
+        # Mock alias count query results
+        alias_row_1 = MagicMock()
+        alias_row_1.canonical_tag_id = ct_id_1
+        alias_row_1.new_alias_count = 3
+
+        alias_row_2 = MagicMock()
+        alias_row_2.canonical_tag_id = ct_id_2
+        alias_row_2.new_alias_count = 2
+
+        # Mock video count query results
+        video_row_1 = MagicMock()
+        video_row_1.canonical_tag_id = ct_id_1
+        video_row_1.new_video_count = 10
+
+        video_row_2 = MagicMock()
+        video_row_2.canonical_tag_id = ct_id_2
+        video_row_2.new_video_count = 5
+
+        # Current counts match new counts exactly
+        current_row_1 = MagicMock()
+        current_row_1.id = ct_id_1
+        current_row_1.alias_count = 3
+        current_row_1.video_count = 10
+
+        current_row_2 = MagicMock()
+        current_row_2.id = ct_id_2
+        current_row_2.alias_count = 2
+        current_row_2.video_count = 5
+
+        alias_result = MagicMock()
+        alias_result.all.return_value = [alias_row_1, alias_row_2]
+
+        video_result = MagicMock()
+        video_result.all.return_value = [video_row_1, video_row_2]
+
+        current_result = MagicMock()
+        current_result.all.return_value = [current_row_1, current_row_2]
+
+        # UPDATE statements still execute even if no rows change
+        update_result = MagicMock()
+        update_result.rowcount = 0
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                alias_result,
+                video_result,
+                current_result,
+                update_result,  # alias_count UPDATE
+                update_result,  # video_count UPDATE
+            ]
+        )
+
+        mock_console = MagicMock()
+        await service.run_recount(mock_session, dry_run=False, console=mock_console)
+
+        # With no deltas, "Total updated: 0" should be printed
+        print_calls = [str(c) for c in mock_console.print.call_args_list]
+        output = " ".join(print_calls)
+        assert "Total updated: 0" in output
+
+        # commit is always called in non-dry-run mode
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_recount_with_stale_counts(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """When counts are stale, deltas are detected and updates written."""
+        self._mock_tables_exist(mock_session)
+
+        ct_id_1 = uuid.uuid4()
+
+        # New alias count = 5, but current = 3 (stale)
+        alias_row = MagicMock()
+        alias_row.canonical_tag_id = ct_id_1
+        alias_row.new_alias_count = 5
+
+        # New video count = 15, but current = 10 (stale)
+        video_row = MagicMock()
+        video_row.canonical_tag_id = ct_id_1
+        video_row.new_video_count = 15
+
+        current_row = MagicMock()
+        current_row.id = ct_id_1
+        current_row.alias_count = 3
+        current_row.video_count = 10
+
+        alias_result = MagicMock()
+        alias_result.all.return_value = [alias_row]
+
+        video_result = MagicMock()
+        video_result.all.return_value = [video_row]
+
+        current_result = MagicMock()
+        current_result.all.return_value = [current_row]
+
+        # UPDATE alias_count, UPDATE video_count each return a result
+        update_result = MagicMock()
+        update_result.rowcount = 1
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                alias_result,
+                video_result,
+                current_result,
+                update_result,  # alias_count UPDATE
+                update_result,  # video_count UPDATE
+            ]
+        )
+
+        mock_console = MagicMock()
+        await service.run_recount(mock_session, dry_run=False, console=mock_console)
+
+        # Should report 1 updated
+        print_calls = [str(c) for c in mock_console.print.call_args_list]
+        output = " ".join(print_calls)
+        assert "Total updated: 1" in output
+
+        # commit should have been called
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_shows_deltas(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """dry_run=True shows delta table without writing to database."""
+        self._mock_tables_exist(mock_session)
+
+        ct_id_1 = uuid.uuid4()
+
+        # Stale alias count
+        alias_row = MagicMock()
+        alias_row.canonical_tag_id = ct_id_1
+        alias_row.new_alias_count = 7
+
+        video_row = MagicMock()
+        video_row.canonical_tag_id = ct_id_1
+        video_row.new_video_count = 20
+
+        current_row = MagicMock()
+        current_row.id = ct_id_1
+        current_row.alias_count = 3
+        current_row.video_count = 10
+
+        alias_result = MagicMock()
+        alias_result.all.return_value = [alias_row]
+
+        video_result = MagicMock()
+        video_result.all.return_value = [video_row]
+
+        current_result = MagicMock()
+        current_result.all.return_value = [current_row]
+
+        mock_session.execute = AsyncMock(
+            side_effect=[alias_result, video_result, current_result]
+        )
+
+        mock_console = MagicMock()
+        await service.run_recount(mock_session, dry_run=True, console=mock_console)
+
+        # Should NOT have called commit (dry run)
+        mock_session.commit.assert_not_called()
+
+        # Should have printed the delta table and total
+        print_calls = [str(c) for c in mock_console.print.call_args_list]
+        output = " ".join(print_calls)
+        assert "Total with deltas: 1" in output
+
+        # Only 3 execute calls (read queries), no UPDATE executes
+        assert mock_session.execute.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_canonical_tags(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """Empty canonical_tags table returns 0 updated with no error."""
+        self._mock_tables_exist(mock_session)
+
+        # All queries return empty results
+        empty_result = MagicMock()
+        empty_result.all.return_value = []
+
+        # UPDATE statements also return a result
+        update_result = MagicMock()
+        update_result.rowcount = 0
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                empty_result,   # alias count query
+                empty_result,   # video count query
+                empty_result,   # current counts query
+                update_result,  # alias_count UPDATE
+                update_result,  # video_count UPDATE
+            ]
+        )
+
+        mock_console = MagicMock()
+        await service.run_recount(mock_session, dry_run=False, console=mock_console)
+
+        # Should report 0 updated
+        print_calls = [str(c) for c in mock_console.print.call_args_list]
+        output = " ".join(print_calls)
+        assert "Total updated: 0" in output
+
+    @pytest.mark.asyncio
+    async def test_dry_run_correct_counts_message(
+        self, service: TagBackfillService, mock_session: AsyncMock
+    ) -> None:
+        """dry_run=True with correct counts prints 'All counts are correct.'."""
+        self._mock_tables_exist(mock_session)
+
+        ct_id_1 = uuid.uuid4()
+
+        alias_row = MagicMock()
+        alias_row.canonical_tag_id = ct_id_1
+        alias_row.new_alias_count = 3
+
+        video_row = MagicMock()
+        video_row.canonical_tag_id = ct_id_1
+        video_row.new_video_count = 10
+
+        current_row = MagicMock()
+        current_row.id = ct_id_1
+        current_row.alias_count = 3
+        current_row.video_count = 10
+
+        alias_result = MagicMock()
+        alias_result.all.return_value = [alias_row]
+
+        video_result = MagicMock()
+        video_result.all.return_value = [video_row]
+
+        current_result = MagicMock()
+        current_result.all.return_value = [current_row]
+
+        mock_session.execute = AsyncMock(
+            side_effect=[alias_result, video_result, current_result]
+        )
+
+        mock_console = MagicMock()
+        await service.run_recount(mock_session, dry_run=True, console=mock_console)
+
+        # Should print "All counts are correct."
+        print_calls = [str(c) for c in mock_console.print.call_args_list]
+        output = " ".join(print_calls)
+        assert "All counts are correct." in output
+
+        # No writes at all
+        mock_session.commit.assert_not_called()

--- a/tests/unit/services/test_tag_normalization.py
+++ b/tests/unit/services/test_tag_normalization.py
@@ -113,26 +113,24 @@ class TestNormalize:
         else:
             assert svc.normalize(first) == first
 
-    def test_idempotency_double_hash_converges(
+    def test_idempotency_double_hash_strips_all(
         self, svc: TagNormalizationService
     ) -> None:
-        """'##double' converges after two passes (output with leading '#' is not stable)."""
-        first = svc.normalize("##double")
-        assert first == "#double"
-        second = svc.normalize(first)
-        assert second == "double"
-        # Third pass is stable
-        assert svc.normalize(second) == second
+        """'##double' strips ALL leading '#' characters in one pass (FR-007 idempotency)."""
+        result = svc.normalize("##double")
+        assert result == "double"
+        # Second pass is stable (idempotent)
+        assert svc.normalize(result) == result
 
     # ----- edge cases: hashtag stripping ---------------------------------
 
-    def test_triple_hash_strips_one(self, svc: TagNormalizationService) -> None:
-        """'###' strips one '#' leaving '##'."""
-        assert svc.normalize("###") == "##"
+    def test_triple_hash_strips_all(self, svc: TagNormalizationService) -> None:
+        """'###' strips ALL '#' characters, yielding None (empty string)."""
+        assert svc.normalize("###") is None
 
     def test_double_hash_tag(self, svc: TagNormalizationService) -> None:
-        """'##double' strips one '#' leaving '#double'."""
-        assert svc.normalize("##double") == "#double"
+        """'##double' strips ALL leading '#' characters, leaving 'double'."""
+        assert svc.normalize("##double") == "double"
 
     # ----- edge cases: zero-width characters -----------------------------
 


### PR DESCRIPTION
## Summary

- **TagBackfillService** bulk pipeline: processes 141,163 distinct tags through the 9-step Unicode normalization pipeline into 124,686 canonical groups with 141,163 aliases
- Three new CLI commands: `tags normalize` (backfill), `tags analyze` (read-only preview with collision detection), `tags recount` (count recalculation)
- SQLAlchemy Core `INSERT ... ON CONFLICT DO NOTHING` bulk inserts with pre-generated UUIDv7 primary keys and per-batch (1,000) transaction commits
- Idempotency fix: changed single `#` strip to `lstrip("#")` in `TagNormalizationService` so `normalize(normalize(x)) == normalize(x)` holds for all inputs
- Version bump to v0.32.0

## Key Design Decisions

- **SQLAlchemy Core over ORM**: First use in codebase — justified by 140K+ inserts (ORM would be prohibitively slow)
- **Two-pass video_count**: Insert `canonical_tags` with `video_count=0`, then single SQL `UPDATE ... FROM (subquery JOIN)` for accuracy
- **Shared `_normalize_and_group_core()`**: Used by both backfill (with UUID generation) and analysis (read-only, no UUIDs)
- **Collision detection**: Flags diacritic-affected merges (e.g., Perú/Peru) for manual review — not errors, just review candidates
- **`KNOWN_FALSE_MERGE_PATTERNS`**: Source-code-only display labels (5 entries); does not prevent merges or persist to DB

## Test plan

- [x] 37 unit tests for `TagBackfillService` (normalization grouping, batch inserts, table checks, collision detection, analysis, recount)
- [x] 12 integration tests against real DB (full pipeline, idempotent rerun, video counts, edge cases, interrupted-then-resumed)
- [x] 17 CLI integration tests for `normalize`, `analyze`, `recount` commands
- [x] 6 unit tests for `get_distinct_tags_with_counts()` repository method
- [x] Hypothesis property-based idempotency tests (500 examples)
- [x] Updated 3 existing normalization tests for `lstrip("#")` fix
- [x] Full suite: 5,255 backend + 1,965 frontend = 7,220 tests passing, 0 regressions
- [x] mypy strict: 0 errors on all new and modified files