### PR TITLE
feat(tags): add tag management CLI (Feature 031, ADR-003 Phase 4)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive user guide and API reference
 - Architecture documentation
 
+## [0.34.0] - 2026-02-27
+
+### Added
+- **Feature 031: Tag Management CLI (ADR-003 Phase 4)**
+  - 7 new CLI commands for manual curation of 124,686 canonical tags with full undo capability
+  - `tags merge <sources...> --into <target>` — merge spelling variants with multi-source support (single atomic operation)
+  - `tags split <normalized_form> --aliases "raw1,raw2,..."` — split incorrectly merged aliases into a new canonical tag
+  - `tags rename <normalized_form> --to "New Form"` — change display form without affecting normalized form
+  - `tags classify <normalized_form> --type <entity_type>` — assign entity type (person, organization, place, event, work, technical_term, topic, descriptor)
+  - `tags classify --top N` — display top N unclassified canonical tags by video count for triage
+  - `tags deprecate <normalized_form>` — soft-delete junk tags (excluded from search/browse, data preserved)
+  - `tags collisions` — interactive review of Tier 1 diacritic collision candidates with [s]plit/[k]eep/[n]ext actions
+  - `tags undo <operation_id>` — reverse any operation using self-contained `rollback_data` JSONB
+  - `tags undo --list` — show 20 most recent operations with IDs, types, timestamps, rolled_back status
+  - `TagManagementService` orchestrating all operations with atomic transactions and type-specific undo handlers
+  - Entity classification creates `named_entities` + `entity_aliases` records for entity-producing types; topic/descriptor set `entity_type` only
+  - Upsert semantics for entity alias creation handling duplicate normalized forms (e.g., "Aaron Mate" / "Aaron Maté")
+  - `TagOperationLogRepository` for audit trail access (get, exists, get_recent, get_by_operation_id)
+  - 4 Pydantic V2 models: `TagOperationLogBase`, `TagOperationLogCreate`, `TagOperationLogUpdate`, `TagOperationLog`
+  - 7 result dataclasses: `MergeResult`, `SplitResult`, `RenameResult`, `ClassifyResult`, `DeprecateResult`, `UndoResult`, `CollisionGroup`
+  - All commands support `--reason "text"` flag stored in operation logs
+  - Rich console output with formatted panels and tables for all operations
+
+### Fixed
+- UUID JSON serialization in `tag_operation_logs` JSONB columns (Pydantic V2 coercion workaround)
+- Entity alias unique constraint violation during classify when multiple aliases normalize to same form
+
+### Technical
+- 181 new tests (73 unit service + 35 unit repository + 73 integration CLI)
+- 5,493 total tests passing with 0 regressions
+- mypy strict compliance (0 errors across 415 source files)
+- No new dependencies, no database migrations
+- `video_tags` table never modified (Safety Guarantee #1 from ADR-003)
+
 ## [0.33.0] - 2026-02-23
 
 ### Added

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -94,6 +94,26 @@ Project-specific terminology used throughout chronovista documentation and code.
 **Tier 1 Diacritics**
 :   Eight combining marks that are universally safe to strip during normalization: acute, grave, circumflex, diaeresis, macron, breve, dot above, and ring above. Stripping these merges common accent variants (e.g., café/cafe) without changing letter identity.
 
+## Tag Management Concepts
+
+**Tag Management**
+:   Manual curation of the canonical tag system via CLI commands. Includes merging spelling variants, splitting incorrectly merged tags, renaming display forms, classifying tags as named entities, reviewing diacritic collisions, and deprecating junk tags. All operations are logged with full rollback data for undo capability.
+
+**Tag Operation Log**
+:   An audit trail record in the `tag_operation_logs` table. Each tag management operation (merge, split, rename, classify, deprecate) creates a log entry with `operation_type`, `reason`, `performed_by`, and `rollback_data` JSONB containing the complete previous state needed to reverse the operation.
+
+**Rollback Data**
+:   A self-contained JSON snapshot stored in `tag_operation_logs.rollback_data` that captures everything needed to undo an operation without reading other tables. For example, a merge operation's rollback data includes the source canonical IDs, alias reassignments, and previous counts.
+
+**Entity Classification**
+:   Assigning an `entity_type` to a canonical tag (e.g., person, organization, place). Entity-producing types (person, organization, place, event, work, technical_term) create a `named_entities` record and copy tag aliases as `entity_aliases`. Tag-only types (topic, descriptor) set `entity_type` on the canonical tag without creating entity records.
+
+**Deprecated Tag**
+:   A canonical tag with `status = 'deprecated'`. Excluded from search and browse results but all data (aliases, video links) is preserved. Deprecation is reversible via `tags undo`.
+
+**Diacritic Collision**
+:   A canonical tag group where raw forms differ by accents that were stripped during Tier 1 normalization. For example, "café" and "cafe" both normalize to "cafe" and get merged. The `tags collisions` command identifies these for manual review — most are correct merges, but some may need splitting.
+
 ## Technical Concepts
 
 **Development Mode**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.33.0"
+version = "0.34.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/cli/tag_commands.py
+++ b/src/chronovista/cli/tag_commands.py
@@ -8,7 +8,11 @@ add to their videos to help with discoverability and categorization.
 from __future__ import annotations
 
 import asyncio
-from typing import List, Optional
+import logging
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from chronovista.services.tag_management import TagManagementService
 
 import typer
 from rich.console import Console
@@ -19,6 +23,8 @@ from chronovista.config.database import db_manager
 from chronovista.models.video_tag import VideoTagSearchFilters
 from chronovista.repositories.video_repository import VideoRepository
 from chronovista.repositories.video_tag_repository import VideoTagRepository
+
+logger = logging.getLogger(__name__)
 
 console = Console()
 
@@ -556,3 +562,802 @@ def recount_tags(
         asyncio.run(_run())
     except SystemExit as e:
         raise typer.Exit(code=e.code if isinstance(e.code, int) else 1)
+
+
+# ---------------------------------------------------------------------------
+# Tag Management Commands (Feature 031)
+# ---------------------------------------------------------------------------
+
+
+def _reason_callback(value: Optional[str]) -> Optional[str]:
+    """Validate --reason text length (max 1000 characters)."""
+    if value is not None and len(value) > 1000:
+        raise typer.BadParameter(
+            f"Reason text is too long ({len(value)} chars). "
+            "Maximum is 1,000 characters."
+        )
+    return value
+
+
+def _create_tag_management_service() -> "TagManagementService":
+    """Create a TagManagementService with all required repositories."""
+    from chronovista.repositories.canonical_tag_repository import (
+        CanonicalTagRepository,
+    )
+    from chronovista.repositories.entity_alias_repository import (
+        EntityAliasRepository,
+    )
+    from chronovista.repositories.named_entity_repository import (
+        NamedEntityRepository,
+    )
+    from chronovista.repositories.tag_alias_repository import TagAliasRepository
+    from chronovista.repositories.tag_operation_log_repository import (
+        TagOperationLogRepository,
+    )
+    from chronovista.services.tag_management import TagManagementService
+
+    return TagManagementService(
+        canonical_tag_repo=CanonicalTagRepository(),
+        tag_alias_repo=TagAliasRepository(),
+        named_entity_repo=NamedEntityRepository(),
+        entity_alias_repo=EntityAliasRepository(),
+        operation_log_repo=TagOperationLogRepository(),
+    )
+
+
+@tag_app.command("merge")
+def merge_tags(
+    sources: List[str] = typer.Argument(
+        ..., help="Normalized form(s) of source tag(s) to merge"
+    ),
+    into: str = typer.Option(
+        ..., "--into", help="Normalized form of the target tag to merge into"
+    ),
+    reason: Optional[str] = typer.Option(
+        None,
+        "--reason",
+        help="Reason for the merge (max 1000 chars)",
+        callback=_reason_callback,
+    ),
+) -> None:
+    """Merge one or more source tags into a target tag."""
+
+    async def _run() -> None:
+        from chronovista.services.tag_management import MergeResult
+
+        service = _create_tag_management_service()
+
+        async for session in db_manager.get_session(echo=False):
+            try:
+                result: MergeResult = await service.merge(
+                    session,
+                    source_normalized_forms=sources,
+                    target_normalized_form=into,
+                    reason=reason,
+                )
+                await session.commit()
+
+                details = (
+                    f"[bold]Source(s):[/bold] {', '.join(result.source_tags)}\n"
+                    f"[bold]Target:[/bold] {result.target_tag}\n"
+                    f"[bold]Aliases moved:[/bold] {result.aliases_moved}\n"
+                    f"[bold]Target alias count:[/bold] {result.new_alias_count}\n"
+                    f"[bold]Target video count:[/bold] {result.new_video_count}\n"
+                    f"[bold]Operation ID:[/bold] {result.operation_id}"
+                )
+                if result.entity_hint:
+                    details += f"\n\n[yellow]{result.entity_hint}[/yellow]"
+
+                console.print(
+                    Panel(
+                        details,
+                        title="[green]Merge Successful[/green]",
+                        border_style="green",
+                    )
+                )
+            except ValueError as e:
+                logger.warning("Merge validation failed: %s", e)
+                console.print(
+                    Panel(
+                        f"[red]{e}[/red]",
+                        title="Merge Failed",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=1)
+
+    asyncio.run(_run())
+
+
+@tag_app.command("split")
+def split_tag(
+    normalized_form: str = typer.Argument(
+        help="Normalized form of the canonical tag to split."
+    ),
+    aliases: str = typer.Option(
+        ...,
+        "--aliases",
+        help="Comma-separated list of raw alias forms to split out.",
+    ),
+    reason: Optional[str] = typer.Option(
+        None,
+        "--reason",
+        callback=_reason_callback,
+        help="Reason for the split (max 1000 chars).",
+    ),
+) -> None:
+    """Split specific aliases from a canonical tag into a new tag."""
+
+    async def _run() -> None:
+        from chronovista.services.tag_management import SplitResult
+
+        service = _create_tag_management_service()
+        alias_list = [a.strip() for a in aliases.split(",") if a.strip()]
+
+        async for session in db_manager.get_session(echo=False):
+            try:
+                result: SplitResult = await service.split(
+                    session,
+                    normalized_form=normalized_form,
+                    alias_raw_forms=alias_list,
+                    reason=reason,
+                )
+                await session.commit()
+
+                details = (
+                    f"[bold]Original tag:[/bold] {result.original_tag}\n"
+                    f"[bold]New tag:[/bold] {result.new_tag}\n"
+                    f"[bold]New canonical form:[/bold] {result.new_canonical_form}\n"
+                    f"[bold]Aliases moved:[/bold] {result.aliases_moved}\n"
+                    f"[bold]Original alias count:[/bold] {result.original_alias_count}\n"
+                    f"[bold]Original video count:[/bold] {result.original_video_count}\n"
+                    f"[bold]New alias count:[/bold] {result.new_alias_count}\n"
+                    f"[bold]New video count:[/bold] {result.new_video_count}\n"
+                    f"[bold]Operation ID:[/bold] {result.operation_id}"
+                )
+
+                console.print(
+                    Panel(
+                        details,
+                        title="[green]Split Successful[/green]",
+                        border_style="green",
+                    )
+                )
+            except ValueError as e:
+                logger.warning("Split validation failed: %s", e)
+                console.print(
+                    Panel(
+                        f"[red]{e}[/red]",
+                        title="Split Failed",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=1)
+
+    asyncio.run(_run())
+
+
+@tag_app.command("rename")
+def rename_tag(
+    normalized_form: str = typer.Argument(
+        help="Normalized form of the canonical tag to rename."
+    ),
+    to: str = typer.Option(
+        ..., "--to", help="New display form for the canonical tag."
+    ),
+    reason: Optional[str] = typer.Option(
+        None,
+        "--reason",
+        callback=_reason_callback,
+        help="Reason for the rename (max 1000 chars).",
+    ),
+) -> None:
+    """Rename a canonical tag's display form."""
+
+    async def _run() -> None:
+        from chronovista.services.tag_management import RenameResult
+
+        service = _create_tag_management_service()
+
+        async for session in db_manager.get_session(echo=False):
+            try:
+                result: RenameResult = await service.rename(
+                    session,
+                    normalized_form=normalized_form,
+                    new_display_form=to,
+                    reason=reason,
+                )
+                await session.commit()
+
+                details = (
+                    f"[bold]Old display form:[/bold] {result.old_form}\n"
+                    f"[bold]New display form:[/bold] {result.new_form}\n"
+                    f"[bold]Normalized form:[/bold] {result.normalized_form}\n"
+                    f"[bold]Operation ID:[/bold] {result.operation_id}"
+                )
+
+                console.print(
+                    Panel(
+                        details,
+                        title="[green]Rename Successful[/green]",
+                        border_style="green",
+                    )
+                )
+            except ValueError as e:
+                logger.warning("Rename validation failed: %s", e)
+                console.print(
+                    Panel(
+                        f"[red]{e}[/red]",
+                        title="Rename Failed",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=1)
+
+    asyncio.run(_run())
+
+
+@tag_app.command("deprecate")
+def deprecate_tag(
+    normalized_form: Optional[str] = typer.Argument(
+        None, help="Normalized form of the canonical tag to deprecate."
+    ),
+    list_deprecated: bool = typer.Option(
+        False,
+        "--list",
+        is_flag=True,
+        help="List all deprecated canonical tags.",
+    ),
+    reason: Optional[str] = typer.Option(
+        None,
+        "--reason",
+        callback=_reason_callback,
+        help="Reason for the deprecation (max 1000 chars).",
+    ),
+) -> None:
+    """Deprecate a canonical tag (soft delete) or list deprecated tags."""
+
+    # Mutual exclusivity check
+    if list_deprecated and normalized_form is not None:
+        console.print(
+            Panel(
+                "[red]Cannot use --list together with a tag argument.[/red]",
+                title="Invalid Usage",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(code=2)
+
+    if not list_deprecated and normalized_form is None:
+        console.print(
+            Panel(
+                "[red]Provide a tag to deprecate or use --list to see "
+                "deprecated tags.[/red]",
+                title="Invalid Usage",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(code=2)
+
+    async def _run() -> None:
+        service = _create_tag_management_service()
+
+        async for session in db_manager.get_session(echo=False):
+            if list_deprecated:
+                deprecated_tags = await service.list_deprecated(session)
+
+                if not deprecated_tags:
+                    console.print(
+                        Panel(
+                            "[yellow]No deprecated tags found.[/yellow]",
+                            title="Deprecated Tags",
+                            border_style="yellow",
+                        )
+                    )
+                    return
+
+                dep_table = Table(
+                    title=f"Deprecated Tags ({len(deprecated_tags)} total)",
+                    show_header=True,
+                    header_style="bold blue",
+                )
+                dep_table.add_column("Normalized Form", style="cyan", width=40)
+                dep_table.add_column("Canonical Form", style="white", width=40)
+                dep_table.add_column("Aliases", style="green", width=10)
+                dep_table.add_column("Videos", style="green", width=10)
+
+                for tag in deprecated_tags:
+                    dep_table.add_row(
+                        tag.normalized_form,
+                        tag.canonical_form,
+                        str(tag.alias_count),
+                        str(tag.video_count),
+                    )
+
+                console.print(dep_table)
+            else:
+                assert normalized_form is not None  # type narrowing
+                try:
+                    from chronovista.services.tag_management import DeprecateResult
+
+                    result: DeprecateResult = await service.deprecate(
+                        session,
+                        normalized_form=normalized_form,
+                        reason=reason,
+                    )
+                    await session.commit()
+
+                    details = (
+                        f"[bold]Tag:[/bold] {result.normalized_form}\n"
+                        f"[bold]Canonical form:[/bold] {result.canonical_form}\n"
+                        f"[bold]Aliases preserved:[/bold] {result.alias_count}\n"
+                        f"[bold]Operation ID:[/bold] {result.operation_id}"
+                    )
+
+                    console.print(
+                        Panel(
+                            details,
+                            title="[green]Deprecate Successful[/green]",
+                            border_style="green",
+                        )
+                    )
+                except ValueError as e:
+                    logger.warning("Deprecate validation failed: %s", e)
+                    console.print(
+                        Panel(
+                            f"[red]{e}[/red]",
+                            title="Deprecate Failed",
+                            border_style="red",
+                        )
+                    )
+                    raise typer.Exit(code=1)
+
+    asyncio.run(_run())
+
+
+@tag_app.command("undo")
+def undo_operation(
+    operation_id: Optional[str] = typer.Argument(
+        None, help="UUID of the operation to undo."
+    ),
+    list_ops: bool = typer.Option(
+        False, "--list", is_flag=True, help="List recent operations."
+    ),
+) -> None:
+    """Undo a previous tag operation, or list recent operations."""
+
+    async def _run() -> None:
+        import uuid
+
+        from chronovista.services.tag_management import (
+            UndoNotImplementedError,
+            UndoResult,
+        )
+
+        service = _create_tag_management_service()
+
+        async for session in db_manager.get_session(echo=False):
+            if list_ops:
+                operations = await service.list_recent_operations(
+                    session, limit=20
+                )
+                if not operations:
+                    console.print(
+                        Panel(
+                            "[yellow]No operations found in the audit log[/yellow]",
+                            title="No Operations",
+                            border_style="yellow",
+                        )
+                    )
+                    return
+
+                ops_table = Table(
+                    title=f"Recent Tag Operations ({len(operations)})",
+                    show_header=True,
+                    header_style="bold blue",
+                )
+                ops_table.add_column("ID", style="cyan", width=12)
+                ops_table.add_column("Type", style="white", width=10)
+                ops_table.add_column("Timestamp", style="white", width=20)
+                ops_table.add_column("Rolled Back", width=12)
+                ops_table.add_column("Reason", style="dim", width=50)
+
+                for op in operations:
+                    op_id_short = str(op.id)[:8] + "..."
+                    timestamp = (
+                        op.performed_at.strftime("%Y-%m-%d %H:%M:%S")
+                        if op.performed_at
+                        else "N/A"
+                    )
+                    rolled_back_str = (
+                        "[green]yes[/green]"
+                        if op.rolled_back
+                        else "[red]no[/red]"
+                    )
+                    reason_str = (
+                        (op.reason[:50] if len(op.reason) > 50 else op.reason)
+                        if op.reason
+                        else ""
+                    )
+                    ops_table.add_row(
+                        op_id_short,
+                        op.operation_type,
+                        timestamp,
+                        rolled_back_str,
+                        reason_str,
+                    )
+
+                console.print(ops_table)
+                return
+
+            if operation_id is None:
+                console.print(
+                    Panel(
+                        "[red]Provide an operation ID or use --list to see "
+                        "recent operations[/red]",
+                        title="Missing Argument",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=2)
+
+            try:
+                op_uuid = uuid.UUID(operation_id)
+            except ValueError:
+                console.print(
+                    Panel(
+                        f"[red]Invalid UUID: '{operation_id}'[/red]",
+                        title="Invalid Operation ID",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=1)
+
+            try:
+                result: UndoResult = await service.undo(session, op_uuid)
+                await session.commit()
+
+                details = (
+                    f"[bold]Operation type:[/bold] {result.operation_type}\n"
+                    f"[bold]Details:[/bold] {result.details}\n"
+                    f"[bold]Operation ID:[/bold] {result.operation_id}"
+                )
+
+                console.print(
+                    Panel(
+                        details,
+                        title="[green]Undo Successful[/green]",
+                        border_style="green",
+                    )
+                )
+            except ValueError as e:
+                logger.warning("Undo validation failed: %s", e)
+                console.print(
+                    Panel(
+                        f"[red]{e}[/red]",
+                        title="Undo Failed",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=1)
+            except UndoNotImplementedError as e:
+                logger.warning("Undo not implemented: %s", e)
+                console.print(
+                    Panel(
+                        f"[red]{e}[/red]",
+                        title="Undo Not Available",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=1)
+
+    asyncio.run(_run())
+
+
+@tag_app.command("classify")
+def classify_tag(
+    normalized_form: Optional[str] = typer.Argument(
+        None, help="Normalized form of the canonical tag to classify."
+    ),
+    entity_type: Optional[str] = typer.Option(
+        None,
+        "--type",
+        help=(
+            "Entity type to assign. Valid values: person, organization, "
+            "place, event, work, technical_term, topic, descriptor."
+        ),
+    ),
+    top: Optional[int] = typer.Option(
+        None,
+        "--top",
+        help="Show top N unclassified tags by video count.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        is_flag=True,
+        help="Override existing classification.",
+    ),
+    reason: Optional[str] = typer.Option(
+        None,
+        "--reason",
+        callback=_reason_callback,
+        help="Reason for the classification (max 1000 chars).",
+    ),
+) -> None:
+    """Classify a canonical tag with an entity type, or list top unclassified tags."""
+
+    # Mutual exclusivity check
+    if top is not None and normalized_form is not None:
+        console.print(
+            Panel(
+                "[red]Cannot use --top together with a tag argument. "
+                "Use either --top N or provide a normalized form with --type.[/red]",
+                title="Invalid Usage",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(code=2)
+
+    if top is None and normalized_form is None:
+        console.print(
+            Panel(
+                "[red]Provide a tag to classify with --type, or use --top N "
+                "to see top unclassified tags.[/red]",
+                title="Invalid Usage",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(code=2)
+
+    if normalized_form is not None and entity_type is None:
+        console.print(
+            Panel(
+                "[red]--type is required when classifying a tag. "
+                "Valid values: person, organization, place, event, work, "
+                "technical_term, topic, descriptor.[/red]",
+                title="Missing --type",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(code=2)
+
+    async def _run() -> None:
+        from chronovista.models.enums import EntityType
+        from chronovista.services.tag_management import ClassifyResult
+
+        service = _create_tag_management_service()
+
+        async for session in db_manager.get_session(echo=False):
+            if top is not None:
+                # Show top unclassified tags
+                tags = await service.classify_top_unclassified(
+                    session, limit=top
+                )
+
+                if not tags:
+                    console.print(
+                        Panel(
+                            "[yellow]No unclassified tags found.[/yellow]",
+                            title="Unclassified Tags",
+                            border_style="yellow",
+                        )
+                    )
+                    return
+
+                classify_table = Table(
+                    title=f"Top {len(tags)} Unclassified Tags",
+                    show_header=True,
+                    header_style="bold blue",
+                )
+                classify_table.add_column(
+                    "Normalized Form", style="cyan", width=40
+                )
+                classify_table.add_column(
+                    "Canonical Form", style="white", width=40
+                )
+                classify_table.add_column(
+                    "Videos", style="green", width=10
+                )
+                classify_table.add_column(
+                    "Aliases", style="green", width=10
+                )
+
+                for tag in tags:
+                    classify_table.add_row(
+                        tag.normalized_form,
+                        tag.canonical_form,
+                        str(tag.video_count),
+                        str(tag.alias_count),
+                    )
+
+                console.print(classify_table)
+            else:
+                assert normalized_form is not None  # type narrowing
+                assert entity_type is not None  # type narrowing
+
+                # Parse entity type string to enum
+                try:
+                    parsed_type = EntityType(entity_type)
+                except ValueError:
+                    valid_types = ", ".join(t.value for t in EntityType)
+                    console.print(
+                        Panel(
+                            f"[red]Invalid entity type '{entity_type}'. "
+                            f"Valid values: {valid_types}[/red]",
+                            title="Invalid --type",
+                            border_style="red",
+                        )
+                    )
+                    raise typer.Exit(code=1)
+
+                try:
+                    result: ClassifyResult = await service.classify(
+                        session,
+                        normalized_form=normalized_form,
+                        entity_type=parsed_type,
+                        force=force,
+                        reason=reason,
+                    )
+                    await session.commit()
+
+                    details = (
+                        f"[bold]Tag:[/bold] {result.normalized_form}\n"
+                        f"[bold]Canonical form:[/bold] {result.canonical_form}\n"
+                        f"[bold]Entity type:[/bold] {result.entity_type}\n"
+                        f"[bold]Entity created:[/bold] {result.entity_created}\n"
+                        f"[bold]Entity aliases:[/bold] {result.entity_alias_count}\n"
+                        f"[bold]Operation ID:[/bold] {result.operation_id}"
+                    )
+
+                    console.print(
+                        Panel(
+                            details,
+                            title="[green]Classify Successful[/green]",
+                            border_style="green",
+                        )
+                    )
+                except ValueError as e:
+                    logger.warning("Classify validation failed: %s", e)
+                    console.print(
+                        Panel(
+                            f"[red]{e}[/red]",
+                            title="Classify Failed",
+                            border_style="red",
+                        )
+                    )
+                    raise typer.Exit(code=1)
+
+    asyncio.run(_run())
+
+
+@tag_app.command("collisions")
+def review_collisions(
+    format: str = typer.Option(
+        "table",
+        "--format",
+        help="Output format: table (interactive) or json.",
+    ),
+    limit: Optional[int] = typer.Option(
+        None,
+        "--limit",
+        help="Maximum number of collision groups to review.",
+    ),
+    include_reviewed: bool = typer.Option(
+        False,
+        "--include-reviewed",
+        help="Include previously reviewed collisions.",
+    ),
+) -> None:
+    """Review diacritic collision candidates interactively."""
+    import json as json_module
+
+    from rich.prompt import Prompt
+    from rich.table import Table
+
+    async def _run() -> None:
+        from chronovista.services.tag_management import CollisionGroup
+
+        service = _create_tag_management_service()
+
+        async for session in db_manager.get_session(echo=False):
+            collisions: list[CollisionGroup] = await service.get_collisions(
+                session,
+                limit=limit,
+                include_reviewed=include_reviewed,
+            )
+
+            if not collisions:
+                console.print("[green]No collision candidates found.[/green]")
+                return
+
+            if format == "json":
+                output = [
+                    {
+                        "canonical_form": c.canonical_form,
+                        "normalized_form": c.normalized_form,
+                        "canonical_tag_id": str(c.canonical_tag_id),
+                        "aliases": c.aliases,
+                        "total_occurrence_count": c.total_occurrence_count,
+                    }
+                    for c in collisions
+                ]
+                console.print(json_module.dumps(output, indent=2, default=str))
+                return
+
+            # Interactive review mode
+            console.print(
+                f"\n[bold]Found {len(collisions)} collision candidate(s)[/bold]\n"
+            )
+
+            for i, collision in enumerate(collisions, 1):
+                console.print(
+                    Panel(
+                        f"[bold]Canonical form:[/bold] {collision.canonical_form}\n"
+                        f"[bold]Normalized form:[/bold] {collision.normalized_form}\n"
+                        f"[bold]Total occurrences:[/bold] {collision.total_occurrence_count}",
+                        title=f"[yellow]Collision {i}/{len(collisions)}[/yellow]",
+                        border_style="yellow",
+                    )
+                )
+
+                # Show aliases table
+                alias_table = Table(title="Aliases")
+                alias_table.add_column("Raw Form", style="cyan")
+                alias_table.add_column("Occurrences", justify="right")
+                for alias in collision.aliases:
+                    alias_table.add_row(
+                        alias["raw_form"],
+                        str(alias["occurrence_count"]),
+                    )
+                console.print(alias_table)
+
+                # Prompt for action
+                action = Prompt.ask(
+                    "\n[bold]Action[/bold]",
+                    choices=["s", "k", "n"],
+                    default="n",
+                )
+
+                if action == "s":
+                    # Split: ask which aliases to pull out
+                    alias_forms = [a["raw_form"] for a in collision.aliases]
+                    console.print(
+                        f"[bold]Available aliases:[/bold] {', '.join(alias_forms)}"
+                    )
+                    split_input = Prompt.ask(
+                        "Enter comma-separated aliases to split out"
+                    )
+                    split_aliases = [
+                        a.strip() for a in split_input.split(",") if a.strip()
+                    ]
+                    if split_aliases:
+                        try:
+                            split_result = await service.split(
+                                session,
+                                normalized_form=collision.normalized_form,
+                                alias_raw_forms=split_aliases,
+                                reason="Split from collision review",
+                            )
+                            await session.commit()
+                            console.print(
+                                f"[green]Split successful: "
+                                f"new tag '{split_result.new_tag}' with "
+                                f"{split_result.aliases_moved} aliases[/green]"
+                            )
+                        except ValueError as e:
+                            console.print(f"[red]Split failed: {e}[/red]")
+                elif action == "k":
+                    # Keep: mark as reviewed
+                    await service.log_collision_reviewed(
+                        session, collision.canonical_tag_id
+                    )
+                    await session.commit()
+                    console.print("[green]Marked as reviewed.[/green]")
+                else:
+                    # Next: skip
+                    console.print("[dim]Skipped.[/dim]")
+
+                console.print()  # blank line between groups
+
+    asyncio.run(_run())

--- a/src/chronovista/models/__init__.py
+++ b/src/chronovista/models/__init__.py
@@ -196,6 +196,12 @@ from .entity_alias import (
     EntityAliasCreate,
     EntityAliasUpdate,
 )
+from .tag_operation_log import (
+    TagOperationLog,
+    TagOperationLogBase,
+    TagOperationLogCreate,
+    TagOperationLogUpdate,
+)
 
 __all__ = [
     # YouTube API Response Models (FR-005, FR-006, FR-007)
@@ -369,6 +375,11 @@ __all__ = [
     "EntityAliasCreate",
     "EntityAliasUpdate",
     "EntityAliasBase",
+    # Tag Operation Logs (Feature 031 - Tag Management CLI)
+    "TagOperationLog",
+    "TagOperationLogCreate",
+    "TagOperationLogUpdate",
+    "TagOperationLogBase",
     # Utility functions
     "get_model_count",
 ]

--- a/src/chronovista/models/tag_operation_log.py
+++ b/src/chronovista/models/tag_operation_log.py
@@ -1,0 +1,122 @@
+"""
+Tag operation log models for audit trail of tag normalization operations.
+
+Defines Pydantic models for tag operation logs that record merges, splits,
+renames, deletions, and creations of canonical tags, with rollback support.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+ALLOWED_OPERATION_TYPES = {"merge", "split", "rename", "delete", "create"}
+
+
+class TagOperationLogBase(BaseModel):
+    """Base model for tag operation log data."""
+
+    operation_type: str = Field(
+        ...,
+        max_length=30,
+        description="Type of operation: merge, split, rename, delete, or create",
+    )
+    reason: Optional[str] = Field(
+        default=None, description="Human-readable reason for the operation"
+    )
+
+    @field_validator("operation_type")
+    @classmethod
+    def validate_operation_type(cls, v: str) -> str:
+        """Validate operation_type is one of the allowed values."""
+        if v not in ALLOWED_OPERATION_TYPES:
+            raise ValueError(
+                f"operation_type must be one of {sorted(ALLOWED_OPERATION_TYPES)}, got {v!r}"
+            )
+        return v
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class TagOperationLogCreate(TagOperationLogBase):
+    """Model for creating tag operation log entries."""
+
+    source_canonical_ids: list[str] = Field(
+        default_factory=list,
+        description="List of source canonical tag UUID strings (stored as JSONB)",
+    )
+    target_canonical_id: Optional[uuid.UUID] = Field(
+        default=None,
+        description="Target canonical tag UUID (e.g. merge destination)",
+    )
+    affected_alias_ids: list[str] = Field(
+        default_factory=list,
+        description="List of tag alias UUID strings (stored as JSONB)",
+    )
+    rollback_data: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Snapshot data required to reverse the operation",
+    )
+    performed_by: str = Field(
+        default="cli",
+        max_length=100,
+        description="Actor that performed the operation (e.g. 'cli', 'system')",
+    )
+
+
+class TagOperationLogUpdate(BaseModel):
+    """Model for updating tag operation logs (PATCH-style, all fields optional)."""
+
+    rolled_back: Optional[bool] = Field(
+        default=None, description="Whether this operation has been rolled back"
+    )
+    rolled_back_at: Optional[datetime] = Field(
+        default=None, description="Timestamp when the rollback was performed"
+    )
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
+
+class TagOperationLog(TagOperationLogBase):
+    """Full tag operation log model with all persisted fields."""
+
+    id: uuid.UUID = Field(..., description="Tag operation log UUID (UUIDv7)")
+    source_canonical_ids: list[uuid.UUID] = Field(
+        ..., description="List of source canonical tag UUIDs involved in the operation"
+    )
+    target_canonical_id: Optional[uuid.UUID] = Field(
+        default=None,
+        description="Target canonical tag UUID (e.g. merge destination)",
+    )
+    affected_alias_ids: list[uuid.UUID] = Field(
+        ..., description="List of tag alias UUIDs affected by the operation"
+    )
+    performed_by: str = Field(
+        ...,
+        max_length=100,
+        description="Actor that performed the operation",
+    )
+    performed_at: datetime = Field(
+        ..., description="Timestamp when the operation was performed"
+    )
+    rollback_data: dict[str, Any] = Field(
+        ..., description="Snapshot data required to reverse the operation"
+    )
+    rolled_back: bool = Field(
+        ..., description="Whether this operation has been rolled back"
+    )
+    rolled_back_at: Optional[datetime] = Field(
+        default=None, description="Timestamp when the rollback was performed"
+    )
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        validate_assignment=True,
+    )

--- a/src/chronovista/repositories/__init__.py
+++ b/src/chronovista/repositories/__init__.py
@@ -14,6 +14,7 @@ from .named_entity_repository import NamedEntityRepository
 from .playlist_membership_repository import PlaylistMembershipRepository
 from .playlist_repository import PlaylistRepository
 from .tag_alias_repository import TagAliasRepository
+from .tag_operation_log_repository import TagOperationLogRepository
 from .topic_category_repository import TopicCategoryRepository
 from .transcript_segment_repository import TranscriptSegmentRepository
 from .user_language_preference_repository import UserLanguagePreferenceRepository
@@ -37,6 +38,7 @@ __all__ = [
     "PlaylistMembershipRepository",
     "PlaylistRepository",
     "TagAliasRepository",
+    "TagOperationLogRepository",
     "TopicCategoryRepository",
     "TranscriptSegmentRepository",
     "UserLanguagePreferenceRepository",

--- a/src/chronovista/repositories/tag_operation_log_repository.py
+++ b/src/chronovista/repositories/tag_operation_log_repository.py
@@ -1,0 +1,128 @@
+"""
+Tag operation log repository for audit trail management.
+
+Handles CRUD operations for tag operation logs that record normalization
+and management operations with rollback support.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import TagOperationLog as TagOperationLogDB
+from chronovista.models.tag_operation_log import TagOperationLogCreate, TagOperationLogUpdate
+from chronovista.repositories.base import BaseSQLAlchemyRepository
+
+
+class TagOperationLogRepository(
+    BaseSQLAlchemyRepository[
+        TagOperationLogDB,
+        TagOperationLogCreate,
+        TagOperationLogUpdate,
+        uuid.UUID,
+    ]
+):
+    """Repository for tag operation log CRUD operations."""
+
+    def __init__(self) -> None:
+        """Initialize repository with TagOperationLog model."""
+        super().__init__(TagOperationLogDB)
+
+    async def get(
+        self, session: AsyncSession, id: uuid.UUID
+    ) -> Optional[TagOperationLogDB]:
+        """
+        Get tag operation log entry by UUID primary key.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        id : uuid.UUID
+            Primary key of the operation log entry.
+
+        Returns
+        -------
+        Optional[TagOperationLogDB]
+            The matching log entry, or ``None`` if not found.
+        """
+        result = await session.execute(
+            select(TagOperationLogDB).where(TagOperationLogDB.id == id)
+        )
+        return result.scalar_one_or_none()
+
+    async def exists(self, session: AsyncSession, id: uuid.UUID) -> bool:
+        """
+        Check if a tag operation log entry exists by UUID primary key.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        id : uuid.UUID
+            Primary key of the operation log entry.
+
+        Returns
+        -------
+        bool
+            ``True`` if the entry exists, ``False`` otherwise.
+        """
+        result = await session.execute(
+            select(TagOperationLogDB.id).where(TagOperationLogDB.id == id)
+        )
+        return result.first() is not None
+
+    async def get_recent(
+        self,
+        session: AsyncSession,
+        *,
+        limit: int = 20,
+    ) -> list[TagOperationLogDB]:
+        """
+        Get recent tag operation log entries ordered by performed_at descending.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        limit : int, optional
+            Maximum number of entries to return (default 20).
+
+        Returns
+        -------
+        list[TagOperationLogDB]
+            Operation log entries ordered by ``performed_at DESC``.
+        """
+        result = await session.execute(
+            select(TagOperationLogDB)
+            .order_by(desc(TagOperationLogDB.performed_at))
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def get_by_operation_id(
+        self, session: AsyncSession, operation_id: uuid.UUID
+    ) -> Optional[TagOperationLogDB]:
+        """
+        Get tag operation log entry by operation UUID.
+
+        Semantically equivalent to ``get()`` but uses a more descriptive name
+        intended for undo/rollback command contexts.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        operation_id : uuid.UUID
+            Primary key of the operation log entry.
+
+        Returns
+        -------
+        Optional[TagOperationLogDB]
+            The matching log entry, or ``None`` if not found.
+        """
+        return await self.get(session, operation_id)

--- a/src/chronovista/services/tag_management.py
+++ b/src/chronovista/services/tag_management.py
@@ -1,0 +1,1634 @@
+"""
+Tag management service for CLI curation operations.
+
+Orchestrates merge, split, undo, rename, classify, deprecate, and collision
+review operations on the canonical tag system. All mutations are atomic
+(single transaction) and logged to tag_operation_logs with self-contained
+rollback_data for undo capability.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy import distinct, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import CanonicalTag as CanonicalTagDB
+from chronovista.db.models import EntityAlias as EntityAliasDB
+from chronovista.db.models import NamedEntity as NamedEntityDB
+from chronovista.db.models import TagAlias as TagAliasDB
+from chronovista.db.models import TagOperationLog as TagOperationLogDB
+from chronovista.db.models import VideoTag
+from chronovista.models.enums import (
+    DiscoveryMethod,
+    EntityAliasType,
+    EntityType,
+    TagOperationType,
+    TagStatus,
+)
+from chronovista.models.tag_operation_log import (
+    TagOperationLogCreate,
+    TagOperationLogUpdate,
+)
+from chronovista.repositories.canonical_tag_repository import CanonicalTagRepository
+from chronovista.repositories.entity_alias_repository import EntityAliasRepository
+from chronovista.repositories.named_entity_repository import NamedEntityRepository
+from chronovista.repositories.tag_alias_repository import TagAliasRepository
+from chronovista.repositories.tag_operation_log_repository import (
+    TagOperationLogRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types — service-layer return types for CLI formatting
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MergeResult:
+    """Result of a merge operation."""
+
+    source_tags: list[str]
+    target_tag: str
+    aliases_moved: int
+    new_alias_count: int
+    new_video_count: int
+    operation_id: uuid.UUID
+    entity_hint: Optional[str] = None
+
+
+@dataclass
+class SplitResult:
+    """Result of a split operation."""
+
+    original_tag: str
+    new_tag: str
+    new_canonical_form: str
+    new_normalized_form: str
+    aliases_moved: int
+    original_alias_count: int
+    original_video_count: int
+    new_alias_count: int
+    new_video_count: int
+    operation_id: uuid.UUID
+
+
+@dataclass
+class RenameResult:
+    """Result of a rename operation."""
+
+    normalized_form: str
+    old_form: str
+    new_form: str
+    operation_id: uuid.UUID
+
+
+@dataclass
+class ClassifyResult:
+    """Result of a classify operation."""
+
+    normalized_form: str
+    canonical_form: str
+    entity_type: str
+    entity_created: bool
+    entity_alias_count: int
+    operation_id: uuid.UUID
+
+
+@dataclass
+class DeprecateResult:
+    """Result of a deprecate operation."""
+
+    normalized_form: str
+    canonical_form: str
+    alias_count: int
+    operation_id: uuid.UUID
+
+
+@dataclass
+class UndoResult:
+    """Result of an undo operation."""
+
+    operation_type: str
+    operation_id: uuid.UUID
+    details: str
+
+
+@dataclass
+class CollisionGroup:
+    """A group of aliases that may represent a diacritic collision."""
+
+    canonical_form: str
+    normalized_form: str
+    canonical_tag_id: uuid.UUID
+    aliases: list[dict[str, Any]] = field(default_factory=list)
+    total_occurrence_count: int = 0
+
+
+class UndoNotImplementedError(Exception):
+    """Raised when undo for a specific operation type is not yet implemented."""
+
+    pass
+
+
+class TagManagementService:
+    """
+    Service for managing canonical tags via CLI curation operations.
+
+    All operations are atomic (single transaction), logged with self-contained
+    rollback data, and reversible via the undo mechanism.
+    """
+
+    def __init__(
+        self,
+        canonical_tag_repo: CanonicalTagRepository,
+        tag_alias_repo: TagAliasRepository,
+        named_entity_repo: NamedEntityRepository,
+        entity_alias_repo: EntityAliasRepository,
+        operation_log_repo: TagOperationLogRepository,
+    ) -> None:
+        self._canonical_tag_repo = canonical_tag_repo
+        self._tag_alias_repo = tag_alias_repo
+        self._named_entity_repo = named_entity_repo
+        self._entity_alias_repo = entity_alias_repo
+        self._operation_log_repo = operation_log_repo
+
+    # -------------------------------------------------------------------
+    # Shared private utilities
+    # -------------------------------------------------------------------
+
+    async def _validate_active_tag(
+        self, session: AsyncSession, normalized_form: str
+    ) -> CanonicalTagDB:
+        """
+        Look up a canonical tag by normalized form and validate it is active.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        normalized_form : str
+            Normalized form to look up.
+
+        Returns
+        -------
+        CanonicalTagDB
+            The active canonical tag.
+
+        Raises
+        ------
+        ValueError
+            If the tag does not exist or is not active.
+        """
+        tag = await self._canonical_tag_repo.get_by_normalized_form(
+            session, normalized_form
+        )
+        if tag is None:
+            # Check if it exists with any status
+            any_status_tag = await self._canonical_tag_repo.get_by_normalized_form(
+                session, normalized_form, status="merged"
+            )
+            if any_status_tag is None:
+                any_status_tag = await self._canonical_tag_repo.get_by_normalized_form(
+                    session, normalized_form, status="deprecated"
+                )
+            if any_status_tag is not None:
+                raise ValueError(
+                    f"Tag '{normalized_form}' exists but has status "
+                    f"'{any_status_tag.status}' (expected 'active')"
+                )
+            raise ValueError(f"Tag '{normalized_form}' not found")
+        return tag
+
+    async def _recalculate_counts(
+        self, session: AsyncSession, canonical_tag_id: uuid.UUID
+    ) -> tuple[int, int]:
+        """
+        Recalculate alias_count and video_count for a canonical tag.
+
+        Uses COUNT and COUNT DISTINCT queries scoped to the specific tag,
+        not a full table recount.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        canonical_tag_id : uuid.UUID
+            The canonical tag to recalculate counts for.
+
+        Returns
+        -------
+        tuple[int, int]
+            (alias_count, video_count)
+        """
+        # alias_count
+        alias_result = await session.execute(
+            select(func.count()).select_from(TagAliasDB).where(
+                TagAliasDB.canonical_tag_id == canonical_tag_id
+            )
+        )
+        alias_count: int = alias_result.scalar_one()
+
+        # video_count via raw_form JOIN
+        video_result = await session.execute(
+            select(func.count(distinct(VideoTag.video_id)))
+            .select_from(VideoTag)
+            .join(TagAliasDB, VideoTag.tag == TagAliasDB.raw_form)
+            .where(TagAliasDB.canonical_tag_id == canonical_tag_id)
+        )
+        video_count: int = video_result.scalar_one()
+
+        # Update the canonical tag
+        await session.execute(
+            update(CanonicalTagDB)
+            .where(CanonicalTagDB.id == canonical_tag_id)
+            .values(alias_count=alias_count, video_count=video_count)
+        )
+
+        return alias_count, video_count
+
+    async def _log_operation(
+        self,
+        session: AsyncSession,
+        *,
+        operation_type: str,
+        source_ids: list[uuid.UUID],
+        target_id: Optional[uuid.UUID],
+        alias_ids: list[uuid.UUID],
+        reason: Optional[str],
+        rollback_data: dict[str, Any],
+    ) -> uuid.UUID:
+        """
+        Create a tag_operation_logs entry for an operation.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        operation_type : str
+            One of: merge, split, rename, delete, create.
+        source_ids : list[uuid.UUID]
+            Source canonical tag IDs involved.
+        target_id : Optional[uuid.UUID]
+            Target canonical tag ID (if applicable).
+        alias_ids : list[uuid.UUID]
+            Affected alias IDs.
+        reason : Optional[str]
+            Human-readable reason for the operation.
+        rollback_data : dict[str, Any]
+            Self-contained data for reversing the operation.
+
+        Returns
+        -------
+        uuid.UUID
+            The operation log entry ID.
+        """
+        # Convert UUID objects to strings for JSONB serialization.
+        # source_canonical_ids and affected_alias_ids are JSONB columns;
+        # Python's json.dumps() cannot serialize uuid.UUID objects.
+        serialized_source_ids = [str(s) for s in source_ids]
+        serialized_alias_ids = [str(a) for a in alias_ids]
+
+        log_create = TagOperationLogCreate(
+            operation_type=operation_type,
+            source_canonical_ids=serialized_source_ids,
+            target_canonical_id=target_id,
+            affected_alias_ids=serialized_alias_ids,
+            reason=reason,
+            rollback_data=rollback_data,
+            performed_by="cli",
+        )
+        log_entry = await self._operation_log_repo.create(
+            session, obj_in=log_create
+        )
+        logger.info(
+            "Operation logged: type=%s, id=%s, sources=%s, target=%s",
+            operation_type,
+            log_entry.id,
+            [str(s) for s in source_ids],
+            str(target_id) if target_id else None,
+        )
+        return log_entry.id
+
+    # -------------------------------------------------------------------
+    # Public operation methods (stubs — implemented in later phases)
+    # -------------------------------------------------------------------
+
+    async def merge(
+        self,
+        session: AsyncSession,
+        source_normalized_forms: list[str],
+        target_normalized_form: str,
+        *,
+        reason: Optional[str] = None,
+    ) -> MergeResult:
+        """
+        Merge one or more source canonical tags into a target.
+
+        Reassigns all aliases from source tags to the target, marks sources
+        as merged, recalculates target counts, and logs the operation with
+        self-contained rollback data.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session (caller manages transaction).
+        source_normalized_forms : list[str]
+            Normalized forms of source tags to merge.
+        target_normalized_form : str
+            Normalized form of the target tag.
+        reason : Optional[str]
+            Human-readable reason for the merge.
+
+        Returns
+        -------
+        MergeResult
+            Summary of the merge for CLI display.
+
+        Raises
+        ------
+        ValueError
+            If validation fails (self-merge, missing tags, non-active tags).
+        """
+        if not source_normalized_forms:
+            raise ValueError("At least one source tag is required")
+
+        # Validate target
+        target = await self._validate_active_tag(session, target_normalized_form)
+
+        # Validate no self-merge
+        for src_form in source_normalized_forms:
+            if src_form == target_normalized_form:
+                raise ValueError(
+                    f"Cannot merge tag '{src_form}' into itself"
+                )
+
+        # Validate all sources are active
+        sources: list[CanonicalTagDB] = []
+        for src_form in source_normalized_forms:
+            src = await self._validate_active_tag(session, src_form)
+            sources.append(src)
+
+        # Build rollback data
+        rollback_sources = []
+        all_moved_alias_ids: list[uuid.UUID] = []
+        total_aliases_moved = 0
+
+        for src in sources:
+            # Get all aliases for this source
+            alias_result = await session.execute(
+                select(TagAliasDB).where(
+                    TagAliasDB.canonical_tag_id == src.id
+                )
+            )
+            source_aliases = list(alias_result.scalars().all())
+            alias_ids = [a.id for a in source_aliases]
+
+            rollback_sources.append({
+                "canonical_tag_id": str(src.id),
+                "previous_status": src.status,
+                "previous_alias_count": src.alias_count,
+                "previous_video_count": src.video_count,
+                "previous_entity_type": (
+                    src.entity_type if src.entity_type else None
+                ),
+                "previous_entity_id": (
+                    str(src.entity_id) if src.entity_id else None
+                ),
+                "alias_ids": [str(a) for a in alias_ids],
+            })
+
+            # Reassign aliases to target
+            if alias_ids:
+                await session.execute(
+                    update(TagAliasDB)
+                    .where(TagAliasDB.canonical_tag_id == src.id)
+                    .values(canonical_tag_id=target.id)
+                )
+                all_moved_alias_ids.extend(alias_ids)
+                total_aliases_moved += len(alias_ids)
+
+            # Mark source as merged
+            src.status = TagStatus.MERGED.value
+            src.merged_into_id = target.id
+            session.add(src)
+
+        rollback_data = {
+            "sources": rollback_sources,
+            "target": {
+                "canonical_tag_id": str(target.id),
+                "previous_alias_count": target.alias_count,
+                "previous_video_count": target.video_count,
+            },
+        }
+
+        # Recalculate target counts
+        new_alias_count, new_video_count = await self._recalculate_counts(
+            session, target.id
+        )
+
+        # Log operation
+        operation_id = await self._log_operation(
+            session,
+            operation_type=TagOperationType.MERGE.value,
+            source_ids=[s.id for s in sources],
+            target_id=target.id,
+            alias_ids=all_moved_alias_ids,
+            reason=reason,
+            rollback_data=rollback_data,
+        )
+
+        # FR-005a: entity hint if target is unclassified but sources had types
+        entity_hint = None
+        if target.entity_type is None:
+            source_types = [
+                s.entity_type for s in sources if s.entity_type is not None
+            ]
+            if source_types:
+                entity_hint = (
+                    f"Source tag(s) had entity type(s): "
+                    f"{', '.join(source_types)}. "
+                    f"Consider classifying target '{target_normalized_form}'."
+                )
+
+        logger.info(
+            "Merge complete: %s -> %s, %d aliases moved",
+            [s.normalized_form for s in sources],
+            target_normalized_form,
+            total_aliases_moved,
+        )
+
+        return MergeResult(
+            source_tags=[s.normalized_form for s in sources],
+            target_tag=target_normalized_form,
+            aliases_moved=total_aliases_moved,
+            new_alias_count=new_alias_count,
+            new_video_count=new_video_count,
+            operation_id=operation_id,
+            entity_hint=entity_hint,
+        )
+
+    async def split(
+        self,
+        session: AsyncSession,
+        normalized_form: str,
+        alias_raw_forms: list[str],
+        *,
+        reason: Optional[str] = None,
+    ) -> SplitResult:
+        """
+        Split specific aliases from a canonical tag into a new canonical tag.
+
+        Creates a new canonical tag from the specified aliases, using the
+        existing select_canonical_form algorithm and TagNormalizationService
+        for normalized form computation.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session (caller manages transaction).
+        normalized_form : str
+            Normalized form of the source tag to split from.
+        alias_raw_forms : list[str]
+            Raw forms of aliases to move to the new tag.
+        reason : Optional[str]
+            Human-readable reason for the split.
+
+        Returns
+        -------
+        SplitResult
+            Summary of the split for CLI display.
+
+        Raises
+        ------
+        ValueError
+            If validation fails.
+        """
+        from chronovista.services.tag_normalization import TagNormalizationService
+
+        if not alias_raw_forms:
+            raise ValueError("At least one alias must be specified for split")
+
+        # Validate source tag is active
+        source_tag = await self._validate_active_tag(session, normalized_form)
+
+        # Get all aliases for the source tag
+        all_aliases_result = await session.execute(
+            select(TagAliasDB).where(
+                TagAliasDB.canonical_tag_id == source_tag.id
+            )
+        )
+        all_aliases = list(all_aliases_result.scalars().all())
+        all_raw_forms = {a.raw_form for a in all_aliases}
+
+        # Validate all specified aliases belong to this tag (all-or-nothing FR-010)
+        invalid_aliases = [
+            rf for rf in alias_raw_forms if rf not in all_raw_forms
+        ]
+        if invalid_aliases:
+            raise ValueError(
+                f"Alias(es) not found on tag '{normalized_form}': "
+                f"{', '.join(invalid_aliases)}"
+            )
+
+        # Ensure at least one alias remains on the original tag
+        remaining_count = len(all_aliases) - len(alias_raw_forms)
+        if remaining_count < 1:
+            raise ValueError(
+                f"Cannot split all aliases from '{normalized_form}'. "
+                "At least one alias must remain. Use 'deprecate' to remove a tag entirely."
+            )
+
+        # Select canonical form from moved aliases using existing algorithm
+        normalization_service = TagNormalizationService()
+        moved_aliases = [
+            a for a in all_aliases if a.raw_form in alias_raw_forms
+        ]
+        forms_with_counts = [
+            (a.raw_form, a.occurrence_count) for a in moved_aliases
+        ]
+        new_canonical_form = normalization_service.select_canonical_form(
+            forms_with_counts
+        )
+
+        # Compute normalized form
+        new_normalized_form = normalization_service.normalize(new_canonical_form)
+        if new_normalized_form is None:
+            raise ValueError(
+                f"Normalization of '{new_canonical_form}' produced empty result"
+            )
+
+        # Check for collision with existing active or deprecated tag (FR-010)
+        existing = await self._canonical_tag_repo.get_by_normalized_form(
+            session, new_normalized_form
+        )
+        if existing is not None:
+            raise ValueError(
+                f"Normalized form '{new_normalized_form}' already exists as an "
+                f"active canonical tag. Consider using 'merge' instead."
+            )
+        # Also check deprecated
+        existing_deprecated = await self._canonical_tag_repo.get_by_normalized_form(
+            session, new_normalized_form, status="deprecated"
+        )
+        if existing_deprecated is not None:
+            raise ValueError(
+                f"Normalized form '{new_normalized_form}' already exists as a "
+                f"deprecated canonical tag."
+            )
+
+        # Create new canonical tag
+        from chronovista.models.canonical_tag import CanonicalTagCreate
+
+        new_tag_create = CanonicalTagCreate(
+            canonical_form=new_canonical_form,
+            normalized_form=new_normalized_form,
+            alias_count=0,
+            video_count=0,
+        )
+        new_tag = await self._canonical_tag_repo.create(
+            session, obj_in=new_tag_create
+        )
+
+        # Reassign aliases to the new tag
+        moved_alias_ids = [a.id for a in moved_aliases]
+        await session.execute(
+            update(TagAliasDB)
+            .where(TagAliasDB.id.in_(moved_alias_ids))
+            .values(canonical_tag_id=new_tag.id)
+        )
+
+        # Build rollback data
+        rollback_data = {
+            "original_canonical_id": str(source_tag.id),
+            "created_canonical_id": str(new_tag.id),
+            "moved_alias_ids": [str(a) for a in moved_alias_ids],
+            "previous_counts": {
+                "original_alias_count": source_tag.alias_count,
+                "original_video_count": source_tag.video_count,
+            },
+        }
+
+        # Recalculate counts on both tags
+        orig_alias_count, orig_video_count = await self._recalculate_counts(
+            session, source_tag.id
+        )
+        new_alias_count, new_video_count = await self._recalculate_counts(
+            session, new_tag.id
+        )
+
+        # Log operation
+        operation_id = await self._log_operation(
+            session,
+            operation_type=TagOperationType.SPLIT.value,
+            source_ids=[source_tag.id],
+            target_id=new_tag.id,
+            alias_ids=moved_alias_ids,
+            reason=reason,
+            rollback_data=rollback_data,
+        )
+
+        logger.info(
+            "Split complete: %s -> %s, %d aliases moved",
+            normalized_form,
+            new_normalized_form,
+            len(moved_alias_ids),
+        )
+
+        return SplitResult(
+            original_tag=normalized_form,
+            new_tag=new_normalized_form,
+            new_canonical_form=new_canonical_form,
+            new_normalized_form=new_normalized_form,
+            aliases_moved=len(moved_alias_ids),
+            original_alias_count=orig_alias_count,
+            original_video_count=orig_video_count,
+            new_alias_count=new_alias_count,
+            new_video_count=new_video_count,
+            operation_id=operation_id,
+        )
+
+    async def undo(
+        self,
+        session: AsyncSession,
+        operation_id: uuid.UUID,
+    ) -> UndoResult:
+        """
+        Undo a previously logged operation.
+
+        Looks up the operation by ID, dispatches to the appropriate undo
+        handler based on operation type, marks the log entry as rolled back,
+        and returns a summary for CLI display.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session (caller manages transaction).
+        operation_id : uuid.UUID
+            The operation log entry ID to undo.
+
+        Returns
+        -------
+        UndoResult
+            Summary of the undo for CLI display.
+
+        Raises
+        ------
+        ValueError
+            If the operation is not found, already undone, or has an unknown type.
+        UndoNotImplementedError
+            If undo for the operation type is not yet implemented.
+        """
+        # Look up the operation
+        log_entry = await self._operation_log_repo.get(session, operation_id)
+        if log_entry is None:
+            raise ValueError(f"Operation '{operation_id}' not found")
+
+        if log_entry.rolled_back is True:
+            raise ValueError(
+                f"Operation '{operation_id}' has already been undone"
+            )
+
+        # Dispatch based on operation type
+        op_type = log_entry.operation_type
+        if op_type == TagOperationType.MERGE.value:
+            details = await self._undo_merge(session, log_entry)
+        elif op_type == TagOperationType.SPLIT.value:
+            details = await self._undo_split(session, log_entry)
+        elif op_type == TagOperationType.RENAME.value:
+            details = await self._undo_rename(session, log_entry)
+        elif op_type == TagOperationType.CREATE.value:
+            details = await self._undo_classify(session, log_entry)
+        elif op_type == TagOperationType.DELETE.value:
+            details = await self._undo_deprecate(session, log_entry)
+        else:
+            raise ValueError(f"Unknown operation type: {op_type}")
+
+        # Mark the log entry as rolled back
+        log_entry.rolled_back = True
+        log_entry.rolled_back_at = datetime.now(timezone.utc)
+        session.add(log_entry)
+
+        logger.info(
+            "Undo complete: type=%s, operation_id=%s",
+            op_type,
+            operation_id,
+        )
+
+        return UndoResult(
+            operation_type=op_type,
+            operation_id=operation_id,
+            details=details,
+        )
+
+    async def list_recent_operations(
+        self,
+        session: AsyncSession,
+        *,
+        limit: int = 20,
+    ) -> list[TagOperationLogDB]:
+        """List recent operations from the audit log."""
+        return await self._operation_log_repo.get_recent(session, limit=limit)
+
+    async def rename(
+        self,
+        session: AsyncSession,
+        normalized_form: str,
+        new_display_form: str,
+        *,
+        reason: Optional[str] = None,
+    ) -> RenameResult:
+        """
+        Rename a canonical tag's display form (canonical_form).
+
+        Updates the canonical_form on the tag without changing the
+        normalized_form or any alias mappings. Logged with rollback data
+        for undo capability.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session (caller manages transaction).
+        normalized_form : str
+            Normalized form of the tag to rename.
+        new_display_form : str
+            New display form (canonical_form) for the tag.
+        reason : Optional[str]
+            Human-readable reason for the rename.
+
+        Returns
+        -------
+        RenameResult
+            Summary of the rename for CLI display.
+
+        Raises
+        ------
+        ValueError
+            If the tag is not found/active or new_display_form is empty.
+        """
+        # Validate new display form is not empty
+        new_display_form = new_display_form.strip()
+        if not new_display_form:
+            raise ValueError("New display form cannot be empty")
+
+        # Validate tag is active
+        tag = await self._validate_active_tag(session, normalized_form)
+
+        old_form = tag.canonical_form
+
+        # Update canonical_form
+        tag.canonical_form = new_display_form
+        session.add(tag)
+
+        # Build rollback data
+        rollback_data = {
+            "canonical_id": str(tag.id),
+            "previous_form": old_form,
+            "new_form": new_display_form,
+        }
+
+        # Log operation
+        operation_id = await self._log_operation(
+            session,
+            operation_type=TagOperationType.RENAME.value,
+            source_ids=[tag.id],
+            target_id=None,
+            alias_ids=[],
+            reason=reason,
+            rollback_data=rollback_data,
+        )
+
+        logger.info(
+            "Rename complete: '%s' -> '%s' (normalized: %s)",
+            old_form,
+            new_display_form,
+            normalized_form,
+        )
+
+        return RenameResult(
+            normalized_form=normalized_form,
+            old_form=old_form,
+            new_form=new_display_form,
+            operation_id=operation_id,
+        )
+
+    async def classify(
+        self,
+        session: AsyncSession,
+        normalized_form: str,
+        entity_type: EntityType,
+        *,
+        force: bool = False,
+        reason: Optional[str] = None,
+    ) -> ClassifyResult:
+        """
+        Classify a canonical tag with an entity type.
+
+        For entity-producing types (person, organization, place, event, work,
+        technical_term), creates or links a NamedEntity record and copies
+        tag aliases as entity aliases. For tag-only types (topic, descriptor),
+        only sets entity_type on the canonical tag with no entity record.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session (caller manages transaction).
+        normalized_form : str
+            Normalized form of the tag to classify.
+        entity_type : EntityType
+            The entity type to assign.
+        force : bool
+            If True, override existing classification.
+        reason : Optional[str]
+            Human-readable reason for the classification.
+
+        Returns
+        -------
+        ClassifyResult
+            Summary of the classification for CLI display.
+
+        Raises
+        ------
+        ValueError
+            If the tag is not found/active or already classified without force.
+        """
+        from chronovista.models.entity_alias import EntityAliasCreate
+        from chronovista.models.named_entity import NamedEntityCreate
+
+        # 1. Validate tag is active
+        tag = await self._validate_active_tag(session, normalized_form)
+
+        # 2. Check existing classification
+        previous_entity_type = tag.entity_type
+        if previous_entity_type is not None and not force:
+            raise ValueError(
+                f"Tag '{normalized_form}' is already classified as "
+                f"'{previous_entity_type}'. Use --force to override."
+            )
+
+        if previous_entity_type is not None and force:
+            # If old entity was user_created, delete it and its aliases
+            if tag.entity_id is not None:
+                old_entity = await self._named_entity_repo.get(
+                    session, tag.entity_id
+                )
+                if (
+                    old_entity is not None
+                    and old_entity.discovery_method
+                    == DiscoveryMethod.USER_CREATED.value
+                ):
+                    # Delete entity aliases for old entity
+                    old_aliases_result = await session.execute(
+                        select(EntityAliasDB).where(
+                            EntityAliasDB.entity_id == old_entity.id
+                        )
+                    )
+                    for old_alias in old_aliases_result.scalars().all():
+                        await session.delete(old_alias)
+                    await session.flush()
+                    # Delete the entity itself
+                    await session.delete(old_entity)
+                    await session.flush()
+
+            # Clear entity_type and entity_id on the tag
+            tag.entity_type = None
+            tag.entity_id = None
+
+        # 3. Determine entity-producing vs tag-only types
+        entity_producing_types = {
+            EntityType.PERSON,
+            EntityType.ORGANIZATION,
+            EntityType.PLACE,
+            EntityType.EVENT,
+            EntityType.WORK,
+            EntityType.TECHNICAL_TERM,
+        }
+        tag_only_types = {EntityType.TOPIC, EntityType.DESCRIPTOR}
+
+        created_entity_id: Optional[uuid.UUID] = None
+        linked_existing_entity_id: Optional[uuid.UUID] = None
+        created_entity_alias_ids: list[uuid.UUID] = []
+        entity_created = False
+
+        if entity_type in entity_producing_types:
+            # 4. Check if a named_entity already exists with same name and type
+            existing_entity_result = await session.execute(
+                select(NamedEntityDB).where(
+                    NamedEntityDB.canonical_name_normalized
+                    == tag.normalized_form,
+                    NamedEntityDB.entity_type == entity_type.value,
+                )
+            )
+            existing_entity = existing_entity_result.scalar_one_or_none()
+
+            if existing_entity is not None:
+                # Link to existing entity
+                tag.entity_type = entity_type.value
+                tag.entity_id = existing_entity.id
+                linked_existing_entity_id = existing_entity.id
+            else:
+                # Create new NamedEntity
+                entity_create = NamedEntityCreate(
+                    canonical_name=tag.canonical_form,
+                    canonical_name_normalized=tag.normalized_form,
+                    entity_type=entity_type,
+                    discovery_method=DiscoveryMethod.USER_CREATED,
+                    confidence=1.0,
+                )
+                new_entity = await self._named_entity_repo.create(
+                    session, obj_in=entity_create
+                )
+                tag.entity_type = entity_type.value
+                tag.entity_id = new_entity.id
+                created_entity_id = new_entity.id
+                entity_created = True
+
+            # Copy tag_aliases as entity_aliases
+            tag_aliases_result = await session.execute(
+                select(TagAliasDB).where(
+                    TagAliasDB.canonical_tag_id == tag.id
+                )
+            )
+            tag_aliases = list(tag_aliases_result.scalars().all())
+
+            entity_id_for_aliases = tag.entity_id
+            # Track normalized forms we've already seen to handle
+            # multiple tag aliases that normalize to the same form
+            # (e.g., "Aaron Mate" and "Aaron Maté" both → "aaron mate").
+            # FR-019: upsert semantics — update occurrence_count on conflict.
+            seen_normalized: dict[str, EntityAliasDB] = {}
+            for tag_alias in tag_aliases:
+                norm = tag_alias.normalized_form
+                if norm in seen_normalized:
+                    # Same normalized form already inserted in this batch —
+                    # accumulate occurrence_count on the existing record.
+                    existing_ea = seen_normalized[norm]
+                    existing_ea.occurrence_count = (
+                        (existing_ea.occurrence_count or 0)
+                        + (tag_alias.occurrence_count or 0)
+                    )
+                    session.add(existing_ea)
+                    continue
+
+                # Check if entity alias already exists in DB
+                existing_result = await session.execute(
+                    select(EntityAliasDB).where(
+                        EntityAliasDB.entity_id == entity_id_for_aliases,
+                        EntityAliasDB.alias_name_normalized == norm,
+                    )
+                )
+                existing_db = existing_result.scalar_one_or_none()
+                if existing_db is not None:
+                    # Upsert: update occurrence_count on existing record
+                    existing_db.occurrence_count = (
+                        (existing_db.occurrence_count or 0)
+                        + (tag_alias.occurrence_count or 0)
+                    )
+                    session.add(existing_db)
+                    seen_normalized[norm] = existing_db
+                    # Don't add to created_entity_alias_ids — pre-existing
+                    continue
+
+                ea_create = EntityAliasCreate(
+                    entity_id=entity_id_for_aliases,
+                    alias_name=tag_alias.raw_form,
+                    alias_name_normalized=norm,
+                    alias_type=EntityAliasType.NAME_VARIANT,
+                    occurrence_count=tag_alias.occurrence_count,
+                )
+                ea_db = await self._entity_alias_repo.create(
+                    session, obj_in=ea_create
+                )
+                created_entity_alias_ids.append(ea_db.id)
+                seen_normalized[norm] = ea_db
+
+        elif entity_type in tag_only_types:
+            # 5. Tag-only types: set entity_type only
+            tag.entity_type = entity_type.value
+            # No entity record, no entity_aliases, entity_id stays None
+
+        session.add(tag)
+
+        # 6. Build rollback_data
+        rollback_data: dict[str, Any] = {
+            "canonical_id": str(tag.id),
+            "previous_entity_type": previous_entity_type,
+            "new_entity_type": entity_type.value,
+            "created_entity_id": (
+                str(created_entity_id) if created_entity_id else None
+            ),
+            "linked_existing_entity_id": (
+                str(linked_existing_entity_id)
+                if linked_existing_entity_id
+                else None
+            ),
+            "created_entity_alias_ids": [
+                str(ea_id) for ea_id in created_entity_alias_ids
+            ],
+        }
+
+        # 7. Log operation
+        operation_id = await self._log_operation(
+            session,
+            operation_type=TagOperationType.CREATE.value,
+            source_ids=[tag.id],
+            target_id=None,
+            alias_ids=[],
+            reason=reason,
+            rollback_data=rollback_data,
+        )
+
+        logger.info(
+            "Classify complete: %s -> %s (entity_created=%s, aliases=%d)",
+            normalized_form,
+            entity_type.value,
+            entity_created,
+            len(created_entity_alias_ids),
+        )
+
+        # 8. Return ClassifyResult
+        return ClassifyResult(
+            normalized_form=normalized_form,
+            canonical_form=tag.canonical_form,
+            entity_type=entity_type.value,
+            entity_created=entity_created,
+            entity_alias_count=len(created_entity_alias_ids),
+            operation_id=operation_id,
+        )
+
+    async def classify_top_unclassified(
+        self,
+        session: AsyncSession,
+        *,
+        limit: int = 20,
+    ) -> list[CanonicalTagDB]:
+        """
+        Get top unclassified canonical tags by video count.
+
+        Queries active canonical tags that have no entity_type set,
+        ordered by video_count descending so the most impactful tags
+        are surfaced first for classification.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        limit : int
+            Maximum number of tags to return (default 20).
+
+        Returns
+        -------
+        list[CanonicalTagDB]
+            Unclassified active canonical tags, ordered by video_count desc.
+        """
+        result = await session.execute(
+            select(CanonicalTagDB)
+            .where(CanonicalTagDB.entity_type.is_(None))
+            .where(CanonicalTagDB.status == TagStatus.ACTIVE.value)
+            .order_by(CanonicalTagDB.video_count.desc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def get_collisions(
+        self,
+        session: AsyncSession,
+        *,
+        limit: Optional[int] = None,
+        include_reviewed: bool = False,
+    ) -> list[CollisionGroup]:
+        """
+        Get diacritic collision candidates from active canonical tags.
+
+        Detects groups where a single canonical tag has aliases whose
+        casefolded forms (after stripping # and whitespace but preserving
+        diacritics) are distinct — indicating potential false merges from
+        Tier 1 diacritic stripping.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        limit : Optional[int]
+            Maximum number of collision groups to return.
+        include_reviewed : bool
+            If True, include collisions that have been previously reviewed
+            (marked via collision_reviewed log entries).
+
+        Returns
+        -------
+        list[CollisionGroup]
+            Collision candidates sorted by total occurrence count descending.
+        """
+        # Query all active canonical tags with their aliases
+        result = await session.execute(
+            select(CanonicalTagDB).where(
+                CanonicalTagDB.status == TagStatus.ACTIVE.value
+            )
+        )
+        active_tags = list(result.scalars().all())
+
+        # Get reviewed collision tag IDs (if filtering)
+        reviewed_tag_ids: set[str] = set()
+        if not include_reviewed:
+            reviewed_result = await session.execute(
+                select(TagOperationLogDB).where(
+                    TagOperationLogDB.operation_type == TagOperationType.CREATE.value,
+                    TagOperationLogDB.reason == "collision_reviewed",
+                    TagOperationLogDB.rolled_back == False,  # noqa: E712
+                )
+            )
+            for log_entry in reviewed_result.scalars().all():
+                if log_entry.source_canonical_ids:
+                    for sid in log_entry.source_canonical_ids:
+                        reviewed_tag_ids.add(str(sid))
+
+        collisions: list[CollisionGroup] = []
+
+        for tag in active_tags:
+            if not include_reviewed and str(tag.id) in reviewed_tag_ids:
+                continue
+
+            # Get aliases for this tag
+            alias_result = await session.execute(
+                select(TagAliasDB).where(
+                    TagAliasDB.canonical_tag_id == tag.id
+                )
+            )
+            aliases = list(alias_result.scalars().all())
+
+            if len(aliases) < 2:
+                continue
+
+            # Detect collision: distinct casefolded forms (preserving diacritics)
+            casefolded_set: set[str] = set()
+            for alias in aliases:
+                cleaned = alias.raw_form.strip()
+                if cleaned.startswith("#"):
+                    cleaned = cleaned[1:]
+                cleaned = cleaned.strip().casefold()
+                casefolded_set.add(cleaned)
+
+            if len(casefolded_set) < 2:
+                continue
+
+            total_count = sum(a.occurrence_count for a in aliases)
+
+            collisions.append(
+                CollisionGroup(
+                    canonical_form=tag.canonical_form,
+                    normalized_form=tag.normalized_form,
+                    canonical_tag_id=tag.id,
+                    aliases=[
+                        {
+                            "raw_form": a.raw_form,
+                            "occurrence_count": a.occurrence_count,
+                        }
+                        for a in aliases
+                    ],
+                    total_occurrence_count=total_count,
+                )
+            )
+
+        # Sort by total occurrence count descending
+        collisions.sort(key=lambda c: c.total_occurrence_count, reverse=True)
+
+        if limit is not None:
+            collisions = collisions[:limit]
+
+        return collisions
+
+    async def log_collision_reviewed(
+        self,
+        session: AsyncSession,
+        canonical_tag_id: uuid.UUID,
+    ) -> uuid.UUID:
+        """
+        Log that a collision was reviewed and kept as-is.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        canonical_tag_id : uuid.UUID
+            The canonical tag that was reviewed.
+
+        Returns
+        -------
+        uuid.UUID
+            The operation log entry ID.
+        """
+        return await self._log_operation(
+            session,
+            operation_type=TagOperationType.CREATE.value,
+            source_ids=[canonical_tag_id],
+            target_id=None,
+            alias_ids=[],
+            reason="collision_reviewed",
+            rollback_data={"canonical_id": str(canonical_tag_id)},
+        )
+
+    async def deprecate(
+        self,
+        session: AsyncSession,
+        normalized_form: str,
+        *,
+        reason: Optional[str] = None,
+    ) -> DeprecateResult:
+        """
+        Deprecate a canonical tag (soft delete).
+
+        Sets the tag status to deprecated, preserving all aliases and
+        video associations. The operation is logged and reversible via undo.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session (caller manages transaction).
+        normalized_form : str
+            Normalized form of the tag to deprecate.
+        reason : Optional[str]
+            Human-readable reason for the deprecation.
+
+        Returns
+        -------
+        DeprecateResult
+            Summary of the deprecation for CLI display.
+
+        Raises
+        ------
+        ValueError
+            If the tag does not exist or is not active.
+        """
+        # Validate tag is active (rejects merged/deprecated)
+        tag = await self._validate_active_tag(session, normalized_form)
+
+        # Build rollback data before mutation
+        rollback_data: dict[str, Any] = {
+            "canonical_id": str(tag.id),
+            "previous_status": tag.status,
+        }
+
+        # Mark as deprecated
+        tag.status = TagStatus.DEPRECATED.value
+        session.add(tag)
+
+        # Log operation (operation_type=DELETE per spec)
+        operation_id = await self._log_operation(
+            session,
+            operation_type=TagOperationType.DELETE.value,
+            source_ids=[tag.id],
+            target_id=None,
+            alias_ids=[],
+            reason=reason,
+            rollback_data=rollback_data,
+        )
+
+        logger.info(
+            "Deprecate complete: %s (canonical: %s), alias_count=%d",
+            normalized_form,
+            tag.canonical_form,
+            tag.alias_count,
+        )
+
+        return DeprecateResult(
+            normalized_form=normalized_form,
+            canonical_form=tag.canonical_form,
+            alias_count=tag.alias_count,
+            operation_id=operation_id,
+        )
+
+    async def list_deprecated(
+        self,
+        session: AsyncSession,
+    ) -> list[CanonicalTagDB]:
+        """
+        List all deprecated canonical tags.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+
+        Returns
+        -------
+        list[CanonicalTagDB]
+            All canonical tags with status 'deprecated', ordered by
+            canonical_form alphabetically.
+        """
+        result = await session.execute(
+            select(CanonicalTagDB)
+            .where(CanonicalTagDB.status == TagStatus.DEPRECATED.value)
+            .order_by(CanonicalTagDB.canonical_form)
+        )
+        return list(result.scalars().all())
+
+    # -------------------------------------------------------------------
+    # Private undo reversal methods (stubs — implemented per phase)
+    # -------------------------------------------------------------------
+
+    async def _undo_merge(
+        self, session: AsyncSession, log_entry: TagOperationLogDB
+    ) -> str:
+        """
+        Reverse a merge operation.
+
+        Reassigns aliases back to their original source canonical tags,
+        restores source status to active, clears merged_into_id, and
+        recalculates counts on all affected tags.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        log_entry : TagOperationLogDB
+            The operation log entry with rollback_data.
+
+        Returns
+        -------
+        str
+            Human-readable description of what was reversed.
+        """
+        rollback = log_entry.rollback_data
+        sources = rollback["sources"]
+        target_info = rollback["target"]
+        target_id = uuid.UUID(target_info["canonical_tag_id"])
+
+        restored_tags = []
+
+        for source_data in sources:
+            source_id = uuid.UUID(source_data["canonical_tag_id"])
+            alias_ids = [uuid.UUID(a) for a in source_data["alias_ids"]]
+
+            # Reassign aliases back to the source
+            if alias_ids:
+                for alias_id in alias_ids:
+                    await session.execute(
+                        update(TagAliasDB)
+                        .where(TagAliasDB.id == alias_id)
+                        .values(canonical_tag_id=source_id)
+                    )
+
+            # Restore source tag to active
+            source_tag = await self._canonical_tag_repo.get(session, source_id)
+            if source_tag is not None:
+                source_tag.status = TagStatus.ACTIVE.value
+                source_tag.merged_into_id = None
+                session.add(source_tag)
+
+                # Recalculate counts on source
+                await self._recalculate_counts(session, source_id)
+                restored_tags.append(source_tag.normalized_form)
+
+        # Recalculate counts on target
+        await self._recalculate_counts(session, target_id)
+
+        return f"Unmerged {', '.join(restored_tags)} from target"
+
+    async def _undo_split(
+        self, session: AsyncSession, log_entry: TagOperationLogDB
+    ) -> str:
+        """
+        Reverse a split operation.
+
+        Moves aliases back to the original canonical tag, deletes the
+        created canonical tag, and recalculates counts. Blocked if the
+        created tag has subsequent non-rolled-back operations (FR-012a).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        log_entry : TagOperationLogDB
+            The operation log entry with rollback_data.
+
+        Returns
+        -------
+        str
+            Human-readable description of what was reversed.
+
+        Raises
+        ------
+        ValueError
+            If the created tag has subsequent operations (FR-012a).
+        """
+        rollback = log_entry.rollback_data
+        original_id = uuid.UUID(rollback["original_canonical_id"])
+        created_id = uuid.UUID(rollback["created_canonical_id"])
+        moved_alias_ids = [uuid.UUID(a) for a in rollback["moved_alias_ids"]]
+
+        # FR-012a: Check for subsequent operations on the created tag
+        subsequent_ops_result = await session.execute(
+            select(TagOperationLogDB).where(
+                TagOperationLogDB.id != log_entry.id,
+                TagOperationLogDB.rolled_back == False,  # noqa: E712
+                (
+                    TagOperationLogDB.source_canonical_ids.contains(
+                        [str(created_id)]
+                    )
+                    | (TagOperationLogDB.target_canonical_id == created_id)
+                ),
+            )
+        )
+        subsequent_ops = list(subsequent_ops_result.scalars().all())
+        if subsequent_ops:
+            op_types = [op.operation_type for op in subsequent_ops]
+            raise ValueError(
+                f"Cannot undo split: tag created by this split has "
+                f"{len(subsequent_ops)} subsequent operation(s) "
+                f"({', '.join(op_types)}). Undo those operations first."
+            )
+
+        # Move aliases back to original
+        if moved_alias_ids:
+            for alias_id in moved_alias_ids:
+                await session.execute(
+                    update(TagAliasDB)
+                    .where(TagAliasDB.id == alias_id)
+                    .values(canonical_tag_id=original_id)
+                )
+
+        # Delete the created canonical tag
+        created_tag = await self._canonical_tag_repo.get(session, created_id)
+        if created_tag is not None:
+            await session.delete(created_tag)
+            await session.flush()
+
+        # Recalculate counts on original
+        await self._recalculate_counts(session, original_id)
+
+        original_tag = await self._canonical_tag_repo.get(session, original_id)
+        original_name = (
+            original_tag.normalized_form if original_tag else str(original_id)
+        )
+        return f"Reunited {len(moved_alias_ids)} aliases back into '{original_name}'"
+
+    async def _undo_rename(
+        self, session: AsyncSession, log_entry: TagOperationLogDB
+    ) -> str:
+        """
+        Reverse a rename operation.
+
+        Restores the canonical_form to its previous value using the
+        rollback data stored in the operation log entry.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        log_entry : TagOperationLogDB
+            The operation log entry with rollback_data.
+
+        Returns
+        -------
+        str
+            Human-readable description of what was reversed.
+        """
+        rollback = log_entry.rollback_data
+        canonical_id = uuid.UUID(rollback["canonical_id"])
+        previous_form = rollback["previous_form"]
+        new_form = rollback["new_form"]
+
+        tag = await self._canonical_tag_repo.get(session, canonical_id)
+        if tag is None:
+            raise ValueError(
+                f"Cannot undo rename: canonical tag {canonical_id} not found"
+            )
+
+        tag.canonical_form = previous_form
+        session.add(tag)
+
+        return f"Renamed '{new_form}' back to '{previous_form}'"
+
+    async def _undo_classify(
+        self, session: AsyncSession, log_entry: TagOperationLogDB
+    ) -> str:
+        """
+        Reverse a classify operation.
+
+        Clears entity_type and entity_id on the canonical tag. If a new
+        entity was created (created_entity_id), deletes its entity aliases
+        and the entity itself (only if user_created). If an existing entity
+        was linked (linked_existing_entity_id), only clears the link and
+        deletes entity aliases that were created during the classify.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        log_entry : TagOperationLogDB
+            The operation log entry with rollback_data.
+
+        Returns
+        -------
+        str
+            Human-readable description of what was reversed.
+
+        Raises
+        ------
+        ValueError
+            If the canonical tag cannot be found.
+        """
+        rollback = log_entry.rollback_data
+        canonical_id = uuid.UUID(rollback["canonical_id"])
+        previous_entity_type = rollback.get("previous_entity_type")
+        created_entity_id_str = rollback.get("created_entity_id")
+        linked_existing_entity_id_str = rollback.get("linked_existing_entity_id")
+        created_entity_alias_ids = [
+            uuid.UUID(ea_id)
+            for ea_id in rollback.get("created_entity_alias_ids", [])
+        ]
+
+        # Look up the canonical tag
+        tag = await self._canonical_tag_repo.get(session, canonical_id)
+        if tag is None:
+            raise ValueError(
+                f"Cannot undo classify: canonical tag {canonical_id} not found"
+            )
+
+        # Clear entity_type and entity_id on the tag
+        tag.entity_type = previous_entity_type
+        tag.entity_id = None
+        session.add(tag)
+
+        # Delete created entity aliases
+        if created_entity_alias_ids:
+            for ea_id in created_entity_alias_ids:
+                ea = await self._entity_alias_repo.get(session, ea_id)
+                if ea is not None:
+                    await session.delete(ea)
+            await session.flush()
+
+        if created_entity_id_str is not None:
+            # We created a new entity — delete it if user_created
+            created_entity_id = uuid.UUID(created_entity_id_str)
+            entity = await self._named_entity_repo.get(
+                session, created_entity_id
+            )
+            if (
+                entity is not None
+                and entity.discovery_method
+                == DiscoveryMethod.USER_CREATED.value
+            ):
+                await session.delete(entity)
+                await session.flush()
+
+        # If linked_existing_entity_id, we only clear the link (already done above)
+        # and deleted the created aliases (also done above). No entity deletion.
+
+        new_entity_type = rollback.get("new_entity_type", "unknown")
+        return (
+            f"Unclassified '{tag.normalized_form}' "
+            f"(removed type '{new_entity_type}')"
+        )
+
+    async def _undo_deprecate(
+        self, session: AsyncSession, log_entry: TagOperationLogDB
+    ) -> str:
+        """
+        Reverse a deprecate operation.
+
+        Restores the canonical tag's status to its previous value
+        (typically 'active') using the rollback data stored in the
+        operation log entry.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        log_entry : TagOperationLogDB
+            The operation log entry with rollback_data.
+
+        Returns
+        -------
+        str
+            Human-readable description of what was reversed.
+
+        Raises
+        ------
+        ValueError
+            If the canonical tag cannot be found.
+        """
+        rollback = log_entry.rollback_data
+        canonical_id = uuid.UUID(rollback["canonical_id"])
+        previous_status = rollback["previous_status"]
+
+        tag = await self._canonical_tag_repo.get(session, canonical_id)
+        if tag is None:
+            raise ValueError(
+                f"Cannot undo deprecate: canonical tag {canonical_id} not found"
+            )
+
+        tag.status = previous_status
+        session.add(tag)
+
+        return (
+            f"Restored '{tag.normalized_form}' from deprecated to {previous_status}"
+        )

--- a/tests/integration/cli/test_tag_management_commands.py
+++ b/tests/integration/cli/test_tag_management_commands.py
@@ -1,0 +1,1672 @@
+"""
+Integration tests for Tag Management CLI commands (Feature 031).
+
+Covers `tags merge`, `tags split`, `tags undo`, `tags rename`, `tags classify`,
+`tags collisions`, and `tags deprecate` commands.
+
+These tests mock the database layer and the TagManagementService to verify:
+- Correct CLI argument parsing and option handling
+- Rich output contains expected human-readable strings
+- Exit codes for success (0), validation failure (1), and usage error (2)
+- --reason flag propagation to the service
+- Interactive undo list output formatting
+
+NOTE: The CLI commands use asyncio.run() internally. Tests remain synchronous
+and mock db_manager.get_session so no real database connection is needed.
+Pattern mirrors tests/integration/cli/test_tag_normalize_commands.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from chronovista.services.tag_management import CollisionGroup
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from typer.testing import CliRunner
+
+from chronovista.cli.main import app
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_OP_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+
+def _make_get_session(mock_session: AsyncMock) -> Any:
+    """
+    Return an async generator factory that yields *mock_session* once,
+    matching the signature of db_manager.get_session(echo=False).
+    """
+
+    async def _gen(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    return _gen()
+
+
+# ---------------------------------------------------------------------------
+# Merge command tests
+# ---------------------------------------------------------------------------
+
+
+class TestMergeCommand:
+    """Integration tests for `chronovista tags merge`."""
+
+    def test_successful_single_source_merge_exit_code_zero(self) -> None:
+        """Successful single-source merge returns exit code 0."""
+        from chronovista.services.tag_management import MergeResult
+
+        mock_result = MergeResult(
+            source_tags=["mejico"],
+            target_tag="mexico",
+            aliases_moved=3,
+            new_alias_count=7,
+            new_video_count=42,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.merge.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "merge", "mejico", "--into", "mexico"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_successful_merge_output_contains_key_fields(self) -> None:
+        """Successful merge output contains source, target, aliases_moved, and operation_id."""
+        from chronovista.services.tag_management import MergeResult
+
+        mock_result = MergeResult(
+            source_tags=["mejico"],
+            target_tag="mexico",
+            aliases_moved=3,
+            new_alias_count=7,
+            new_video_count=42,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.merge.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "merge", "mejico", "--into", "mexico"])
+
+        assert "Merge Successful" in result.output
+        assert "mejico" in result.output
+        assert "mexico" in result.output
+        assert "3" in result.output  # aliases_moved
+        assert str(_OP_ID) in result.output
+
+    def test_successful_merge_with_entity_hint_shows_hint(self) -> None:
+        """When merge returns an entity_hint, it is printed in yellow."""
+        from chronovista.services.tag_management import MergeResult
+
+        hint = "Source tag(s) had entity type(s): person. Consider classifying target 'mexico'."
+        mock_result = MergeResult(
+            source_tags=["mejico"],
+            target_tag="mexico",
+            aliases_moved=1,
+            new_alias_count=4,
+            new_video_count=10,
+            operation_id=_OP_ID,
+            entity_hint=hint,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.merge.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "merge", "mejico", "--into", "mexico"])
+
+        assert result.exit_code == 0
+        # The hint text itself should appear
+        assert "Consider classifying" in result.output
+
+    def test_merge_with_reason_flag_propagates_reason(self) -> None:
+        """--reason flag is forwarded to service.merge()."""
+        from chronovista.services.tag_management import MergeResult
+
+        mock_result = MergeResult(
+            source_tags=["mejico"],
+            target_tag="mexico",
+            aliases_moved=2,
+            new_alias_count=5,
+            new_video_count=20,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.merge.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                ["tags", "merge", "mejico", "--into", "mexico", "--reason", "Test reason"],
+            )
+
+        assert result.exit_code == 0
+        mock_service.merge.assert_called_once()
+        call_kwargs = mock_service.merge.call_args[1]
+        assert call_kwargs.get("reason") == "Test reason"
+
+    def test_multi_source_merge_passes_all_sources(self) -> None:
+        """Multiple source arguments are all forwarded to service.merge()."""
+        from chronovista.services.tag_management import MergeResult
+
+        mock_result = MergeResult(
+            source_tags=["mejico", "mexiko"],
+            target_tag="mexico",
+            aliases_moved=5,
+            new_alias_count=9,
+            new_video_count=80,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.merge.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "merge", "mejico", "mexiko", "--into", "mexico"]
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_service.merge.call_args
+        sources = call_kwargs[1]["source_normalized_forms"]
+        assert "mejico" in sources
+        assert "mexiko" in sources
+
+    def test_merge_value_error_exits_code_1(self) -> None:
+        """ValueError from service (e.g., tag not found) produces exit code 1."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.merge.side_effect = ValueError("Tag 'nonexistent' not found")
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "merge", "nonexistent", "--into", "mexico"])
+
+        assert result.exit_code == 1
+
+    def test_merge_value_error_shows_error_panel(self) -> None:
+        """ValueError message is printed in the output."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.merge.side_effect = ValueError("Tag 'nonexistent' not found")
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "merge", "nonexistent", "--into", "mexico"])
+
+        assert "Merge Failed" in result.output
+        assert "nonexistent" in result.output
+
+    def test_merge_self_merge_exits_code_1(self) -> None:
+        """Self-merge (source == target) produces exit code 1."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.merge.side_effect = ValueError(
+                "Cannot merge tag 'mexico' into itself"
+            )
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "merge", "mexico", "--into", "mexico"])
+
+        assert result.exit_code == 1
+
+    def test_merge_reason_too_long_exits_code_2(self) -> None:
+        """--reason exceeding 1000 chars triggers Typer bad parameter (exit 2)."""
+        long_reason = "x" * 1001
+
+        result = runner.invoke(
+            app, ["tags", "merge", "a", "--into", "b", "--reason", long_reason]
+        )
+
+        assert result.exit_code == 2
+
+    def test_merge_missing_into_flag_exits_nonzero(self) -> None:
+        """Missing required --into option exits with a non-zero code."""
+        result = runner.invoke(app, ["tags", "merge", "mejico"])
+
+        assert result.exit_code != 0
+
+    def test_merge_help_flag(self) -> None:
+        """--help shows usage text and exits 0."""
+        result = runner.invoke(app, ["tags", "merge", "--help"])
+
+        assert result.exit_code == 0
+        assert "--into" in result.output
+        assert "--reason" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Split command tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitCommand:
+    """Integration tests for `chronovista tags split`."""
+
+    def test_successful_split_exit_code_zero(self) -> None:
+        """Successful split returns exit code 0."""
+        from chronovista.services.tag_management import SplitResult
+
+        mock_result = SplitResult(
+            original_tag="python",
+            new_tag="python3",
+            new_canonical_form="Python3",
+            new_normalized_form="python3",
+            aliases_moved=2,
+            original_alias_count=5,
+            original_video_count=100,
+            new_alias_count=2,
+            new_video_count=30,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.split.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "split", "python", "--aliases", "Python3,python 3"]
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_successful_split_output_contains_key_fields(self) -> None:
+        """Successful split output shows original tag, new tag, and operation ID."""
+        from chronovista.services.tag_management import SplitResult
+
+        mock_result = SplitResult(
+            original_tag="python",
+            new_tag="python3",
+            new_canonical_form="Python3",
+            new_normalized_form="python3",
+            aliases_moved=2,
+            original_alias_count=5,
+            original_video_count=100,
+            new_alias_count=2,
+            new_video_count=30,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.split.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "split", "python", "--aliases", "Python3,python 3"]
+            )
+
+        assert "Split Successful" in result.output
+        assert "python" in result.output
+        assert "python3" in result.output
+        assert str(_OP_ID) in result.output
+
+    def test_split_with_reason_propagates_reason(self) -> None:
+        """--reason flag is forwarded to service.split()."""
+        from chronovista.services.tag_management import SplitResult
+
+        mock_result = SplitResult(
+            original_tag="python",
+            new_tag="python3",
+            new_canonical_form="Python3",
+            new_normalized_form="python3",
+            aliases_moved=1,
+            original_alias_count=4,
+            original_video_count=80,
+            new_alias_count=1,
+            new_video_count=20,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.split.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "tags",
+                    "split",
+                    "python",
+                    "--aliases",
+                    "Python3",
+                    "--reason",
+                    "Version disambiguation",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_service.split.call_args[1]
+        assert call_kwargs.get("reason") == "Version disambiguation"
+
+    def test_split_aliases_parsed_as_csv(self) -> None:
+        """Comma-separated --aliases are correctly split before passing to service."""
+        from chronovista.services.tag_management import SplitResult
+
+        mock_result = SplitResult(
+            original_tag="python",
+            new_tag="python3",
+            new_canonical_form="Python3",
+            new_normalized_form="python3",
+            aliases_moved=3,
+            original_alias_count=6,
+            original_video_count=100,
+            new_alias_count=3,
+            new_video_count=40,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.split.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "tags",
+                    "split",
+                    "python",
+                    "--aliases",
+                    "Python3, python 3, py3",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Verify the alias list reached the service with whitespace stripped
+        call_kwargs = mock_service.split.call_args[1]
+        alias_list = call_kwargs.get("alias_raw_forms")
+        assert "Python3" in alias_list
+        assert "python 3" in alias_list
+        assert "py3" in alias_list
+
+    def test_split_value_error_exits_code_1(self) -> None:
+        """ValueError from service produces exit code 1."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.split.side_effect = ValueError(
+                "Alias(es) not found on tag 'python': nonexistent_alias"
+            )
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "split", "python", "--aliases", "nonexistent_alias"]
+            )
+
+        assert result.exit_code == 1
+
+    def test_split_value_error_shows_split_failed_panel(self) -> None:
+        """ValueError message is displayed in Split Failed panel."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.split.side_effect = ValueError(
+                "Cannot split all aliases from 'python'"
+            )
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "split", "python", "--aliases", "python"]
+            )
+
+        assert "Split Failed" in result.output
+
+    def test_split_missing_aliases_flag_exits_nonzero(self) -> None:
+        """Missing required --aliases option exits with non-zero code."""
+        result = runner.invoke(app, ["tags", "split", "python"])
+
+        assert result.exit_code != 0
+
+    def test_split_reason_too_long_exits_code_2(self) -> None:
+        """--reason exceeding 1000 chars triggers Typer bad parameter (exit 2)."""
+        long_reason = "y" * 1001
+
+        result = runner.invoke(
+            app,
+            ["tags", "split", "python", "--aliases", "Python3", "--reason", long_reason],
+        )
+
+        assert result.exit_code == 2
+
+    def test_split_help_flag(self) -> None:
+        """--help shows usage text and exits 0."""
+        result = runner.invoke(app, ["tags", "split", "--help"])
+
+        assert result.exit_code == 0
+        assert "--aliases" in result.output
+        assert "--reason" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Rename command tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenameCommand:
+    """Integration tests for `chronovista tags rename`."""
+
+    def test_successful_rename_exit_code_zero(self) -> None:
+        """Successful rename returns exit code 0."""
+        from chronovista.services.tag_management import RenameResult
+
+        mock_result = RenameResult(
+            normalized_form="mexico",
+            old_form="Mexico",
+            new_form="Mexico City",
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.rename.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "rename", "mexico", "--to", "Mexico City"]
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_successful_rename_output_shows_old_and_new_form(self) -> None:
+        """Output shows old display form, new display form, and operation ID."""
+        from chronovista.services.tag_management import RenameResult
+
+        mock_result = RenameResult(
+            normalized_form="mexico",
+            old_form="Mexico",
+            new_form="Mexico City",
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.rename.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "rename", "mexico", "--to", "Mexico City"]
+            )
+
+        assert "Rename Successful" in result.output
+        assert "Mexico" in result.output
+        assert "Mexico City" in result.output
+        assert str(_OP_ID) in result.output
+
+    def test_rename_with_reason_propagates_reason(self) -> None:
+        """--reason flag is forwarded to service.rename()."""
+        from chronovista.services.tag_management import RenameResult
+
+        mock_result = RenameResult(
+            normalized_form="mexico",
+            old_form="Mexico",
+            new_form="Mexico City",
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.rename.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "tags",
+                    "rename",
+                    "mexico",
+                    "--to",
+                    "Mexico City",
+                    "--reason",
+                    "More specific display name",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_service.rename.call_args[1]
+        assert call_kwargs.get("reason") == "More specific display name"
+
+    def test_rename_value_error_exits_code_1(self) -> None:
+        """ValueError from service produces exit code 1."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.rename.side_effect = ValueError("Tag 'nonexistent' not found")
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "rename", "nonexistent", "--to", "Something"]
+            )
+
+        assert result.exit_code == 1
+
+    def test_rename_value_error_shows_rename_failed_panel(self) -> None:
+        """ValueError message is displayed in Rename Failed panel."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.rename.side_effect = ValueError("New display form cannot be empty")
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "rename", "mexico", "--to", "   "]
+            )
+
+        assert "Rename Failed" in result.output
+
+    def test_rename_missing_to_flag_exits_nonzero(self) -> None:
+        """Missing required --to option exits with non-zero code."""
+        result = runner.invoke(app, ["tags", "rename", "mexico"])
+
+        assert result.exit_code != 0
+
+    def test_rename_reason_too_long_exits_code_2(self) -> None:
+        """--reason exceeding 1000 chars triggers Typer bad parameter (exit 2)."""
+        long_reason = "r" * 1001
+
+        result = runner.invoke(
+            app, ["tags", "rename", "mexico", "--to", "Mexico", "--reason", long_reason]
+        )
+
+        assert result.exit_code == 2
+
+    def test_rename_help_flag(self) -> None:
+        """--help shows usage and exits 0."""
+        result = runner.invoke(app, ["tags", "rename", "--help"])
+
+        assert result.exit_code == 0
+        assert "--to" in result.output
+        assert "--reason" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Undo command tests
+# ---------------------------------------------------------------------------
+
+
+def _make_operation_log_mock(
+    op_id: uuid.UUID,
+    op_type: str,
+    rolled_back: bool = False,
+    reason: str | None = None,
+) -> MagicMock:
+    """Build a MagicMock that looks like a TagOperationLog ORM row."""
+    log = MagicMock()
+    log.id = op_id
+    log.operation_type = op_type
+    log.performed_at = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    log.rolled_back = rolled_back
+    log.reason = reason
+    return log
+
+
+class TestUndoCommand:
+    """Integration tests for `chronovista tags undo`."""
+
+    def test_undo_merge_exit_code_zero(self) -> None:
+        """Undoing a merge operation returns exit code 0."""
+        from chronovista.services.tag_management import UndoResult
+
+        mock_result = UndoResult(
+            operation_type="merge",
+            operation_id=_OP_ID,
+            details="Unmerged mejico from target",
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.undo.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", str(_OP_ID)])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_undo_merge_output_shows_undo_successful(self) -> None:
+        """Successful undo output shows 'Undo Successful' panel."""
+        from chronovista.services.tag_management import UndoResult
+
+        mock_result = UndoResult(
+            operation_type="merge",
+            operation_id=_OP_ID,
+            details="Unmerged mejico from target",
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.undo.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", str(_OP_ID)])
+
+        assert "Undo Successful" in result.output
+        assert "merge" in result.output
+        assert "Unmerged" in result.output
+
+    def test_undo_split_exit_code_zero(self) -> None:
+        """Undoing a split operation returns exit code 0."""
+        from chronovista.services.tag_management import UndoResult
+
+        mock_result = UndoResult(
+            operation_type="split",
+            operation_id=_OP_ID,
+            details="Reunited 2 aliases back into 'python'",
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.undo.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", str(_OP_ID)])
+
+        assert result.exit_code == 0
+
+    def test_undo_split_output_shows_reunited_details(self) -> None:
+        """Undo split output contains the reunited-aliases detail string."""
+        from chronovista.services.tag_management import UndoResult
+
+        mock_result = UndoResult(
+            operation_type="split",
+            operation_id=_OP_ID,
+            details="Reunited 2 aliases back into 'python'",
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.undo.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", str(_OP_ID)])
+
+        assert "Reunited" in result.output
+        assert "python" in result.output
+
+    def test_undo_list_shows_recent_operations_table(self) -> None:
+        """--list flag outputs a Recent Tag Operations table."""
+        log_entry = _make_operation_log_mock(_OP_ID, "merge", reason="test reason")
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.list_recent_operations.return_value = [log_entry]
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", "--list"])
+
+        assert result.exit_code == 0
+        # Table heading is always present
+        assert "Recent Tag Operations" in result.output
+        # The Timestamp column header is wide enough to appear untruncated
+        assert "Timestamp" in result.output
+
+    def test_undo_list_empty_shows_no_operations_panel(self) -> None:
+        """--list with no operations shows 'No Operations' panel."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.list_recent_operations.return_value = []
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", "--list"])
+
+        assert result.exit_code == 0
+        assert "No Operations" in result.output
+
+    def test_undo_invalid_uuid_exits_code_1(self) -> None:
+        """Passing a non-UUID string produces exit code 1."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", "not-a-uuid"])
+
+        assert result.exit_code == 1
+
+    def test_undo_invalid_uuid_shows_invalid_operation_id_panel(self) -> None:
+        """Passing a non-UUID string shows 'Invalid Operation ID' panel."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", "not-a-uuid"])
+
+        assert "Invalid Operation ID" in result.output
+
+    def test_undo_no_argument_no_list_exits_code_2(self) -> None:
+        """Invoking undo with no argument and no --list flag exits with code 2."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo"])
+
+        assert result.exit_code == 2
+
+    def test_undo_already_undone_exits_code_1(self) -> None:
+        """ValueError for already-undone operation produces exit code 1."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.undo.side_effect = ValueError(
+                f"Operation '{_OP_ID}' has already been undone"
+            )
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", str(_OP_ID)])
+
+        assert result.exit_code == 1
+
+    def test_undo_not_implemented_exits_code_1(self) -> None:
+        """UndoNotImplementedError produces exit code 1 with 'Undo Not Available' panel."""
+        from chronovista.services.tag_management import UndoNotImplementedError
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.undo.side_effect = UndoNotImplementedError(
+                "Undo for 'delete' is not yet implemented"
+            )
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", str(_OP_ID)])
+
+        assert result.exit_code == 1
+        assert "Undo Not Available" in result.output
+
+    def test_undo_list_shows_rolled_back_yes_for_rolled_back_ops(self) -> None:
+        """Rolled-back operations display 'yes' in the Rolled Back column."""
+        log_entry = _make_operation_log_mock(_OP_ID, "rename", rolled_back=True)
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.list_recent_operations.return_value = [log_entry]
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", "--list"])
+
+        assert result.exit_code == 0
+        # Rich renders "yes" in green but strips markup in test output
+        assert "yes" in result.output
+
+    def test_undo_help_flag(self) -> None:
+        """--help shows usage text and exits 0."""
+        result = runner.invoke(app, ["tags", "undo", "--help"])
+
+        assert result.exit_code == 0
+        assert "--list" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Classify command tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyCommand:
+    """Integration tests for `chronovista tags classify`."""
+
+    def test_classify_person_exit_code_zero(self) -> None:
+        """Classifying a tag as 'person' returns exit code 0."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="elon musk",
+            canonical_form="Elon Musk",
+            entity_type="person",
+            entity_created=True,
+            entity_alias_count=3,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "classify", "elon musk", "--type", "person"]
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_classify_person_output_shows_classify_successful(self) -> None:
+        """Classify output shows 'Classify Successful' panel with entity type."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="elon musk",
+            canonical_form="Elon Musk",
+            entity_type="person",
+            entity_created=True,
+            entity_alias_count=3,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "classify", "elon musk", "--type", "person"]
+            )
+
+        assert "Classify Successful" in result.output
+        assert "person" in result.output
+        assert "Elon Musk" in result.output
+        assert str(_OP_ID) in result.output
+
+    def test_classify_topic_exit_code_zero(self) -> None:
+        """Classifying a tag as 'topic' (tag-only type) returns exit code 0."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="machine learning",
+            canonical_form="Machine Learning",
+            entity_type="topic",
+            entity_created=False,
+            entity_alias_count=0,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "classify", "machine learning", "--type", "topic"]
+            )
+
+        assert result.exit_code == 0
+
+    def test_classify_top_browses_unclassified_tags(self) -> None:
+        """--top N shows a table of top unclassified canonical tags."""
+        # Build simple ORM-like mocks
+        tag1 = MagicMock()
+        tag1.normalized_form = "python"
+        tag1.canonical_form = "Python"
+        tag1.video_count = 500
+        tag1.alias_count = 5
+
+        tag2 = MagicMock()
+        tag2.normalized_form = "javascript"
+        tag2.canonical_form = "JavaScript"
+        tag2.video_count = 400
+        tag2.alias_count = 3
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.classify_top_unclassified.return_value = [tag1, tag2]
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "classify", "--top", "2"])
+
+        assert result.exit_code == 0
+        assert "python" in result.output
+        assert "javascript" in result.output
+        mock_service.classify_top_unclassified.assert_called_once()
+
+    def test_classify_top_no_unclassified_shows_empty_panel(self) -> None:
+        """--top N with no unclassified tags shows 'No unclassified tags found' panel."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.classify_top_unclassified.return_value = []
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "classify", "--top", "10"])
+
+        assert result.exit_code == 0
+        assert "No unclassified tags" in result.output
+
+    def test_classify_force_flag_passed_to_service(self) -> None:
+        """--force flag is forwarded to service.classify()."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="python",
+            canonical_form="Python",
+            entity_type="topic",
+            entity_created=False,
+            entity_alias_count=0,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "classify", "python", "--type", "topic", "--force"]
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_service.classify.call_args[1]
+        assert call_kwargs.get("force") is True
+
+    def test_classify_invalid_entity_type_exits_code_1(self) -> None:
+        """Invalid --type value exits with code 1 before calling service."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "classify", "python", "--type", "invalid_type"]
+            )
+
+        assert result.exit_code == 1
+        # Service should NOT be called — validation happens before service call
+        mock_service.classify.assert_not_called()
+
+    def test_classify_invalid_entity_type_shows_invalid_type_panel(self) -> None:
+        """Invalid --type shows 'Invalid --type' panel with valid values."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "classify", "python", "--type", "bad_type"]
+            )
+
+        assert "Invalid --type" in result.output
+        # Valid type names must be listed
+        assert "person" in result.output
+
+    def test_classify_top_and_normalized_form_mutual_exclusion_exits_code_2(self) -> None:
+        """Using --top together with a positional tag argument exits with code 2."""
+        result = runner.invoke(
+            app, ["tags", "classify", "python", "--top", "5"]
+        )
+
+        assert result.exit_code == 2
+
+    def test_classify_no_args_exits_code_2(self) -> None:
+        """Invoking classify with no positional arg and no --top exits with code 2."""
+        result = runner.invoke(app, ["tags", "classify"])
+
+        assert result.exit_code == 2
+
+    def test_classify_missing_type_flag_exits_code_2(self) -> None:
+        """Providing a positional tag but omitting --type exits with code 2."""
+        result = runner.invoke(app, ["tags", "classify", "python"])
+
+        assert result.exit_code == 2
+
+    def test_classify_value_error_exits_code_1(self) -> None:
+        """ValueError from service (e.g., already classified) produces exit code 1."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.classify.side_effect = ValueError(
+                "Tag 'python' is already classified as 'topic'. Use --force to override."
+            )
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "classify", "python", "--type", "topic"]
+            )
+
+        assert result.exit_code == 1
+        assert "Classify Failed" in result.output
+
+    def test_classify_with_reason_propagates_reason(self) -> None:
+        """--reason flag is forwarded to service.classify()."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="python",
+            canonical_form="Python",
+            entity_type="technical_term",
+            entity_created=True,
+            entity_alias_count=2,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "tags",
+                    "classify",
+                    "python",
+                    "--type",
+                    "technical_term",
+                    "--reason",
+                    "Programming language",
+                ],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_service.classify.call_args[1]
+        assert call_kwargs.get("reason") == "Programming language"
+
+    def test_classify_help_flag(self) -> None:
+        """--help shows usage text and exits 0."""
+        result = runner.invoke(app, ["tags", "classify", "--help"])
+
+        assert result.exit_code == 0
+        assert "--type" in result.output
+        assert "--top" in result.output
+        assert "--force" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Collisions command tests
+# ---------------------------------------------------------------------------
+
+
+def _make_collision_group(
+    canonical_form: str = "Cafe",
+    normalized_form: str = "cafe",
+    aliases: list[dict[str, Any]] | None = None,
+    total_occurrences: int = 10,
+) -> "CollisionGroup":
+    """Build a CollisionGroup-like mock."""
+    from chronovista.services.tag_management import CollisionGroup
+
+    if aliases is None:
+        aliases = [
+            {"raw_form": "Cafe", "occurrence_count": 6},
+            {"raw_form": "Café", "occurrence_count": 4},
+        ]
+
+    tag_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    return CollisionGroup(
+        canonical_form=canonical_form,
+        normalized_form=normalized_form,
+        canonical_tag_id=tag_id,
+        aliases=aliases,
+        total_occurrence_count=total_occurrences,
+    )
+
+
+class TestCollisionsCommand:
+    """Integration tests for `chronovista tags collisions`."""
+
+    def test_json_format_exits_code_zero(self) -> None:
+        """--format json exits with code 0 when collisions exist."""
+        collision = _make_collision_group()
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.get_collisions.return_value = [collision]
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "collisions", "--format", "json"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_json_format_output_contains_collision_data(self) -> None:
+        """JSON output contains canonical_form, normalized_form, and aliases."""
+        import json
+
+        collision = _make_collision_group(
+            canonical_form="Cafe", normalized_form="cafe"
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.get_collisions.return_value = [collision]
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "collisions", "--format", "json"])
+
+        assert result.exit_code == 0
+        # Output should be parseable JSON
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["canonical_form"] == "Cafe"
+        assert parsed[0]["normalized_form"] == "cafe"
+        assert "aliases" in parsed[0]
+
+    def test_json_format_with_limit_respected(self) -> None:
+        """--limit is forwarded to service.get_collisions()."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.get_collisions.return_value = []
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app, ["tags", "collisions", "--format", "json", "--limit", "5"]
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_service.get_collisions.call_args[1]
+        assert call_kwargs.get("limit") == 5
+
+    def test_no_collisions_shows_no_candidates_message(self) -> None:
+        """No collision candidates prints a green 'No collision candidates found' message."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.get_collisions.return_value = []
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "collisions", "--format", "json"])
+
+        assert result.exit_code == 0
+        assert "No collision candidates found" in result.output
+
+    def test_include_reviewed_flag_forwarded_to_service(self) -> None:
+        """--include-reviewed is forwarded to service.get_collisions()."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.get_collisions.return_value = []
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                ["tags", "collisions", "--format", "json", "--include-reviewed"],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_service.get_collisions.call_args[1]
+        assert call_kwargs.get("include_reviewed") is True
+
+    def test_json_output_multiple_collisions(self) -> None:
+        """JSON output with multiple groups returns a list of correct length."""
+        import json
+
+        collisions = [
+            _make_collision_group("Cafe", "cafe", total_occurrences=20),
+            _make_collision_group("Resume", "resume", total_occurrences=15),
+        ]
+        # Give second collision a distinct canonical_tag_id
+        collisions[1].canonical_tag_id = uuid.UUID(
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.get_collisions.return_value = collisions
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "collisions", "--format", "json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert len(parsed) == 2
+
+    def test_collisions_help_flag(self) -> None:
+        """--help shows usage text and exits 0."""
+        result = runner.invoke(app, ["tags", "collisions", "--help"])
+
+        assert result.exit_code == 0
+        assert "--format" in result.output
+        assert "--limit" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Deprecate command tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecateCommand:
+    """Integration tests for `chronovista tags deprecate`."""
+
+    def test_successful_deprecate_exit_code_zero(self) -> None:
+        """Deprecating an active tag returns exit code 0."""
+        from chronovista.services.tag_management import DeprecateResult
+
+        mock_result = DeprecateResult(
+            normalized_form="old tag",
+            canonical_form="Old Tag",
+            alias_count=3,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.deprecate.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "deprecate", "old tag"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_successful_deprecate_output_shows_deprecate_successful(self) -> None:
+        """Successful deprecation output shows 'Deprecate Successful' panel."""
+        from chronovista.services.tag_management import DeprecateResult
+
+        mock_result = DeprecateResult(
+            normalized_form="old tag",
+            canonical_form="Old Tag",
+            alias_count=3,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.deprecate.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "deprecate", "old tag"])
+
+        assert "Deprecate Successful" in result.output
+        assert "old tag" in result.output
+        assert "Old Tag" in result.output
+        assert str(_OP_ID) in result.output
+
+    def test_deprecate_with_reason_propagates_reason(self) -> None:
+        """--reason flag is forwarded to service.deprecate()."""
+        from chronovista.services.tag_management import DeprecateResult
+
+        mock_result = DeprecateResult(
+            normalized_form="old tag",
+            canonical_form="Old Tag",
+            alias_count=1,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.deprecate.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                ["tags", "deprecate", "old tag", "--reason", "No longer relevant"],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_service.deprecate.call_args[1]
+        assert call_kwargs.get("reason") == "No longer relevant"
+
+    def test_deprecate_list_shows_deprecated_tags_table(self) -> None:
+        """--list flag outputs a table of deprecated canonical tags."""
+        tag1 = MagicMock()
+        tag1.normalized_form = "old tag"
+        tag1.canonical_form = "Old Tag"
+        tag1.alias_count = 2
+        tag1.video_count = 5
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.list_deprecated.return_value = [tag1]
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "deprecate", "--list"])
+
+        assert result.exit_code == 0
+        assert "Deprecated Tags" in result.output
+        assert "old tag" in result.output
+
+    def test_deprecate_list_empty_shows_no_deprecated_panel(self) -> None:
+        """--list with no deprecated tags shows 'No deprecated tags found' panel."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.list_deprecated.return_value = []
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "deprecate", "--list"])
+
+        assert result.exit_code == 0
+        assert "No deprecated tags found" in result.output
+
+    def test_deprecate_list_and_tag_arg_mutual_exclusion_exits_code_2(self) -> None:
+        """Using --list with a positional tag argument exits with code 2."""
+        result = runner.invoke(app, ["tags", "deprecate", "sometag", "--list"])
+
+        assert result.exit_code == 2
+
+    def test_deprecate_no_args_exits_code_2(self) -> None:
+        """Invoking deprecate with no positional arg and no --list exits with code 2."""
+        result = runner.invoke(app, ["tags", "deprecate"])
+
+        assert result.exit_code == 2
+
+    def test_deprecate_value_error_exits_code_1(self) -> None:
+        """ValueError from service (tag not found or already deprecated) exits code 1."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.deprecate.side_effect = ValueError(
+                "Tag 'nonexistent' not found"
+            )
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "deprecate", "nonexistent"])
+
+        assert result.exit_code == 1
+
+    def test_deprecate_value_error_shows_deprecate_failed_panel(self) -> None:
+        """ValueError message is displayed in Deprecate Failed panel."""
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.deprecate.side_effect = ValueError(
+                "Tag 'already-deprecated' exists but has status 'deprecated'"
+            )
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "deprecate", "already-deprecated"])
+
+        assert "Deprecate Failed" in result.output
+
+    def test_deprecate_reason_too_long_exits_code_2(self) -> None:
+        """--reason exceeding 1000 chars triggers Typer bad parameter (exit 2)."""
+        long_reason = "d" * 1001
+
+        result = runner.invoke(
+            app, ["tags", "deprecate", "sometag", "--reason", long_reason]
+        )
+
+        assert result.exit_code == 2
+
+    def test_deprecate_help_flag(self) -> None:
+        """--help shows usage text and exits 0."""
+        result = runner.invoke(app, ["tags", "deprecate", "--help"])
+
+        assert result.exit_code == 0
+        assert "--list" in result.output
+        assert "--reason" in result.output
+
+    def test_undo_deprecate_end_to_end(self) -> None:
+        """Undo a deprecate restores the tag status (end-to-end via mock)."""
+        from chronovista.services.tag_management import UndoResult
+
+        undo_result = UndoResult(
+            operation_type="delete",
+            operation_id=_OP_ID,
+            details="Restored 'old tag' from deprecated to active",
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_service = AsyncMock()
+            mock_service.undo.return_value = undo_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(app, ["tags", "undo", str(_OP_ID)])
+
+        assert result.exit_code == 0
+        assert "Undo Successful" in result.output
+        assert "Restored" in result.output

--- a/tests/unit/repositories/test_tag_operation_log_repository.py
+++ b/tests/unit/repositories/test_tag_operation_log_repository.py
@@ -1,0 +1,883 @@
+"""
+Tests for TagOperationLogRepository.
+
+Covers all public methods:
+- create() (inherited from BaseSQLAlchemyRepository, driven by TagOperationLogCreate)
+- get() – lookup by UUID primary key
+- exists() – presence check by UUID primary key
+- get_recent() – ordered list with default and custom limits
+- get_by_operation_id() – semantic alias for get()
+
+Mock strategy: every test creates a MagicMock(spec=AsyncSession) whose
+``execute`` attribute is an AsyncMock. This mirrors the pattern used in
+``test_canonical_tag_repository.py`` and avoids any real database I/O.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.db.models import TagOperationLog as TagOperationLogDB
+from chronovista.models.tag_operation_log import TagOperationLogCreate
+from chronovista.repositories.tag_operation_log_repository import (
+    TagOperationLogRepository,
+)
+from tests.factories.tag_operation_log_factory import (
+    TagOperationLogFactory,
+    create_merge_operation_log,
+    create_split_operation_log,
+    create_tag_operation_log,
+)
+
+# Ensures every async test in this module is recognised by pytest-asyncio
+# regardless of how coverage is invoked (see CLAUDE.md §pytest-asyncio section).
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_uuid() -> uuid.UUID:
+    """Return a UUIDv7 expressed as a stdlib ``uuid.UUID`` instance."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+
+def _make_log_db(
+    *,
+    id: uuid.UUID | None = None,
+    operation_type: str = "create",
+    source_canonical_ids: list[str] | None = None,
+    target_canonical_id: uuid.UUID | None = None,
+    affected_alias_ids: list[str] | None = None,
+    reason: str | None = None,
+    performed_by: str = "system",
+    performed_at: datetime | None = None,
+    rollback_data: dict[str, Any] | None = None,
+    rolled_back: bool = False,
+    rolled_back_at: datetime | None = None,
+) -> TagOperationLogDB:
+    """
+    Build an in-memory TagOperationLogDB instance without a DB session.
+
+    Parameters
+    ----------
+    id : uuid.UUID, optional
+        Primary key; generated via UUIDv7 when omitted.
+    operation_type : str
+        One of: merge, split, rename, delete, create.
+    source_canonical_ids : list[str], optional
+        JSONB list of source canonical-tag UUIDs as strings.
+    target_canonical_id : uuid.UUID, optional
+        Target canonical tag UUID for merge/rename operations.
+    affected_alias_ids : list[str], optional
+        JSONB list of alias UUIDs as strings.
+    reason : str, optional
+        Human-readable reason for the operation.
+    performed_by : str
+        Actor identifier (default ``"system"``).
+    performed_at : datetime, optional
+        Timestamp; defaults to 2024-01-15 10:30 UTC.
+    rollback_data : dict, optional
+        Snapshot data for rollback; defaults to empty dict.
+    rolled_back : bool
+        Whether the operation has been reversed.
+    rolled_back_at : datetime, optional
+        Timestamp of the rollback, if any.
+
+    Returns
+    -------
+    TagOperationLogDB
+        An ORM instance suitable for use in mock return values.
+    """
+    return TagOperationLogDB(
+        id=id or _make_uuid(),
+        operation_type=operation_type,
+        source_canonical_ids=source_canonical_ids or [],
+        target_canonical_id=target_canonical_id,
+        affected_alias_ids=affected_alias_ids or [],
+        reason=reason,
+        performed_by=performed_by,
+        performed_at=performed_at or datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+        rollback_data=rollback_data or {},
+        rolled_back=rolled_back,
+        rolled_back_at=rolled_back_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestTagOperationLogRepositoryInit
+# ---------------------------------------------------------------------------
+
+
+class TestTagOperationLogRepositoryInit:
+    """Tests that the repository wires the correct ORM model."""
+
+    async def test_model_is_tag_operation_log_db(self) -> None:
+        """Repository must be initialised with TagOperationLogDB."""
+        repo = TagOperationLogRepository()
+        assert repo.model is TagOperationLogDB
+
+    async def test_repository_exposes_expected_methods(self) -> None:
+        """All public methods described in the spec must exist on the repository."""
+        repo = TagOperationLogRepository()
+        for method_name in ("create", "get", "exists", "get_recent", "get_by_operation_id"):
+            assert hasattr(repo, method_name), f"Missing method: {method_name}"
+
+
+# ---------------------------------------------------------------------------
+# TestTagOperationLogRepositoryCreate
+# ---------------------------------------------------------------------------
+
+
+class TestTagOperationLogRepositoryCreate:
+    """Tests for create() which is inherited from BaseSQLAlchemyRepository."""
+
+    @pytest.fixture
+    def repository(self) -> TagOperationLogRepository:
+        """Create repository instance."""
+        return TagOperationLogRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create a mock AsyncSession with async flush/refresh."""
+        session = MagicMock(spec=AsyncSession)
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+        return session
+
+    async def test_create_with_minimal_pydantic_model(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """
+        create() with a minimal TagOperationLogCreate (only operation_type) calls
+        session.add, flush, and refresh in order.
+        """
+        obj_in = TagOperationLogCreate(operation_type="create")
+        db_log = _make_log_db(operation_type="create")
+        mock_session.refresh.side_effect = lambda obj: None
+
+        # Patch the ORM constructor so we control the returned object.
+        with patch.object(
+            TagOperationLogDB,
+            "__init__",
+            return_value=None,
+        ):
+            # We can't easily intercept __init__ and still return db_log, so
+            # instead we verify session interaction through the real flow:
+            pass
+
+        # Use a simpler approach: verify via side effects on session.refresh
+        # that create() passes through the full add→flush→refresh cycle.
+        result_holder: list[TagOperationLogDB] = []
+
+        async def _fake_refresh(obj: TagOperationLogDB) -> None:
+            result_holder.append(obj)
+
+        mock_session.refresh.side_effect = _fake_refresh
+
+        returned = await repository.create(mock_session, obj_in=obj_in)
+
+        mock_session.add.assert_called_once()
+        mock_session.flush.assert_awaited_once()
+        mock_session.refresh.assert_awaited_once()
+        # The object passed to session.add must be a TagOperationLogDB instance.
+        added_obj = mock_session.add.call_args[0][0]
+        assert isinstance(added_obj, TagOperationLogDB)
+        assert added_obj.operation_type == "create"
+
+    async def test_create_with_merge_operation(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """
+        create() with a merge-type TagOperationLogCreate sets all provided fields
+        on the resulting ORM object.
+        """
+        source_id = _make_uuid()
+        target_id = _make_uuid()
+        alias_id = _make_uuid()
+
+        second_source_id = _make_uuid()
+        obj_in = TagOperationLogCreate(
+            operation_type="merge",
+            source_canonical_ids=[str(source_id), str(second_source_id)],
+            target_canonical_id=target_id,
+            affected_alias_ids=[str(alias_id)],
+            reason="Duplicate tags consolidated",
+            performed_by="backfill_script",
+            rollback_data={"original_form": "Python3"},
+        )
+
+        await repository.create(mock_session, obj_in=obj_in)
+
+        added_obj = mock_session.add.call_args[0][0]
+        assert isinstance(added_obj, TagOperationLogDB)
+        assert added_obj.operation_type == "merge"
+        assert added_obj.performed_by == "backfill_script"
+        assert added_obj.reason == "Duplicate tags consolidated"
+        assert added_obj.rollback_data == {"original_form": "Python3"}
+
+    async def test_create_with_all_operation_types(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """
+        create() accepts all five valid operation_type values without raising.
+        """
+        for op_type in ("merge", "split", "rename", "delete", "create"):
+            mock_session.add.reset_mock()
+            mock_session.flush.reset_mock()
+            mock_session.refresh.reset_mock()
+
+            obj_in = TagOperationLogCreate(operation_type=op_type)
+            await repository.create(mock_session, obj_in=obj_in)
+
+            added_obj = mock_session.add.call_args[0][0]
+            assert added_obj.operation_type == op_type
+
+    async def test_create_default_performed_by_is_cli(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """
+        When performed_by is not supplied, the Pydantic default 'cli' is used and
+        propagated to the ORM object.
+        """
+        obj_in = TagOperationLogCreate(operation_type="delete")
+        assert obj_in.performed_by == "cli"
+
+        await repository.create(mock_session, obj_in=obj_in)
+
+        added_obj = mock_session.add.call_args[0][0]
+        assert added_obj.performed_by == "cli"
+
+    async def test_create_with_rollback_data_dict(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """
+        rollback_data dict is faithfully passed to the ORM constructor.
+        """
+        rollback_payload: dict[str, Any] = {
+            "old_canonical_form": "ML",
+            "aliases_affected": ["ml", "M.L."],
+            "video_count_snapshot": 42,
+        }
+        obj_in = TagOperationLogCreate(
+            operation_type="rename",
+            rollback_data=rollback_payload,
+        )
+
+        await repository.create(mock_session, obj_in=obj_in)
+
+        added_obj = mock_session.add.call_args[0][0]
+        assert added_obj.rollback_data == rollback_payload
+
+
+# ---------------------------------------------------------------------------
+# TestTagOperationLogRepositoryGet
+# ---------------------------------------------------------------------------
+
+
+class TestTagOperationLogRepositoryGet:
+    """Tests for get() – lookup by UUID primary key."""
+
+    @pytest.fixture
+    def repository(self) -> TagOperationLogRepository:
+        """Create repository instance."""
+        return TagOperationLogRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create a mock AsyncSession."""
+        session = MagicMock(spec=AsyncSession)
+        session.execute = AsyncMock()
+        return session
+
+    async def test_get_returns_matching_log_entry(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get() returns the TagOperationLogDB when it exists."""
+        log_id = _make_uuid()
+        db_log = _make_log_db(id=log_id, operation_type="split")
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = db_log
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, log_id)
+
+        assert result is db_log
+        mock_session.execute.assert_awaited_once()
+
+    async def test_get_returns_none_when_not_found(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get() returns None for a UUID that does not exist."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, _make_uuid())
+
+        assert result is None
+        mock_session.execute.assert_awaited_once()
+
+    async def test_get_executes_exactly_one_query(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get() issues exactly one SELECT to the session."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        await repository.get(mock_session, _make_uuid())
+
+        assert mock_session.execute.await_count == 1
+
+    async def test_get_with_factory_produced_log(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get() works correctly when the return value is a factory-built object."""
+        factory_log = create_tag_operation_log(operation_type="rename")
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = factory_log
+        mock_session.execute.return_value = mock_result
+
+        # TagOperationLogFactory produces uuid7 instances; convert for the call.
+        log_id = uuid.UUID(bytes=factory_log.id.bytes)
+        result = await repository.get(mock_session, log_id)
+
+        assert result is factory_log
+        assert result.operation_type == "rename"
+
+
+# ---------------------------------------------------------------------------
+# TestTagOperationLogRepositoryExists
+# ---------------------------------------------------------------------------
+
+
+class TestTagOperationLogRepositoryExists:
+    """Tests for exists() – Boolean presence check by UUID."""
+
+    @pytest.fixture
+    def repository(self) -> TagOperationLogRepository:
+        """Create repository instance."""
+        return TagOperationLogRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create a mock AsyncSession."""
+        session = MagicMock(spec=AsyncSession)
+        session.execute = AsyncMock()
+        return session
+
+    async def test_exists_returns_true_when_row_found(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """exists() returns True when the SELECT finds a matching row."""
+        log_id = _make_uuid()
+
+        # session.execute(...).first() is not None → True
+        mock_result = MagicMock()
+        mock_result.first.return_value = (log_id,)  # non-None row
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, log_id)
+
+        assert result is True
+        mock_session.execute.assert_awaited_once()
+
+    async def test_exists_returns_false_when_row_missing(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """exists() returns False when the SELECT returns no rows."""
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, _make_uuid())
+
+        assert result is False
+        mock_session.execute.assert_awaited_once()
+
+    async def test_exists_executes_exactly_one_query(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """exists() must issue exactly one lightweight SELECT per call."""
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        await repository.exists(mock_session, _make_uuid())
+        await repository.exists(mock_session, _make_uuid())
+
+        assert mock_session.execute.await_count == 2
+
+    async def test_exists_true_for_factory_built_log(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """exists() correctly reflects presence for a factory-generated log."""
+        factory_log = create_merge_operation_log()
+        log_id = uuid.UUID(bytes=factory_log.id.bytes)
+
+        mock_result = MagicMock()
+        mock_result.first.return_value = (log_id,)
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, log_id)
+
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# TestTagOperationLogRepositoryGetRecent
+# ---------------------------------------------------------------------------
+
+
+class TestTagOperationLogRepositoryGetRecent:
+    """Tests for get_recent() – ordered list with configurable limit."""
+
+    @pytest.fixture
+    def repository(self) -> TagOperationLogRepository:
+        """Create repository instance."""
+        return TagOperationLogRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create a mock AsyncSession."""
+        session = MagicMock(spec=AsyncSession)
+        session.execute = AsyncMock()
+        return session
+
+    async def test_get_recent_returns_all_logs_when_within_default_limit(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_recent() with no limit argument returns up to 20 entries."""
+        logs = [_make_log_db(operation_type="create") for _ in range(5)]
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = logs
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_recent(mock_session)
+
+        assert result == logs
+        assert len(result) == 5
+        mock_session.execute.assert_awaited_once()
+
+    async def test_get_recent_respects_custom_limit(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_recent() honours an explicit limit parameter."""
+        logs = [_make_log_db(operation_type="merge") for _ in range(3)]
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = logs
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_recent(mock_session, limit=3)
+
+        assert result == logs
+        assert len(result) == 3
+
+    async def test_get_recent_returns_empty_list_when_no_logs(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_recent() returns [] when the table has no entries."""
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_recent(mock_session)
+
+        assert result == []
+
+    async def test_get_recent_result_is_a_list(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_recent() always returns a list (not a SQLAlchemy ScalarResult)."""
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [_make_log_db()]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_recent(mock_session)
+
+        assert isinstance(result, list)
+
+    async def test_get_recent_limit_one_returns_single_item_list(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_recent(limit=1) returns exactly one item."""
+        single_log = _make_log_db(operation_type="delete")
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [single_log]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_recent(mock_session, limit=1)
+
+        assert len(result) == 1
+        assert result[0] is single_log
+
+    async def test_get_recent_with_mixed_operation_types(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """
+        get_recent() can return logs of different operation types as produced by
+        the factory helpers.
+        """
+        create_log = create_tag_operation_log(operation_type="create")
+        merge_log = create_merge_operation_log()
+        split_log = create_split_operation_log()
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [create_log, merge_log, split_log]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_recent(mock_session, limit=10)
+
+        assert len(result) == 3
+        operation_types = {entry.operation_type for entry in result}
+        assert "create" in operation_types
+        assert "merge" in operation_types
+        assert "split" in operation_types
+
+    async def test_get_recent_executes_exactly_one_query(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_recent() must not issue more than one database round-trip."""
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        await repository.get_recent(mock_session, limit=50)
+
+        assert mock_session.execute.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# TestTagOperationLogRepositoryGetByOperationId
+# ---------------------------------------------------------------------------
+
+
+class TestTagOperationLogRepositoryGetByOperationId:
+    """
+    Tests for get_by_operation_id() – semantic alias for get().
+
+    The implementation delegates to self.get(session, operation_id), so these
+    tests verify both the delegation and the contract of the alias.
+    """
+
+    @pytest.fixture
+    def repository(self) -> TagOperationLogRepository:
+        """Create repository instance."""
+        return TagOperationLogRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create a mock AsyncSession."""
+        session = MagicMock(spec=AsyncSession)
+        session.execute = AsyncMock()
+        return session
+
+    async def test_delegates_to_get_and_returns_log(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_by_operation_id() returns the same object as get() for the same UUID."""
+        log_id = _make_uuid()
+        db_log = _make_log_db(id=log_id, operation_type="rename")
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = db_log
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_by_operation_id(mock_session, log_id)
+
+        assert result is db_log
+        mock_session.execute.assert_awaited_once()
+
+    async def test_returns_none_when_operation_id_not_found(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_by_operation_id() returns None for an unknown operation UUID."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_by_operation_id(mock_session, _make_uuid())
+
+        assert result is None
+
+    async def test_get_by_operation_id_is_equivalent_to_get(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """
+        get_by_operation_id() must produce identical results to calling get()
+        directly with the same UUID. We verify this by patching get() and
+        confirming it is invoked with the correct argument.
+        """
+        operation_id = _make_uuid()
+        db_log = _make_log_db(id=operation_id)
+
+        # Patch repository.get to record its invocation.
+        original_get = repository.get
+
+        get_call_args: list[uuid.UUID] = []
+
+        async def _spy_get(session: AsyncSession, id: uuid.UUID) -> TagOperationLogDB | None:
+            get_call_args.append(id)
+            # Reproduce the real SELECT path via mock.
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = db_log
+            mock_session.execute.return_value = mock_result
+            return await original_get(session, id)
+
+        repository.get = _spy_get  # type: ignore[method-assign]
+
+        result = await repository.get_by_operation_id(mock_session, operation_id)
+
+        assert result is db_log
+        assert len(get_call_args) == 1
+        assert get_call_args[0] == operation_id
+
+    async def test_get_by_operation_id_with_merge_factory_log(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_by_operation_id() works with a factory-built merge log entry."""
+        factory_log = create_merge_operation_log(reason="Normalisation pass")
+        log_id = uuid.UUID(bytes=factory_log.id.bytes)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = factory_log
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_by_operation_id(mock_session, log_id)
+
+        assert result is factory_log
+        assert result.operation_type == "merge"
+        assert result.reason == "Normalisation pass"
+
+    async def test_get_by_operation_id_issues_single_query(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_by_operation_id() must not fan out into extra queries."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        await repository.get_by_operation_id(mock_session, _make_uuid())
+
+        assert mock_session.execute.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# TestTagOperationLogRepositoryEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestTagOperationLogRepositoryEdgeCases:
+    """Edge-case and boundary tests that cut across multiple methods."""
+
+    @pytest.fixture
+    def repository(self) -> TagOperationLogRepository:
+        """Create repository instance."""
+        return TagOperationLogRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create a mock AsyncSession."""
+        session = MagicMock(spec=AsyncSession)
+        session.execute = AsyncMock()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+        return session
+
+    async def test_create_with_empty_source_canonical_ids(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """TagOperationLogCreate defaults source_canonical_ids to empty list."""
+        obj_in = TagOperationLogCreate(operation_type="create")
+        assert obj_in.source_canonical_ids == []
+
+        await repository.create(mock_session, obj_in=obj_in)
+
+        added = mock_session.add.call_args[0][0]
+        assert added.source_canonical_ids == []
+
+    async def test_create_with_many_source_ids(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """TagOperationLogCreate accepts arbitrarily many source_canonical_ids."""
+        ids = [str(_make_uuid()) for _ in range(10)]
+        obj_in = TagOperationLogCreate(
+            operation_type="merge",
+            source_canonical_ids=ids,
+        )
+        assert len(obj_in.source_canonical_ids) == 10
+
+        await repository.create(mock_session, obj_in=obj_in)
+
+        added = mock_session.add.call_args[0][0]
+        assert len(added.source_canonical_ids) == 10
+
+    async def test_get_and_exists_are_independent_sessions(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """
+        get() and exists() can be called sequentially on the same mock session
+        without interfering with each other's results.
+        """
+        log_id = _make_uuid()
+        db_log = _make_log_db(id=log_id)
+
+        get_result = MagicMock()
+        get_result.scalar_one_or_none.return_value = db_log
+
+        exists_result = MagicMock()
+        exists_result.first.return_value = (log_id,)
+
+        mock_session.execute.side_effect = [get_result, exists_result]
+
+        fetched = await repository.get(mock_session, log_id)
+        found = await repository.exists(mock_session, log_id)
+
+        assert fetched is db_log
+        assert found is True
+        assert mock_session.execute.await_count == 2
+
+    async def test_get_recent_with_limit_zero_returns_empty(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """
+        When limit=0 is passed the mock returns an empty list; the repository
+        must propagate this without error.
+        """
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_recent(mock_session, limit=0)
+
+        assert result == []
+
+    async def test_pydantic_create_rejects_invalid_operation_type(self) -> None:
+        """
+        TagOperationLogCreate raises ValueError for unknown operation types.
+        This guards the repository against receiving bad input before it reaches
+        the database.
+        """
+        import pytest
+
+        with pytest.raises(Exception):
+            TagOperationLogCreate(operation_type="invalid_op")
+
+    async def test_pydantic_create_all_valid_operation_types(self) -> None:
+        """TagOperationLogCreate accepts each of the five defined operation types."""
+        for op in ("merge", "split", "rename", "delete", "create"):
+            obj = TagOperationLogCreate(operation_type=op)
+            assert obj.operation_type == op
+
+    async def test_get_recent_returns_list_of_tag_operation_log_db_instances(
+        self,
+        repository: TagOperationLogRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Each element returned by get_recent() is a TagOperationLogDB."""
+        logs = [
+            _make_log_db(operation_type="create"),
+            _make_log_db(operation_type="delete"),
+        ]
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = logs
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get_recent(mock_session)
+
+        for entry in result:
+            assert isinstance(entry, TagOperationLogDB)

--- a/tests/unit/services/test_tag_management.py
+++ b/tests/unit/services/test_tag_management.py
@@ -1,0 +1,3376 @@
+"""
+Tests for TagManagementService shared utilities.
+
+Covers the three private helper methods that underpin all tag curation
+operations:
+
+- ``_validate_active_tag``: looks up a canonical tag by normalized form and
+  asserts it is active, raising ``ValueError`` if it is missing, merged, or
+  deprecated.
+- ``_recalculate_counts``: fires COUNT and COUNT DISTINCT queries then issues
+  an UPDATE statement to keep ``alias_count`` and ``video_count`` in sync.
+- ``_log_operation``: creates a ``TagOperationLogCreate`` Pydantic model and
+  persists it via the operation-log repository, returning the new entry UUID.
+
+All database I/O is fully mocked — these are pure unit tests that validate
+service-layer logic without any real database connection.
+
+References
+----------
+- TagManagementService implementation:
+  src/chronovista/services/tag_management.py
+- TagOperationLogCreate Pydantic model:
+  src/chronovista/models/tag_operation_log.py
+- CanonicalTag DB model:
+  src/chronovista/db/models.py (class CanonicalTag)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from chronovista.db.models import CanonicalTag as CanonicalTagDB
+from chronovista.db.models import TagOperationLog as TagOperationLogDB
+from chronovista.models.tag_operation_log import TagOperationLogCreate
+from chronovista.services.tag_management import TagManagementService
+
+# ---------------------------------------------------------------------------
+# CRITICAL: Module-level asyncio marker ensures async tests run properly
+# with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
+# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_canonical_tag_repo() -> AsyncMock:
+    """Provide a mock CanonicalTagRepository with async method stubs."""
+    repo = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_tag_alias_repo() -> AsyncMock:
+    """Provide a mock TagAliasRepository with async method stubs."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_named_entity_repo() -> AsyncMock:
+    """Provide a mock NamedEntityRepository with async method stubs."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_entity_alias_repo() -> AsyncMock:
+    """Provide a mock EntityAliasRepository with async method stubs."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_operation_log_repo() -> AsyncMock:
+    """Provide a mock TagOperationLogRepository with async method stubs."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def service(
+    mock_canonical_tag_repo: AsyncMock,
+    mock_tag_alias_repo: AsyncMock,
+    mock_named_entity_repo: AsyncMock,
+    mock_entity_alias_repo: AsyncMock,
+    mock_operation_log_repo: AsyncMock,
+) -> TagManagementService:
+    """
+    Provide a ``TagManagementService`` instance wired with all mock repos.
+
+    This is the canonical way to instantiate the service in unit tests.
+    The constructor signature is:
+        TagManagementService(
+            canonical_tag_repo,
+            tag_alias_repo,
+            named_entity_repo,
+            entity_alias_repo,
+            operation_log_repo,
+        )
+    """
+    return TagManagementService(
+        canonical_tag_repo=mock_canonical_tag_repo,
+        tag_alias_repo=mock_tag_alias_repo,
+        named_entity_repo=mock_named_entity_repo,
+        entity_alias_repo=mock_entity_alias_repo,
+        operation_log_repo=mock_operation_log_repo,
+    )
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    """Provide a mock AsyncSession."""
+    return AsyncMock()
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a fake CanonicalTagDB instance
+# ---------------------------------------------------------------------------
+
+
+def _make_canonical_tag(
+    *,
+    normalized_form: str = "python",
+    canonical_form: str = "Python",
+    status: str = "active",
+    alias_count: int = 3,
+    video_count: int = 10,
+) -> MagicMock:
+    """
+    Build a lightweight MagicMock that mimics a ``CanonicalTagDB`` row.
+
+    Only the attributes accessed by the service methods under test are set;
+    everything else falls back to MagicMock's default attribute access.
+    """
+    tag = MagicMock(spec=CanonicalTagDB)
+    tag.id = uuid.uuid4()
+    tag.normalized_form = normalized_form
+    tag.canonical_form = canonical_form
+    tag.status = status
+    tag.alias_count = alias_count
+    tag.video_count = video_count
+    return tag
+
+
+# ===========================================================================
+# TestValidateActiveTag
+# ===========================================================================
+
+
+class TestValidateActiveTag:
+    """
+    Tests for ``TagManagementService._validate_active_tag``.
+
+    The method queries the repository three times at most:
+      1. ``get_by_normalized_form(session, normalized_form)``        → status="active" (default)
+      2. ``get_by_normalized_form(session, normalized_form, status="merged")``
+      3. ``get_by_normalized_form(session, normalized_form, status="deprecated")``
+
+    It returns the active tag on success and raises ``ValueError`` in all
+    other cases.
+    """
+
+    async def test_validate_active_tag_success(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Happy path: repo returns an active tag on the first call.
+
+        Expected behaviour:
+        - ``get_by_normalized_form`` is called exactly once with the
+          default status (``"active"``).
+        - The returned ``CanonicalTagDB`` object is passed back unchanged.
+        - No ``ValueError`` is raised.
+        """
+        active_tag = _make_canonical_tag(normalized_form="python", status="active")
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = active_tag
+
+        result = await service._validate_active_tag(mock_session, "python")
+
+        assert result is active_tag
+        # Only the first (active-status) query should have fired
+        mock_canonical_tag_repo.get_by_normalized_form.assert_called_once_with(
+            mock_session, "python"
+        )
+
+    async def test_validate_active_tag_not_found(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Tag not found in any status: all three repo calls return ``None``.
+
+        Expected behaviour:
+        - Three ``get_by_normalized_form`` calls are made (active, merged,
+          deprecated).
+        - ``ValueError("Tag 'x' not found")`` is raised.
+        """
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = None
+
+        with pytest.raises(ValueError, match="Tag 'nonexistent' not found"):
+            await service._validate_active_tag(mock_session, "nonexistent")
+
+        # All three status lookups must have been attempted
+        assert mock_canonical_tag_repo.get_by_normalized_form.call_count == 3
+        calls = mock_canonical_tag_repo.get_by_normalized_form.call_args_list
+        # First call: default (active) — no explicit status keyword
+        assert calls[0] == call(mock_session, "nonexistent")
+        # Second call: merged
+        assert calls[1] == call(mock_session, "nonexistent", status="merged")
+        # Third call: deprecated
+        assert calls[2] == call(mock_session, "nonexistent", status="deprecated")
+
+    async def test_validate_active_tag_merged(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Tag exists but has ``merged`` status.
+
+        Expected behaviour:
+        - First call (active) returns ``None``.
+        - Second call (merged) returns a ``CanonicalTagDB`` with status
+          ``"merged"``.
+        - Third call (deprecated) is never executed.
+        - ``ValueError`` is raised with a message that includes the status
+          string ``"merged"`` and the normalized form.
+        """
+        merged_tag = _make_canonical_tag(normalized_form="oldtag", status="merged")
+        # Return None for "active" query, merged tag for "merged" query
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            None,         # first call: status="active"
+            merged_tag,   # second call: status="merged"
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            await service._validate_active_tag(mock_session, "oldtag")
+
+        error_message = str(exc_info.value)
+        assert "oldtag" in error_message
+        assert "merged" in error_message
+        assert "active" in error_message
+
+        # Only two calls should have been made (active + merged)
+        assert mock_canonical_tag_repo.get_by_normalized_form.call_count == 2
+
+    async def test_validate_active_tag_deprecated(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Tag exists but has ``deprecated`` status.
+
+        Expected behaviour:
+        - First call (active) returns ``None``.
+        - Second call (merged) returns ``None``.
+        - Third call (deprecated) returns a ``CanonicalTagDB`` with status
+          ``"deprecated"``.
+        - ``ValueError`` is raised with a message that includes both the
+          status string ``"deprecated"`` and the normalized form.
+        """
+        deprecated_tag = _make_canonical_tag(
+            normalized_form="oldertag", status="deprecated"
+        )
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            None,           # first call: status="active"
+            None,           # second call: status="merged"
+            deprecated_tag, # third call: status="deprecated"
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            await service._validate_active_tag(mock_session, "oldertag")
+
+        error_message = str(exc_info.value)
+        assert "oldertag" in error_message
+        assert "deprecated" in error_message
+        assert "active" in error_message
+
+        # All three status lookups must have been attempted
+        assert mock_canonical_tag_repo.get_by_normalized_form.call_count == 3
+
+    async def test_validate_active_tag_error_message_contains_status(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The ``ValueError`` message for a non-active tag must quote both
+        the actual status and the string ``'active'`` so callers can display
+        a useful diagnostic to the operator.
+        """
+        merged_tag = _make_canonical_tag(normalized_form="mytag", status="merged")
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            None,
+            merged_tag,
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            await service._validate_active_tag(mock_session, "mytag")
+
+        # Verify the precise phrasing matches the implementation
+        error_message = str(exc_info.value)
+        assert "mytag" in error_message
+        assert "'merged'" in error_message
+        assert "'active'" in error_message
+
+    async def test_validate_active_tag_returns_correct_object(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The method must return the exact object returned by the repository,
+        not a copy or re-constructed instance.
+        """
+        sentinel_tag = _make_canonical_tag(
+            normalized_form="java", canonical_form="Java", status="active"
+        )
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = sentinel_tag
+
+        result = await service._validate_active_tag(mock_session, "java")
+
+        assert result is sentinel_tag, (
+            "Expected the exact CanonicalTagDB object returned by the repo"
+        )
+
+    async def test_validate_active_tag_passes_session_to_repo(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The session passed to ``_validate_active_tag`` must be forwarded
+        to the repository without mutation.
+        """
+        active_tag = _make_canonical_tag(status="active")
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = active_tag
+
+        await service._validate_active_tag(mock_session, "sometag")
+
+        # Verify the exact session object was passed
+        first_call_args = mock_canonical_tag_repo.get_by_normalized_form.call_args_list[0]
+        assert first_call_args.args[0] is mock_session
+
+
+# ===========================================================================
+# TestRecalculateCounts
+# ===========================================================================
+
+
+class TestRecalculateCounts:
+    """
+    Tests for ``TagManagementService._recalculate_counts``.
+
+    The method issues three ``session.execute`` calls in order:
+      1. COUNT query on ``tag_aliases`` filtered by ``canonical_tag_id``.
+      2. COUNT DISTINCT query on ``video_tags`` joined to ``tag_aliases``.
+      3. UPDATE on ``canonical_tags`` setting the two new counts.
+
+    It returns ``(alias_count, video_count)`` as a tuple of ints.
+    """
+
+    def _make_scalar_result(self, value: int) -> MagicMock:
+        """Build a mock SQLAlchemy result whose ``scalar_one()`` returns *value*."""
+        result = MagicMock()
+        result.scalar_one.return_value = value
+        return result
+
+    async def test_recalculate_counts_returns_correct_tuple(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Happy path: session.execute returns alias count then video count.
+
+        Expected behaviour:
+        - First execute call → alias_count scalar.
+        - Second execute call → video_count scalar.
+        - Third execute call → UPDATE statement (result ignored).
+        - The method returns ``(alias_count, video_count)`` exactly.
+        """
+        canonical_tag_id = uuid.uuid4()
+
+        alias_result = self._make_scalar_result(7)
+        video_result = self._make_scalar_result(42)
+        update_result = MagicMock()  # UPDATE return value is unused
+
+        mock_session.execute = AsyncMock(
+            side_effect=[alias_result, video_result, update_result]
+        )
+
+        result = await service._recalculate_counts(mock_session, canonical_tag_id)
+
+        assert result == (7, 42), (
+            f"Expected (7, 42) but got {result!r}"
+        )
+
+    async def test_recalculate_counts_calls_execute_three_times(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        ``session.execute`` must be called exactly three times: two SELECTs
+        plus one UPDATE.
+        """
+        canonical_tag_id = uuid.uuid4()
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                self._make_scalar_result(5),
+                self._make_scalar_result(20),
+                MagicMock(),
+            ]
+        )
+
+        await service._recalculate_counts(mock_session, canonical_tag_id)
+
+        assert mock_session.execute.call_count == 3, (
+            "Expected exactly 3 execute calls (2 SELECTs + 1 UPDATE)"
+        )
+
+    async def test_recalculate_counts_zero_aliases(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Edge case: tag has zero aliases and zero video associations.
+
+        The method must propagate zeros faithfully — the DB CHECK constraint
+        (alias_count >= 1) is enforced at the DB layer, not here.
+        """
+        canonical_tag_id = uuid.uuid4()
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                self._make_scalar_result(0),
+                self._make_scalar_result(0),
+                MagicMock(),
+            ]
+        )
+
+        alias_count, video_count = await service._recalculate_counts(
+            mock_session, canonical_tag_id
+        )
+
+        assert alias_count == 0
+        assert video_count == 0
+
+    async def test_recalculate_counts_large_counts(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Large integer counts are returned without truncation or overflow.
+        """
+        canonical_tag_id = uuid.uuid4()
+        large_alias = 99_999
+        large_video = 500_569
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                self._make_scalar_result(large_alias),
+                self._make_scalar_result(large_video),
+                MagicMock(),
+            ]
+        )
+
+        alias_count, video_count = await service._recalculate_counts(
+            mock_session, canonical_tag_id
+        )
+
+        assert alias_count == large_alias
+        assert video_count == large_video
+
+    async def test_recalculate_counts_return_type_is_tuple_of_ints(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The return value must be a two-element tuple of plain Python ``int``
+        values, matching the declared return type ``tuple[int, int]``.
+        """
+        canonical_tag_id = uuid.uuid4()
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                self._make_scalar_result(3),
+                self._make_scalar_result(15),
+                MagicMock(),
+            ]
+        )
+
+        result = await service._recalculate_counts(mock_session, canonical_tag_id)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], int)
+        assert isinstance(result[1], int)
+
+
+# ===========================================================================
+# TestLogOperation
+# ===========================================================================
+
+
+class TestLogOperation:
+    """
+    Tests for ``TagManagementService._log_operation``.
+
+    The method:
+    1. Constructs a ``TagOperationLogCreate`` Pydantic model from the keyword
+       arguments.
+    2. Delegates persistence to ``self._operation_log_repo.create(session, obj_in=...)``.
+    3. Returns the ``id`` attribute of the persisted ``TagOperationLogDB`` object.
+    """
+
+    def _make_log_entry(self, entry_id: uuid.UUID | None = None) -> MagicMock:
+        """Build a mock ``TagOperationLogDB`` with the given ``id``."""
+        entry = MagicMock(spec=TagOperationLogDB)
+        entry.id = entry_id or uuid.uuid4()
+        return entry
+
+    async def test_log_operation_creates_entry_and_returns_id(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Happy path: ``_log_operation`` delegates to the repo and returns the
+        UUID of the persisted log entry.
+
+        Verifies:
+        - ``operation_log_repo.create`` is called exactly once.
+        - The returned value is the ``id`` of the created entry (a ``uuid.UUID``).
+        """
+        expected_id = uuid.uuid4()
+        log_entry = self._make_log_entry(expected_id)
+        mock_operation_log_repo.create.return_value = log_entry
+
+        source_id = uuid.uuid4()
+        target_id = uuid.uuid4()
+        alias_id = uuid.uuid4()
+
+        result = await service._log_operation(
+            mock_session,
+            operation_type="merge",
+            source_ids=[source_id],
+            target_id=target_id,
+            alias_ids=[alias_id],
+            reason="Consolidating duplicate tags",
+            rollback_data={"snapshot": "data"},
+        )
+
+        assert result == expected_id
+        assert isinstance(result, uuid.UUID)
+        mock_operation_log_repo.create.assert_called_once()
+
+    async def test_log_operation_passes_correct_pydantic_model(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The ``obj_in`` argument to ``repo.create`` must be a
+        ``TagOperationLogCreate`` instance whose fields match the arguments
+        passed to ``_log_operation``.
+
+        Field mapping:
+        - ``operation_type``       → operation_type
+        - ``source_canonical_ids`` → source_ids
+        - ``target_canonical_id``  → target_id
+        - ``affected_alias_ids``   → alias_ids
+        - ``reason``               → reason
+        - ``rollback_data``        → rollback_data
+        - ``performed_by``         → hard-coded to ``"cli"``
+        """
+        log_entry = self._make_log_entry()
+        mock_operation_log_repo.create.return_value = log_entry
+
+        source_id_1 = uuid.uuid4()
+        source_id_2 = uuid.uuid4()
+        target_id = uuid.uuid4()
+        alias_id = uuid.uuid4()
+        rollback: dict[str, Any] = {"previous_canonical_ids": [str(source_id_1)]}
+
+        await service._log_operation(
+            mock_session,
+            operation_type="merge",
+            source_ids=[source_id_1, source_id_2],
+            target_id=target_id,
+            alias_ids=[alias_id],
+            reason="Test merge reason",
+            rollback_data=rollback,
+        )
+
+        mock_operation_log_repo.create.assert_called_once()
+        call_kwargs = mock_operation_log_repo.create.call_args
+
+        # Verify the session was passed as the first positional argument
+        assert call_kwargs.args[0] is mock_session
+
+        # Extract the obj_in keyword argument
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+        assert isinstance(obj_in, TagOperationLogCreate), (
+            f"Expected TagOperationLogCreate, got {type(obj_in).__name__}"
+        )
+
+        # Verify field values
+        assert obj_in.operation_type == "merge"
+        assert obj_in.source_canonical_ids == [str(source_id_1), str(source_id_2)]
+        assert obj_in.target_canonical_id == target_id
+        assert obj_in.affected_alias_ids == [str(alias_id)]
+        assert obj_in.reason == "Test merge reason"
+        assert obj_in.rollback_data == rollback
+        assert obj_in.performed_by == "cli"
+
+    async def test_log_operation_with_none_target_id(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Operations without a target (e.g. ``create``, ``deprecate``) pass
+        ``target_id=None``.  The Pydantic model's ``target_canonical_id``
+        field must be ``None`` in that case.
+        """
+        log_entry = self._make_log_entry()
+        mock_operation_log_repo.create.return_value = log_entry
+
+        await service._log_operation(
+            mock_session,
+            operation_type="create",
+            source_ids=[],
+            target_id=None,
+            alias_ids=[],
+            reason=None,
+            rollback_data={},
+        )
+
+        call_kwargs = mock_operation_log_repo.create.call_args
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+
+        assert obj_in.target_canonical_id is None
+        assert obj_in.reason is None
+
+    async def test_log_operation_with_empty_lists(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Empty ``source_ids`` and ``alias_ids`` are valid inputs for operations
+        like ``rename`` that don't involve alias movement.
+        """
+        log_entry = self._make_log_entry()
+        mock_operation_log_repo.create.return_value = log_entry
+
+        result = await service._log_operation(
+            mock_session,
+            operation_type="rename",
+            source_ids=[],
+            target_id=None,
+            alias_ids=[],
+            reason="Rename to match title case",
+            rollback_data={"old_form": "python3", "new_form": "Python3"},
+        )
+
+        call_kwargs = mock_operation_log_repo.create.call_args
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+
+        assert obj_in.source_canonical_ids == []
+        assert obj_in.affected_alias_ids == []
+        assert isinstance(result, uuid.UUID)
+
+    async def test_log_operation_invalid_operation_type_raises(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Passing an operation_type not in the allowed set
+        ``{"merge", "split", "rename", "delete", "create"}`` must raise a
+        ``ValueError`` from the ``TagOperationLogCreate`` Pydantic validator
+        before the repository is called.
+        """
+        with pytest.raises(ValueError):
+            await service._log_operation(
+                mock_session,
+                operation_type="invalid_type",
+                source_ids=[],
+                target_id=None,
+                alias_ids=[],
+                reason=None,
+                rollback_data={},
+            )
+
+        # Repo must never be called if Pydantic validation fails
+        mock_operation_log_repo.create.assert_not_called()
+
+    async def test_log_operation_performed_by_is_always_cli(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The ``performed_by`` field must always be ``"cli"`` regardless of
+        the caller-supplied arguments — it is hard-coded in the service.
+        """
+        log_entry = self._make_log_entry()
+        mock_operation_log_repo.create.return_value = log_entry
+
+        for op_type in ("merge", "split", "rename", "delete", "create"):
+            mock_operation_log_repo.create.reset_mock()
+
+            await service._log_operation(
+                mock_session,
+                operation_type=op_type,
+                source_ids=[],
+                target_id=None,
+                alias_ids=[],
+                reason=None,
+                rollback_data={},
+            )
+
+            call_kwargs = mock_operation_log_repo.create.call_args
+            obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+            assert obj_in.performed_by == "cli", (
+                f"Expected performed_by='cli' for operation_type={op_type!r}, "
+                f"got {obj_in.performed_by!r}"
+            )
+
+    async def test_log_operation_all_valid_operation_types(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        All five allowed operation types must be accepted without error.
+
+        The allowed types are defined in ``tag_operation_log.ALLOWED_OPERATION_TYPES``:
+        ``{"merge", "split", "rename", "delete", "create"}``.
+        """
+        log_entry = self._make_log_entry()
+        mock_operation_log_repo.create.return_value = log_entry
+
+        allowed_types = {"merge", "split", "rename", "delete", "create"}
+        for op_type in sorted(allowed_types):
+            mock_operation_log_repo.create.reset_mock()
+
+            result = await service._log_operation(
+                mock_session,
+                operation_type=op_type,
+                source_ids=[],
+                target_id=None,
+                alias_ids=[],
+                reason=None,
+                rollback_data={},
+            )
+
+            assert isinstance(result, uuid.UUID), (
+                f"Expected UUID return for operation_type={op_type!r}"
+            )
+
+    async def test_log_operation_rollback_data_preserved(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Arbitrary rollback_data dicts (including nested structures and lists)
+        must be forwarded to the Pydantic model without modification.
+        """
+        log_entry = self._make_log_entry()
+        mock_operation_log_repo.create.return_value = log_entry
+
+        complex_rollback: dict[str, Any] = {
+            "previous_aliases": [
+                {"id": str(uuid.uuid4()), "raw_form": "Python"},
+                {"id": str(uuid.uuid4()), "raw_form": "python"},
+            ],
+            "previous_status": "active",
+            "meta": {"version": 1, "source": "cli"},
+        }
+
+        await service._log_operation(
+            mock_session,
+            operation_type="merge",
+            source_ids=[uuid.uuid4()],
+            target_id=uuid.uuid4(),
+            alias_ids=[uuid.uuid4()],
+            reason="Complex rollback test",
+            rollback_data=complex_rollback,
+        )
+
+        call_kwargs = mock_operation_log_repo.create.call_args
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.rollback_data == complex_rollback
+
+
+# ===========================================================================
+# Helpers for advanced test classes
+# ===========================================================================
+
+
+def _make_tag_alias(
+    *,
+    raw_form: str = "Python",
+    normalized_form: str = "python",
+    canonical_tag_id: uuid.UUID | None = None,
+    occurrence_count: int = 5,
+) -> MagicMock:
+    """
+    Build a lightweight MagicMock that mimics a ``TagAliasDB`` row.
+
+    Only the attributes accessed by service methods under test are set.
+    """
+    from chronovista.db.models import TagAlias as TagAliasDB
+
+    alias = MagicMock(spec=TagAliasDB)
+    alias.id = uuid.uuid4()
+    alias.raw_form = raw_form
+    alias.normalized_form = normalized_form
+    alias.canonical_tag_id = canonical_tag_id or uuid.uuid4()
+    alias.occurrence_count = occurrence_count
+    return alias
+
+
+def _make_operation_log(
+    *,
+    operation_type: str = "merge",
+    rolled_back: bool = False,
+    rollback_data: dict[str, Any] | None = None,
+    source_canonical_ids: list[str] | None = None,
+    target_canonical_id: uuid.UUID | None = None,
+) -> MagicMock:
+    """
+    Build a lightweight MagicMock that mimics a ``TagOperationLogDB`` row.
+    """
+    from chronovista.db.models import TagOperationLog as TagOperationLogDB
+
+    log = MagicMock(spec=TagOperationLogDB)
+    log.id = uuid.uuid4()
+    log.operation_type = operation_type
+    log.rolled_back = rolled_back
+    log.rollback_data = rollback_data or {}
+    log.source_canonical_ids = source_canonical_ids or []
+    log.target_canonical_id = target_canonical_id
+    log.rolled_back_at = None
+    return log
+
+
+def _make_named_entity(
+    *,
+    normalized_form: str = "python",
+    entity_type: str = "technical_term",
+    discovery_method: str = "user_created",
+) -> MagicMock:
+    """
+    Build a lightweight MagicMock that mimics a ``NamedEntityDB`` row.
+    """
+    from chronovista.db.models import NamedEntity as NamedEntityDB
+
+    entity = MagicMock(spec=NamedEntityDB)
+    entity.id = uuid.uuid4()
+    entity.canonical_name_normalized = normalized_form
+    entity.entity_type = entity_type
+    entity.discovery_method = discovery_method
+    return entity
+
+
+def _make_entity_alias(*, entity_id: uuid.UUID | None = None) -> MagicMock:
+    """Build a lightweight MagicMock that mimics an ``EntityAliasDB`` row."""
+    from chronovista.db.models import EntityAlias as EntityAliasDB
+
+    ea = MagicMock(spec=EntityAliasDB)
+    ea.id = uuid.uuid4()
+    ea.entity_id = entity_id or uuid.uuid4()
+    return ea
+
+
+def _make_scalar_result(value: Any) -> MagicMock:
+    """Build a mock SQLAlchemy scalar result returning *value* from scalar_one()."""
+    r = MagicMock()
+    r.scalar_one.return_value = value
+    return r
+
+
+def _make_scalars_result(items: list[Any]) -> MagicMock:
+    """Build a mock result whose .scalars().all() returns *items*."""
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = items
+    result = MagicMock()
+    result.scalars.return_value = scalars_mock
+    return result
+
+
+# ===========================================================================
+# TestMerge
+# ===========================================================================
+
+
+class TestMerge:
+    """
+    Tests for ``TagManagementService.merge``.
+
+    Covers:
+    - Single-source merge happy path
+    - Multi-source merge
+    - Self-merge rejection
+    - Already-merged (non-active) source rejection
+    - Non-existent target rejection
+    - Non-active target rejection
+    - FR-005a entity hint generation
+    - rollback_data structure
+    """
+
+    def _setup_recalculate(self, mock_session: AsyncMock) -> None:
+        """Wire mock_session.execute to return alias=5, video=10, UPDATE=None."""
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([]),  # source alias SELECT (merge reassign)
+                _make_scalar_result(5),    # recalculate alias count
+                _make_scalar_result(10),   # recalculate video count
+                MagicMock(),               # UPDATE
+            ]
+        )
+
+    async def test_single_source_merge_returns_merge_result(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Happy path: single source merges into target.
+
+        Verifies that MergeResult fields are populated correctly: source_tags,
+        target_tag, aliases_moved, new_alias_count, new_video_count,
+        operation_id, entity_hint (None when no entity type on sources).
+        """
+        from chronovista.services.tag_management import MergeResult
+
+        source_tag = _make_canonical_tag(
+            normalized_form="python3",
+            canonical_form="Python3",
+            status="active",
+            alias_count=2,
+            video_count=5,
+        )
+        source_tag.entity_type = None
+        source_tag.entity_id = None
+
+        target_tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="Python",
+            status="active",
+            alias_count=3,
+            video_count=10,
+        )
+        target_tag.entity_type = None
+        target_tag.entity_id = None
+
+        # First get_by_normalized_form call = target validation (active)
+        # Second call = source validation (active)
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            target_tag,   # target validate_active_tag
+            source_tag,   # source validate_active_tag
+        ]
+
+        source_alias = _make_tag_alias(
+            raw_form="python3",
+            canonical_tag_id=source_tag.id,
+        )
+        # SELECT aliases for source tag
+        alias_select_result = _make_scalars_result([source_alias])
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="merge")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        # recalculate: alias_count, video_count, UPDATE
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                alias_select_result,         # SELECT aliases for source
+                MagicMock(),                 # UPDATE aliases to target (bulk UPDATE)
+                _make_scalar_result(4),      # alias count after merge (recalculate)
+                _make_scalar_result(12),     # video count after merge (recalculate)
+                MagicMock(),                 # UPDATE canonical_tags counts
+            ]
+        )
+
+        result = await service.merge(
+            mock_session,
+            source_normalized_forms=["python3"],
+            target_normalized_form="python",
+            reason="Consolidating Python variants",
+        )
+
+        assert isinstance(result, MergeResult)
+        assert result.source_tags == ["python3"]
+        assert result.target_tag == "python"
+        assert result.aliases_moved == 1
+        assert result.new_alias_count == 4
+        assert result.new_video_count == 12
+        assert result.operation_id == op_id
+        assert result.entity_hint is None
+
+    async def test_multi_source_merge_accumulates_aliases(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Multi-source merge: aliases from both sources accumulate into target.
+
+        Verifies aliases_moved equals the sum of all source aliases moved.
+        """
+        from chronovista.services.tag_management import MergeResult
+
+        source1 = _make_canonical_tag(normalized_form="ml", canonical_form="ML", status="active")
+        source1.entity_type = None
+        source1.entity_id = None
+        source2 = _make_canonical_tag(
+            normalized_form="machine learning", canonical_form="Machine Learning", status="active"
+        )
+        source2.entity_type = None
+        source2.entity_id = None
+        target = _make_canonical_tag(
+            normalized_form="machine_learning", canonical_form="Machine_Learning", status="active"
+        )
+        target.entity_type = None
+        target.entity_id = None
+
+        # validate_active_tag calls: target, source1, source2
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            target,    # target
+            source1,   # source1
+            source2,   # source2
+        ]
+
+        alias1 = _make_tag_alias(raw_form="ML", canonical_tag_id=source1.id)
+        alias2a = _make_tag_alias(raw_form="Machine Learning", canonical_tag_id=source2.id)
+        alias2b = _make_tag_alias(raw_form="machine learning", canonical_tag_id=source2.id)
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log()
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias1]),         # SELECT aliases for source1
+                MagicMock(),                             # UPDATE aliases for source1
+                _make_scalars_result([alias2a, alias2b]),  # SELECT aliases for source2
+                MagicMock(),                             # UPDATE aliases for source2
+                _make_scalar_result(6),                  # recalculate alias count
+                _make_scalar_result(15),                 # recalculate video count
+                MagicMock(),                             # UPDATE canonical_tags
+            ]
+        )
+
+        result = await service.merge(
+            mock_session,
+            source_normalized_forms=["ml", "machine learning"],
+            target_normalized_form="machine_learning",
+        )
+
+        assert isinstance(result, MergeResult)
+        assert result.aliases_moved == 3  # 1 + 2
+        assert set(result.source_tags) == {"ml", "machine learning"}
+
+    async def test_self_merge_raises_value_error(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Self-merge (source == target) must raise ValueError immediately.
+
+        The implementation checks self-merge before any alias queries.
+        """
+        target = _make_canonical_tag(normalized_form="python", status="active")
+        target.entity_type = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = target
+
+        with pytest.raises(ValueError, match="Cannot merge tag 'python' into itself"):
+            await service.merge(
+                mock_session,
+                source_normalized_forms=["python"],
+                target_normalized_form="python",
+            )
+
+    async def test_non_active_source_raises_value_error(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Merging a merged (non-active) source must raise ValueError.
+
+        _validate_active_tag is called for each source; a merged source
+        raises ValueError with status information.
+        """
+        target = _make_canonical_tag(normalized_form="python", status="active")
+        target.entity_type = None
+        merged_source = _make_canonical_tag(normalized_form="python3", status="merged")
+
+        # target validation succeeds, then source status check reveals merged
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            target,          # target validate_active_tag -> active
+            None,            # source validate_active_tag -> not active (first call)
+            merged_source,   # source status check -> merged
+        ]
+
+        with pytest.raises(ValueError, match="python3"):
+            await service.merge(
+                mock_session,
+                source_normalized_forms=["python3"],
+                target_normalized_form="python",
+            )
+
+    async def test_non_existent_target_raises_value_error(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Non-existent target must raise ValueError('Tag ... not found').
+        """
+        # All three status queries return None = tag does not exist
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = None
+
+        with pytest.raises(ValueError, match="Tag 'nonexistent' not found"):
+            await service.merge(
+                mock_session,
+                source_normalized_forms=["python3"],
+                target_normalized_form="nonexistent",
+            )
+
+    async def test_non_active_target_raises_value_error(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Deprecated target must raise ValueError with status info.
+        """
+        deprecated_target = _make_canonical_tag(
+            normalized_form="old_python", status="deprecated"
+        )
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            None,              # active query -> None
+            None,              # merged query -> None
+            deprecated_target, # deprecated query -> found
+        ]
+
+        with pytest.raises(ValueError, match="deprecated"):
+            await service.merge(
+                mock_session,
+                source_normalized_forms=["python3"],
+                target_normalized_form="old_python",
+            )
+
+    async def test_entity_hint_generated_when_source_has_entity_type(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        FR-005a: If target has no entity_type but source does, entity_hint
+        must be populated in the result encouraging classification.
+        """
+        from chronovista.services.tag_management import MergeResult
+
+        source = _make_canonical_tag(
+            normalized_form="python3", canonical_form="Python3", status="active"
+        )
+        source.entity_type = "technical_term"
+        source.entity_id = None
+
+        target = _make_canonical_tag(
+            normalized_form="python", canonical_form="Python", status="active"
+        )
+        target.entity_type = None
+        target.entity_id = None
+
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [target, source]
+
+        alias = _make_tag_alias(raw_form="python3", canonical_tag_id=source.id)
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log()
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias]),  # SELECT aliases for source
+                MagicMock(),                     # UPDATE aliases to target
+                _make_scalar_result(4),          # recalculate alias_count
+                _make_scalar_result(12),         # recalculate video_count
+                MagicMock(),                     # UPDATE canonical_tags counts
+            ]
+        )
+
+        result = await service.merge(
+            mock_session,
+            source_normalized_forms=["python3"],
+            target_normalized_form="python",
+        )
+
+        assert isinstance(result, MergeResult)
+        assert result.entity_hint is not None
+        assert "technical_term" in result.entity_hint
+        assert "python" in result.entity_hint
+
+    async def test_no_entity_hint_when_target_already_classified(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        No entity_hint when the target already has an entity_type, even
+        if sources also have entity types.
+        """
+        from chronovista.services.tag_management import MergeResult
+
+        source = _make_canonical_tag(
+            normalized_form="python3", canonical_form="Python3", status="active"
+        )
+        source.entity_type = "technical_term"
+        source.entity_id = None
+
+        target = _make_canonical_tag(
+            normalized_form="python", canonical_form="Python", status="active"
+        )
+        target.entity_type = "technical_term"  # already classified
+        target.entity_id = None
+
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [target, source]
+
+        alias = _make_tag_alias(raw_form="python3", canonical_tag_id=source.id)
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log()
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias]),  # SELECT aliases for source
+                MagicMock(),                     # UPDATE aliases to target
+                _make_scalar_result(4),          # recalculate alias_count
+                _make_scalar_result(10),         # recalculate video_count
+                MagicMock(),                     # UPDATE canonical_tags counts
+            ]
+        )
+
+        result = await service.merge(
+            mock_session,
+            source_normalized_forms=["python3"],
+            target_normalized_form="python",
+        )
+
+        assert isinstance(result, MergeResult)
+        assert result.entity_hint is None
+
+    async def test_merge_rollback_data_structure(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The rollback_data passed to _log_operation must contain:
+        - ``sources``: list with ``canonical_tag_id``, ``previous_status``,
+          ``previous_alias_count``, ``previous_video_count``,
+          ``previous_entity_type``, ``previous_entity_id``, ``alias_ids``
+        - ``target``: dict with ``canonical_tag_id``, ``previous_alias_count``,
+          ``previous_video_count``
+        """
+        source = _make_canonical_tag(
+            normalized_form="py3",
+            canonical_form="Py3",
+            status="active",
+            alias_count=2,
+            video_count=5,
+        )
+        source.entity_type = None
+        source.entity_id = None
+
+        target = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="Python",
+            status="active",
+            alias_count=3,
+            video_count=10,
+        )
+        target.entity_type = None
+        target.entity_id = None
+
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [target, source]
+
+        alias = _make_tag_alias(raw_form="Py3", canonical_tag_id=source.id)
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log()
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias]),  # SELECT aliases for source
+                MagicMock(),                     # UPDATE aliases to target
+                _make_scalar_result(4),          # recalculate alias_count
+                _make_scalar_result(12),         # recalculate video_count
+                MagicMock(),                     # UPDATE canonical_tags counts
+            ]
+        )
+
+        await service.merge(
+            mock_session,
+            source_normalized_forms=["py3"],
+            target_normalized_form="python",
+            reason="Test rollback structure",
+        )
+
+        # Inspect what rollback_data was passed to operation log repo
+        call_kwargs = mock_operation_log_repo.create.call_args
+        from chronovista.models.tag_operation_log import TagOperationLogCreate
+
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+        rollback = obj_in.rollback_data
+
+        assert "sources" in rollback
+        assert "target" in rollback
+        assert len(rollback["sources"]) == 1
+
+        src_data = rollback["sources"][0]
+        assert "canonical_tag_id" in src_data
+        assert "previous_status" in src_data
+        assert "previous_alias_count" in src_data
+        assert "previous_video_count" in src_data
+        assert "previous_entity_type" in src_data
+        assert "previous_entity_id" in src_data
+        assert "alias_ids" in src_data
+        assert src_data["previous_status"] == "active"
+        assert src_data["previous_alias_count"] == 2
+        assert src_data["previous_video_count"] == 5
+
+        tgt_data = rollback["target"]
+        assert "canonical_tag_id" in tgt_data
+        assert "previous_alias_count" in tgt_data
+        assert "previous_video_count" in tgt_data
+        assert tgt_data["previous_alias_count"] == 3
+        assert tgt_data["previous_video_count"] == 10
+
+    async def test_merge_marks_source_as_merged(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        After a successful merge, source.status must be set to 'merged'
+        and source.merged_into_id must be set to target.id.
+        """
+        from chronovista.models.enums import TagStatus
+
+        source = _make_canonical_tag(normalized_form="py3", status="active")
+        source.entity_type = None
+        source.entity_id = None
+        target = _make_canonical_tag(normalized_form="python", status="active")
+        target.entity_type = None
+        target.entity_id = None
+
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [target, source]
+
+        alias = _make_tag_alias(raw_form="Py3", canonical_tag_id=source.id)
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log()
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias]),  # SELECT aliases for source
+                MagicMock(),                     # UPDATE aliases to target
+                _make_scalar_result(4),          # recalculate alias_count
+                _make_scalar_result(12),         # recalculate video_count
+                MagicMock(),                     # UPDATE canonical_tags counts
+            ]
+        )
+
+        await service.merge(
+            mock_session,
+            source_normalized_forms=["py3"],
+            target_normalized_form="python",
+        )
+
+        assert source.status == TagStatus.MERGED.value
+        assert source.merged_into_id == target.id
+
+
+# ===========================================================================
+# TestSplit
+# ===========================================================================
+
+
+class TestSplit:
+    """
+    Tests for ``TagManagementService.split``.
+
+    Covers:
+    - Basic split happy path
+    - Canonical form selection from moved aliases
+    - Normalized form computation
+    - All-aliases-removed rejection
+    - Wrong-alias rejection (aliases not on source tag)
+    - Normalized form collision with active tag
+    - Normalized form collision with deprecated tag
+    - rollback_data structure
+    """
+
+    def _patch_normalization(
+        self,
+        monkeypatch: Any,
+        canonical_form: str = "NewTag",
+        normalized_form: str = "newtag",
+    ) -> None:
+        """
+        Patch TagNormalizationService so tests are deterministic.
+        The split() method imports it at call time (lazy import).
+        """
+        mock_norm = MagicMock()
+        mock_norm.select_canonical_form.return_value = canonical_form
+        mock_norm.normalize.return_value = normalized_form
+
+        import chronovista.services.tag_normalization as _tn_module
+
+        monkeypatch.setattr(
+            _tn_module, "TagNormalizationService", lambda: mock_norm
+        )
+
+    async def test_basic_split_returns_split_result(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+        monkeypatch: Any,
+    ) -> None:
+        """
+        Happy path: split two aliases from a three-alias source tag.
+
+        Verifies SplitResult fields: original_tag, new_tag, new_canonical_form,
+        aliases_moved, original_alias_count, new_alias_count, operation_id.
+        """
+        from chronovista.services.tag_management import SplitResult
+
+        self._patch_normalization(
+            monkeypatch,
+            canonical_form="ML Python",
+            normalized_form="ml python",
+        )
+
+        source_tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="Python",
+            status="active",
+            alias_count=3,
+            video_count=8,
+        )
+        source_tag.entity_type = None
+
+        alias_a = _make_tag_alias(raw_form="ML Python", canonical_tag_id=source_tag.id)
+        alias_b = _make_tag_alias(raw_form="ml-python", canonical_tag_id=source_tag.id)
+        alias_c = _make_tag_alias(raw_form="Python", canonical_tag_id=source_tag.id)
+
+        new_tag = _make_canonical_tag(
+            normalized_form="ml python",
+            canonical_form="ML Python",
+            status="active",
+            alias_count=2,
+            video_count=3,
+        )
+
+        # validate_active_tag -> source
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            source_tag,  # validate source
+            None,        # collision check active
+            None,        # collision check deprecated
+        ]
+        mock_canonical_tag_repo.create.return_value = new_tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="split")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias_a, alias_b, alias_c]),  # all aliases
+                MagicMock(),   # UPDATE aliases (reassign to new tag)
+                _make_scalar_result(1),   # orig recalculate alias_count
+                _make_scalar_result(5),   # orig recalculate video_count
+                MagicMock(),              # orig UPDATE
+                _make_scalar_result(2),   # new recalculate alias_count
+                _make_scalar_result(3),   # new recalculate video_count
+                MagicMock(),              # new UPDATE
+            ]
+        )
+
+        result = await service.split(
+            mock_session,
+            normalized_form="python",
+            alias_raw_forms=["ML Python", "ml-python"],
+            reason="Separate ML Python variant",
+        )
+
+        assert isinstance(result, SplitResult)
+        assert result.original_tag == "python"
+        assert result.new_tag == "ml python"
+        assert result.new_canonical_form == "ML Python"
+        assert result.aliases_moved == 2
+        assert result.original_alias_count == 1
+        assert result.original_video_count == 5
+        assert result.new_alias_count == 2
+        assert result.new_video_count == 3
+        assert result.operation_id == op_id
+
+    async def test_split_all_aliases_removed_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+        monkeypatch: Any,
+    ) -> None:
+        """
+        Attempting to move all aliases must raise ValueError.
+
+        At least one alias must remain on the original tag.
+        """
+        self._patch_normalization(monkeypatch)
+
+        source = _make_canonical_tag(normalized_form="python", status="active")
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = source
+
+        alias_a = _make_tag_alias(raw_form="Python", canonical_tag_id=source.id)
+        alias_b = _make_tag_alias(raw_form="python", canonical_tag_id=source.id)
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias_a, alias_b]),  # all aliases
+            ]
+        )
+
+        with pytest.raises(ValueError, match="Cannot split all aliases"):
+            await service.split(
+                mock_session,
+                normalized_form="python",
+                alias_raw_forms=["Python", "python"],
+            )
+
+    async def test_split_wrong_alias_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+        monkeypatch: Any,
+    ) -> None:
+        """
+        Specifying an alias that does not belong to the source tag raises
+        ValueError with the invalid alias names listed (all-or-nothing FR-010).
+        """
+        self._patch_normalization(monkeypatch)
+
+        source = _make_canonical_tag(normalized_form="python", status="active")
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = source
+
+        alias_a = _make_tag_alias(raw_form="Python", canonical_tag_id=source.id)
+        # Note: "Py3" is NOT in source aliases
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias_a]),  # only Python alias
+            ]
+        )
+
+        with pytest.raises(ValueError, match="Py3"):
+            await service.split(
+                mock_session,
+                normalized_form="python",
+                alias_raw_forms=["Py3"],
+            )
+
+    async def test_split_collision_with_active_tag_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+        monkeypatch: Any,
+    ) -> None:
+        """
+        If the computed normalized form of the new tag collides with an
+        existing active canonical tag, ValueError must be raised.
+        """
+        self._patch_normalization(
+            monkeypatch,
+            canonical_form="ML",
+            normalized_form="ml",
+        )
+
+        source = _make_canonical_tag(normalized_form="python", status="active")
+        existing_active = _make_canonical_tag(normalized_form="ml", status="active")
+
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            source,          # validate source tag
+            existing_active, # collision check: active tag with same normalized form
+        ]
+
+        alias_a = _make_tag_alias(raw_form="ML", canonical_tag_id=source.id)
+        alias_b = _make_tag_alias(raw_form="Python", canonical_tag_id=source.id)
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias_a, alias_b]),
+            ]
+        )
+
+        with pytest.raises(ValueError, match="already exists as an active canonical tag"):
+            await service.split(
+                mock_session,
+                normalized_form="python",
+                alias_raw_forms=["ML"],
+            )
+
+    async def test_split_collision_with_deprecated_tag_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+        monkeypatch: Any,
+    ) -> None:
+        """
+        Collision with a deprecated tag must also raise ValueError (FR-010).
+        """
+        self._patch_normalization(
+            monkeypatch,
+            canonical_form="OldML",
+            normalized_form="oldml",
+        )
+
+        source = _make_canonical_tag(normalized_form="python", status="active")
+        deprecated_tag = _make_canonical_tag(normalized_form="oldml", status="deprecated")
+
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            source,         # validate source
+            None,           # collision check: no active tag
+            deprecated_tag, # collision check: deprecated tag found
+        ]
+
+        alias_a = _make_tag_alias(raw_form="OldML", canonical_tag_id=source.id)
+        alias_b = _make_tag_alias(raw_form="Python", canonical_tag_id=source.id)
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias_a, alias_b]),
+            ]
+        )
+
+        with pytest.raises(ValueError, match="deprecated canonical tag"):
+            await service.split(
+                mock_session,
+                normalized_form="python",
+                alias_raw_forms=["OldML"],
+            )
+
+    async def test_split_rollback_data_structure(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+        monkeypatch: Any,
+    ) -> None:
+        """
+        The rollback_data passed to _log_operation must contain:
+        - ``original_canonical_id``
+        - ``created_canonical_id``
+        - ``moved_alias_ids``
+        - ``previous_counts`` with ``original_alias_count`` and
+          ``original_video_count``
+        """
+        self._patch_normalization(monkeypatch, canonical_form="PY3", normalized_form="py3")
+
+        source = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="Python",
+            status="active",
+            alias_count=3,
+            video_count=8,
+        )
+        new_tag = _make_canonical_tag(
+            normalized_form="py3",
+            canonical_form="PY3",
+            status="active",
+        )
+
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            source, None, None
+        ]
+        mock_canonical_tag_repo.create.return_value = new_tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="split")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        alias_a = _make_tag_alias(raw_form="PY3", canonical_tag_id=source.id)
+        alias_b = _make_tag_alias(raw_form="Python", canonical_tag_id=source.id)
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([alias_a, alias_b]),
+                MagicMock(),
+                _make_scalar_result(1),
+                _make_scalar_result(4),
+                MagicMock(),
+                _make_scalar_result(1),
+                _make_scalar_result(3),
+                MagicMock(),
+            ]
+        )
+
+        await service.split(
+            mock_session,
+            normalized_form="python",
+            alias_raw_forms=["PY3"],
+        )
+
+        call_kwargs = mock_operation_log_repo.create.call_args
+        from chronovista.models.tag_operation_log import TagOperationLogCreate
+
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+        rollback = obj_in.rollback_data
+
+        assert "original_canonical_id" in rollback
+        assert "created_canonical_id" in rollback
+        assert "moved_alias_ids" in rollback
+        assert "previous_counts" in rollback
+        assert "original_alias_count" in rollback["previous_counts"]
+        assert "original_video_count" in rollback["previous_counts"]
+        assert rollback["previous_counts"]["original_alias_count"] == 3
+        assert rollback["previous_counts"]["original_video_count"] == 8
+        assert len(rollback["moved_alias_ids"]) == 1
+
+
+# ===========================================================================
+# TestUndoSplit
+# ===========================================================================
+
+
+class TestUndoSplit:
+    """
+    Tests for ``TagManagementService._undo_split``.
+
+    Covers:
+    - Basic undo split: aliases returned to original, new tag deleted
+    - FR-012a safety check: blocked when subsequent ops exist on created tag
+    """
+
+    async def test_basic_undo_split_returns_description(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Basic undo split: moves aliases back to original, deletes created tag,
+        and returns a human-readable string.
+        """
+        original_id = uuid.uuid4()
+        created_id = uuid.uuid4()
+        alias_id = uuid.uuid4()
+
+        log_entry = _make_operation_log(
+            operation_type="split",
+            rollback_data={
+                "original_canonical_id": str(original_id),
+                "created_canonical_id": str(created_id),
+                "moved_alias_ids": [str(alias_id)],
+                "previous_counts": {
+                    "original_alias_count": 3,
+                    "original_video_count": 8,
+                },
+            },
+        )
+        log_entry.id = uuid.uuid4()
+
+        original_tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="Python",
+            status="active",
+        )
+        created_tag = _make_canonical_tag(
+            normalized_form="py3",
+            canonical_form="PY3",
+            status="active",
+        )
+
+        # SELECT to check subsequent ops -> empty
+        # UPDATE alias back to original
+        # get created_tag for deletion
+        # recalculate original: alias, video, UPDATE
+        # get original_tag for name
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([]),    # subsequent_ops check
+                MagicMock(),                  # UPDATE alias canonical_tag_id
+                _make_scalar_result(3),       # recalculate alias_count
+                _make_scalar_result(8),       # recalculate video_count
+                MagicMock(),                  # UPDATE canonical_tags
+            ]
+        )
+        mock_canonical_tag_repo.get.side_effect = [
+            created_tag,   # get created_tag for deletion
+            original_tag,  # get original_tag for name display
+        ]
+        mock_session.flush = AsyncMock()
+
+        result = await service._undo_split(mock_session, log_entry)
+
+        assert isinstance(result, str)
+        assert "1" in result  # 1 alias moved back
+        assert "python" in result.lower()
+
+    async def test_undo_split_blocked_when_subsequent_ops_exist(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        FR-012a: If the created tag has subsequent non-rolled-back operations,
+        undo must raise ValueError listing the blocking operation types.
+        """
+        original_id = uuid.uuid4()
+        created_id = uuid.uuid4()
+        alias_id = uuid.uuid4()
+
+        log_entry = _make_operation_log(
+            operation_type="split",
+            rollback_data={
+                "original_canonical_id": str(original_id),
+                "created_canonical_id": str(created_id),
+                "moved_alias_ids": [str(alias_id)],
+                "previous_counts": {
+                    "original_alias_count": 3,
+                    "original_video_count": 8,
+                },
+            },
+        )
+        log_entry.id = uuid.uuid4()
+
+        # A subsequent merge operation references the created tag
+        subsequent_op = _make_operation_log(operation_type="merge", rolled_back=False)
+
+        # subsequent_ops check returns one entry
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([subsequent_op]),
+            ]
+        )
+
+        with pytest.raises(ValueError, match="subsequent operation"):
+            await service._undo_split(mock_session, log_entry)
+
+
+# ===========================================================================
+# TestUndo (dispatch)
+# ===========================================================================
+
+
+class TestUndo:
+    """
+    Tests for ``TagManagementService.undo`` (the public dispatch method).
+
+    Covers:
+    - Undo merge dispatch
+    - Undo split dispatch
+    - Already-undone operation rejection
+    - Non-existent operation rejection
+    """
+
+    async def test_undo_non_existent_operation_raises(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Requesting undo on an operation that doesn't exist raises ValueError.
+        """
+        mock_operation_log_repo.get.return_value = None
+        op_id = uuid.uuid4()
+
+        with pytest.raises(ValueError, match=str(op_id)):
+            await service.undo(mock_session, op_id)
+
+    async def test_undo_already_undone_raises(
+        self,
+        service: TagManagementService,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Requesting undo on an already-rolled-back operation raises ValueError.
+        """
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="merge", rolled_back=True)
+        log_entry.id = op_id
+        mock_operation_log_repo.get.return_value = log_entry
+
+        with pytest.raises(ValueError, match="already been undone"):
+            await service.undo(mock_session, op_id)
+
+    async def test_undo_merge_dispatches_correctly(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Undo of a merge operation dispatches to _undo_merge and returns
+        an UndoResult with operation_type='merge'.
+        """
+        from chronovista.services.tag_management import UndoResult
+
+        source_id = uuid.uuid4()
+        target_id = uuid.uuid4()
+        alias_id = uuid.uuid4()
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(
+            operation_type="merge",
+            rolled_back=False,
+            rollback_data={
+                "sources": [
+                    {
+                        "canonical_tag_id": str(source_id),
+                        "previous_status": "active",
+                        "previous_alias_count": 2,
+                        "previous_video_count": 5,
+                        "previous_entity_type": None,
+                        "previous_entity_id": None,
+                        "alias_ids": [str(alias_id)],
+                    }
+                ],
+                "target": {
+                    "canonical_tag_id": str(target_id),
+                    "previous_alias_count": 3,
+                    "previous_video_count": 10,
+                },
+            },
+        )
+        log_entry.id = op_id
+        mock_operation_log_repo.get.return_value = log_entry
+
+        source_tag = _make_canonical_tag(
+            normalized_form="py3",
+            canonical_form="Py3",
+            status="merged",
+        )
+        mock_canonical_tag_repo.get.return_value = source_tag
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                MagicMock(),              # UPDATE alias back to source
+                _make_scalar_result(2),   # source recalculate alias_count
+                _make_scalar_result(5),   # source recalculate video_count
+                MagicMock(),              # source UPDATE
+                _make_scalar_result(3),   # target recalculate alias_count
+                _make_scalar_result(10),  # target recalculate video_count
+                MagicMock(),              # target UPDATE
+            ]
+        )
+        mock_session.add = MagicMock()
+
+        result = await service.undo(mock_session, op_id)
+
+        assert isinstance(result, UndoResult)
+        assert result.operation_type == "merge"
+        assert result.operation_id == op_id
+
+    async def test_undo_split_dispatches_correctly(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Undo of a split operation dispatches to _undo_split and returns
+        an UndoResult with operation_type='split'.
+        """
+        from chronovista.services.tag_management import UndoResult
+
+        original_id = uuid.uuid4()
+        created_id = uuid.uuid4()
+        alias_id = uuid.uuid4()
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(
+            operation_type="split",
+            rolled_back=False,
+            rollback_data={
+                "original_canonical_id": str(original_id),
+                "created_canonical_id": str(created_id),
+                "moved_alias_ids": [str(alias_id)],
+                "previous_counts": {
+                    "original_alias_count": 3,
+                    "original_video_count": 8,
+                },
+            },
+        )
+        log_entry.id = op_id
+        mock_operation_log_repo.get.return_value = log_entry
+
+        original_tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="Python",
+            status="active",
+        )
+        created_tag = _make_canonical_tag(
+            normalized_form="py3",
+            canonical_form="PY3",
+            status="active",
+        )
+        mock_canonical_tag_repo.get.side_effect = [created_tag, original_tag]
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([]),  # no subsequent ops
+                MagicMock(),               # UPDATE alias
+                _make_scalar_result(3),    # recalculate alias_count
+                _make_scalar_result(8),    # recalculate video_count
+                MagicMock(),               # UPDATE
+            ]
+        )
+        mock_session.flush = AsyncMock()
+        mock_session.add = MagicMock()
+
+        result = await service.undo(mock_session, op_id)
+
+        assert isinstance(result, UndoResult)
+        assert result.operation_type == "split"
+        assert result.operation_id == op_id
+
+    async def test_undo_marks_log_entry_as_rolled_back(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        After a successful undo, the log entry must have rolled_back=True
+        and rolled_back_at set to a non-None datetime.
+        """
+        source_id = uuid.uuid4()
+        target_id = uuid.uuid4()
+        alias_id = uuid.uuid4()
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(
+            operation_type="merge",
+            rolled_back=False,
+            rollback_data={
+                "sources": [
+                    {
+                        "canonical_tag_id": str(source_id),
+                        "previous_status": "active",
+                        "previous_alias_count": 2,
+                        "previous_video_count": 5,
+                        "previous_entity_type": None,
+                        "previous_entity_id": None,
+                        "alias_ids": [str(alias_id)],
+                    }
+                ],
+                "target": {
+                    "canonical_tag_id": str(target_id),
+                    "previous_alias_count": 3,
+                    "previous_video_count": 10,
+                },
+            },
+        )
+        log_entry.id = op_id
+        mock_operation_log_repo.get.return_value = log_entry
+
+        source_tag = _make_canonical_tag(normalized_form="py3", status="merged")
+        mock_canonical_tag_repo.get.return_value = source_tag
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                MagicMock(),
+                _make_scalar_result(2),
+                _make_scalar_result(5),
+                MagicMock(),
+                _make_scalar_result(3),
+                _make_scalar_result(10),
+                MagicMock(),
+            ]
+        )
+        mock_session.add = MagicMock()
+
+        await service.undo(mock_session, op_id)
+
+        assert log_entry.rolled_back is True
+        assert log_entry.rolled_back_at is not None
+
+
+# ===========================================================================
+# TestRename
+# ===========================================================================
+
+
+class TestRename:
+    """
+    Tests for ``TagManagementService.rename``.
+
+    Covers:
+    - Basic rename happy path
+    - Empty/whitespace display form rejection
+    - Non-existent tag rejection
+    - Non-active tag rejection
+    - rollback_data structure
+    """
+
+    async def test_basic_rename_returns_rename_result(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Happy path: rename updates canonical_form and returns RenameResult.
+
+        Verifies: normalized_form, old_form, new_form, operation_id.
+        """
+        from chronovista.services.tag_management import RenameResult
+
+        tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="python",
+            status="active",
+        )
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="rename")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        result = await service.rename(
+            mock_session,
+            normalized_form="python",
+            new_display_form="Python",
+            reason="Title-case correction",
+        )
+
+        assert isinstance(result, RenameResult)
+        assert result.normalized_form == "python"
+        assert result.old_form == "python"
+        assert result.new_form == "Python"
+        assert result.operation_id == op_id
+
+    async def test_rename_updates_canonical_form_on_tag(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The canonical_form attribute on the tag object must be set to
+        the new display form after rename.
+        """
+        tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="OldPython",
+            status="active",
+        )
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="rename")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        await service.rename(
+            mock_session,
+            normalized_form="python",
+            new_display_form="Python",
+        )
+
+        assert tag.canonical_form == "Python"
+
+    async def test_rename_empty_form_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Empty new_display_form (including whitespace-only) must raise ValueError
+        before any database access.
+        """
+        with pytest.raises(ValueError, match="cannot be empty"):
+            await service.rename(
+                mock_session,
+                normalized_form="python",
+                new_display_form="   ",
+            )
+
+        mock_canonical_tag_repo.get_by_normalized_form.assert_not_called()
+
+    async def test_rename_non_existent_tag_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Renaming a tag that does not exist must raise ValueError.
+        """
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = None
+
+        with pytest.raises(ValueError, match="not found"):
+            await service.rename(
+                mock_session,
+                normalized_form="doesnotexist",
+                new_display_form="New Form",
+            )
+
+    async def test_rename_non_active_tag_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Renaming a deprecated tag must raise ValueError with status info.
+        """
+        deprecated = _make_canonical_tag(normalized_form="oldtag", status="deprecated")
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            None, None, deprecated
+        ]
+
+        with pytest.raises(ValueError, match="deprecated"):
+            await service.rename(
+                mock_session,
+                normalized_form="oldtag",
+                new_display_form="New Form",
+            )
+
+    async def test_rename_rollback_data_structure(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The rollback_data for a rename must contain:
+        - ``canonical_id``: str UUID of the tag
+        - ``previous_form``: the old canonical_form
+        - ``new_form``: the new canonical_form
+        """
+        tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="OldPython",
+            status="active",
+        )
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="rename")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        await service.rename(
+            mock_session,
+            normalized_form="python",
+            new_display_form="Python",
+            reason="Fix case",
+        )
+
+        call_kwargs = mock_operation_log_repo.create.call_args
+        from chronovista.models.tag_operation_log import TagOperationLogCreate
+
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+        rollback = obj_in.rollback_data
+
+        assert "canonical_id" in rollback
+        assert rollback["canonical_id"] == str(tag.id)
+        assert "previous_form" in rollback
+        assert rollback["previous_form"] == "OldPython"
+        assert "new_form" in rollback
+        assert rollback["new_form"] == "Python"
+
+    async def test_undo_rename_restores_old_form(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        _undo_rename must restore canonical_form to its previous value.
+        """
+        canonical_id = uuid.uuid4()
+        log_entry = _make_operation_log(
+            operation_type="rename",
+            rollback_data={
+                "canonical_id": str(canonical_id),
+                "previous_form": "OldPython",
+                "new_form": "Python",
+            },
+        )
+
+        tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="Python",
+            status="active",
+        )
+        mock_canonical_tag_repo.get.return_value = tag
+        mock_session.add = MagicMock()
+
+        result = await service._undo_rename(mock_session, log_entry)
+
+        assert tag.canonical_form == "OldPython"
+        assert "OldPython" in result
+        assert "Python" in result
+
+
+# ===========================================================================
+# TestClassify
+# ===========================================================================
+
+
+class TestClassify:
+    """
+    Tests for ``TagManagementService.classify``.
+
+    Covers:
+    - Entity-producing type (creates new NamedEntity + entity aliases)
+    - Tag-only type (topic/descriptor: no entity record)
+    - Already-classified rejection (without force)
+    - --force reclassification (deletes old entity if user_created)
+    - rollback_data structure
+    """
+
+    async def test_classify_entity_producing_type_creates_entity(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Classifying with EntityType.PERSON (entity-producing) must:
+        1. Create a new NamedEntity.
+        2. Copy tag aliases as entity aliases.
+        3. Return ClassifyResult with entity_created=True.
+        """
+        from chronovista.models.enums import EntityType
+        from chronovista.services.tag_management import ClassifyResult
+
+        tag = _make_canonical_tag(
+            normalized_form="elon musk",
+            canonical_form="Elon Musk",
+            status="active",
+        )
+        tag.entity_type = None
+        tag.entity_id = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        # No existing entity with same normalized form
+        alias_a = _make_tag_alias(
+            raw_form="Elon Musk", normalized_form="elon musk", canonical_tag_id=tag.id
+        )
+        alias_b = _make_tag_alias(
+            raw_form="ElonMusk", normalized_form="elonmusk", canonical_tag_id=tag.id
+        )
+
+        new_entity = _make_named_entity(
+            normalized_form="elon musk",
+            entity_type="person",
+            discovery_method="user_created",
+        )
+        mock_named_entity_repo.create.return_value = new_entity
+
+        ea1 = _make_entity_alias(entity_id=new_entity.id)
+        ea2 = _make_entity_alias(entity_id=new_entity.id)
+        mock_entity_alias_repo.create.side_effect = [ea1, ea2]
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="create")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        # SELECT: no existing entity, SELECT: tag aliases,
+        # SELECT: entity alias existence check per alias (upsert logic)
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # existing entity check
+                _make_scalars_result([alias_a, alias_b]),                # tag aliases
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # alias_a upsert check
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # alias_b upsert check
+            ]
+        )
+        mock_session.add = MagicMock()
+
+        result = await service.classify(
+            mock_session,
+            normalized_form="elon musk",
+            entity_type=EntityType.PERSON,
+            reason="Known person",
+        )
+
+        assert isinstance(result, ClassifyResult)
+        assert result.entity_created is True
+        assert result.entity_type == "person"
+        assert result.entity_alias_count == 2
+        assert result.operation_id == op_id
+        mock_named_entity_repo.create.assert_called_once()
+
+    async def test_classify_tag_only_type_no_entity_created(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Classifying with EntityType.TOPIC (tag-only) must:
+        1. NOT create any NamedEntity.
+        2. Set entity_type on the tag.
+        3. Return ClassifyResult with entity_created=False, entity_alias_count=0.
+        """
+        from chronovista.models.enums import EntityType
+        from chronovista.services.tag_management import ClassifyResult
+
+        tag = _make_canonical_tag(
+            normalized_form="coding tips",
+            canonical_form="Coding Tips",
+            status="active",
+        )
+        tag.entity_type = None
+        tag.entity_id = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="create")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        result = await service.classify(
+            mock_session,
+            normalized_form="coding tips",
+            entity_type=EntityType.TOPIC,
+        )
+
+        assert isinstance(result, ClassifyResult)
+        assert result.entity_created is False
+        assert result.entity_type == "topic"
+        assert result.entity_alias_count == 0
+        mock_named_entity_repo.create.assert_not_called()
+        mock_entity_alias_repo.create.assert_not_called()
+
+    async def test_classify_descriptor_type_no_entity_created(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Classifying with EntityType.DESCRIPTOR (tag-only) must not create
+        any entity record.
+        """
+        from chronovista.models.enums import EntityType
+        from chronovista.services.tag_management import ClassifyResult
+
+        tag = _make_canonical_tag(
+            normalized_form="beginner friendly",
+            canonical_form="Beginner Friendly",
+            status="active",
+        )
+        tag.entity_type = None
+        tag.entity_id = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="create")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        result = await service.classify(
+            mock_session,
+            normalized_form="beginner friendly",
+            entity_type=EntityType.DESCRIPTOR,
+        )
+
+        assert isinstance(result, ClassifyResult)
+        assert result.entity_created is False
+        assert result.entity_type == "descriptor"
+        assert result.entity_alias_count == 0
+
+    async def test_classify_already_classified_without_force_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Classifying an already-classified tag without force=True must raise
+        ValueError with a message suggesting --force.
+        """
+        from chronovista.models.enums import EntityType
+
+        tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="Python",
+            status="active",
+        )
+        tag.entity_type = "technical_term"  # already classified
+        tag.entity_id = uuid.uuid4()
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        with pytest.raises(ValueError, match="--force"):
+            await service.classify(
+                mock_session,
+                normalized_form="python",
+                entity_type=EntityType.TOPIC,
+                force=False,
+            )
+
+    async def test_classify_force_reclassifies_tag_only_to_entity_producing(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        With force=True, an already-classified tag can be reclassified.
+        If entity_id is None (tag-only previous type), no entity deletion needed.
+        """
+        from chronovista.models.enums import EntityType
+        from chronovista.services.tag_management import ClassifyResult
+
+        tag = _make_canonical_tag(
+            normalized_form="python",
+            canonical_form="Python",
+            status="active",
+        )
+        tag.entity_type = "topic"    # previously classified as topic (tag-only)
+        tag.entity_id = None         # no entity record for tag-only
+
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        alias_a = _make_tag_alias(raw_form="Python", canonical_tag_id=tag.id)
+        new_entity = _make_named_entity(
+            normalized_form="python",
+            entity_type="technical_term",
+            discovery_method="user_created",
+        )
+        mock_named_entity_repo.create.return_value = new_entity
+
+        ea = _make_entity_alias(entity_id=new_entity.id)
+        mock_entity_alias_repo.create.return_value = ea
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="create")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # existing entity check
+                _make_scalars_result([alias_a]),                          # tag aliases
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # alias_a upsert check
+            ]
+        )
+        mock_session.add = MagicMock()
+
+        result = await service.classify(
+            mock_session,
+            normalized_form="python",
+            entity_type=EntityType.TECHNICAL_TERM,
+            force=True,
+        )
+
+        assert isinstance(result, ClassifyResult)
+        assert result.entity_created is True
+        assert result.entity_type == "technical_term"
+
+    async def test_classify_rollback_data_structure(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        rollback_data for classify must contain:
+        - ``canonical_id``
+        - ``previous_entity_type``
+        - ``new_entity_type``
+        - ``created_entity_id`` (str UUID or None)
+        - ``linked_existing_entity_id`` (str UUID or None)
+        - ``created_entity_alias_ids`` (list of str UUIDs)
+        """
+        from chronovista.models.enums import EntityType
+        from chronovista.models.tag_operation_log import TagOperationLogCreate
+
+        tag = _make_canonical_tag(
+            normalized_form="google",
+            canonical_form="Google",
+            status="active",
+        )
+        tag.entity_type = None
+        tag.entity_id = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        alias_a = _make_tag_alias(raw_form="Google", canonical_tag_id=tag.id)
+        new_entity = _make_named_entity(
+            normalized_form="google",
+            entity_type="organization",
+            discovery_method="user_created",
+        )
+        mock_named_entity_repo.create.return_value = new_entity
+
+        ea = _make_entity_alias(entity_id=new_entity.id)
+        mock_entity_alias_repo.create.return_value = ea
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="create")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # existing entity check
+                _make_scalars_result([alias_a]),                          # tag aliases
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # alias_a upsert check
+            ]
+        )
+        mock_session.add = MagicMock()
+
+        await service.classify(
+            mock_session,
+            normalized_form="google",
+            entity_type=EntityType.ORGANIZATION,
+        )
+
+        call_kwargs = mock_operation_log_repo.create.call_args
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+        rollback = obj_in.rollback_data
+
+        assert "canonical_id" in rollback
+        assert rollback["canonical_id"] == str(tag.id)
+        assert "previous_entity_type" in rollback
+        assert rollback["previous_entity_type"] is None
+        assert "new_entity_type" in rollback
+        assert rollback["new_entity_type"] == "organization"
+        assert "created_entity_id" in rollback
+        assert rollback["created_entity_id"] == str(new_entity.id)
+        assert "linked_existing_entity_id" in rollback
+        assert rollback["linked_existing_entity_id"] is None
+        assert "created_entity_alias_ids" in rollback
+        assert len(rollback["created_entity_alias_ids"]) == 1
+
+
+# ===========================================================================
+# TestUndoClassify
+# ===========================================================================
+
+
+class TestUndoClassify:
+    """
+    Tests for ``TagManagementService._undo_classify``.
+
+    Covers:
+    - Undo when a new entity was created (delete entity + aliases)
+    - Undo when tag-only classification (no entity to delete)
+    """
+
+    async def test_undo_classify_new_entity_deleted(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When rollback_data has ``created_entity_id``, the entity and its
+        aliases must be deleted and the tag's entity_type cleared.
+        """
+        canonical_id = uuid.uuid4()
+        entity_id = uuid.uuid4()
+        ea_id = uuid.uuid4()
+
+        log_entry = _make_operation_log(
+            operation_type="create",
+            rollback_data={
+                "canonical_id": str(canonical_id),
+                "previous_entity_type": None,
+                "new_entity_type": "person",
+                "created_entity_id": str(entity_id),
+                "linked_existing_entity_id": None,
+                "created_entity_alias_ids": [str(ea_id)],
+            },
+        )
+
+        tag = _make_canonical_tag(
+            normalized_form="elon musk",
+            canonical_form="Elon Musk",
+            status="active",
+        )
+        tag.entity_type = "person"
+        tag.entity_id = entity_id
+
+        entity = _make_named_entity(
+            normalized_form="elon musk",
+            entity_type="person",
+            discovery_method="user_created",
+        )
+
+        ea = _make_entity_alias(entity_id=entity_id)
+        ea.id = ea_id
+
+        mock_canonical_tag_repo.get.return_value = tag
+        mock_named_entity_repo.get.return_value = entity
+        mock_entity_alias_repo.get.return_value = ea
+
+        mock_session.delete = AsyncMock()
+        mock_session.flush = AsyncMock()
+        mock_session.add = MagicMock()
+
+        result = await service._undo_classify(mock_session, log_entry)
+
+        # Tag entity_type should be restored to previous (None)
+        assert tag.entity_type is None
+        assert tag.entity_id is None
+        # entity alias deleted
+        mock_session.delete.assert_any_call(ea)
+        # entity deleted
+        mock_session.delete.assert_any_call(entity)
+        assert isinstance(result, str)
+        assert "elon musk" in result
+
+    async def test_undo_classify_tag_only_clears_entity_type(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        For a tag-only classification (no entity), undo must clear entity_type
+        without attempting to delete any entity.
+        """
+        canonical_id = uuid.uuid4()
+
+        log_entry = _make_operation_log(
+            operation_type="create",
+            rollback_data={
+                "canonical_id": str(canonical_id),
+                "previous_entity_type": None,
+                "new_entity_type": "topic",
+                "created_entity_id": None,
+                "linked_existing_entity_id": None,
+                "created_entity_alias_ids": [],
+            },
+        )
+
+        tag = _make_canonical_tag(
+            normalized_form="tutorials",
+            canonical_form="Tutorials",
+            status="active",
+        )
+        tag.entity_type = "topic"
+        tag.entity_id = None
+
+        mock_canonical_tag_repo.get.return_value = tag
+        mock_session.flush = AsyncMock()
+        mock_session.add = MagicMock()
+
+        result = await service._undo_classify(mock_session, log_entry)
+
+        assert tag.entity_type is None
+        assert tag.entity_id is None
+        mock_named_entity_repo.get.assert_not_called()
+        assert isinstance(result, str)
+
+
+# ===========================================================================
+# TestGetCollisions
+# ===========================================================================
+
+
+class TestGetCollisions:
+    """
+    Tests for ``TagManagementService.get_collisions``.
+
+    Covers:
+    - Basic collision detection (aliases with distinct casefolded forms)
+    - Tags with no collision (single alias or all same casefold) are excluded
+    - --include-reviewed flag controls filtering
+    - --limit truncates results
+    - Sorted by total_occurrence_count descending
+    """
+
+    async def test_basic_collision_detected(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        A tag with two aliases whose casefolded forms differ (e.g. 'cafe' vs
+        'café') must appear in the collision list.
+        """
+        from chronovista.services.tag_management import CollisionGroup
+
+        tag = _make_canonical_tag(
+            normalized_form="cafe",
+            canonical_form="Cafe",
+            status="active",
+        )
+        tag.id = uuid.uuid4()
+
+        alias_a = _make_tag_alias(
+            raw_form="cafe",
+            canonical_tag_id=tag.id,
+            occurrence_count=10,
+        )
+        alias_b = _make_tag_alias(
+            raw_form="café",
+            canonical_tag_id=tag.id,
+            occurrence_count=5,
+        )
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([tag]),               # active tags (first)
+                _make_scalars_result([]),                  # reviewed log entries (none)
+                _make_scalars_result([alias_a, alias_b]),  # aliases for tag
+            ]
+        )
+
+        result = await service.get_collisions(
+            mock_session,
+            include_reviewed=False,
+        )
+
+        assert len(result) == 1
+        assert isinstance(result[0], CollisionGroup)
+        assert result[0].normalized_form == "cafe"
+        assert result[0].total_occurrence_count == 15
+        assert len(result[0].aliases) == 2
+
+    async def test_no_collision_when_aliases_same_casefold(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        A tag whose aliases all casefold to the same string must NOT appear
+        in the collision list (e.g. 'Python' and 'PYTHON' both casefold to 'python').
+        """
+        tag = _make_canonical_tag(normalized_form="python", canonical_form="Python", status="active")
+
+        alias_a = _make_tag_alias(raw_form="Python", canonical_tag_id=tag.id)
+        alias_b = _make_tag_alias(raw_form="PYTHON", canonical_tag_id=tag.id)
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([tag]),               # active tags (first)
+                _make_scalars_result([]),                  # reviewed entries (none)
+                _make_scalars_result([alias_a, alias_b]),  # aliases
+            ]
+        )
+
+        result = await service.get_collisions(mock_session)
+
+        assert len(result) == 0
+
+    async def test_single_alias_tag_excluded_from_collisions(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Tags with fewer than 2 aliases must not appear as collision candidates.
+        """
+        tag = _make_canonical_tag(normalized_form="python", status="active")
+        alias_a = _make_tag_alias(raw_form="Python", canonical_tag_id=tag.id)
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([tag]),      # active tags (first)
+                _make_scalars_result([]),          # reviewed (none)
+                _make_scalars_result([alias_a]),   # single alias
+            ]
+        )
+
+        result = await service.get_collisions(mock_session)
+
+        assert len(result) == 0
+
+    async def test_collisions_sorted_by_occurrence_count_descending(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Collision groups must be sorted by total_occurrence_count descending
+        so the highest-impact collisions appear first.
+        """
+        from chronovista.services.tag_management import CollisionGroup
+
+        tag1 = _make_canonical_tag(normalized_form="cafe", canonical_form="Cafe", status="active")
+        tag1.id = uuid.uuid4()
+        tag2 = _make_canonical_tag(normalized_form="resume", canonical_form="Resume", status="active")
+        tag2.id = uuid.uuid4()
+
+        alias1a = _make_tag_alias(raw_form="cafe", canonical_tag_id=tag1.id, occurrence_count=2)
+        alias1b = _make_tag_alias(raw_form="café", canonical_tag_id=tag1.id, occurrence_count=3)
+        # tag1 total = 5
+
+        alias2a = _make_tag_alias(raw_form="resume", canonical_tag_id=tag2.id, occurrence_count=50)
+        alias2b = _make_tag_alias(raw_form="résumé", canonical_tag_id=tag2.id, occurrence_count=50)
+        # tag2 total = 100
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([tag1, tag2]),           # active tags (first)
+                _make_scalars_result([]),                     # reviewed (none)
+                _make_scalars_result([alias1a, alias1b]),     # tag1 aliases
+                _make_scalars_result([alias2a, alias2b]),     # tag2 aliases
+            ]
+        )
+
+        result = await service.get_collisions(mock_session)
+
+        assert len(result) == 2
+        # tag2 (100 occurrences) should come before tag1 (5 occurrences)
+        assert result[0].total_occurrence_count == 100
+        assert result[1].total_occurrence_count == 5
+
+    async def test_collisions_with_limit(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        --limit must truncate the result list to at most N collision groups.
+        """
+        tags_and_aliases = []
+
+        active_tags = []
+        for i in range(5):
+            tag = _make_canonical_tag(
+                normalized_form=f"tag{i}",
+                canonical_form=f"Tag{i}",
+                status="active",
+            )
+            tag.id = uuid.uuid4()
+            active_tags.append(tag)
+            alias_a = _make_tag_alias(
+                raw_form=f"tag{i}lower",
+                canonical_tag_id=tag.id,
+                occurrence_count=10,
+            )
+            alias_b = _make_tag_alias(
+                raw_form=f"Tag{i}UPPER",
+                canonical_tag_id=tag.id,
+                occurrence_count=5,
+            )
+            tags_and_aliases.append((tag, [alias_a, alias_b]))
+
+        # Order: active tags first, reviewed second, then per-tag alias queries
+        execute_sides: list[Any] = [_make_scalars_result(active_tags)]  # active tags
+        execute_sides.append(_make_scalars_result([]))  # reviewed (none)
+        for _tag, aliases in tags_and_aliases:
+            execute_sides.append(_make_scalars_result(aliases))
+
+        mock_session.execute = AsyncMock(side_effect=execute_sides)
+
+        result = await service.get_collisions(mock_session, limit=2)
+
+        assert len(result) == 2
+
+    async def test_collisions_include_reviewed_flag(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        With include_reviewed=True, the reviewed-log query must NOT be
+        executed and all collision candidates must be included.
+        """
+        from chronovista.services.tag_management import CollisionGroup
+
+        tag = _make_canonical_tag(
+            normalized_form="naïve",
+            canonical_form="Naïve",
+            status="active",
+        )
+        tag.id = uuid.uuid4()
+
+        alias_a = _make_tag_alias(raw_form="naive", canonical_tag_id=tag.id, occurrence_count=10)
+        alias_b = _make_tag_alias(raw_form="naïve", canonical_tag_id=tag.id, occurrence_count=5)
+
+        # With include_reviewed=True: no reviewed-log query, just active tags + aliases
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([tag]),           # active tags
+                _make_scalars_result([alias_a, alias_b]),  # aliases
+            ]
+        )
+
+        result = await service.get_collisions(mock_session, include_reviewed=True)
+
+        assert len(result) == 1
+        assert isinstance(result[0], CollisionGroup)
+
+    async def test_hashtag_stripping_in_collision_detection(
+        self,
+        service: TagManagementService,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Leading '#' characters must be stripped before casefolding for
+        collision detection. '#cafe' and 'café' should produce a collision
+        since 'cafe' != 'caf\xe9'.
+        """
+        from chronovista.services.tag_management import CollisionGroup
+
+        tag = _make_canonical_tag(normalized_form="cafe", canonical_form="Cafe", status="active")
+        tag.id = uuid.uuid4()
+
+        alias_a = _make_tag_alias(raw_form="#cafe", canonical_tag_id=tag.id, occurrence_count=8)
+        alias_b = _make_tag_alias(raw_form="café", canonical_tag_id=tag.id, occurrence_count=4)
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                _make_scalars_result([tag]),               # active tags (first)
+                _make_scalars_result([]),                  # reviewed (none)
+                _make_scalars_result([alias_a, alias_b]),  # aliases
+            ]
+        )
+
+        result = await service.get_collisions(mock_session)
+
+        assert len(result) == 1
+        assert isinstance(result[0], CollisionGroup)
+
+
+# ===========================================================================
+# TestDeprecate
+# ===========================================================================
+
+
+class TestDeprecate:
+    """
+    Tests for ``TagManagementService.deprecate``.
+
+    Covers:
+    - Basic deprecate happy path
+    - Already-deprecated tag rejection
+    - Merged tag rejection
+    - rollback_data structure
+    - Undo deprecate restores previous status
+    """
+
+    async def test_basic_deprecate_returns_deprecate_result(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Happy path: deprecate marks an active tag as deprecated.
+
+        Verifies DeprecateResult fields: normalized_form, canonical_form,
+        alias_count, operation_id.
+        """
+        from chronovista.services.tag_management import DeprecateResult
+
+        tag = _make_canonical_tag(
+            normalized_form="oldtag",
+            canonical_form="OldTag",
+            status="active",
+            alias_count=3,
+            video_count=5,
+        )
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="delete")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        result = await service.deprecate(
+            mock_session,
+            normalized_form="oldtag",
+            reason="Superseded by newer tag",
+        )
+
+        assert isinstance(result, DeprecateResult)
+        assert result.normalized_form == "oldtag"
+        assert result.canonical_form == "OldTag"
+        assert result.alias_count == 3
+        assert result.operation_id == op_id
+
+    async def test_deprecate_sets_status_to_deprecated(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        After deprecate, tag.status must be 'deprecated'.
+        """
+        from chronovista.models.enums import TagStatus
+
+        tag = _make_canonical_tag(normalized_form="oldtag", status="active")
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="delete")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        await service.deprecate(mock_session, normalized_form="oldtag")
+
+        assert tag.status == TagStatus.DEPRECATED.value
+
+    async def test_deprecate_already_deprecated_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Attempting to deprecate a tag that is already deprecated must raise
+        ValueError with the current status in the message.
+        """
+        deprecated = _make_canonical_tag(normalized_form="oldtag", status="deprecated")
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            None, None, deprecated
+        ]
+
+        with pytest.raises(ValueError, match="deprecated"):
+            await service.deprecate(mock_session, normalized_form="oldtag")
+
+    async def test_deprecate_merged_tag_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Attempting to deprecate a merged tag must raise ValueError with
+        the 'merged' status mentioned.
+        """
+        merged = _make_canonical_tag(normalized_form="oldtag", status="merged")
+        mock_canonical_tag_repo.get_by_normalized_form.side_effect = [
+            None, merged
+        ]
+
+        with pytest.raises(ValueError, match="merged"):
+            await service.deprecate(mock_session, normalized_form="oldtag")
+
+    async def test_deprecate_rollback_data_structure(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        rollback_data for deprecate must contain:
+        - ``canonical_id``: str UUID of the tag
+        - ``previous_status``: the status before deprecation ('active')
+        """
+        from chronovista.models.tag_operation_log import TagOperationLogCreate
+
+        tag = _make_canonical_tag(
+            normalized_form="oldtag",
+            canonical_form="OldTag",
+            status="active",
+        )
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="delete")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        await service.deprecate(
+            mock_session,
+            normalized_form="oldtag",
+            reason="Superseded",
+        )
+
+        call_kwargs = mock_operation_log_repo.create.call_args
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+        rollback = obj_in.rollback_data
+
+        assert "canonical_id" in rollback
+        assert rollback["canonical_id"] == str(tag.id)
+        assert "previous_status" in rollback
+        assert rollback["previous_status"] == "active"
+
+    async def test_deprecate_logs_with_delete_operation_type(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The operation log entry must use operation_type='delete' (per spec),
+        not 'deprecate' (which is not a valid operation type).
+        """
+        from chronovista.models.tag_operation_log import TagOperationLogCreate
+
+        tag = _make_canonical_tag(normalized_form="oldtag", status="active")
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="delete")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        await service.deprecate(mock_session, normalized_form="oldtag")
+
+        call_kwargs = mock_operation_log_repo.create.call_args
+        obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.operation_type == "delete"
+
+    async def test_undo_deprecate_restores_previous_status(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        _undo_deprecate must restore the tag status to its previous value
+        (typically 'active').
+        """
+        canonical_id = uuid.uuid4()
+        log_entry = _make_operation_log(
+            operation_type="delete",
+            rollback_data={
+                "canonical_id": str(canonical_id),
+                "previous_status": "active",
+            },
+        )
+
+        tag = _make_canonical_tag(
+            normalized_form="oldtag",
+            canonical_form="OldTag",
+            status="deprecated",
+        )
+        mock_canonical_tag_repo.get.return_value = tag
+        mock_session.add = MagicMock()
+
+        result = await service._undo_deprecate(mock_session, log_entry)
+
+        assert tag.status == "active"
+        assert isinstance(result, str)
+        assert "oldtag" in result
+        assert "active" in result
+
+    async def test_undo_deprecate_tag_not_found_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        _undo_deprecate must raise ValueError if the canonical tag referenced
+        in rollback_data no longer exists.
+        """
+        canonical_id = uuid.uuid4()
+        log_entry = _make_operation_log(
+            operation_type="delete",
+            rollback_data={
+                "canonical_id": str(canonical_id),
+                "previous_status": "active",
+            },
+        )
+
+        mock_canonical_tag_repo.get.return_value = None
+
+        with pytest.raises(ValueError, match="Cannot undo deprecate"):
+            await service._undo_deprecate(mock_session, log_entry)


### PR DESCRIPTION
## Summary

- Add 7 CLI commands for manual curation of the canonical tag system: `merge`, `split`, `rename`, `classify`, `deprecate`, `collisions`, `undo`
- Implement `TagManagementService` with atomic transactions, self-contained rollback data, and full undo capability via `tag_operation_logs`
- Add `TagOperationLogRepository`, 4 Pydantic models, 7 result dataclasses for type-safe CLI output
- Update documentation: CLI reference, glossary, data model, ADR-003 Phase 4 status, changelog
- Bump version 0.33.0 → 0.34.0

## New Commands

| Command | Description |
|---------|-------------|
| `tags merge <source...> --into <target>` | Merge canonical tags (multi-source supported) |
| `tags split <norm> --aliases "raw1,raw2"` | Split aliases into new canonical tag |
| `tags rename <norm> --to "New Form"` | Rename display form (cosmetic only) |
| `tags classify <norm> --type <type>` | Classify as entity type; `--top N` to browse |
| `tags deprecate <norm>` | Soft-delete junk tags; `--list` to view |
| `tags collisions` | Interactive diacritic collision review |
| `tags undo <id>` | Reverse any operation; `--list` for history |

## Key Design Decisions

- All mutations atomic (single DB transaction) — partial failures roll back entirely
- `rollback_data` JSONB is self-contained — undo reads only `tag_operation_logs`, not other tables
- `video_tags` table is NEVER modified (Safety Guarantee #1 from ADR-003)
- Entity alias creation uses upsert (`ON CONFLICT DO UPDATE`) to handle duplicate normalized forms
- UUID values serialized to strings in rollback_data for JSON compatibility

## Test Plan

- [x] 73 unit tests (TagManagementService + TagOperationLogRepository)
- [x] 67 integration tests (all 7 CLI commands with mock service)
- [x] 41 integration tests (API regression — no breaking changes)
- [x] 181 total new tests, 5,493 total suite — 0 regressions
- [x] mypy --strict clean on all new and modified files
- [x] Manual verification: `classify` tested against live DB (aaron mate, sofia ramirez)