### PR TITLE
feat(transcripts): add transcript corrections audit table (Feature 033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [0.36.0] - 2026-03-02
+
+### Added
+
+#### Feature 033: Transcript Corrections Audit Table (ADR-005 Increment 3)
+
+Append-only audit table and service layer for recording, applying, reverting, and protecting transcript corrections. All mutations use the flush-only transaction pattern — the caller owns the transaction lifecycle. Backend only — no new API endpoints, no frontend changes, no CLI commands.
+
+**Database Migration:**
+- New `transcript_corrections` table with columns: id (UUIDv7 PK), video_id, language_code, segment_id (nullable FK), correction_type, original_text, corrected_text, correction_note (nullable), corrected_by_user_id (nullable), corrected_at (server_default now()), version_number
+- Composite FK to `video_transcripts(video_id, language_code)` with RESTRICT on delete
+- Optional FK to `transcript_segments(id)` with RESTRICT on delete
+- CHECK constraint: `version_number >= 1`
+- Indexes: `idx_transcript_corrections_lookup (video_id, language_code, corrected_at)` and `idx_transcript_corrections_segment (segment_id, corrected_at)`
+- 3 new columns on `video_transcripts`: `has_corrections` (BOOLEAN, default false), `last_corrected_at` (TIMESTAMP), `correction_count` (INTEGER, default 0)
+- Fully reversible: downgrade drops table and removes columns
+
+**CorrectionType Enum (6 values):**
+- `spelling`, `profanity_fix`, `context_correction`, `formatting`, `asr_error`, `revert`
+
+**TranscriptCorrectionRepository (append-only, FR-018):**
+- `update()` and `delete()` raise `NotImplementedError` — immutable audit trail
+- `get_by_segment()` — corrections for a segment ordered by `version_number DESC`
+- `get_by_video()` — paginated corrections for a transcript with total count
+- `count_by_video()` — total corrections for a (video_id, language_code) pair
+- `get_latest_version()` — highest version_number with `FOR UPDATE` row lock (NFR-005)
+- `get()` and `exists()` by UUID primary key
+
+**TranscriptCorrectionService:**
+- `apply_correction()` — atomically creates audit record, updates segment `corrected_text` and `has_correction`, updates transcript metadata (`has_corrections`, `correction_count`, `last_corrected_at`); version chain: `original_text` is the current effective text, not the original raw text (FR-008a); raises `ValueError` for non-existent segment or identical text (no-op prevention)
+- `revert_correction()` — reverts to previous state: revert-to-original (V_N==1: clears `corrected_text`, `has_correction=False`, decrements `correction_count`, recomputes `has_corrections` via EXISTS scan) or revert-to-prior (V_N>1: restores to `V_N.original_text`, keeps `has_correction=True`); records revert as new audit entry with `correction_type='revert'`
+- All mutations use `session.flush()` only — never calls `session.commit()` or `session.rollback()` (FR-007a)
+- Structured INFO logging for all operations (NFR-006)
+
+**Re-Download Protection (US5):**
+- Transcript sync checks `has_correction` before overwriting segment text
+- Corrected segments: raw `text` column updated, `corrected_text` preserved, warning logged about divergence
+- `--force-overwrite` flag bypasses protection and recomputes transcript metadata
+- Uncorrected segments update normally
+
+**Pydantic V2 Domain Models:**
+- `TranscriptCorrectionBase`, `TranscriptCorrectionCreate`, `TranscriptCorrectionRead`
+- `ConfigDict(strict=True, from_attributes=True)` pattern
+
+**Cross-Feature Contract Verification:**
+- `display_text` property returns `corrected_text` after `apply_correction` and original `text` after revert-to-original
+- Search router ILIKE queries cover `corrected_text` column for corrected segments
+- SRT export uses `display_text` for corrected segment output
+- Transcripts API inline ternary returns correct effective text
+- Transcript metadata columns (`has_corrections`, `correction_count`, `last_corrected_at`) verified in API responses
+
+### Technical
+- 139 new tests: 34 unit (models), 44 unit (repository), 31 unit (service), 9 unit (transcript service US5), 21 integration (full DB flows + cross-feature contracts)
+- Hypothesis property-based tests for CorrectionType exhaustiveness, text field edge cases, version chain integrity
+- 5,632 total tests passing with 0 regressions
+- Coverage: 97-100% on all new source files (transcript_correction.py, transcript_correction_repository.py, transcript_correction_service.py, migration)
+- mypy strict compliance (0 errors on all new and modified files)
+- No new dependencies (uses existing SQLAlchemy, Alembic, Pydantic V2, uuid_utils)
+- Test factory: `TranscriptCorrectionFactory` with UUIDv7 PK generation via `uuid.UUID(bytes=uuid7().bytes)`
+
 ## [0.35.0] - 2026-02-27
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive user guide and API reference
 - Architecture documentation
 
+## [0.36.0] - 2026-03-02
+
+### Added
+- **Feature 033: Transcript Corrections Audit Table (ADR-005 Increment 3)**
+  - Append-only `transcript_corrections` audit table with UUIDv7 PKs, composite FK to `video_transcripts`, version chains, and `CorrectionType` enum (spelling, profanity_fix, context_correction, formatting, asr_error, revert)
+  - `TranscriptCorrectionRepository` with immutability enforcement (`update()`/`delete()` raise `NotImplementedError`), segment/video queries, pagination, and `FOR UPDATE` row locking for version safety
+  - `TranscriptCorrectionService.apply_correction()` — atomically creates audit record + updates segment `corrected_text`/`has_correction` + updates transcript metadata (`has_corrections`, `correction_count`, `last_corrected_at`); version chain preserves previous effective text as `original_text`
+  - `TranscriptCorrectionService.revert_correction()` — reverts to previous state (revert-to-original clears correction, revert-to-prior restores previous version); records revert as new audit entry
+  - Re-download protection: corrected segments preserve `corrected_text` during transcript sync; `--force-overwrite` flag bypasses protection
+  - 3 new columns on `video_transcripts`: `has_corrections`, `last_corrected_at`, `correction_count`
+  - Flush-only transaction pattern throughout (caller owns transaction lifecycle)
+  - Cross-feature contract tests: `display_text` property, search ILIKE on `corrected_text`, SRT export, API responses
+  - Pydantic V2 domain models: `TranscriptCorrectionBase`, `TranscriptCorrectionCreate`, `TranscriptCorrectionRead`
+  - Alembic migration fully reversible (downgrade drops table and removes columns)
+
+### Technical
+- 139 new tests (34 unit models + 44 unit repository + 31 unit service + 9 unit transcript service + 21 integration)
+- Hypothesis property-based tests for enum exhaustiveness, text edge cases, version chain integrity
+- 5,632 total tests passing with 0 regressions
+- 97-100% coverage on all new source files
+- mypy strict compliance (0 errors)
+- No new dependencies, no new API endpoints, no frontend changes
+
 ## [0.35.0] - 2026-02-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.35.0"
+version = "0.36.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.35.0"
+__version__ = "0.36.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/db/migrations/versions/033_create_transcript_corrections.py
+++ b/src/chronovista/db/migrations/versions/033_create_transcript_corrections.py
@@ -1,0 +1,197 @@
+"""create_transcript_corrections
+
+Revision ID: a7c3d9e5f1b4
+Revises: f9b5c8d6e3a1
+Create Date: 2026-03-02 12:00:00.000000
+
+This migration implements the transcript corrections and audit trail schema
+for Feature 033 (Transcript Corrections & Audit). It creates the
+transcript_corrections table and adds correction-tracking columns to the
+video_transcripts table.
+
+New Tables:
+1. transcript_corrections - Audit log for individual transcript text corrections
+
+Changes to video_transcripts:
+1. has_corrections - Boolean flag indicating any corrections exist
+2. last_corrected_at - Timestamp of the most recent correction
+3. correction_count - Running total of corrections applied
+
+Key Features:
+- UUID primary key for transcript_corrections (PostgreSQL UUID type)
+- Composite FK to video_transcripts(video_id, language_code) with RESTRICT
+- Optional FK to transcript_segments(id) for segment-level corrections
+- CHECK constraint enforcing version_number >= 1
+- 2 performance indexes on lookup patterns
+- Fully reversible downgrade
+
+Related: Feature 033 (Transcript Corrections & Audit)
+Architecture: ADR-003 Tag Normalization (audit log pattern reference)
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "a7c3d9e5f1b4"
+down_revision = "f9b5c8d6e3a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """
+    Create transcript_corrections table and add correction-tracking columns
+    to video_transcripts.
+
+    Operations performed in dependency order:
+    1. Create transcript_corrections table (depends on video_transcripts and
+       transcript_segments)
+    2. Add has_corrections, last_corrected_at, correction_count to
+       video_transcripts
+    3. Create indexes on transcript_corrections
+    """
+    # =========================================================================
+    # TABLE: transcript_corrections
+    # =========================================================================
+    op.create_table(
+        "transcript_corrections",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("video_id", sa.String(20), nullable=False),
+        sa.Column("language_code", sa.String(10), nullable=False),
+        sa.Column("segment_id", sa.Integer(), nullable=True),
+        sa.Column("correction_type", sa.String(30), nullable=False),
+        sa.Column("original_text", sa.Text(), nullable=False),
+        sa.Column("corrected_text", sa.Text(), nullable=False),
+        sa.Column("correction_note", sa.Text(), nullable=True),
+        sa.Column("corrected_by_user_id", sa.String(100), nullable=True),
+        sa.Column(
+            "corrected_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("version_number", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_transcript_corrections"),
+        sa.ForeignKeyConstraint(
+            ["video_id", "language_code"],
+            ["video_transcripts.video_id", "video_transcripts.language_code"],
+            name="fk_transcript_corrections_transcript",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["segment_id"],
+            ["transcript_segments.id"],
+            name="fk_transcript_corrections_segment",
+            ondelete="RESTRICT",
+        ),
+        sa.CheckConstraint(
+            "version_number >= 1",
+            name="chk_transcript_corrections_version_number_positive",
+        ),
+    )
+
+    # =========================================================================
+    # INDEXES on transcript_corrections
+    # =========================================================================
+
+    # Index 1: Primary lookup pattern — by transcript + time ordering
+    op.create_index(
+        "idx_transcript_corrections_lookup",
+        "transcript_corrections",
+        ["video_id", "language_code", "corrected_at"],
+        unique=False,
+    )
+
+    # Index 2: Segment-level correction lookup — by segment + time ordering
+    op.create_index(
+        "idx_transcript_corrections_segment",
+        "transcript_corrections",
+        ["segment_id", "corrected_at"],
+        unique=False,
+    )
+
+    # =========================================================================
+    # ADD COLUMNS to video_transcripts
+    # =========================================================================
+
+    # Column 1: Flag indicating whether any corrections exist for this transcript
+    op.add_column(
+        "video_transcripts",
+        sa.Column(
+            "has_corrections",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    # Column 2: Timestamp of the most recent correction applied
+    op.add_column(
+        "video_transcripts",
+        sa.Column(
+            "last_corrected_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+    # Column 3: Running total of corrections applied to this transcript
+    op.add_column(
+        "video_transcripts",
+        sa.Column(
+            "correction_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """
+    Drop transcript_corrections table and remove correction-tracking columns
+    from video_transcripts.
+
+    WARNING: This will permanently delete all transcript correction records
+    including:
+    - All correction history (original text, corrected text, notes)
+    - Correction authorship and timestamps
+    - Version history
+
+    Ensure you have backups if this data is needed.
+
+    Drop order reverses upgrade to respect FK constraints:
+    1. Drop indexes on transcript_corrections
+    2. Drop transcript_corrections table (removes FKs to video_transcripts)
+    3. Remove correction-tracking columns from video_transcripts
+    """
+    # =========================================================================
+    # DROP INDEXES (reverse order of creation)
+    # =========================================================================
+
+    op.drop_index(
+        "idx_transcript_corrections_segment",
+        table_name="transcript_corrections",
+    )
+    op.drop_index(
+        "idx_transcript_corrections_lookup",
+        table_name="transcript_corrections",
+    )
+
+    # =========================================================================
+    # DROP TABLE
+    # =========================================================================
+
+    op.drop_table("transcript_corrections")
+
+    # =========================================================================
+    # REMOVE COLUMNS from video_transcripts (reverse order of addition)
+    # =========================================================================
+
+    op.drop_column("video_transcripts", "correction_count")
+    op.drop_column("video_transcripts", "last_corrected_at")
+    op.drop_column("video_transcripts", "has_corrections")

--- a/src/chronovista/db/models.py
+++ b/src/chronovista/db/models.py
@@ -315,6 +315,20 @@ class VideoTranscript(Base):
         comment="Source: youtube_transcript_api, youtube_data_api_v3, manual_upload, unknown"
     )
 
+    # Correction metadata (Feature 033)
+    has_corrections: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default=text("false"),
+        comment="Whether any segment has active corrections"
+    )
+    last_corrected_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+        comment="Timestamp of most recent correction"
+    )
+    correction_count: Mapped[int] = mapped_column(
+        Integer, default=0, nullable=False, server_default=text("0"),
+        comment="Count of active (non-reverted) corrections"
+    )
+
     # Relationships
     video: Mapped["Video"] = relationship("Video", back_populates="transcripts")
     segments: Mapped[list["TranscriptSegment"]] = relationship(
@@ -322,6 +336,11 @@ class VideoTranscript(Base):
         back_populates="transcript",
         order_by="TranscriptSegment.sequence_number",
         cascade="all, delete-orphan",
+    )
+    corrections: Mapped[list["TranscriptCorrection"]] = relationship(
+        "TranscriptCorrection",
+        back_populates="transcript",
+        order_by="TranscriptCorrection.corrected_at.desc()",
     )
 
 
@@ -1001,6 +1020,64 @@ class TagOperationLog(Base):
     )
 
 
+class TranscriptCorrection(Base):
+    """Append-only audit record for transcript segment corrections (Feature 033).
+
+    Records are never updated or deleted. Each row captures a single correction
+    event including the before/after text, correction type, and version number
+    within the segment's correction chain.
+    """
+
+    __tablename__ = "transcript_corrections"
+
+    # Primary key (UUIDv7, time-ordered)
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid7)
+
+    # Transcript linkage (composite FK to video_transcripts)
+    video_id: Mapped[str] = mapped_column(String(20), nullable=False)
+    language_code: Mapped[str] = mapped_column(String(10), nullable=False)
+
+    # Segment linkage (optional FK to transcript_segments)
+    segment_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("transcript_segments.id", ondelete="RESTRICT"), nullable=True
+    )
+
+    # Correction content
+    correction_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    original_text: Mapped[str] = mapped_column(Text, nullable=False)
+    corrected_text: Mapped[str] = mapped_column(Text, nullable=False)
+    correction_note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    # Audit metadata
+    corrected_by_user_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    corrected_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    version_number: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # Table constraints
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["video_id", "language_code"],
+            ["video_transcripts.video_id", "video_transcripts.language_code"],
+            name="fk_transcript_corrections_transcript",
+            ondelete="RESTRICT",
+        ),
+        CheckConstraint(
+            "version_number >= 1",
+            name="chk_transcript_corrections_version_number_positive",
+        ),
+    )
+
+    # Relationships
+    transcript: Mapped["VideoTranscript"] = relationship(
+        "VideoTranscript", back_populates="corrections"
+    )
+    segment: Mapped[Optional["TranscriptSegment"]] = relationship(
+        "TranscriptSegment"
+    )
+
+
 # Export all models
 __all__ = [
     "Base",
@@ -1025,4 +1102,5 @@ __all__ = [
     "CanonicalTag",
     "TagAlias",
     "TagOperationLog",
+    "TranscriptCorrection",
 ]

--- a/src/chronovista/models/enums.py
+++ b/src/chronovista/models/enums.py
@@ -293,3 +293,14 @@ class TagOperationType(str, Enum):
     RENAME = "rename"
     DELETE = "delete"
     CREATE = "create"
+
+
+class CorrectionType(str, Enum):
+    """Types of corrections that can be applied to a transcript."""
+
+    SPELLING = "spelling"
+    PROFANITY_FIX = "profanity_fix"
+    CONTEXT_CORRECTION = "context_correction"
+    FORMATTING = "formatting"
+    ASR_ERROR = "asr_error"
+    REVERT = "revert"

--- a/src/chronovista/models/transcript_correction.py
+++ b/src/chronovista/models/transcript_correction.py
@@ -1,0 +1,174 @@
+"""
+Pydantic models for transcript corrections.
+
+This module provides Pydantic V2 models for transcript correction management,
+following the Base/Create/Full model hierarchy per the project Constitution.
+
+Transcript corrections are append-only (FR-018): no update model is provided.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, ValidationInfo
+
+from chronovista.models.enums import CorrectionType
+
+
+class TranscriptCorrectionBase(BaseModel):
+    """Base model for transcript corrections with validation.
+
+    Contains common fields and validators for all transcript correction
+    operations. Follows the Base/Create/Full model hierarchy per the
+    project Constitution.
+
+    Notes
+    -----
+    Corrections are append-only (FR-018). No update operations are
+    supported on this entity.
+    """
+
+    video_id: str = Field(
+        ...,
+        max_length=20,
+        description="YouTube video ID",
+    )
+    language_code: str = Field(
+        ...,
+        max_length=10,
+        description="BCP-47 language code for the transcript being corrected",
+    )
+    segment_id: int | None = Field(
+        default=None,
+        description="Optional reference to the transcript segment being corrected",
+    )
+    correction_type: CorrectionType = Field(
+        ...,
+        description="Category of correction applied",
+    )
+    original_text: str = Field(
+        ...,
+        description="Original transcript text before correction",
+    )
+    corrected_text: str = Field(
+        ...,
+        description="Corrected transcript text after applying the correction",
+    )
+    correction_note: str | None = Field(
+        default=None,
+        description="Optional human-readable explanation for the correction",
+    )
+    corrected_by_user_id: str | None = Field(
+        default=None,
+        max_length=100,
+        description="Identifier of the user who made the correction",
+    )
+    version_number: int = Field(
+        ...,
+        ge=1,
+        description="Version number of this correction (must be >= 1)",
+    )
+
+    @field_validator("version_number")
+    @classmethod
+    def validate_version_number(cls, v: int) -> int:
+        """Ensure version_number is at least 1.
+
+        Parameters
+        ----------
+        v : int
+            The version_number value to validate.
+
+        Returns
+        -------
+        int
+            The validated version_number value.
+
+        Raises
+        ------
+        ValueError
+            If version_number is less than 1.
+        """
+        if v < 1:
+            raise ValueError(
+                f"version_number must be >= 1, got {v}"
+            )
+        return v
+
+    @field_validator("corrected_text")
+    @classmethod
+    def validate_corrected_text_differs(
+        cls, v: str, info: ValidationInfo
+    ) -> str:
+        """Ensure corrected_text is different from original_text (no-op prevention).
+
+        Parameters
+        ----------
+        v : str
+            The corrected_text value to validate.
+        info : ValidationInfo
+            Validation context containing other field values.
+
+        Returns
+        -------
+        str
+            The validated corrected_text value.
+
+        Raises
+        ------
+        ValueError
+            If corrected_text is identical to original_text.
+        """
+        original = info.data.get("original_text")
+        if original is not None and v == original:
+            raise ValueError(
+                "corrected_text must differ from original_text; "
+                "no-op corrections are not permitted"
+            )
+        return v
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+        str_strip_whitespace=True,
+    )
+
+
+class TranscriptCorrectionCreate(TranscriptCorrectionBase):
+    """Model for creating transcript corrections (used as creation input).
+
+    Extends TranscriptCorrectionBase with no additional fields. This model
+    is used as the input payload when recording a new correction. Updates
+    are not supported (FR-018 — append-only entity).
+    """
+
+
+class TranscriptCorrectionRead(TranscriptCorrectionBase):
+    """Full transcript correction model with database fields.
+
+    Extends TranscriptCorrectionBase with database-specific fields such as
+    the surrogate primary key and the timestamp recorded at insertion time.
+    Used when reading corrections back from the database.
+    """
+
+    id: uuid.UUID = Field(
+        ...,
+        description="Surrogate primary key (UUIDv7)",
+    )
+    corrected_at: datetime = Field(
+        ...,
+        description="Timestamp when the correction was recorded",
+    )
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        validate_assignment=True,
+    )
+
+
+__all__ = [
+    "TranscriptCorrectionBase",
+    "TranscriptCorrectionCreate",
+    "TranscriptCorrectionRead",
+]

--- a/src/chronovista/repositories/transcript_correction_repository.py
+++ b/src/chronovista/repositories/transcript_correction_repository.py
@@ -1,0 +1,334 @@
+"""
+Repository for TranscriptCorrection database operations.
+
+Provides append-only audit log access following the repository pattern.
+Records are immutable once created (FR-018): update() and delete() raise
+NotImplementedError.
+
+This repository supports Feature 033: Transcript Corrections Audit (FR-012,
+FR-018, NFR-005).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+from uuid import UUID
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
+from chronovista.models.transcript_correction import TranscriptCorrectionCreate
+from chronovista.repositories.base import BaseSQLAlchemyRepository
+
+
+class TranscriptCorrectionRepository(
+    BaseSQLAlchemyRepository[
+        TranscriptCorrectionDB,
+        TranscriptCorrectionCreate,
+        TranscriptCorrectionCreate,  # No separate Update schema — immutable
+        UUID,
+    ]
+):
+    """Repository for TranscriptCorrection database operations.
+
+    This is an **append-only** repository. The ``update()`` and ``delete()``
+    methods are overridden to raise ``NotImplementedError`` because transcript
+    corrections form an immutable audit trail (FR-018).
+
+    Attributes
+    ----------
+    model : type[TranscriptCorrectionDB]
+        The SQLAlchemy model class for transcript corrections.
+    """
+
+    def __init__(self) -> None:
+        """Initialize repository with TranscriptCorrection model."""
+        super().__init__(TranscriptCorrectionDB)
+
+    # ------------------------------------------------------------------
+    # Immutability guards (FR-018)
+    # ------------------------------------------------------------------
+
+    async def update(
+        self,
+        session: AsyncSession,
+        *,
+        db_obj: TranscriptCorrectionDB,
+        obj_in: Union[TranscriptCorrectionCreate, dict[str, Any]],
+    ) -> TranscriptCorrectionDB:
+        """Raise unconditionally — corrections are immutable.
+
+        Raises
+        ------
+        NotImplementedError
+            Always. Transcript corrections are an append-only audit table.
+        """
+        raise NotImplementedError(
+            "TranscriptCorrection records are immutable — append-only audit table"
+        )
+
+    async def delete(
+        self,
+        session: AsyncSession,
+        *,
+        id: UUID,
+    ) -> Optional[TranscriptCorrectionDB]:
+        """Raise unconditionally — corrections are immutable.
+
+        Raises
+        ------
+        NotImplementedError
+            Always. Transcript corrections are an append-only audit table.
+        """
+        raise NotImplementedError(
+            "TranscriptCorrection records are immutable — append-only audit table"
+        )
+
+    # ------------------------------------------------------------------
+    # Primary-key lookups
+    # ------------------------------------------------------------------
+
+    async def get(
+        self,
+        session: AsyncSession,
+        id: UUID,
+    ) -> Optional[TranscriptCorrectionDB]:
+        """
+        Get a correction by its UUID primary key.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        id : UUID
+            Correction primary key (UUIDv7).
+
+        Returns
+        -------
+        Optional[TranscriptCorrectionDB]
+            The correction if found, None otherwise.
+        """
+        result = await session.execute(
+            select(TranscriptCorrectionDB).where(TranscriptCorrectionDB.id == id)
+        )
+        return result.scalar_one_or_none()
+
+    async def exists(
+        self,
+        session: AsyncSession,
+        id: UUID,
+    ) -> bool:
+        """
+        Check if a correction exists by UUID primary key.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        id : UUID
+            Correction primary key (UUIDv7).
+
+        Returns
+        -------
+        bool
+            True if the correction exists, False otherwise.
+        """
+        result = await session.execute(
+            select(TranscriptCorrectionDB.id).where(TranscriptCorrectionDB.id == id)
+        )
+        return result.first() is not None
+
+    # ------------------------------------------------------------------
+    # Domain-specific queries
+    # ------------------------------------------------------------------
+
+    async def get_by_segment(
+        self,
+        session: AsyncSession,
+        video_id: str,
+        language_code: str,
+        segment_id: int,
+        *,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> list[TranscriptCorrectionDB]:
+        """
+        Get corrections for a specific segment, ordered by version DESC.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        video_id : str
+            YouTube video ID.
+        language_code : str
+            BCP-47 language code.
+        segment_id : int
+            FK to transcript_segments.id.
+        skip : int, optional
+            Number of rows to skip (default 0).
+        limit : int, optional
+            Maximum rows to return (default 50).
+
+        Returns
+        -------
+        list[TranscriptCorrectionDB]
+            Corrections ordered by version_number DESC (newest first).
+        """
+        stmt = (
+            select(TranscriptCorrectionDB)
+            .where(
+                and_(
+                    TranscriptCorrectionDB.video_id == video_id,
+                    TranscriptCorrectionDB.language_code == language_code,
+                    TranscriptCorrectionDB.segment_id == segment_id,
+                )
+            )
+            .order_by(TranscriptCorrectionDB.version_number.desc())
+            .offset(skip)
+            .limit(limit)
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_by_video(
+        self,
+        session: AsyncSession,
+        video_id: str,
+        language_code: str,
+        *,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[TranscriptCorrectionDB], int]:
+        """
+        Get paginated corrections for a video transcript.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        video_id : str
+            YouTube video ID.
+        language_code : str
+            BCP-47 language code.
+        skip : int, optional
+            Number of rows to skip (default 0).
+        limit : int, optional
+            Maximum rows to return (default 50).
+
+        Returns
+        -------
+        tuple[list[TranscriptCorrectionDB], int]
+            A tuple of (items, total_count). ``total_count`` reflects all
+            corrections for the (video_id, language_code) pair, not just
+            the current page.
+        """
+        # Count query first
+        count_stmt = select(func.count()).where(
+            and_(
+                TranscriptCorrectionDB.video_id == video_id,
+                TranscriptCorrectionDB.language_code == language_code,
+            )
+        ).select_from(TranscriptCorrectionDB)
+        count_result = await session.execute(count_stmt)
+        total = count_result.scalar_one()
+
+        # Items query
+        items_stmt = (
+            select(TranscriptCorrectionDB)
+            .where(
+                and_(
+                    TranscriptCorrectionDB.video_id == video_id,
+                    TranscriptCorrectionDB.language_code == language_code,
+                )
+            )
+            .order_by(TranscriptCorrectionDB.corrected_at.desc())
+            .offset(skip)
+            .limit(limit)
+        )
+        items_result = await session.execute(items_stmt)
+        items = list(items_result.scalars().all())
+
+        return items, total
+
+    async def count_by_video(
+        self,
+        session: AsyncSession,
+        video_id: str,
+        language_code: str,
+    ) -> int:
+        """
+        Count total corrections for a video transcript.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        video_id : str
+            YouTube video ID.
+        language_code : str
+            BCP-47 language code.
+
+        Returns
+        -------
+        int
+            Total number of corrections for the (video_id, language_code) pair.
+        """
+        stmt = select(func.count()).where(
+            and_(
+                TranscriptCorrectionDB.video_id == video_id,
+                TranscriptCorrectionDB.language_code == language_code,
+            )
+        ).select_from(TranscriptCorrectionDB)
+        result = await session.execute(stmt)
+        return result.scalar_one()
+
+    async def get_latest_version(
+        self,
+        session: AsyncSession,
+        video_id: str,
+        language_code: str,
+        segment_id: int,
+    ) -> int:
+        """
+        Get the highest version_number for a segment's correction chain.
+
+        Uses ``SELECT ... FOR UPDATE`` to prevent concurrent inserts from
+        creating duplicate version numbers (NFR-005).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        video_id : str
+            YouTube video ID.
+        language_code : str
+            BCP-47 language code.
+        segment_id : int
+            FK to transcript_segments.id.
+
+        Returns
+        -------
+        int
+            The highest version_number, or 0 if no corrections exist yet.
+        """
+        # Lock the matching rows first, then compute max in Python.
+        # PostgreSQL does not allow FOR UPDATE with aggregate functions.
+        stmt = (
+            select(TranscriptCorrectionDB.version_number)
+            .where(
+                and_(
+                    TranscriptCorrectionDB.video_id == video_id,
+                    TranscriptCorrectionDB.language_code == language_code,
+                    TranscriptCorrectionDB.segment_id == segment_id,
+                )
+            )
+            .with_for_update()
+        )
+        result = await session.execute(stmt)
+        versions = result.scalars().all()
+        return max(versions) if versions else 0
+
+
+__all__ = ["TranscriptCorrectionRepository"]

--- a/src/chronovista/services/transcript_correction_service.py
+++ b/src/chronovista/services/transcript_correction_service.py
@@ -1,0 +1,345 @@
+"""
+Transcript correction service for applying and auditing corrections.
+
+Orchestrates the apply_correction workflow: validates the segment, creates
+an append-only audit record, updates the segment's corrected text, and
+updates transcript-level correction metadata.  All mutations use
+``session.flush()`` only — the caller owns the transaction lifecycle
+(same flush-only pattern as ``TagManagementService``).
+
+Feature 033 — Transcript Corrections Audit
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import exists, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
+from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+from chronovista.models.enums import CorrectionType
+from chronovista.models.transcript_correction import TranscriptCorrectionCreate
+from chronovista.repositories.transcript_correction_repository import (
+    TranscriptCorrectionRepository,
+)
+from chronovista.repositories.transcript_segment_repository import (
+    TranscriptSegmentRepository,
+)
+from chronovista.repositories.video_transcript_repository import (
+    VideoTranscriptRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TranscriptCorrectionService:
+    """
+    Service for applying transcript corrections with full audit trail.
+
+    All operations follow the flush-only pattern: ``session.flush()`` is
+    called after each mutation step, but ``session.commit()`` and
+    ``session.rollback()`` are never called.  The caller is responsible
+    for managing the transaction lifecycle.
+
+    Parameters
+    ----------
+    correction_repo : TranscriptCorrectionRepository
+        Repository for transcript correction audit records.
+    segment_repo : TranscriptSegmentRepository
+        Repository for transcript segment lookups.
+    transcript_repo : VideoTranscriptRepository
+        Repository for transcript metadata updates.
+    """
+
+    def __init__(
+        self,
+        correction_repo: TranscriptCorrectionRepository,
+        segment_repo: TranscriptSegmentRepository,
+        transcript_repo: VideoTranscriptRepository,
+    ) -> None:
+        self._correction_repo = correction_repo
+        self._segment_repo = segment_repo
+        self._transcript_repo = transcript_repo
+
+    async def apply_correction(
+        self,
+        session: AsyncSession,
+        *,
+        video_id: str,
+        language_code: str,
+        segment_id: int,
+        corrected_text: str,
+        correction_type: CorrectionType,
+        correction_note: str | None = None,
+        corrected_by_user_id: str | None = None,
+    ) -> TranscriptCorrectionDB:
+        """
+        Apply a correction to a transcript segment.
+
+        Creates an append-only audit record, updates the segment's corrected
+        text, and updates transcript-level correction metadata.  All mutations
+        are flushed within the caller's transaction.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session (caller manages transaction).
+        video_id : str
+            YouTube video ID.
+        language_code : str
+            BCP-47 language code.
+        segment_id : int
+            Primary key of the transcript segment to correct.
+        corrected_text : str
+            The new corrected text for the segment.
+        correction_type : CorrectionType
+            Category of the correction.
+        correction_note : str | None, optional
+            Human-readable explanation for the correction.
+        corrected_by_user_id : str | None, optional
+            Identifier of the user who made the correction.
+
+        Returns
+        -------
+        TranscriptCorrectionDB
+            The created transcript correction audit record.
+
+        Raises
+        ------
+        ValueError
+            If the segment does not exist.
+        ValueError
+            If ``corrected_text`` is identical to the segment's current
+            effective text (no-op prevention).
+        """
+        # Step 1: Get segment — raise ValueError if not found
+        segment = await self._segment_repo.get(session, segment_id)
+        if segment is None:
+            raise ValueError(
+                f"Transcript segment with id={segment_id} not found"
+            )
+
+        # Step 2: Determine effective text
+        effective_text: str = (
+            segment.corrected_text if segment.has_correction else segment.text
+        ) or ""
+
+        # Step 3: No-op prevention
+        if corrected_text == effective_text:
+            raise ValueError(
+                f"corrected_text is identical to the segment's current "
+                f"effective text — no-op corrections are not permitted"
+            )
+
+        # Step 4: Get latest version (acquires FOR UPDATE lock)
+        latest_version = await self._correction_repo.get_latest_version(
+            session, video_id, language_code, segment_id
+        )
+        new_version = latest_version + 1
+
+        # Step 5: Create audit record
+        create_model = TranscriptCorrectionCreate(
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            correction_type=correction_type,
+            original_text=effective_text,
+            corrected_text=corrected_text,
+            correction_note=correction_note,
+            corrected_by_user_id=corrected_by_user_id,
+            version_number=new_version,
+        )
+
+        # Step 6: Persist audit record via repo (this flushes internally)
+        correction_record = await self._correction_repo.create(
+            session, obj_in=create_model
+        )
+
+        # Step 7: Update segment
+        segment.corrected_text = corrected_text
+        segment.has_correction = True
+        await session.flush()
+
+        # Step 8-9: Update transcript metadata
+        transcript = await self._transcript_repo.get(
+            session, (video_id, language_code)
+        )
+        if transcript is not None:
+            transcript.has_corrections = True
+            transcript.correction_count = transcript.correction_count + 1
+            transcript.last_corrected_at = datetime.now(tz=timezone.utc)
+            await session.flush()
+
+        # Step 10: Emit structured INFO log (NFR-006)
+        logger.info(
+            "Correction applied: video_id=%s, language_code=%s, "
+            "segment_id=%s, correction_type=%s, version_number=%d, "
+            "corrected_by_user_id=%s",
+            video_id,
+            language_code,
+            segment_id,
+            correction_type.value if isinstance(correction_type, CorrectionType) else correction_type,
+            new_version,
+            corrected_by_user_id,
+        )
+
+        # Step 11: Return created record
+        return correction_record
+
+    async def revert_correction(
+        self,
+        session: AsyncSession,
+        *,
+        segment_id: int,
+    ) -> TranscriptCorrectionDB:
+        """
+        Revert the latest correction applied to a transcript segment.
+
+        Creates an append-only revert audit record, restores the segment to
+        its previous state, and updates transcript-level correction metadata.
+        All mutations are flushed within the caller's transaction.
+
+        The revert semantics are:
+        - Fetch V_N (the latest audit record by version_number).
+        - If V_N.version_number == 1: restore segment to its original
+          uncorrected state (corrected_text=None, has_correction=False).
+        - If V_N.version_number > 1: restore segment to V_N.original_text
+          (the text immediately prior to that correction), has_correction=True.
+        - In both cases create a new audit record with correction_type='revert'.
+
+        Transcript metadata is updated per the revert type:
+        - Revert-to-original: decrement correction_count, recompute
+          has_corrections via EXISTS scan (FR-014a, FR-014b).
+        - Revert-to-prior-version: correction_count unchanged,
+          has_corrections remains True.
+        - last_corrected_at is always updated (FR-014c).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session (caller manages transaction).
+        segment_id : int
+            Primary key of the transcript segment to revert.
+
+        Returns
+        -------
+        TranscriptCorrectionDB
+            The created revert audit record.
+
+        Raises
+        ------
+        ValueError
+            If the segment does not exist or has no active correction
+            (segment.has_correction is False).
+        """
+        # Step 1: Get segment — raise ValueError if not found or has_correction=False
+        segment = await self._segment_repo.get(session, segment_id)
+        if segment is None:
+            raise ValueError(
+                f"Transcript segment with id={segment_id} not found"
+            )
+        if not segment.has_correction:
+            raise ValueError(
+                f"Transcript segment with id={segment_id} has no active "
+                f"correction to revert (has_correction=False)"
+            )
+
+        # Step 2: Fetch V_N — the latest audit record (highest version_number)
+        latest_records = await self._correction_repo.get_by_segment(
+            session,
+            segment.video_id,
+            segment.language_code,
+            segment_id,
+            limit=1,
+        )
+        if not latest_records:
+            raise ValueError(
+                f"Transcript segment with id={segment_id} has has_correction=True "
+                f"but no audit records were found — data integrity violation"
+            )
+        v_n = latest_records[0]
+
+        # Determine revert type:
+        # version_number == 1 → revert to original (segment becomes uncorrected)
+        # version_number > 1  → revert to prior correction (segment keeps correction)
+        is_revert_to_original = v_n.version_number == 1
+
+        # Step 3: Create revert audit record
+        # original_text = what the segment had BEFORE this revert (V_N.corrected_text)
+        # corrected_text = what the segment will be restored TO (V_N.original_text)
+        revert_version = v_n.version_number + 1
+        revert_create = TranscriptCorrectionCreate(
+            video_id=segment.video_id,
+            language_code=segment.language_code,
+            segment_id=segment_id,
+            correction_type=CorrectionType.REVERT,
+            original_text=v_n.corrected_text,
+            corrected_text=v_n.original_text,
+            version_number=revert_version,
+            correction_note=None,
+            corrected_by_user_id=None,
+        )
+        revert_record = await self._correction_repo.create(
+            session, obj_in=revert_create
+        )
+
+        # Step 4 / 5: Update segment based on revert type
+        if is_revert_to_original:
+            # Full revert: segment returns to its original uncorrected state
+            segment.corrected_text = None
+            segment.has_correction = False
+        else:
+            # Partial revert: restore to the text that was current before V_N
+            segment.corrected_text = v_n.original_text
+            # has_correction remains True (the segment is still corrected)
+
+        await session.flush()
+
+        # Step 6: Update transcript metadata
+        transcript = await self._transcript_repo.get(
+            session, (segment.video_id, segment.language_code)
+        )
+        if transcript is not None:
+            # FR-014c: a revert is always a correction event
+            transcript.last_corrected_at = datetime.now(tz=timezone.utc)
+
+            if is_revert_to_original:
+                # FR-014a: decrement correction_count (one fewer active correction)
+                transcript.correction_count = max(0, transcript.correction_count - 1)
+
+                # FR-014b: recompute has_corrections by scanning remaining segments
+                # Uses EXISTS so we stop at the first corrected segment (efficient)
+                exists_stmt = select(
+                    exists().where(
+                        TranscriptSegmentDB.video_id == segment.video_id,
+                        TranscriptSegmentDB.language_code == segment.language_code,
+                        TranscriptSegmentDB.has_correction.is_(True),
+                    )
+                )
+                result = await session.execute(exists_stmt)
+                transcript.has_corrections = bool(result.scalar_one())
+            # else: revert-to-prior — correction_count and has_corrections unchanged
+
+            await session.flush()
+
+        # Step 7: Emit structured INFO log (NFR-006)
+        logger.info(
+            "Correction reverted: segment_id=%s, video_id=%s, language_code=%s, "
+            "reverted_version_number=%d, revert_version_number=%d, "
+            "revert_type=%s",
+            segment_id,
+            segment.video_id,
+            segment.language_code,
+            v_n.version_number,
+            revert_version,
+            "revert_to_original" if is_revert_to_original else "revert_to_prior",
+        )
+
+        # Step 8: Return the revert audit record
+        return revert_record
+
+
+__all__ = ["TranscriptCorrectionService"]

--- a/src/chronovista/services/transcript_service.py
+++ b/src/chronovista/services/transcript_service.py
@@ -659,6 +659,71 @@ class TranscriptService(TranscriptServiceInterface):
 
         return results
 
+    def _update_segment_text(
+        self,
+        segment: Any,
+        new_text: str,
+        force_overwrite: bool = False,
+    ) -> None:
+        """
+        Update a transcript segment's raw text with re-download protection.
+
+        Implements FR-015 and FR-016 from Feature 033: if a segment has an
+        existing manual correction (has_correction=True), the corrected_text is
+        preserved by default so that human corrections are not silently lost
+        during a transcript re-download.
+
+        Parameters
+        ----------
+        segment : Any
+            ORM or domain object with attributes: ``text``, ``corrected_text``,
+            ``has_correction``.  Mutated in-place.
+        new_text : str
+            The fresh raw text from the re-downloaded transcript.
+        force_overwrite : bool, optional
+            When True, bypass correction protection: clear ``corrected_text``,
+            set ``has_correction = False``, and update ``text`` with
+            ``new_text``.  Callers MUST recompute the parent transcript's
+            ``has_corrections`` / ``correction_count`` after processing all
+            segments.  Defaults to False.
+
+        Notes
+        -----
+        - When *force_overwrite* is False and the segment has a correction, a
+          WARNING is logged about the divergence between raw and corrected text
+          (FR-016).
+        - When *force_overwrite* is True, an INFO message is logged.
+        - When the segment has no correction, the update proceeds silently.
+        - This method does **not** touch the database; it only mutates the
+          in-memory object.  The caller is responsible for flushing/committing.
+        - Recomputation of transcript-level ``has_corrections`` and
+          ``correction_count`` after a force-overwrite is the caller's
+          responsibility (EC-FORCE-OVERWRITE-AUDIT).
+        """
+        if segment.has_correction:
+            if force_overwrite:
+                logger.info(
+                    "Segment %s: force-overwrite requested; "
+                    "clearing corrected_text and resetting has_correction",
+                    getattr(segment, "id", "<unknown>"),
+                )
+                segment.text = new_text
+                segment.corrected_text = None
+                segment.has_correction = False
+            else:
+                # FR-015: preserve corrected_text; only update the raw column
+                # FR-016: warn about divergence between raw and corrected text
+                logger.warning(
+                    "Segment %s has correction; raw text updated but "
+                    "corrected_text preserved",
+                    getattr(segment, "id", "<unknown>"),
+                )
+                segment.text = new_text
+                # corrected_text intentionally left unchanged
+        else:
+            # No correction — update normally
+            segment.text = new_text
+
     def is_service_available(self) -> bool:
         """Check if the transcript service is available."""
         return self._api_available or self.enable_mock_fallback

--- a/tests/factories/transcript_correction_factory.py
+++ b/tests/factories/transcript_correction_factory.py
@@ -1,0 +1,177 @@
+"""
+Factory for TranscriptCorrection ORM models using factory_boy.
+
+Provides reusable test data factories for the TranscriptCorrection ORM model
+(append-only audit records for transcript segment corrections, Feature 033)
+with sensible defaults and easy customization.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import factory
+from factory import LazyFunction, Sequence
+from uuid_utils import uuid7
+
+from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
+from chronovista.models.enums import CorrectionType
+
+
+def _uuid7() -> uuid.UUID:
+    """Generate a UUIDv7 as a standard uuid.UUID for Pydantic compatibility."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+
+class TranscriptCorrectionFactory(factory.Factory[TranscriptCorrectionDB]):
+    """Factory for TranscriptCorrectionDB ORM models.
+
+    Produces fully-populated TranscriptCorrection ORM instances suitable
+    for unit tests that do not touch the database.  Use `.build()` to
+    instantiate without a session; use `.create()` only inside database-backed
+    integration tests with a live session.
+    """
+
+    class Meta:
+        model = TranscriptCorrectionDB
+
+    id: Any = LazyFunction(_uuid7)
+    video_id: Any = LazyFunction(lambda: "dQw4w9WgXcQ")
+    language_code: Any = LazyFunction(lambda: "en")
+    segment_id: Any = LazyFunction(lambda: 1)
+    correction_type: Any = LazyFunction(lambda: CorrectionType.SPELLING.value)
+    original_text: Any = Sequence(lambda n: f"original text {n}")
+    corrected_text: Any = Sequence(lambda n: f"corrected text {n}")
+    correction_note: Any = LazyFunction(lambda: None)
+    corrected_by_user_id: Any = LazyFunction(lambda: "cli")
+    corrected_at: Any = LazyFunction(lambda: datetime.now(tz=timezone.utc))
+    version_number: Any = LazyFunction(lambda: 1)
+
+
+# ---------------------------------------------------------------------------
+# Convenience factory function
+# ---------------------------------------------------------------------------
+
+
+def create_transcript_correction(**kwargs: Any) -> TranscriptCorrectionDB:
+    """Create a TranscriptCorrectionDB ORM instance with keyword arguments.
+
+    Parameters
+    ----------
+    **kwargs : Any
+        Any field overrides to apply on top of factory defaults.
+
+    Returns
+    -------
+    TranscriptCorrectionDB
+        A built (not persisted) TranscriptCorrection ORM instance.
+    """
+    result = TranscriptCorrectionFactory.build(**kwargs)
+    assert isinstance(result, TranscriptCorrectionDB)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Common test data patterns
+# ---------------------------------------------------------------------------
+
+
+class TranscriptCorrectionTestData:
+    """Common test data patterns for TranscriptCorrection models."""
+
+    VALID_CORRECTION_DATA: dict[str, Any] = {
+        "video_id": "dQw4w9WgXcQ",
+        "language_code": "en",
+        "segment_id": 1,
+        "correction_type": CorrectionType.SPELLING.value,
+        "original_text": "teh quick brown fox",
+        "corrected_text": "the quick brown fox",
+        "correction_note": None,
+        "corrected_by_user_id": "cli",
+        "corrected_at": datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+        "version_number": 1,
+    }
+
+    VALID_CORRECTION_TYPES = [
+        CorrectionType.SPELLING,
+        CorrectionType.PROFANITY_FIX,
+        CorrectionType.CONTEXT_CORRECTION,
+        CorrectionType.FORMATTING,
+        CorrectionType.ASR_ERROR,
+        CorrectionType.REVERT,
+    ]
+
+    VALID_LANGUAGE_CODES = [
+        "en",
+        "en-US",
+        "es",
+        "fr",
+        "de",
+        "ja",
+        "ko",
+        "zh-CN",
+        "pt-BR",
+    ]
+
+    VALID_VIDEO_IDS = [
+        "dQw4w9WgXcQ",
+        "9bZkp7q19f0",
+        "3tmd-ClpJxA",
+        "jNQXAC9IVRw",
+        "MejbOFk7H6c",
+    ]
+
+    @classmethod
+    def valid_correction_data(cls) -> dict[str, Any]:
+        """Get a copy of the canonical valid correction data dictionary.
+
+        Returns
+        -------
+        dict[str, Any]
+            A fresh copy of VALID_CORRECTION_DATA safe to mutate in tests.
+        """
+        return dict(cls.VALID_CORRECTION_DATA)
+
+    @classmethod
+    def asr_error_data(cls) -> dict[str, Any]:
+        """Get valid correction data for an ASR error correction.
+
+        Returns
+        -------
+        dict[str, Any]
+            Correction data with correction_type set to ASR_ERROR.
+        """
+        data = cls.valid_correction_data()
+        data.update(
+            {
+                "correction_type": CorrectionType.ASR_ERROR.value,
+                "original_text": "i went two the store",
+                "corrected_text": "i went to the store",
+                "correction_note": "ASR confused homophone",
+                "version_number": 2,
+            }
+        )
+        return data
+
+    @classmethod
+    def revert_data(cls) -> dict[str, Any]:
+        """Get valid correction data for a revert operation.
+
+        Returns
+        -------
+        dict[str, Any]
+            Correction data with correction_type set to REVERT.
+        """
+        data = cls.valid_correction_data()
+        data.update(
+            {
+                "correction_type": CorrectionType.REVERT.value,
+                "original_text": "the quick brown fox",
+                "corrected_text": "teh quick brown fox",
+                "correction_note": "Reverted erroneous spelling correction",
+                "version_number": 3,
+            }
+        )
+        return data

--- a/tests/integration/test_transcript_corrections.py
+++ b/tests/integration/test_transcript_corrections.py
@@ -1,0 +1,2122 @@
+"""
+Integration tests for TranscriptCorrectionService.apply_correction.
+
+Uses a real PostgreSQL test database (via the ``db_session`` fixture from
+``tests/integration/conftest.py``) to verify the full end-to-end flow:
+
+  create transcript + segment → apply_correction → verify persisted state
+
+Database URL defaults to:
+  postgresql+asyncpg://dev_user:dev_password@localhost:5434/chronovista_integration_test
+
+Override with DATABASE_INTEGRATION_URL or CHRONOVISTA_INTEGRATION_DB_URL env var.
+
+Tests in this module validate:
+  - T010: Full apply_correction flow (T009 = unit, T010 = integration)
+  - NFR-007: display_text property returns corrected text after apply_correction
+  - Version chain integrity with two consecutive corrections
+  - GAP-1/6/7: display_text after revert_correction (to-original and to-prior)
+  - GAP-2: Search contract integration (ILIKE on both text and corrected_text)
+  - GAP-3: SRT export integration (format_segment_srt uses display_text)
+  - GAP-4: Transcript segments API inline ternary logic
+  - GAP-5: Transcript metadata fields available on ORM after correction
+
+Feature 033 — Transcript Corrections Audit
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
+from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+from chronovista.db.models import Video as VideoDB
+from chronovista.db.models import VideoTranscript as VideoTranscriptDB
+from chronovista.models.enums import CorrectionType
+from chronovista.models.transcript_segment import TranscriptSegment
+from chronovista.repositories.transcript_correction_repository import (
+    TranscriptCorrectionRepository,
+)
+from chronovista.repositories.transcript_segment_repository import (
+    TranscriptSegmentRepository,
+)
+from chronovista.repositories.video_transcript_repository import (
+    VideoTranscriptRepository,
+)
+
+# ---------------------------------------------------------------------------
+# CRITICAL: Module-level asyncio marker ensures async tests run properly
+# with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
+# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# DB seed helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_video(session: AsyncSession, video_id: str = "dQw4w9WgXcQ") -> VideoDB:
+    """Insert a minimal Video row to satisfy the transcript FK constraint."""
+    video = VideoDB(
+        video_id=video_id,
+        title="Integration Test Video",
+        upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        duration=300,
+    )
+    session.add(video)
+    await session.flush()
+    return video
+
+
+async def _seed_transcript(
+    session: AsyncSession,
+    video_id: str = "dQw4w9WgXcQ",
+    language_code: str = "en",
+) -> VideoTranscriptDB:
+    """Insert a VideoTranscript row with correction metadata defaults."""
+    transcript = VideoTranscriptDB(
+        video_id=video_id,
+        language_code=language_code,
+        transcript_text="teh quick brown fox jumps over the lazy dog",
+        transcript_type="manual",
+        download_reason="user_request",
+        is_cc=False,
+        is_auto_synced=False,
+        track_kind="standard",
+        source="youtube_transcript_api",
+        # Feature 033 columns — explicit defaults
+        has_corrections=False,
+        correction_count=0,
+        last_corrected_at=None,
+    )
+    session.add(transcript)
+    await session.flush()
+    return transcript
+
+
+async def _seed_segment(
+    session: AsyncSession,
+    video_id: str = "dQw4w9WgXcQ",
+    language_code: str = "en",
+    text: str = "teh quick brown fox",
+    sequence_number: int = 0,
+    corrected_text: str | None = None,
+    has_correction: bool = False,
+) -> TranscriptSegmentDB:
+    """Insert a TranscriptSegment row linked to the given transcript."""
+    segment = TranscriptSegmentDB(
+        video_id=video_id,
+        language_code=language_code,
+        text=text,
+        start_time=0.0,
+        duration=2.5,
+        end_time=2.5,
+        sequence_number=sequence_number,
+        corrected_text=corrected_text,
+        has_correction=has_correction,
+    )
+    session.add(segment)
+    await session.flush()
+    return segment
+
+
+# ---------------------------------------------------------------------------
+# TestApplyCorrectionIntegration
+# ---------------------------------------------------------------------------
+
+
+class TestApplyCorrectionIntegration:
+    """
+    End-to-end integration tests for TranscriptCorrectionService.apply_correction
+    using a real PostgreSQL test database.
+
+    Each test uses ``db_session`` from ``tests/integration/conftest.py`` which
+    creates all tables, yields the session, then rolls back and drops all tables
+    for full isolation between tests.
+    """
+
+    @pytest.fixture
+    def correction_repo(self) -> TranscriptCorrectionRepository:
+        """Provide a real TranscriptCorrectionRepository."""
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def segment_repo(self) -> TranscriptSegmentRepository:
+        """Provide a real TranscriptSegmentRepository."""
+        return TranscriptSegmentRepository()
+
+    @pytest.fixture
+    def transcript_repo(self) -> VideoTranscriptRepository:
+        """Provide a real VideoTranscriptRepository."""
+        return VideoTranscriptRepository()
+
+    @pytest.fixture
+    def service(
+        self,
+        correction_repo: TranscriptCorrectionRepository,
+        segment_repo: TranscriptSegmentRepository,
+        transcript_repo: VideoTranscriptRepository,
+    ) -> object:
+        """
+        Provide a TranscriptCorrectionService wired with real repositories.
+
+        Imported lazily so TDD tests can be written before implementation exists.
+        """
+        from chronovista.services.transcript_correction_service import (
+            TranscriptCorrectionService,
+        )
+
+        return TranscriptCorrectionService(
+            correction_repo=correction_repo,
+            segment_repo=segment_repo,
+            transcript_repo=transcript_repo,
+        )
+
+    async def test_apply_correction_end_to_end(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        Full end-to-end test for apply_correction (T010).
+
+        Creates a transcript + segment in the DB, calls apply_correction, then
+        verifies all six expected state changes are persisted to the database:
+
+        1. TranscriptCorrection audit record exists with correct fields
+        2. segment.corrected_text = the new corrected text
+        3. segment.has_correction = True
+        4. transcript.has_corrections = True
+        5. transcript.correction_count = 1
+        6. transcript.last_corrected_at is not None
+
+        This validates FR-007 (atomic guarantee) and FR-008 (audit record fields).
+        """
+        # Arrange: seed the minimum required rows in dependency order
+        video_id = "dQw4w9WgXcQ"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="teh quick brown fox",
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Act: apply the first correction
+        result = await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="the quick brown fox",
+            correction_type=CorrectionType.SPELLING,
+            correction_note="Fixed typo: teh → the",
+            corrected_by_user_id="cli",
+        )
+
+        # Flush to surface any constraint violations before assertions
+        await db_session.flush()
+
+        # Assert 1: audit record was persisted with correct field values
+        correction_result = await db_session.execute(
+            select(TranscriptCorrectionDB).where(
+                TranscriptCorrectionDB.id == result.id
+            )
+        )
+        persisted_correction = correction_result.scalar_one_or_none()
+        assert persisted_correction is not None, (
+            "TranscriptCorrection audit record must be persisted to the database"
+        )
+        assert persisted_correction.video_id == video_id
+        assert persisted_correction.language_code == language_code
+        assert persisted_correction.segment_id == segment_id
+        assert persisted_correction.version_number == 1, (
+            "First correction must have version_number=1"
+        )
+        assert persisted_correction.original_text == "teh quick brown fox", (
+            "original_text must be the segment's pre-correction text"
+        )
+        assert persisted_correction.corrected_text == "the quick brown fox", (
+            "corrected_text must be the new corrected text"
+        )
+        assert persisted_correction.correction_note == "Fixed typo: teh → the"
+        assert persisted_correction.corrected_by_user_id == "cli"
+
+        # Assert 2-3: segment state updated
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(
+                TranscriptSegmentDB.id == segment_id
+            )
+        )
+        persisted_segment = segment_result.scalar_one()
+        assert persisted_segment.corrected_text == "the quick brown fox", (
+            "segment.corrected_text must be set to the corrected text"
+        )
+        assert persisted_segment.has_correction is True, (
+            "segment.has_correction must be True after correction"
+        )
+
+        # Assert 4-6: transcript metadata updated
+        transcript_result = await db_session.execute(
+            select(VideoTranscriptDB).where(
+                VideoTranscriptDB.video_id == video_id,
+                VideoTranscriptDB.language_code == language_code,
+            )
+        )
+        persisted_transcript = transcript_result.scalar_one()
+        assert persisted_transcript.has_corrections is True, (
+            "transcript.has_corrections must be True after correction"
+        )
+        assert persisted_transcript.correction_count == 1, (
+            "transcript.correction_count must be incremented to 1"
+        )
+        assert persisted_transcript.last_corrected_at is not None, (
+            "transcript.last_corrected_at must be set after correction"
+        )
+
+    async def test_display_text_returns_corrected_text_after_apply(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        NFR-007: After apply_correction, loading the segment as a Pydantic
+        TranscriptSegment model and calling display_text must return the
+        corrected text, not the original.
+
+        This validates the downstream contract used by SRT export and CLI output.
+        """
+        video_id = "abc1234DEFG"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="i went two the store",
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply correction
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="i went to the store",
+            correction_type=CorrectionType.ASR_ERROR,
+            correction_note="ASR confused homophone 'two' → 'to'",
+        )
+        await db_session.flush()
+
+        # Reload the segment from the DB and convert to Pydantic model
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(
+                TranscriptSegmentDB.id == segment_id
+            )
+        )
+        db_segment = segment_result.scalar_one()
+
+        pydantic_segment = TranscriptSegment.model_validate(db_segment)
+
+        # NFR-007: display_text must return the corrected text
+        assert pydantic_segment.display_text == "i went to the store", (
+            "NFR-007: display_text must return corrected_text after apply_correction, "
+            f"got '{pydantic_segment.display_text}' instead"
+        )
+        assert pydantic_segment.text == "i went two the store", (
+            "The original text field must be preserved unchanged"
+        )
+        assert pydantic_segment.has_correction is True
+        assert pydantic_segment.corrected_text == "i went to the store"
+
+    async def test_version_chain_integration(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        Apply two corrections to the same segment and verify the version chain:
+        - version 1: original_text = segment.text, corrected_text = first_correction
+        - version 2: original_text = first_correction (effective after v1), corrected_text = second_correction
+
+        This validates that version_number increments correctly and that
+        original_text always captures the "before" state for that specific version
+        (enabling revert to reconstruct any point in the chain).
+        """
+        video_id = "XYZxyz12345"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="teh lazy dog",
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply first correction (v1)
+        correction_v1 = await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="the lazy dog",
+            correction_type=CorrectionType.SPELLING,
+            corrected_by_user_id="cli",
+        )
+        await db_session.flush()
+
+        # Apply second correction (v2)
+        correction_v2 = await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="The lazy dog.",
+            correction_type=CorrectionType.FORMATTING,
+            corrected_by_user_id="cli",
+        )
+        await db_session.flush()
+
+        # Reload both correction records from DB
+        v1_result = await db_session.execute(
+            select(TranscriptCorrectionDB).where(
+                TranscriptCorrectionDB.id == correction_v1.id
+            )
+        )
+        v1 = v1_result.scalar_one()
+
+        v2_result = await db_session.execute(
+            select(TranscriptCorrectionDB).where(
+                TranscriptCorrectionDB.id == correction_v2.id
+            )
+        )
+        v2 = v2_result.scalar_one()
+
+        # Verify version_numbers are 1 and 2
+        assert v1.version_number == 1, (
+            "First correction must have version_number=1"
+        )
+        assert v2.version_number == 2, (
+            "Second correction must have version_number=2"
+        )
+
+        # Verify the chain: v2.original_text == v1.corrected_text
+        assert v2.original_text == v1.corrected_text, (
+            "The original_text of v2 must equal the corrected_text of v1 "
+            "(the effective text between corrections). "
+            f"v1.corrected_text='{v1.corrected_text}', "
+            f"v2.original_text='{v2.original_text}'"
+        )
+
+        # Verify v1.original_text is the raw segment text
+        assert v1.original_text == "teh lazy dog", (
+            "v1.original_text must be the segment's raw text before any correction"
+        )
+
+        # Verify final segment state
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(
+                TranscriptSegmentDB.id == segment_id
+            )
+        )
+        final_segment = segment_result.scalar_one()
+        assert final_segment.corrected_text == "The lazy dog.", (
+            "segment.corrected_text must reflect the most recent correction"
+        )
+        assert final_segment.has_correction is True
+
+        # Verify transcript correction_count = 2 (two active corrections)
+        transcript_result = await db_session.execute(
+            select(VideoTranscriptDB).where(
+                VideoTranscriptDB.video_id == video_id,
+                VideoTranscriptDB.language_code == language_code,
+            )
+        )
+        transcript = transcript_result.scalar_one()
+        assert transcript.correction_count == 2, (
+            "transcript.correction_count must be 2 after two apply_correction calls"
+        )
+        assert transcript.has_corrections is True
+        assert transcript.last_corrected_at is not None
+
+    async def test_apply_correction_raises_for_nonexistent_segment(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        apply_correction must raise ValueError when the segment_id does not
+        exist in the database. No audit record must be written.
+        """
+        video_id = "dQw4w9WgXcQ"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+
+        nonexistent_segment_id = 999_999
+
+        with pytest.raises(ValueError):
+            await service.apply_correction(  # type: ignore[attr-defined]
+                db_session,
+                video_id=video_id,
+                language_code=language_code,
+                segment_id=nonexistent_segment_id,
+                corrected_text="anything",
+                correction_type=CorrectionType.SPELLING,
+            )
+
+        # Verify no corrections were inserted
+        count_result = await db_session.execute(
+            select(TranscriptCorrectionDB).where(
+                TranscriptCorrectionDB.segment_id == nonexistent_segment_id
+            )
+        )
+        assert count_result.scalar_one_or_none() is None, (
+            "No audit record must be created when segment does not exist"
+        )
+
+    async def test_apply_correction_raises_for_identical_text(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        apply_correction must raise ValueError when corrected_text is identical
+        to the segment's current effective text (no-op prevention).
+        """
+        video_id = "dQw4w9WgXcQ"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="already correct text",
+        )
+
+        with pytest.raises(ValueError):
+            await service.apply_correction(  # type: ignore[attr-defined]
+                db_session,
+                video_id=video_id,
+                language_code=language_code,
+                segment_id=segment.id,
+                corrected_text="already correct text",  # identical to segment.text
+                correction_type=CorrectionType.SPELLING,
+            )
+
+    async def test_correction_count_increments_on_each_apply(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        Each successive apply_correction call must increment
+        transcript.correction_count by exactly 1 each time.
+        """
+        video_id = "corCount12A"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+
+        segment_a = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="segment a text",
+            sequence_number=0,
+        )
+        segment_b = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="segment b text",
+            sequence_number=1,
+        )
+
+        # First correction on segment_a
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_a.id,
+            corrected_text="segment a corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Second correction on segment_b
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_b.id,
+            corrected_text="segment b corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Verify correction_count = 2
+        transcript_result = await db_session.execute(
+            select(VideoTranscriptDB).where(
+                VideoTranscriptDB.video_id == video_id,
+                VideoTranscriptDB.language_code == language_code,
+            )
+        )
+        transcript = transcript_result.scalar_one()
+        assert transcript.correction_count == 2, (
+            "correction_count must equal the number of apply_correction calls "
+            f"(expected 2, got {transcript.correction_count})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestRevertCorrectionIntegration
+# ---------------------------------------------------------------------------
+
+
+class TestRevertCorrectionIntegration:
+    """
+    End-to-end integration tests for TranscriptCorrectionService.revert_correction
+    using a real PostgreSQL test database.
+
+    Each test uses ``db_session`` from ``tests/integration/conftest.py`` which
+    creates all tables, yields the session, then rolls back and drops all tables
+    for full isolation between tests.
+
+    Tests validate:
+    - Revert-to-original restores segment state and decrements correction_count
+    - Revert with multiple segments correctly recomputes has_corrections
+    - Version chain integrity is maintained across apply → revert cycles
+    """
+
+    @pytest.fixture
+    def correction_repo(self) -> TranscriptCorrectionRepository:
+        """Provide a real TranscriptCorrectionRepository."""
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def segment_repo(self) -> TranscriptSegmentRepository:
+        """Provide a real TranscriptSegmentRepository."""
+        return TranscriptSegmentRepository()
+
+    @pytest.fixture
+    def transcript_repo(self) -> VideoTranscriptRepository:
+        """Provide a real VideoTranscriptRepository."""
+        return VideoTranscriptRepository()
+
+    @pytest.fixture
+    def service(
+        self,
+        correction_repo: TranscriptCorrectionRepository,
+        segment_repo: TranscriptSegmentRepository,
+        transcript_repo: VideoTranscriptRepository,
+    ) -> object:
+        """
+        Provide a TranscriptCorrectionService wired with real repositories.
+        """
+        from chronovista.services.transcript_correction_service import (
+            TranscriptCorrectionService,
+        )
+
+        return TranscriptCorrectionService(
+            correction_repo=correction_repo,
+            segment_repo=segment_repo,
+            transcript_repo=transcript_repo,
+        )
+
+    async def test_revert_single_correction(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        Apply a single correction then revert it. Verify the segment is fully
+        restored to its original uncorrected state:
+
+        1. segment.corrected_text = None
+        2. segment.has_correction = False
+        3. transcript.has_corrections = False (no other corrected segments)
+        4. transcript.correction_count decremented back to 0 (FR-014a)
+        5. transcript.last_corrected_at updated (FR-014c)
+        6. A revert audit record is persisted with correction_type='revert'
+        """
+        video_id = "revertSingle1"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="teh quick brown fox",
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply correction (creates v1)
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="the quick brown fox",
+            correction_type=CorrectionType.SPELLING,
+            correction_note="Fixed typo",
+            corrected_by_user_id="cli",
+        )
+        await db_session.flush()
+
+        # Revert (creates v2 audit record)
+        revert_record = await service.revert_correction(  # type: ignore[attr-defined]
+            db_session,
+            segment_id=segment_id,
+        )
+        await db_session.flush()
+
+        # Assert 1-2: segment fully restored
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(TranscriptSegmentDB.id == segment_id)
+        )
+        persisted_segment = segment_result.scalar_one()
+        assert persisted_segment.corrected_text is None, (
+            "After revert-to-original, segment.corrected_text must be None"
+        )
+        assert persisted_segment.has_correction is False, (
+            "After revert-to-original, segment.has_correction must be False"
+        )
+
+        # Assert 3-5: transcript metadata reflects the revert
+        transcript_result = await db_session.execute(
+            select(VideoTranscriptDB).where(
+                VideoTranscriptDB.video_id == video_id,
+                VideoTranscriptDB.language_code == language_code,
+            )
+        )
+        persisted_transcript = transcript_result.scalar_one()
+        assert persisted_transcript.has_corrections is False, (
+            "transcript.has_corrections must be False after revert to original "
+            "(no other corrected segments exist)"
+        )
+        assert persisted_transcript.correction_count == 0, (
+            "FR-014a: transcript.correction_count must be decremented to 0 "
+            f"after revert-to-original (got {persisted_transcript.correction_count})"
+        )
+        assert persisted_transcript.last_corrected_at is not None, (
+            "FR-014c: transcript.last_corrected_at must be updated after revert"
+        )
+
+        # Assert 6: revert audit record persisted
+        revert_result = await db_session.execute(
+            select(TranscriptCorrectionDB).where(
+                TranscriptCorrectionDB.id == revert_record.id
+            )
+        )
+        persisted_revert = revert_result.scalar_one_or_none()
+        assert persisted_revert is not None, (
+            "Revert audit record must be persisted to the database"
+        )
+        assert persisted_revert.correction_type == "revert", (
+            "Revert audit record must have correction_type='revert'"
+        )
+        assert persisted_revert.version_number == 2, (
+            "Revert audit record must have version_number=2 (was v1 correction)"
+        )
+        assert persisted_revert.original_text == "the quick brown fox", (
+            "Revert audit original_text must be the text BEFORE the revert "
+            "(i.e., the corrected text from v1)"
+        )
+        assert persisted_revert.corrected_text == "teh quick brown fox", (
+            "Revert audit corrected_text must be the original segment text "
+            "(i.e., what the segment is restored to)"
+        )
+
+    async def test_revert_with_multiple_segments_scans_has_corrections(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        FR-014b: Two segments have corrections. Revert one segment to its
+        original state. Since the other segment still has has_correction=True,
+        transcript.has_corrections must remain True after the revert.
+
+        This validates that the EXISTS scan correctly identifies remaining
+        corrected segments, not just the segment being reverted.
+        """
+        video_id = "revertMultSeg"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+
+        segment_a = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="first segment text",
+            sequence_number=0,
+        )
+        segment_b = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="second segment text",
+            sequence_number=1,
+        )
+
+        # Apply corrections to both segments
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_a.id,
+            corrected_text="first segment corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_b.id,
+            corrected_text="second segment corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Verify both corrections are in place
+        transcript_result = await db_session.execute(
+            select(VideoTranscriptDB).where(
+                VideoTranscriptDB.video_id == video_id,
+                VideoTranscriptDB.language_code == language_code,
+            )
+        )
+        transcript_before_revert = transcript_result.scalar_one()
+        assert transcript_before_revert.correction_count == 2
+        assert transcript_before_revert.has_corrections is True
+
+        # Revert segment_a to original — segment_b still has a correction
+        await service.revert_correction(  # type: ignore[attr-defined]
+            db_session,
+            segment_id=segment_a.id,
+        )
+        await db_session.flush()
+
+        # Reload transcript and assert has_corrections remains True
+        transcript_result = await db_session.execute(
+            select(VideoTranscriptDB).where(
+                VideoTranscriptDB.video_id == video_id,
+                VideoTranscriptDB.language_code == language_code,
+            )
+        )
+        transcript_after_revert = transcript_result.scalar_one()
+        assert transcript_after_revert.has_corrections is True, (
+            "FR-014b: transcript.has_corrections must remain True because "
+            "segment_b still has an active correction"
+        )
+        assert transcript_after_revert.correction_count == 1, (
+            "FR-014a: transcript.correction_count must be decremented to 1 "
+            f"after reverting segment_a (got {transcript_after_revert.correction_count})"
+        )
+
+        # Verify segment_a is fully restored
+        seg_a_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(TranscriptSegmentDB.id == segment_a.id)
+        )
+        persisted_seg_a = seg_a_result.scalar_one()
+        assert persisted_seg_a.corrected_text is None
+        assert persisted_seg_a.has_correction is False
+
+        # Verify segment_b is untouched
+        seg_b_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(TranscriptSegmentDB.id == segment_b.id)
+        )
+        persisted_seg_b = seg_b_result.scalar_one()
+        assert persisted_seg_b.corrected_text == "second segment corrected"
+        assert persisted_seg_b.has_correction is True
+
+    async def test_version_chain_after_apply_revert_cycle(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        Verify the full version chain after an apply → apply → revert sequence:
+
+        v1: apply "the lazy dog"           (original: "teh lazy dog")
+        v2: apply "The lazy dog."          (original: "the lazy dog")
+        v3: revert (corrected_text=v2.original_text="the lazy dog")
+
+        Expected state after v3:
+        - segment.corrected_text = "the lazy dog" (reverted to v1 corrected text)
+        - segment.has_correction = True
+        - transcript.correction_count = 2 (unchanged — revert-to-prior, not original)
+        - v3.correction_type = 'revert'
+        - v3.original_text = "The lazy dog." (what segment had before this revert)
+        - v3.corrected_text = "the lazy dog" (what segment is restored to)
+        - v3.version_number = 3
+        """
+        video_id = "revertChain01"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="teh lazy dog",
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply v1
+        correction_v1 = await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="the lazy dog",
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Apply v2
+        correction_v2 = await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="The lazy dog.",
+            correction_type=CorrectionType.FORMATTING,
+        )
+        await db_session.flush()
+
+        # Revert (creates v3)
+        correction_v3 = await service.revert_correction(  # type: ignore[attr-defined]
+            db_session,
+            segment_id=segment_id,
+        )
+        await db_session.flush()
+
+        # Reload all records from DB
+        v1_result = await db_session.execute(
+            select(TranscriptCorrectionDB).where(
+                TranscriptCorrectionDB.id == correction_v1.id
+            )
+        )
+        v1 = v1_result.scalar_one()
+
+        v2_result = await db_session.execute(
+            select(TranscriptCorrectionDB).where(
+                TranscriptCorrectionDB.id == correction_v2.id
+            )
+        )
+        v2 = v2_result.scalar_one()
+
+        v3_result = await db_session.execute(
+            select(TranscriptCorrectionDB).where(
+                TranscriptCorrectionDB.id == correction_v3.id
+            )
+        )
+        v3 = v3_result.scalar_one()
+
+        # Assert version chain integrity
+        assert v1.version_number == 1
+        assert v2.version_number == 2
+        assert v3.version_number == 3, (
+            "Revert audit record must have version_number = max_version + 1 = 3"
+        )
+
+        assert v3.correction_type == "revert", (
+            "Revert audit record must have correction_type='revert'"
+        )
+        assert v3.original_text == "The lazy dog.", (
+            "v3.original_text must be what the segment had BEFORE the revert "
+            f"(v2.corrected_text='The lazy dog.', got '{v3.original_text}')"
+        )
+        assert v3.corrected_text == "the lazy dog", (
+            "v3.corrected_text must be what the segment is restored to "
+            f"(v2.original_text='the lazy dog', got '{v3.corrected_text}')"
+        )
+
+        # Assert segment state after revert-to-prior (version > 1)
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(TranscriptSegmentDB.id == segment_id)
+        )
+        final_segment = segment_result.scalar_one()
+        assert final_segment.corrected_text == "the lazy dog", (
+            "After revert-to-prior, segment.corrected_text must be V_N.original_text "
+            f"(expected 'the lazy dog', got '{final_segment.corrected_text}')"
+        )
+        assert final_segment.has_correction is True, (
+            "After revert-to-prior, segment.has_correction must remain True "
+            "(segment is still corrected, just to the prior version)"
+        )
+
+        # Assert transcript metadata for revert-to-prior
+        transcript_result = await db_session.execute(
+            select(VideoTranscriptDB).where(
+                VideoTranscriptDB.video_id == video_id,
+                VideoTranscriptDB.language_code == language_code,
+            )
+        )
+        final_transcript = transcript_result.scalar_one()
+        assert final_transcript.correction_count == 2, (
+            "FR-014a: revert-to-prior must NOT change correction_count "
+            f"(expected 2, got {final_transcript.correction_count})"
+        )
+        assert final_transcript.has_corrections is True, (
+            "transcript.has_corrections must remain True after revert-to-prior "
+            "(segment still has an active correction)"
+        )
+        assert final_transcript.last_corrected_at is not None, (
+            "FR-014c: transcript.last_corrected_at must be updated after revert"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestRepositoryQueryIntegration
+# ---------------------------------------------------------------------------
+
+
+class TestRepositoryQueryIntegration:
+    """
+    Integration tests for TranscriptCorrectionRepository domain-specific
+    query methods: get_by_segment, get_by_video, count_by_video.
+
+    Each test seeds the minimum required rows (Video → VideoTranscript →
+    TranscriptSegment) via the helper functions defined at the top of this
+    module, then drives data creation through
+    ``TranscriptCorrectionService.apply_correction`` so that every
+    correction record is created by realistic production code paths rather
+    than raw DB inserts.
+
+    Tests validate:
+      - SC-001: get_by_segment returns records ordered version_number DESC
+      - SC-002: get_by_video returns paginated (items, total) tuples
+      - SC-003: get_by_segment wall-clock time < 1 s for 100 records (smoke)
+      - Language-code isolation for both get_by_video and count_by_video
+    """
+
+    # ------------------------------------------------------------------
+    # Fixtures
+    # ------------------------------------------------------------------
+
+    @pytest.fixture
+    def correction_repo(self) -> TranscriptCorrectionRepository:
+        """Provide a real TranscriptCorrectionRepository."""
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def segment_repo(self) -> TranscriptSegmentRepository:
+        """Provide a real TranscriptSegmentRepository."""
+        return TranscriptSegmentRepository()
+
+    @pytest.fixture
+    def transcript_repo(self) -> VideoTranscriptRepository:
+        """Provide a real VideoTranscriptRepository."""
+        return VideoTranscriptRepository()
+
+    @pytest.fixture
+    def service(
+        self,
+        correction_repo: TranscriptCorrectionRepository,
+        segment_repo: TranscriptSegmentRepository,
+        transcript_repo: VideoTranscriptRepository,
+    ) -> object:
+        """Provide a TranscriptCorrectionService wired with real repositories."""
+        from chronovista.services.transcript_correction_service import (
+            TranscriptCorrectionService,
+        )
+
+        return TranscriptCorrectionService(
+            correction_repo=correction_repo,
+            segment_repo=segment_repo,
+            transcript_repo=transcript_repo,
+        )
+
+    # ------------------------------------------------------------------
+    # SC-001: get_by_segment ordering
+    # ------------------------------------------------------------------
+
+    async def test_get_by_segment_returns_version_number_desc(
+        self,
+        db_session: AsyncSession,
+        correction_repo: TranscriptCorrectionRepository,
+        service: object,
+    ) -> None:
+        """
+        SC-001: get_by_segment must return records ordered by version_number
+        DESC (newest correction first).
+
+        Creates three successive corrections on the same segment using
+        apply_correction (v1 → v2 → v3), then queries get_by_segment and
+        asserts the result list is ordered [v3, v2, v1].
+        """
+        video_id = "segOrderABC"
+        language_code = "en"
+
+        # Seed prerequisite rows
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="version one text",
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply three consecutive corrections to build a version chain v1→v2→v3
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="version two text",
+            correction_type=CorrectionType.SPELLING,
+            correction_note="v1 correction",
+        )
+        await db_session.flush()
+
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="version three text",
+            correction_type=CorrectionType.SPELLING,
+            correction_note="v2 correction",
+        )
+        await db_session.flush()
+
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="version four text",
+            correction_type=CorrectionType.FORMATTING,
+            correction_note="v3 correction",
+        )
+        await db_session.flush()
+
+        # Query via repository
+        corrections = await correction_repo.get_by_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+        )
+
+        # Must return exactly three records
+        assert len(corrections) == 3, (
+            f"Expected 3 corrections for segment, got {len(corrections)}"
+        )
+
+        # Must be ordered version_number DESC: [3, 2, 1]
+        version_numbers = [c.version_number for c in corrections]
+        assert version_numbers == [3, 2, 1], (
+            "get_by_segment must return corrections ordered by version_number DESC. "
+            f"Got order: {version_numbers}"
+        )
+
+    # ------------------------------------------------------------------
+    # SC-002: get_by_video pagination
+    # ------------------------------------------------------------------
+
+    async def test_get_by_video_returns_paginated_results(
+        self,
+        db_session: AsyncSession,
+        correction_repo: TranscriptCorrectionRepository,
+        service: object,
+    ) -> None:
+        """
+        SC-002: get_by_video with limit=2 skip=0 must return exactly 2 items
+        while reporting total=5 (the full uncapped count for the transcript).
+
+        Creates five separate segments, applies one correction to each, then
+        verifies the (items, total) contract of get_by_video.
+        """
+        video_id = "paginateVID"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+
+        # Seed 5 segments, each with a unique original text
+        for seq in range(5):
+            segment = await _seed_segment(
+                db_session,
+                video_id=video_id,
+                language_code=language_code,
+                text=f"original segment text number {seq}",
+                sequence_number=seq,
+            )
+            await service.apply_correction(  # type: ignore[attr-defined]
+                db_session,
+                video_id=video_id,
+                language_code=language_code,
+                segment_id=segment.id,
+                corrected_text=f"corrected segment text number {seq}",
+                correction_type=CorrectionType.SPELLING,
+            )
+            await db_session.flush()
+
+        # Fetch first page: limit=2, skip=0
+        items, total = await correction_repo.get_by_video(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            skip=0,
+            limit=2,
+        )
+
+        assert len(items) == 2, (
+            f"limit=2 must return exactly 2 items; got {len(items)}"
+        )
+        assert total == 5, (
+            f"total must reflect all 5 corrections in the transcript; got {total}"
+        )
+
+    # ------------------------------------------------------------------
+    # Language-code isolation: get_by_video
+    # ------------------------------------------------------------------
+
+    async def test_get_by_video_requires_language_code(
+        self,
+        db_session: AsyncSession,
+        correction_repo: TranscriptCorrectionRepository,
+        service: object,
+    ) -> None:
+        """
+        get_by_video must filter strictly by language_code: querying with a
+        different language_code must return an empty item list and total=0.
+
+        Creates corrections under language_code "en", then queries for "fr"
+        and asserts an empty result.
+        """
+        video_id = "langIsoVID1"
+        en_language_code = "en"
+        fr_language_code = "fr"
+
+        await _seed_video(db_session, video_id=video_id)
+
+        # Seed English transcript and one correction
+        await _seed_transcript(
+            db_session, video_id=video_id, language_code=en_language_code
+        )
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=en_language_code,
+            text="english original text",
+            sequence_number=0,
+        )
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=en_language_code,
+            segment_id=segment.id,
+            corrected_text="english corrected text",
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Query using the French language_code — no French transcript or
+        # corrections exist, so the result must be empty
+        items, total = await correction_repo.get_by_video(
+            db_session,
+            video_id=video_id,
+            language_code=fr_language_code,
+        )
+
+        assert items == [], (
+            "get_by_video must return an empty item list when no corrections "
+            f"exist for language_code='{fr_language_code}'; got {items}"
+        )
+        assert total == 0, (
+            "get_by_video must return total=0 when no corrections exist for "
+            f"language_code='{fr_language_code}'; got total={total}"
+        )
+
+    # ------------------------------------------------------------------
+    # count_by_video per-language scoping
+    # ------------------------------------------------------------------
+
+    async def test_count_by_video_across_languages(
+        self,
+        db_session: AsyncSession,
+        correction_repo: TranscriptCorrectionRepository,
+        service: object,
+    ) -> None:
+        """
+        count_by_video must scope its count to the requested language_code.
+
+        Creates 3 corrections under "en" and 2 corrections under "es" for the
+        same video.  Verifies that:
+          - count_by_video(video_id, "en") == 3
+          - count_by_video(video_id, "es") == 2
+
+        This confirms the per-language isolation contract: the method never
+        conflates corrections from different transcripts of the same video.
+        """
+        video_id = "countLangVD"
+        en_code = "en"
+        es_code = "es"
+
+        await _seed_video(db_session, video_id=video_id)
+
+        # English transcript: 3 segments → 3 corrections
+        await _seed_transcript(db_session, video_id=video_id, language_code=en_code)
+        for seq in range(3):
+            seg_en = await _seed_segment(
+                db_session,
+                video_id=video_id,
+                language_code=en_code,
+                text=f"en original {seq}",
+                sequence_number=seq,
+            )
+            await service.apply_correction(  # type: ignore[attr-defined]
+                db_session,
+                video_id=video_id,
+                language_code=en_code,
+                segment_id=seg_en.id,
+                corrected_text=f"en corrected {seq}",
+                correction_type=CorrectionType.SPELLING,
+            )
+            await db_session.flush()
+
+        # Spanish transcript: 2 segments → 2 corrections
+        await _seed_transcript(db_session, video_id=video_id, language_code=es_code)
+        for seq in range(2):
+            seg_es = await _seed_segment(
+                db_session,
+                video_id=video_id,
+                language_code=es_code,
+                text=f"es original {seq}",
+                sequence_number=seq,
+            )
+            await service.apply_correction(  # type: ignore[attr-defined]
+                db_session,
+                video_id=video_id,
+                language_code=es_code,
+                segment_id=seg_es.id,
+                corrected_text=f"es corrected {seq}",
+                correction_type=CorrectionType.SPELLING,
+            )
+            await db_session.flush()
+
+        en_count = await correction_repo.count_by_video(
+            db_session, video_id=video_id, language_code=en_code
+        )
+        es_count = await correction_repo.count_by_video(
+            db_session, video_id=video_id, language_code=es_code
+        )
+
+        assert en_count == 3, (
+            f"count_by_video for 'en' must return 3; got {en_count}"
+        )
+        assert es_count == 2, (
+            f"count_by_video for 'es' must return 2; got {es_count}"
+        )
+
+    # ------------------------------------------------------------------
+    # Empty segment query
+    # ------------------------------------------------------------------
+
+    async def test_get_by_segment_empty_for_no_corrections(
+        self,
+        db_session: AsyncSession,
+        correction_repo: TranscriptCorrectionRepository,
+    ) -> None:
+        """
+        get_by_segment must return an empty list when no corrections exist for
+        the given segment_id, without raising an error.
+
+        Creates a valid segment (to satisfy FK constraints) but applies no
+        corrections to it.  The repository must return [] gracefully.
+        """
+        video_id = "emptySegVID"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="a segment with no corrections",
+            sequence_number=0,
+        )
+
+        corrections = await correction_repo.get_by_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment.id,
+        )
+
+        assert corrections == [], (
+            "get_by_segment must return an empty list when no corrections exist "
+            f"for segment_id={segment.id}; got {corrections}"
+        )
+
+    # ------------------------------------------------------------------
+    # SC-003: 100-record performance smoke test
+    # ------------------------------------------------------------------
+
+    async def test_100_record_performance_smoke_test(
+        self,
+        db_session: AsyncSession,
+        correction_repo: TranscriptCorrectionRepository,
+        service: object,
+    ) -> None:
+        """
+        SC-003: get_by_segment wall-clock time must be < 1 second when
+        retrieving a 100-record correction chain for a single segment.
+
+        Inserts 100 corrections for a single segment using apply_correction
+        (the realistic production path), then measures the elapsed time for
+        a single get_by_segment call with limit=100.
+
+        This is a smoke test that catches pathological N+1 or missing-index
+        regressions. The threshold of 1 second provides generous headroom for
+        CI variability while still catching gross inefficiencies.
+        """
+        video_id = "perf100VID1"
+        language_code = "en"
+        correction_count = 100
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="initial text version 0",
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply 100 consecutive corrections to build a long version chain.
+        # Each iteration's corrected_text differs from the previous, satisfying
+        # the no-op guard inside apply_correction.
+        for i in range(1, correction_count + 1):
+            await service.apply_correction(  # type: ignore[attr-defined]
+                db_session,
+                video_id=video_id,
+                language_code=language_code,
+                segment_id=segment_id,
+                corrected_text=f"corrected text version {i}",
+                correction_type=CorrectionType.SPELLING,
+                correction_note=f"correction #{i}",
+            )
+        # Flush all 100 records in one batch at the end
+        await db_session.flush()
+
+        # Verify all 100 records are actually in the DB before timing the read
+        total_inserted = await correction_repo.count_by_video(
+            db_session, video_id=video_id, language_code=language_code
+        )
+        assert total_inserted == correction_count, (
+            f"Expected {correction_count} corrections to be inserted; "
+            f"got {total_inserted}"
+        )
+
+        # Time the get_by_segment query with limit=100
+        t_start = time.perf_counter()
+        results = await correction_repo.get_by_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            limit=correction_count,
+        )
+        elapsed = time.perf_counter() - t_start
+
+        assert len(results) == correction_count, (
+            f"get_by_segment must return all {correction_count} records; "
+            f"got {len(results)}"
+        )
+        assert elapsed < 1.0, (
+            f"SC-003: get_by_segment for {correction_count} records took "
+            f"{elapsed:.3f}s, which exceeds the 1-second threshold. "
+            "This indicates a missing index or N+1 query regression."
+        )
+
+
+# ---------------------------------------------------------------------------
+# GAP-1 / GAP-6 / GAP-7: display_text after revert_correction
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayTextAfterRevert:
+    """
+    Integration tests validating that the ``display_text`` property returns
+    the correct value after revert_correction in both scenarios:
+
+    - Revert-to-original (single correction reverted → display_text = raw text)
+    - Revert-to-prior (two corrections, revert second → display_text = first
+      correction's text)
+
+    These tests close GAP-1, GAP-6, and GAP-7 from the Feature 033 cross-feature
+    data contract audit.
+    """
+
+    @pytest.fixture
+    def correction_repo(self) -> TranscriptCorrectionRepository:
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def segment_repo(self) -> TranscriptSegmentRepository:
+        return TranscriptSegmentRepository()
+
+    @pytest.fixture
+    def transcript_repo(self) -> VideoTranscriptRepository:
+        return VideoTranscriptRepository()
+
+    @pytest.fixture
+    def service(
+        self,
+        correction_repo: TranscriptCorrectionRepository,
+        segment_repo: TranscriptSegmentRepository,
+        transcript_repo: VideoTranscriptRepository,
+    ) -> object:
+        from chronovista.services.transcript_correction_service import (
+            TranscriptCorrectionService,
+        )
+
+        return TranscriptCorrectionService(
+            correction_repo=correction_repo,
+            segment_repo=segment_repo,
+            transcript_repo=transcript_repo,
+        )
+
+    async def test_display_text_returns_original_after_revert_to_original(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        GAP-1: After a single correction is reverted (revert-to-original),
+        the Pydantic model's display_text must return the original raw text.
+
+        Steps:
+        1. Seed a segment with raw text
+        2. Apply one correction
+        3. Revert it (single correction → revert-to-original)
+        4. Reload segment from DB, convert to Pydantic model
+        5. Assert display_text == original raw text
+        """
+        video_id = "dspRevOrig1"
+        language_code = "en"
+        original_text = "teh orignal text"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text=original_text,
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply one correction
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="the original text",
+            correction_type=CorrectionType.SPELLING,
+            correction_note="Fixed typos",
+        )
+        await db_session.flush()
+
+        # Revert (single correction → revert-to-original)
+        await service.revert_correction(  # type: ignore[attr-defined]
+            db_session,
+            segment_id=segment_id,
+        )
+        await db_session.flush()
+
+        # Reload segment from DB and convert to Pydantic model
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(TranscriptSegmentDB.id == segment_id)
+        )
+        db_segment = segment_result.scalar_one()
+        pydantic_segment = TranscriptSegment.model_validate(db_segment)
+
+        # Assert: display_text returns the original raw text
+        assert pydantic_segment.display_text == original_text, (
+            "GAP-1: After revert-to-original, display_text must return the "
+            f"original raw text '{original_text}', "
+            f"got '{pydantic_segment.display_text}'"
+        )
+        assert pydantic_segment.has_correction is False, (
+            "After revert-to-original, has_correction must be False"
+        )
+        assert pydantic_segment.corrected_text is None, (
+            "After revert-to-original, corrected_text must be None"
+        )
+
+    async def test_display_text_returns_prior_correction_after_revert_to_prior(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        GAP-6/7: After two corrections, reverting the second must leave
+        display_text returning the FIRST correction's text (not the raw text).
+
+        Steps:
+        1. Seed a segment with raw text
+        2. Apply first correction
+        3. Apply second correction
+        4. Revert the second correction (revert-to-prior)
+        5. Reload segment from DB, convert to Pydantic model
+        6. Assert display_text == first correction's text
+        """
+        video_id = "dspRevPrior"
+        language_code = "en"
+        raw_text = "teh lazy dgo"
+        first_correction = "the lazy dgo"
+        second_correction = "the lazy dog"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text=raw_text,
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply first correction (v1)
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text=first_correction,
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Apply second correction (v2)
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text=second_correction,
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Revert (v3 — revert-to-prior, not to original)
+        await service.revert_correction(  # type: ignore[attr-defined]
+            db_session,
+            segment_id=segment_id,
+        )
+        await db_session.flush()
+
+        # Reload segment from DB and convert to Pydantic model
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(TranscriptSegmentDB.id == segment_id)
+        )
+        db_segment = segment_result.scalar_one()
+        pydantic_segment = TranscriptSegment.model_validate(db_segment)
+
+        # Assert: display_text returns the FIRST correction's text
+        assert pydantic_segment.display_text == first_correction, (
+            "GAP-6/7: After revert-to-prior, display_text must return the "
+            f"first correction's text '{first_correction}', "
+            f"got '{pydantic_segment.display_text}'"
+        )
+        assert pydantic_segment.has_correction is True, (
+            "After revert-to-prior, has_correction must remain True"
+        )
+        assert pydantic_segment.corrected_text == first_correction, (
+            "After revert-to-prior, corrected_text must be the first "
+            f"correction's text '{first_correction}', "
+            f"got '{pydantic_segment.corrected_text}'"
+        )
+        # Also verify raw text is still untouched
+        assert pydantic_segment.text == raw_text, (
+            "The original raw text must never be modified by corrections"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GAP-2: Search contract integration
+# ---------------------------------------------------------------------------
+
+
+class TestSearchContractIntegration:
+    """
+    Integration tests validating that the search router's ILIKE queries
+    can find segments by both ``text`` and ``corrected_text`` columns.
+
+    The search router (``search.py:140-147``) uses ``or_(text.ilike(...),
+    corrected_text.ilike(...))`` — this test verifies both columns are set
+    correctly after apply_correction and that ILIKE on corrected_text would
+    find the corrected content.
+
+    Closes GAP-2 from the Feature 033 cross-feature data contract audit.
+    """
+
+    @pytest.fixture
+    def correction_repo(self) -> TranscriptCorrectionRepository:
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def segment_repo(self) -> TranscriptSegmentRepository:
+        return TranscriptSegmentRepository()
+
+    @pytest.fixture
+    def transcript_repo(self) -> VideoTranscriptRepository:
+        return VideoTranscriptRepository()
+
+    @pytest.fixture
+    def service(
+        self,
+        correction_repo: TranscriptCorrectionRepository,
+        segment_repo: TranscriptSegmentRepository,
+        transcript_repo: VideoTranscriptRepository,
+    ) -> object:
+        from chronovista.services.transcript_correction_service import (
+            TranscriptCorrectionService,
+        )
+
+        return TranscriptCorrectionService(
+            correction_repo=correction_repo,
+            segment_repo=segment_repo,
+            transcript_repo=transcript_repo,
+        )
+
+    async def test_search_finds_corrected_text_via_ilike(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        GAP-2: After apply_correction, the segment's corrected_text column
+        must be set so that an ILIKE search on corrected_text can find the
+        corrected content.
+
+        Steps:
+        1. Seed a segment with text "teh quick brown fox"
+        2. Apply a correction changing it to "the quick brown fox"
+        3. Verify both text and corrected_text columns are set correctly
+        4. Verify corrected_text is findable by ILIKE search
+        """
+        video_id = "srchGap2VD1"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="teh quick brown fox",
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply correction
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text="the quick brown fox",
+            correction_type=CorrectionType.SPELLING,
+            correction_note="Fixed typo: teh → the",
+        )
+        await db_session.flush()
+
+        # Verify both columns are set correctly on the DB row
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(TranscriptSegmentDB.id == segment_id)
+        )
+        db_seg = segment_result.scalar_one()
+        assert db_seg.text == "teh quick brown fox", (
+            "Original text column must be preserved unchanged"
+        )
+        assert db_seg.corrected_text == "the quick brown fox", (
+            "corrected_text column must contain the corrected content"
+        )
+
+        # Verify ILIKE on corrected_text finds the segment
+        # This mirrors the search router's or_(text.ilike(...), corrected_text.ilike(...))
+        ilike_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(
+                or_(
+                    TranscriptSegmentDB.text.ilike("%the quick brown%"),
+                    TranscriptSegmentDB.corrected_text.ilike("%the quick brown%"),
+                )
+            )
+        )
+        found_segments = list(ilike_result.scalars().all())
+        found_ids = [s.id for s in found_segments]
+        assert segment_id in found_ids, (
+            "GAP-2: ILIKE search on corrected_text must find the segment "
+            f"(segment_id={segment_id} not found in {found_ids})"
+        )
+
+        # Verify that searching for the ORIGINAL (misspelled) text also works
+        ilike_original = await db_session.execute(
+            select(TranscriptSegmentDB).where(
+                or_(
+                    TranscriptSegmentDB.text.ilike("%teh quick%"),
+                    TranscriptSegmentDB.corrected_text.ilike("%teh quick%"),
+                )
+            )
+        )
+        found_original = list(ilike_original.scalars().all())
+        found_original_ids = [s.id for s in found_original]
+        assert segment_id in found_original_ids, (
+            "Search must also find the segment by its original (uncorrected) text"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GAP-3 / GAP-4 / GAP-5: Downstream consumer integration
+# ---------------------------------------------------------------------------
+
+
+class TestDownstreamConsumerIntegration:
+    """
+    Integration tests validating that downstream consumers (SRT export,
+    transcript segments API, transcript metadata) correctly surface
+    corrected text after apply_correction.
+
+    Closes GAP-3 (SRT export), GAP-4 (API inline ternary), and GAP-5
+    (transcript metadata) from the Feature 033 cross-feature data contract
+    audit.
+    """
+
+    @pytest.fixture
+    def correction_repo(self) -> TranscriptCorrectionRepository:
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def segment_repo(self) -> TranscriptSegmentRepository:
+        return TranscriptSegmentRepository()
+
+    @pytest.fixture
+    def transcript_repo(self) -> VideoTranscriptRepository:
+        return VideoTranscriptRepository()
+
+    @pytest.fixture
+    def service(
+        self,
+        correction_repo: TranscriptCorrectionRepository,
+        segment_repo: TranscriptSegmentRepository,
+        transcript_repo: VideoTranscriptRepository,
+    ) -> object:
+        from chronovista.services.transcript_correction_service import (
+            TranscriptCorrectionService,
+        )
+
+        return TranscriptCorrectionService(
+            correction_repo=correction_repo,
+            segment_repo=segment_repo,
+            transcript_repo=transcript_repo,
+        )
+
+    async def test_srt_export_uses_corrected_text(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        GAP-3: format_segment_srt uses segment.display_text, which must
+        return corrected_text after apply_correction. The SRT output
+        must contain the corrected text, not the original.
+
+        Steps:
+        1. Seed a segment and apply a correction
+        2. Reload the segment, convert to Pydantic model
+        3. Call format_segment_srt(segment, sequence=1)
+        4. Assert the SRT output contains the corrected text
+        """
+        from chronovista.services.segment_service import format_segment_srt
+
+        video_id = "srtExprtGp3"
+        language_code = "en"
+        original_text = "teh cat sat on teh mat"
+        corrected_text = "the cat sat on the mat"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text=original_text,
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply correction
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text=corrected_text,
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Reload segment and convert to Pydantic model
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(TranscriptSegmentDB.id == segment_id)
+        )
+        db_seg = segment_result.scalar_one()
+        pydantic_seg = TranscriptSegment.model_validate(db_seg)
+
+        # Format as SRT
+        srt_output = format_segment_srt(pydantic_seg, sequence=1)
+
+        assert corrected_text in srt_output, (
+            "GAP-3: SRT output must contain the corrected text "
+            f"'{corrected_text}', got:\n{srt_output}"
+        )
+        assert original_text not in srt_output, (
+            "GAP-3: SRT output must NOT contain the original uncorrected text "
+            f"'{original_text}', got:\n{srt_output}"
+        )
+        # Verify SRT structure: sequence number, timestamps, and text
+        assert srt_output.startswith("1\n"), (
+            "SRT output must start with the sequence number"
+        )
+        assert "-->" in srt_output, (
+            "SRT output must contain the timestamp arrow separator"
+        )
+
+    async def test_api_inline_ternary_returns_corrected_text(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        GAP-4: The transcript segments API endpoint (transcripts.py:303)
+        uses an inline ternary:
+            seg.corrected_text if seg.has_correction and seg.corrected_text else seg.text
+        This test verifies that logic returns the corrected text.
+
+        Steps:
+        1. Seed a segment with a correction
+        2. Read the segment from DB (ORM object)
+        3. Simulate the inline ternary logic
+        4. Assert the result is the corrected text
+        """
+        video_id = "apiTernGap4"
+        language_code = "en"
+        original_text = "wrold peace"
+        corrected_text = "world peace"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text=original_text,
+            sequence_number=0,
+        )
+        segment_id = segment.id
+
+        # Apply correction
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_id,
+            corrected_text=corrected_text,
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Read the ORM object (as the API does)
+        segment_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(TranscriptSegmentDB.id == segment_id)
+        )
+        seg = segment_result.scalar_one()
+
+        # Simulate the exact inline ternary from transcripts.py:303
+        display = (
+            seg.corrected_text
+            if seg.has_correction and seg.corrected_text
+            else seg.text
+        )
+
+        assert display == corrected_text, (
+            "GAP-4: The API inline ternary must return the corrected text "
+            f"'{corrected_text}', got '{display}'"
+        )
+
+        # Also verify the uncorrected path (for completeness)
+        # A segment without corrections should return the raw text
+        uncorrected_segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="no corrections here",
+            sequence_number=1,
+        )
+        await db_session.flush()
+
+        uncorrected_result = await db_session.execute(
+            select(TranscriptSegmentDB).where(
+                TranscriptSegmentDB.id == uncorrected_segment.id
+            )
+        )
+        uncorr_seg = uncorrected_result.scalar_one()
+
+        uncorrected_display = (
+            uncorr_seg.corrected_text
+            if uncorr_seg.has_correction and uncorr_seg.corrected_text
+            else uncorr_seg.text
+        )
+        assert uncorrected_display == "no corrections here", (
+            "Uncorrected segment must return raw text from the API ternary"
+        )
+
+    async def test_transcript_metadata_after_correction(
+        self,
+        db_session: AsyncSession,
+        service: object,
+    ) -> None:
+        """
+        GAP-5: After apply_correction, the transcript ORM object must have
+        has_corrections, correction_count, and last_corrected_at set correctly
+        — confirming these fields would be available for API serialization.
+
+        Steps:
+        1. Seed a transcript and segment
+        2. Apply a correction via the service
+        3. Reload the transcript from DB
+        4. Assert has_corrections, correction_count, and last_corrected_at
+        """
+        video_id = "metaGap5VID"
+        language_code = "en"
+
+        await _seed_video(db_session, video_id=video_id)
+        await _seed_transcript(db_session, video_id=video_id, language_code=language_code)
+        segment = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="original text for metadata test",
+            sequence_number=0,
+        )
+
+        # Apply correction
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment.id,
+            corrected_text="corrected text for metadata test",
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Reload transcript from DB
+        transcript_result = await db_session.execute(
+            select(VideoTranscriptDB).where(
+                VideoTranscriptDB.video_id == video_id,
+                VideoTranscriptDB.language_code == language_code,
+            )
+        )
+        transcript = transcript_result.scalar_one()
+
+        # Assert metadata fields are set correctly
+        assert transcript.has_corrections is True, (
+            "GAP-5: has_corrections must be True after apply_correction"
+        )
+        assert transcript.correction_count == 1, (
+            "GAP-5: correction_count must be 1 after one apply_correction call, "
+            f"got {transcript.correction_count}"
+        )
+        assert transcript.last_corrected_at is not None, (
+            "GAP-5: last_corrected_at must be set after apply_correction"
+        )
+
+        # Verify the fields are accessible attributes on the ORM object
+        # (confirming they'd be available for API serialization)
+        assert hasattr(transcript, "has_corrections"), (
+            "ORM object must have has_corrections attribute for API serialization"
+        )
+        assert hasattr(transcript, "correction_count"), (
+            "ORM object must have correction_count attribute for API serialization"
+        )
+        assert hasattr(transcript, "last_corrected_at"), (
+            "ORM object must have last_corrected_at attribute for API serialization"
+        )
+
+        # Apply a second correction to another segment and verify count increments
+        segment_b = await _seed_segment(
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            text="second segment text",
+            sequence_number=1,
+        )
+        await service.apply_correction(  # type: ignore[attr-defined]
+            db_session,
+            video_id=video_id,
+            language_code=language_code,
+            segment_id=segment_b.id,
+            corrected_text="second segment corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+        await db_session.flush()
+
+        # Reload and verify incremented count
+        transcript_result_2 = await db_session.execute(
+            select(VideoTranscriptDB).where(
+                VideoTranscriptDB.video_id == video_id,
+                VideoTranscriptDB.language_code == language_code,
+            )
+        )
+        transcript_2 = transcript_result_2.scalar_one()
+        assert transcript_2.correction_count == 2, (
+            "GAP-5: correction_count must be 2 after two apply_correction calls, "
+            f"got {transcript_2.correction_count}"
+        )

--- a/tests/unit/models/test_transcript_correction.py
+++ b/tests/unit/models/test_transcript_correction.py
@@ -1,0 +1,733 @@
+"""
+Tests for TranscriptCorrection Pydantic domain models.
+
+Validates field constraints, enum enforcement, cross-field validators,
+and ORM compatibility for TranscriptCorrectionCreate and
+TranscriptCorrectionRead models (Feature 033, FR-018 append-only).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+from uuid_utils import uuid7
+
+from chronovista.models.enums import CorrectionType
+from chronovista.models.transcript_correction import (
+    TranscriptCorrectionCreate,
+    TranscriptCorrectionRead,
+)
+from tests.factories.transcript_correction_factory import (
+    TranscriptCorrectionFactory,
+    TranscriptCorrectionTestData,
+    create_transcript_correction,
+)
+
+# CRITICAL: Ensure async tests work with coverage tooling.
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_ALL_CORRECTION_TYPES = list(CorrectionType)
+
+_VALID_VIDEO_ID = "dQw4w9WgXcQ"
+_VALID_LANGUAGE_CODE = "en"
+
+
+def _make_correction_create(**overrides: Any) -> TranscriptCorrectionCreate:
+    """Return a valid TranscriptCorrectionCreate with optional field overrides.
+
+    Parameters
+    ----------
+    **overrides : Any
+        Any field values to override on top of sensible defaults.
+
+    Returns
+    -------
+    TranscriptCorrectionCreate
+        A fully-populated create model.
+    """
+    defaults: dict[str, Any] = {
+        "video_id": _VALID_VIDEO_ID,
+        "language_code": _VALID_LANGUAGE_CODE,
+        "segment_id": 1,
+        "correction_type": CorrectionType.SPELLING,
+        "original_text": "teh quick brown fox",
+        "corrected_text": "the quick brown fox",
+        "correction_note": None,
+        "corrected_by_user_id": None,
+        "version_number": 1,
+    }
+    defaults.update(overrides)
+    return TranscriptCorrectionCreate(**defaults)
+
+
+def _make_uuid7() -> uuid.UUID:
+    """Generate a standard uuid.UUID from UUIDv7 bytes."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+
+# ---------------------------------------------------------------------------
+# TranscriptCorrectionCreate tests
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptCorrectionCreate:
+    """Tests for TranscriptCorrectionCreate Pydantic model validation."""
+
+    # ------------------------------------------------------------------
+    # Valid creation scenarios
+    # ------------------------------------------------------------------
+
+    def test_valid_create_required_fields_only(self) -> None:
+        """TranscriptCorrectionCreate is valid with only the required fields.
+
+        Notes
+        -----
+        segment_id, correction_note, and corrected_by_user_id all default to
+        None, so they must not be supplied to exercise this path.
+        """
+        correction = TranscriptCorrectionCreate(
+            video_id=_VALID_VIDEO_ID,
+            language_code=_VALID_LANGUAGE_CODE,
+            correction_type=CorrectionType.SPELLING,
+            original_text="teh quick brown fox",
+            corrected_text="the quick brown fox",
+            version_number=1,
+        )
+
+        assert correction.video_id == _VALID_VIDEO_ID
+        assert correction.language_code == _VALID_LANGUAGE_CODE
+        assert correction.segment_id is None
+        assert correction.correction_type == CorrectionType.SPELLING
+        assert correction.original_text == "teh quick brown fox"
+        assert correction.corrected_text == "the quick brown fox"
+        assert correction.correction_note is None
+        assert correction.corrected_by_user_id is None
+        assert correction.version_number == 1
+
+    def test_valid_create_with_all_optional_fields(self) -> None:
+        """TranscriptCorrectionCreate accepts all optional fields populated."""
+        correction = TranscriptCorrectionCreate(
+            video_id=_VALID_VIDEO_ID,
+            language_code="en-US",
+            segment_id=42,
+            correction_type=CorrectionType.ASR_ERROR,
+            original_text="i went two the store",
+            corrected_text="i went to the store",
+            correction_note="ASR confused homophone 'to'/'two'",
+            corrected_by_user_id="user_abc123",
+            version_number=2,
+        )
+
+        assert correction.segment_id == 42
+        assert correction.correction_note == "ASR confused homophone 'to'/'two'"
+        assert correction.corrected_by_user_id == "user_abc123"
+        assert correction.version_number == 2
+
+    def test_valid_create_using_factory_defaults(self) -> None:
+        """Factory-built ORM object has field values matching Pydantic expectations."""
+        orm_obj = create_transcript_correction()
+
+        # Build a Pydantic Create model from the ORM object's attribute dict
+        correction = TranscriptCorrectionCreate(
+            video_id=orm_obj.video_id,
+            language_code=orm_obj.language_code,
+            segment_id=orm_obj.segment_id,
+            correction_type=CorrectionType(orm_obj.correction_type),
+            original_text=orm_obj.original_text,
+            corrected_text=orm_obj.corrected_text,
+            correction_note=orm_obj.correction_note,
+            corrected_by_user_id=orm_obj.corrected_by_user_id,
+            version_number=orm_obj.version_number,
+        )
+
+        assert correction.video_id == orm_obj.video_id
+        assert correction.version_number == orm_obj.version_number
+
+    def test_valid_create_test_data_asr_error(self) -> None:
+        """TranscriptCorrectionTestData.asr_error_data() produces a valid model."""
+        data = TranscriptCorrectionTestData.asr_error_data()
+        # Remove ORM-only field not present on Create model
+        data.pop("corrected_at", None)
+        data.pop("id", None)
+
+        correction = TranscriptCorrectionCreate(**data)
+
+        assert correction.correction_type == CorrectionType.ASR_ERROR
+        assert correction.version_number == 2
+
+    def test_valid_create_test_data_revert(self) -> None:
+        """TranscriptCorrectionTestData.revert_data() produces a valid model."""
+        data = TranscriptCorrectionTestData.revert_data()
+        data.pop("corrected_at", None)
+        data.pop("id", None)
+
+        correction = TranscriptCorrectionCreate(**data)
+
+        assert correction.correction_type == CorrectionType.REVERT
+        assert correction.version_number == 3
+
+    # ------------------------------------------------------------------
+    # CorrectionType enum enforcement — all 6 values
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "correction_type",
+        [
+            CorrectionType.SPELLING,
+            CorrectionType.PROFANITY_FIX,
+            CorrectionType.CONTEXT_CORRECTION,
+            CorrectionType.FORMATTING,
+            CorrectionType.ASR_ERROR,
+            CorrectionType.REVERT,
+        ],
+        ids=[
+            "SPELLING",
+            "PROFANITY_FIX",
+            "CONTEXT_CORRECTION",
+            "FORMATTING",
+            "ASR_ERROR",
+            "REVERT",
+        ],
+    )
+    def test_all_correction_type_enum_values_are_valid(
+        self, correction_type: CorrectionType
+    ) -> None:
+        """Every CorrectionType value produces a valid TranscriptCorrectionCreate.
+
+        Notes
+        -----
+        This test exercises all six enum members defined in CorrectionType so
+        that adding a seventh value without updating tests causes a CI failure.
+        """
+        correction = _make_correction_create(correction_type=correction_type)
+        assert correction.correction_type == correction_type
+        assert isinstance(correction.correction_type, CorrectionType)
+
+    def test_invalid_correction_type_string_raises_validation_error(self) -> None:
+        """Unrecognised string passed as correction_type raises ValidationError."""
+        with pytest.raises(ValidationError, match="correction_type"):
+            _make_correction_create(correction_type="nonexistent_type")
+
+    def test_invalid_correction_type_int_raises_validation_error(self) -> None:
+        """Integer passed as correction_type raises ValidationError."""
+        with pytest.raises(ValidationError):
+            _make_correction_create(correction_type=99)
+
+    def test_invalid_correction_type_none_raises_validation_error(self) -> None:
+        """None passed for required correction_type raises ValidationError."""
+        with pytest.raises(ValidationError):
+            _make_correction_create(correction_type=None)
+
+    # ------------------------------------------------------------------
+    # version_number constraints — must be >= 1
+    # ------------------------------------------------------------------
+
+    def test_version_number_minimum_boundary_is_accepted(self) -> None:
+        """version_number == 1 (the minimum) is accepted."""
+        correction = _make_correction_create(version_number=1)
+        assert correction.version_number == 1
+
+    def test_version_number_zero_raises_validation_error(self) -> None:
+        """version_number == 0 violates the >= 1 constraint."""
+        with pytest.raises(ValidationError, match="version_number"):
+            _make_correction_create(version_number=0)
+
+    def test_version_number_negative_raises_validation_error(self) -> None:
+        """Negative version_number violates the >= 1 constraint."""
+        with pytest.raises(ValidationError, match="version_number"):
+            _make_correction_create(version_number=-1)
+
+    def test_version_number_large_positive_is_accepted(self) -> None:
+        """Large positive version_number values are accepted."""
+        correction = _make_correction_create(version_number=9_999)
+        assert correction.version_number == 9_999
+
+    # ------------------------------------------------------------------
+    # No-op prevention — corrected_text must differ from original_text
+    # ------------------------------------------------------------------
+
+    def test_corrected_text_same_as_original_raises_validation_error(self) -> None:
+        """Identical original_text and corrected_text raise ValidationError (no-op prevention)."""
+        with pytest.raises(ValidationError, match="no-op corrections are not permitted"):
+            TranscriptCorrectionCreate(
+                video_id=_VALID_VIDEO_ID,
+                language_code=_VALID_LANGUAGE_CODE,
+                correction_type=CorrectionType.SPELLING,
+                original_text="hello world",
+                corrected_text="hello world",  # identical — must be rejected
+                version_number=1,
+            )
+
+    def test_corrected_text_differs_from_original_is_valid(self) -> None:
+        """corrected_text that differs from original_text is accepted."""
+        correction = _make_correction_create(
+            original_text="helo world",
+            corrected_text="hello world",
+        )
+        assert correction.corrected_text == "hello world"
+
+    def test_no_op_check_is_case_sensitive(self) -> None:
+        """Strings differing only in case are NOT considered equal (case-sensitive no-op check)."""
+        # "Hello" != "hello" — should be accepted
+        correction = _make_correction_create(
+            original_text="Hello world",
+            corrected_text="hello world",
+        )
+        assert correction.corrected_text == "hello world"
+
+    # ------------------------------------------------------------------
+    # corrected_by_user_id max length (100 characters)
+    # ------------------------------------------------------------------
+
+    def test_corrected_by_user_id_at_max_length_is_accepted(self) -> None:
+        """corrected_by_user_id at exactly 100 characters is accepted."""
+        user_id_100 = "u" * 100
+        correction = _make_correction_create(corrected_by_user_id=user_id_100)
+        # str_strip_whitespace is set; "u"*100 has no whitespace to strip
+        assert correction.corrected_by_user_id == user_id_100
+
+    def test_corrected_by_user_id_exceeding_max_length_raises_error(self) -> None:
+        """corrected_by_user_id longer than 100 characters raises ValidationError."""
+        with pytest.raises(ValidationError):
+            _make_correction_create(corrected_by_user_id="u" * 101)
+
+    def test_corrected_by_user_id_none_is_accepted(self) -> None:
+        """corrected_by_user_id=None (default) is accepted."""
+        correction = _make_correction_create(corrected_by_user_id=None)
+        assert correction.corrected_by_user_id is None
+
+    def test_corrected_by_user_id_short_string_is_accepted(self) -> None:
+        """Short corrected_by_user_id strings are accepted."""
+        correction = _make_correction_create(corrected_by_user_id="cli")
+        assert correction.corrected_by_user_id == "cli"
+
+    # ------------------------------------------------------------------
+    # Empty string handling
+    # ------------------------------------------------------------------
+
+    def test_empty_original_text_is_accepted(self) -> None:
+        """original_text may be an empty string (no non-empty constraint in model).
+
+        Notes
+        -----
+        The model does not enforce non-empty text at the Pydantic layer.
+        str_strip_whitespace is configured, so leading/trailing whitespace is
+        stripped before the no-op cross-field check runs.
+        """
+        # Empty original_text + non-empty corrected_text differs → valid
+        correction = _make_correction_create(
+            original_text="",
+            corrected_text="some corrected text",
+        )
+        assert correction.original_text == ""
+
+    def test_empty_corrected_text_differs_from_nonempty_original(self) -> None:
+        """Empty corrected_text is accepted when original_text is non-empty."""
+        correction = _make_correction_create(
+            original_text="some original text",
+            corrected_text="",
+        )
+        assert correction.corrected_text == ""
+
+    def test_both_empty_strings_raises_validation_error(self) -> None:
+        """Two empty strings are equal so should trigger no-op prevention."""
+        with pytest.raises(ValidationError, match="no-op corrections are not permitted"):
+            _make_correction_create(
+                original_text="",
+                corrected_text="",
+            )
+
+    def test_whitespace_stripped_before_no_op_check(self) -> None:
+        """str_strip_whitespace strips whitespace; equal stripped values raise ValidationError.
+
+        Notes
+        -----
+        The base model sets str_strip_whitespace=True.  After stripping,
+        "  hello  " becomes "hello" and " hello " also becomes "hello",
+        so the no-op validator should fire.
+        """
+        with pytest.raises(ValidationError, match="no-op corrections are not permitted"):
+            _make_correction_create(
+                original_text="  hello  ",
+                corrected_text=" hello ",
+            )
+
+    # ------------------------------------------------------------------
+    # Model serialisation
+    # ------------------------------------------------------------------
+
+    def test_model_dump_serialises_enum_to_string(self) -> None:
+        """model_dump() serialises CorrectionType to its string value."""
+        correction = _make_correction_create(correction_type=CorrectionType.FORMATTING)
+        data = correction.model_dump()
+
+        assert data["correction_type"] == "formatting"
+        assert isinstance(data["correction_type"], str)
+
+    def test_model_dump_round_trip(self) -> None:
+        """model_dump() output can be used to reconstruct an equivalent model."""
+        original = _make_correction_create()
+        data = original.model_dump()
+        reconstructed = TranscriptCorrectionCreate(**data)
+
+        assert reconstructed == original
+
+
+# ---------------------------------------------------------------------------
+# TranscriptCorrectionRead tests
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptCorrectionRead:
+    """Tests for TranscriptCorrectionRead Pydantic model.
+
+    TranscriptCorrectionRead extends TranscriptCorrectionCreate with two
+    database-side fields: id (UUIDv7) and corrected_at (datetime).
+    It is configured with from_attributes=True for SQLAlchemy ORM compatibility.
+    """
+
+    def _make_read(self, **overrides: Any) -> TranscriptCorrectionRead:
+        """Build a valid TranscriptCorrectionRead with optional field overrides."""
+        now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        defaults: dict[str, Any] = {
+            "id": _make_uuid7(),
+            "video_id": _VALID_VIDEO_ID,
+            "language_code": _VALID_LANGUAGE_CODE,
+            "segment_id": None,
+            "correction_type": CorrectionType.SPELLING,
+            "original_text": "teh quick brown fox",
+            "corrected_text": "the quick brown fox",
+            "correction_note": None,
+            "corrected_by_user_id": None,
+            "version_number": 1,
+            "corrected_at": now,
+        }
+        defaults.update(overrides)
+        return TranscriptCorrectionRead(**defaults)
+
+    # ------------------------------------------------------------------
+    # Valid creation scenarios
+    # ------------------------------------------------------------------
+
+    def test_valid_read_with_required_fields(self) -> None:
+        """TranscriptCorrectionRead is valid with all required fields present."""
+        correction_id = _make_uuid7()
+        now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        correction = TranscriptCorrectionRead(
+            id=correction_id,
+            video_id=_VALID_VIDEO_ID,
+            language_code=_VALID_LANGUAGE_CODE,
+            correction_type=CorrectionType.SPELLING,
+            original_text="teh quick brown fox",
+            corrected_text="the quick brown fox",
+            version_number=1,
+            corrected_at=now,
+        )
+
+        assert correction.id == correction_id
+        assert correction.corrected_at == now
+        assert correction.video_id == _VALID_VIDEO_ID
+
+    def test_all_fields_present_including_id_and_corrected_at(self) -> None:
+        """TranscriptCorrectionRead exposes all expected fields including id and corrected_at."""
+        correction = self._make_read()
+
+        # Base inherited fields
+        assert hasattr(correction, "video_id")
+        assert hasattr(correction, "language_code")
+        assert hasattr(correction, "segment_id")
+        assert hasattr(correction, "correction_type")
+        assert hasattr(correction, "original_text")
+        assert hasattr(correction, "corrected_text")
+        assert hasattr(correction, "correction_note")
+        assert hasattr(correction, "corrected_by_user_id")
+        assert hasattr(correction, "version_number")
+        # Read-specific fields
+        assert hasattr(correction, "id")
+        assert hasattr(correction, "corrected_at")
+
+    def test_id_is_uuid_instance(self) -> None:
+        """id field is a uuid.UUID instance."""
+        correction = self._make_read()
+        assert isinstance(correction.id, uuid.UUID)
+
+    def test_corrected_at_is_datetime_instance(self) -> None:
+        """corrected_at field is a datetime instance."""
+        correction = self._make_read()
+        assert isinstance(correction.corrected_at, datetime)
+
+    # ------------------------------------------------------------------
+    # from_attributes ORM compatibility
+    # ------------------------------------------------------------------
+
+    def test_from_attributes_works_with_orm_like_object(self) -> None:
+        """TranscriptCorrectionRead.model_validate() works against ORM-like object.
+
+        Notes
+        -----
+        TranscriptCorrectionRead has from_attributes=True in its ConfigDict.
+        This test verifies model_validate() can consume a SQLAlchemy ORM
+        object built via the factory (which mirrors the ORM model structure).
+        """
+        orm_obj = create_transcript_correction(
+            correction_type=CorrectionType.ASR_ERROR.value,
+            original_text="i went two the store",
+            corrected_text="i went to the store",
+            correction_note="ASR homophone error",
+            version_number=2,
+        )
+
+        pydantic_obj = TranscriptCorrectionRead.model_validate(orm_obj)
+
+        assert pydantic_obj.id == orm_obj.id
+        assert pydantic_obj.video_id == orm_obj.video_id
+        assert pydantic_obj.language_code == orm_obj.language_code
+        assert pydantic_obj.correction_type == CorrectionType.ASR_ERROR
+        assert pydantic_obj.original_text == orm_obj.original_text
+        assert pydantic_obj.corrected_text == orm_obj.corrected_text
+        assert pydantic_obj.correction_note == orm_obj.correction_note
+        assert pydantic_obj.version_number == orm_obj.version_number
+        assert isinstance(pydantic_obj.corrected_at, datetime)
+
+    def test_from_attributes_factory_batch_produces_unique_ids(self) -> None:
+        """Factory-built ORM objects produce unique UUIDs when validated via model_validate."""
+        orm_objects = TranscriptCorrectionFactory.build_batch(3)
+        pydantic_objects = [
+            TranscriptCorrectionRead.model_validate(o) for o in orm_objects
+        ]
+        ids = [o.id for o in pydantic_objects]
+        assert len(ids) == len(set(ids)), "Each factory-built object must have a unique id"
+
+    def test_from_attributes_all_correction_types(self) -> None:
+        """model_validate() correctly coerces the string correction_type from ORM to enum."""
+        for correction_type in CorrectionType:
+            orm_obj = create_transcript_correction(
+                correction_type=correction_type.value,
+            )
+            pydantic_obj = TranscriptCorrectionRead.model_validate(orm_obj)
+            assert pydantic_obj.correction_type == correction_type
+
+    # ------------------------------------------------------------------
+    # Missing database fields raise ValidationError
+    # ------------------------------------------------------------------
+
+    def test_missing_id_raises_validation_error(self) -> None:
+        """TranscriptCorrectionRead without id raises ValidationError."""
+        with pytest.raises(ValidationError):
+            TranscriptCorrectionRead(  # type: ignore[call-arg]
+                # id deliberately omitted
+                video_id=_VALID_VIDEO_ID,
+                language_code=_VALID_LANGUAGE_CODE,
+                correction_type=CorrectionType.SPELLING,
+                original_text="teh",
+                corrected_text="the",
+                version_number=1,
+                corrected_at=datetime.now(timezone.utc),
+            )
+
+    def test_missing_corrected_at_raises_validation_error(self) -> None:
+        """TranscriptCorrectionRead without corrected_at raises ValidationError."""
+        with pytest.raises(ValidationError):
+            TranscriptCorrectionRead(  # type: ignore[call-arg]
+                id=_make_uuid7(),
+                video_id=_VALID_VIDEO_ID,
+                language_code=_VALID_LANGUAGE_CODE,
+                correction_type=CorrectionType.SPELLING,
+                original_text="teh",
+                corrected_text="the",
+                version_number=1,
+                # corrected_at deliberately omitted
+            )
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def test_model_dump_includes_id_and_corrected_at(self) -> None:
+        """model_dump() output includes both id and corrected_at keys."""
+        correction = self._make_read()
+        data = correction.model_dump()
+
+        assert "id" in data
+        assert "corrected_at" in data
+        assert isinstance(data["id"], uuid.UUID)
+        assert isinstance(data["corrected_at"], datetime)
+
+    def test_model_dump_serialises_correction_type_to_string(self) -> None:
+        """model_dump() serialises correction_type enum to its string value."""
+        correction = self._make_read(correction_type=CorrectionType.PROFANITY_FIX)
+        data = correction.model_dump()
+        assert data["correction_type"] == "profanity_fix"
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis-based property tests
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptCorrectionHypothesis:
+    """Property-based tests using Hypothesis (Constitution §V).
+
+    These tests search for unexpected failure modes by generating many
+    variations of input data and asserting invariants that should hold
+    for all valid (or invalid) inputs.
+    """
+
+    # ------------------------------------------------------------------
+    # CorrectionType enum exhaustiveness
+    # ------------------------------------------------------------------
+
+    @given(correction_type=st.sampled_from(CorrectionType))
+    def test_all_enum_values_produce_valid_models(
+        self, correction_type: CorrectionType
+    ) -> None:
+        """Every CorrectionType member produces a valid TranscriptCorrectionCreate.
+
+        Notes
+        -----
+        If a new CorrectionType member is added to the enum this test will
+        automatically cover it, ensuring exhaustiveness without manual
+        parametrisation updates.
+        """
+        correction = _make_correction_create(correction_type=correction_type)
+        assert correction.correction_type == correction_type
+        assert isinstance(correction.correction_type, CorrectionType)
+
+    # ------------------------------------------------------------------
+    # Text field edge cases
+    # ------------------------------------------------------------------
+
+    @given(text=st.text(min_size=1, max_size=500))
+    def test_non_identical_text_pairs_are_always_valid(self, text: str) -> None:
+        """Any pair of distinct text values (original, corrected) produces a valid model.
+
+        Notes
+        -----
+        We suffix the corrected text to guarantee non-equality after
+        str_strip_whitespace normalisation.
+        """
+        suffix = "_CORRECTED"
+        original = text
+        corrected = text + suffix
+
+        # Both strings stripped; they will differ as long as the suffix survives
+        # after strip. Since suffix contains no leading/trailing whitespace, it
+        # always survives stripping.
+        correction = _make_correction_create(
+            original_text=original,
+            corrected_text=corrected,
+        )
+        assert correction.corrected_text.endswith(suffix)
+
+    @given(
+        text=st.text(
+            alphabet=st.characters(
+                whitelist_categories=("Lu", "Ll", "Nd", "Po"),
+                whitelist_characters=" ",
+            ),
+            min_size=1,
+            max_size=200,
+        )
+    )
+    def test_identical_text_always_raises_validation_error(self, text: str) -> None:
+        """Two identical non-empty strings always trigger the no-op validator.
+
+        Notes
+        -----
+        We restrict the alphabet to printable characters without leading or
+        trailing whitespace characters so that str_strip_whitespace does not
+        reduce two distinct raw strings to the same stripped form.
+        """
+        stripped = text.strip()
+        # Only test non-empty stripped values to avoid ambiguity with the
+        # empty-string edge case which is also rejected but for the same reason.
+        assume(len(stripped) > 0)
+
+        with pytest.raises(ValidationError, match="no-op corrections are not permitted"):
+            _make_correction_create(
+                original_text=stripped,
+                corrected_text=stripped,
+            )
+
+    @given(
+        text=st.text(
+            # Unicode supplementary plane including emoji and combining chars
+            alphabet=st.characters(whitelist_categories=("So", "Mn", "Ll")),
+            min_size=1,
+            max_size=100,
+        )
+    )
+    def test_unicode_and_emoji_original_text_accepted(self, text: str) -> None:
+        """Unicode / emoji content in original_text is accepted by the model.
+
+        Notes
+        -----
+        The corrected text is forced to differ by appending an ASCII suffix.
+        """
+        corrected = text + "X"
+        try:
+            correction = _make_correction_create(
+                original_text=text,
+                corrected_text=corrected,
+            )
+            # If no error, the model must have stored the values
+            assert correction.original_text is not None
+        except ValidationError:
+            # str_strip_whitespace may normalise both to identical empty strings
+            # for pure-whitespace / combining-only inputs — that is expected.
+            pass
+
+    # ------------------------------------------------------------------
+    # version_number boundary tests
+    # ------------------------------------------------------------------
+
+    @given(version_number=st.integers(min_value=1, max_value=100_000))
+    def test_positive_version_numbers_are_always_valid(
+        self, version_number: int
+    ) -> None:
+        """Any version_number >= 1 is accepted."""
+        correction = _make_correction_create(version_number=version_number)
+        assert correction.version_number == version_number
+
+    @given(version_number=st.integers(max_value=0))
+    def test_non_positive_version_numbers_always_raise_error(
+        self, version_number: int
+    ) -> None:
+        """Any version_number <= 0 raises ValidationError."""
+        with pytest.raises(ValidationError):
+            _make_correction_create(version_number=version_number)
+
+    @settings(max_examples=50)
+    @given(
+        version_number=st.integers(min_value=1, max_value=1_000_000),
+        user_id_len=st.integers(min_value=1, max_value=100),
+    )
+    def test_version_and_user_id_combinations_are_independent(
+        self, version_number: int, user_id_len: int
+    ) -> None:
+        """version_number and corrected_by_user_id constraints are independent.
+
+        Notes
+        -----
+        A valid version_number combined with a valid corrected_by_user_id
+        always produces a valid model.  This guards against accidental
+        cross-field coupling.
+        """
+        user_id = "u" * user_id_len  # 1..100 chars, all valid
+        correction = _make_correction_create(
+            version_number=version_number,
+            corrected_by_user_id=user_id,
+        )
+        assert correction.version_number == version_number
+        assert correction.corrected_by_user_id == user_id

--- a/tests/unit/repositories/test_transcript_correction_repository.py
+++ b/tests/unit/repositories/test_transcript_correction_repository.py
@@ -1,0 +1,683 @@
+"""
+Tests for TranscriptCorrectionRepository (Feature 033 — T008).
+
+Covers all public methods:
+- update()  — overridden to raise NotImplementedError (FR-018 immutability)
+- delete()  — overridden to raise NotImplementedError (FR-018 immutability)
+- get()     — lookup by UUID primary key
+- exists()  — presence check by UUID primary key
+- get_by_segment() — corrections for a (segment_id, video_id, language_code) triple,
+                     ordered by version_number DESC
+- get_by_video()   — paginated corrections for a (video_id, language_code) pair
+- count_by_video() — total correction count for a (video_id, language_code) pair
+- get_latest_version() — highest version_number for a segment, or 0 when none exist
+
+Mock strategy: every test creates a ``MagicMock(spec=AsyncSession)`` whose
+``execute`` attribute is an ``AsyncMock``.  This avoids real database I/O and
+follows the pattern used in ``test_canonical_tag_repository.py`` and
+``test_tag_operation_log_repository.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
+from chronovista.models.enums import CorrectionType
+from chronovista.models.transcript_correction import TranscriptCorrectionCreate
+from chronovista.repositories.transcript_correction_repository import (
+    TranscriptCorrectionRepository,
+)
+from tests.factories.transcript_correction_factory import (
+    TranscriptCorrectionFactory,
+    create_transcript_correction,
+)
+
+# Ensures every async test in this module is recognised by pytest-asyncio
+# regardless of how coverage is invoked (see CLAUDE.md §pytest-asyncio section).
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_uuid() -> uuid.UUID:
+    """Return a UUIDv7 expressed as a stdlib ``uuid.UUID`` instance."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+
+def _make_correction_db(
+    *,
+    id: uuid.UUID | None = None,
+    video_id: str = "dQw4w9WgXcQ",
+    language_code: str = "en",
+    segment_id: int | None = 1,
+    correction_type: str = CorrectionType.SPELLING.value,
+    original_text: str = "teh quick brown fox",
+    corrected_text: str = "the quick brown fox",
+    correction_note: str | None = None,
+    corrected_by_user_id: str | None = "cli",
+    corrected_at: datetime | None = None,
+    version_number: int = 1,
+) -> TranscriptCorrectionDB:
+    """Build an in-memory TranscriptCorrectionDB instance without a DB session.
+
+    Parameters
+    ----------
+    id : uuid.UUID, optional
+        Primary key; generated via UUIDv7 when omitted.
+    video_id : str
+        YouTube video ID (max 20 chars).
+    language_code : str
+        BCP-47 language code.
+    segment_id : int or None
+        Optional FK to transcript_segments.id.
+    correction_type : str
+        One of the CorrectionType enum values.
+    original_text : str
+        Text before the correction.
+    corrected_text : str
+        Text after the correction.
+    correction_note : str or None
+        Optional human-readable note.
+    corrected_by_user_id : str or None
+        Identifier of the user who made the correction.
+    corrected_at : datetime or None
+        Timestamp; defaults to now(UTC).
+    version_number : int
+        Must be >= 1.
+
+    Returns
+    -------
+    TranscriptCorrectionDB
+        In-memory ORM instance.
+    """
+    return TranscriptCorrectionDB(
+        id=id or _make_uuid(),
+        video_id=video_id,
+        language_code=language_code,
+        segment_id=segment_id,
+        correction_type=correction_type,
+        original_text=original_text,
+        corrected_text=corrected_text,
+        correction_note=correction_note,
+        corrected_by_user_id=corrected_by_user_id,
+        corrected_at=corrected_at or datetime.now(tz=timezone.utc),
+        version_number=version_number,
+    )
+
+
+def _make_mock_session() -> MagicMock:
+    """Create a MagicMock AsyncSession with an AsyncMock execute attribute.
+
+    Returns
+    -------
+    MagicMock
+        Mock session compatible with AsyncSession interface.
+    """
+    session = MagicMock(spec=AsyncSession)
+    session.execute = AsyncMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# TestTranscriptCorrectionRepositoryImmutability
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptCorrectionRepositoryImmutability:
+    """Verify that update() and delete() raise NotImplementedError (FR-018).
+
+    The transcript corrections table is an append-only audit log. No
+    mutation or deletion is permitted after a row has been inserted.
+    """
+
+    @pytest.fixture
+    def repository(self) -> TranscriptCorrectionRepository:
+        """Provide a fresh repository instance for each test."""
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    async def test_update_raises_not_implemented(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Calling update() must raise NotImplementedError with an 'immutable' message.
+
+        FR-018 mandates that transcript corrections are append-only. The
+        repository must actively prevent any caller from mutating an existing
+        row via the standard repository interface.
+        """
+        db_obj = _make_correction_db()
+        update_data: dict[str, Any] = {"corrected_text": "something different"}
+
+        with pytest.raises(NotImplementedError, match="immutable"):
+            await repository.update(
+                mock_session,
+                db_obj=db_obj,
+                obj_in=update_data,
+            )
+
+        # Session must never be touched — no database round-trip should occur.
+        mock_session.execute.assert_not_called()
+
+    async def test_delete_raises_not_implemented(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Calling delete() must raise NotImplementedError with an 'immutable' message.
+
+        FR-018 mandates that transcript corrections are append-only. Rows must
+        never be removed once inserted.
+        """
+        correction_id = _make_uuid()
+
+        with pytest.raises(NotImplementedError, match="immutable"):
+            await repository.delete(mock_session, id=correction_id)
+
+        mock_session.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestTranscriptCorrectionRepositoryGet
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptCorrectionRepositoryGet:
+    """Tests for get() and exists() — primary-key lookup methods."""
+
+    @pytest.fixture
+    def repository(self) -> TranscriptCorrectionRepository:
+        """Provide a fresh repository instance for each test."""
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    async def test_get_returns_correction_by_id(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get() returns the matching TranscriptCorrectionDB when the row exists."""
+        correction = _make_correction_db(video_id="abc123ABC12", version_number=1)
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = correction
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, correction.id)
+
+        assert result is correction
+        mock_session.execute.assert_called_once()
+
+    async def test_get_returns_none_for_missing(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get() returns None when no row matches the given UUID."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, _make_uuid())
+
+        assert result is None
+        mock_session.execute.assert_called_once()
+
+    async def test_exists_returns_true_for_existing(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """exists() returns True when the row is present in the database."""
+        correction_id = _make_uuid()
+
+        mock_result = MagicMock()
+        # first() returns a non-None row tuple when the row exists
+        mock_result.first.return_value = (correction_id,)
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, correction_id)
+
+        assert result is True
+        mock_session.execute.assert_called_once()
+
+    async def test_exists_returns_false_for_missing(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """exists() returns False when no row matches the given UUID."""
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.exists(mock_session, _make_uuid())
+
+        assert result is False
+        mock_session.execute.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestTranscriptCorrectionRepositoryQueries
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptCorrectionRepositoryQueries:
+    """Tests for the domain-specific query methods.
+
+    Covers:
+    - get_by_segment()       — corrections for a segment, ordered version DESC
+    - get_by_video()         — paginated corrections for a video transcript
+    - count_by_video()       — total correction count for a video transcript
+    - get_latest_version()   — highest version_number, or 0 if no corrections
+    """
+
+    @pytest.fixture
+    def repository(self) -> TranscriptCorrectionRepository:
+        """Provide a fresh repository instance for each test."""
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    # ------------------------------------------------------------------
+    # get_by_segment
+    # ------------------------------------------------------------------
+
+    async def test_get_by_segment_orders_by_version_desc(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_by_segment() returns corrections ordered by version_number DESC.
+
+        The repository must order results so that the most recent correction
+        (highest version_number) appears first. This is the canonical order
+        consumers expect when replaying the correction chain for a segment.
+        """
+        # Build three corrections for the same segment in descending version order
+        # as the DB would return them after ORDER BY version_number DESC.
+        correction_v3 = _make_correction_db(
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=42,
+            version_number=3,
+            original_text="original v2 text",
+            corrected_text="corrected v3 text",
+        )
+        correction_v2 = _make_correction_db(
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=42,
+            version_number=2,
+            original_text="original v1 text",
+            corrected_text="corrected v2 text",
+        )
+        correction_v1 = _make_correction_db(
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=42,
+            version_number=1,
+            original_text="teh quick brown fox",
+            corrected_text="the quick brown fox",
+        )
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [correction_v3, correction_v2, correction_v1]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        results = await repository.get_by_segment(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=42,
+        )
+
+        assert len(results) == 3
+        # Verify descending order by version_number
+        assert results[0].version_number == 3
+        assert results[1].version_number == 2
+        assert results[2].version_number == 1
+        mock_session.execute.assert_called_once()
+
+    async def test_get_by_segment_empty_list_for_no_corrections(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_by_segment() returns an empty list when no corrections exist for the segment."""
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        results = await repository.get_by_segment(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=999,
+        )
+
+        assert results == []
+        mock_session.execute.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # get_by_video
+    # ------------------------------------------------------------------
+
+    async def test_get_by_video_returns_paginated_results_with_count(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_by_video() returns (items, total) tuple with pagination applied.
+
+        The total reflects the full row count for the (video_id, language_code)
+        pair, not just the current page. Items contain only the requested page.
+        """
+        correction_a = _make_correction_db(
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            version_number=1,
+            original_text="teh",
+            corrected_text="the",
+        )
+        correction_b = _make_correction_db(
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=2,
+            version_number=1,
+            original_text="wold",
+            corrected_text="world",
+        )
+
+        # First execute: count query
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 5  # Total across all pages
+
+        # Second execute: items query (page returns 2 of 5)
+        items_scalars = MagicMock()
+        items_scalars.all.return_value = [correction_a, correction_b]
+        items_result = MagicMock()
+        items_result.scalars.return_value = items_scalars
+
+        mock_session.execute.side_effect = [count_result, items_result]
+
+        items, total = await repository.get_by_video(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            skip=0,
+            limit=2,
+        )
+
+        assert total == 5
+        assert len(items) == 2
+        assert items[0] is correction_a
+        assert items[1] is correction_b
+        assert mock_session.execute.call_count == 2
+
+    async def test_get_by_video_requires_language_code(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_by_video() filters by both video_id AND language_code.
+
+        Corrections for the same video in a different language must not appear
+        in results. The query must include a language_code equality predicate.
+        """
+        correction_en = _make_correction_db(
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            version_number=1,
+            original_text="teh fox",
+            corrected_text="the fox",
+        )
+
+        # Count query for "en" returns 1 (the "es" corrections are excluded)
+        count_result = MagicMock()
+        count_result.scalar_one.return_value = 1
+
+        items_scalars = MagicMock()
+        items_scalars.all.return_value = [correction_en]
+        items_result = MagicMock()
+        items_result.scalars.return_value = items_scalars
+
+        mock_session.execute.side_effect = [count_result, items_result]
+
+        items, total = await repository.get_by_video(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+        )
+
+        assert total == 1
+        assert len(items) == 1
+        assert items[0].language_code == "en"
+
+        # Inspect SQL to confirm language_code is in the WHERE clause
+        count_stmt = mock_session.execute.call_args_list[0].args[0]
+        sql_string = str(count_stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "language_code" in sql_string, (
+            "Expected language_code filter in get_by_video SQL; "
+            f"got: {sql_string}"
+        )
+
+    # ------------------------------------------------------------------
+    # count_by_video
+    # ------------------------------------------------------------------
+
+    async def test_count_by_video_returns_total(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """count_by_video() returns the total number of corrections for a video transcript."""
+        mock_result = MagicMock()
+        mock_result.scalar_one.return_value = 7
+        mock_session.execute.return_value = mock_result
+
+        count = await repository.count_by_video(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+        )
+
+        assert count == 7
+        mock_session.execute.assert_called_once()
+
+    async def test_count_by_video_returns_zero_when_no_corrections(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """count_by_video() returns 0 when the video transcript has no corrections."""
+        mock_result = MagicMock()
+        mock_result.scalar_one.return_value = 0
+        mock_session.execute.return_value = mock_result
+
+        count = await repository.count_by_video(
+            mock_session,
+            video_id="nonExistVid1",
+            language_code="en",
+        )
+
+        assert count == 0
+        mock_session.execute.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # get_latest_version
+    # ------------------------------------------------------------------
+
+    async def test_get_latest_version_returns_max(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_latest_version() returns the highest version_number for the segment.
+
+        This value is used by the apply-correction service to determine the
+        version_number to assign to the next correction in the chain.
+        """
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [1, 2, 3, 4]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        version = await repository.get_latest_version(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=42,
+        )
+
+        assert version == 4
+        mock_session.execute.assert_called_once()
+
+    async def test_get_latest_version_returns_zero_for_no_corrections(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """get_latest_version() returns 0 when the segment has no corrections yet.
+
+        The caller uses this as a sentinel value: 0 means no prior corrections
+        exist, so the next correction should be assigned version_number = 1.
+        """
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        version = await repository.get_latest_version(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=999,
+        )
+
+        assert version == 0
+        mock_session.execute.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestTranscriptCorrectionRepositoryInitialization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestWarning")
+class TestTranscriptCorrectionRepositoryInitialization:
+    """Tests for repository initialization.
+
+    Note: These tests are synchronous even though the module-level
+    pytestmark applies asyncio mode to the entire module. The
+    filterwarnings decorator suppresses unrelated asyncio warnings.
+    """
+
+    def test_repository_can_be_instantiated(self) -> None:
+        """TranscriptCorrectionRepository can be constructed without arguments."""
+        repo = TranscriptCorrectionRepository()
+        assert repo is not None
+
+    def test_repository_model_attribute_is_correct(self) -> None:
+        """repository.model points to TranscriptCorrectionDB ORM class."""
+        repo = TranscriptCorrectionRepository()
+        assert repo.model is TranscriptCorrectionDB
+
+
+# ---------------------------------------------------------------------------
+# TestTranscriptCorrectionRepositoryFactoryIntegration
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptCorrectionRepositoryFactoryIntegration:
+    """Smoke-tests that the factory produces valid ORM instances compatible
+    with the repository interface.  These tests do not touch a real database.
+    """
+
+    @pytest.fixture
+    def repository(self) -> TranscriptCorrectionRepository:
+        """Provide a fresh repository instance for each test."""
+        return TranscriptCorrectionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    async def test_factory_built_correction_is_accepted_by_get(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """A correction built by TranscriptCorrectionFactory can be returned from get()."""
+        correction = TranscriptCorrectionFactory.build()
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = correction
+        mock_session.execute.return_value = mock_result
+
+        result = await repository.get(mock_session, correction.id)
+
+        assert result is correction
+
+    async def test_create_transcript_correction_convenience_function(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """create_transcript_correction() helper returns a valid ORM instance."""
+        correction = create_transcript_correction(
+            video_id="9bZkp7q19f0",
+            language_code="es",
+            version_number=2,
+        )
+
+        assert isinstance(correction, TranscriptCorrectionDB)
+        assert correction.video_id == "9bZkp7q19f0"
+        assert correction.language_code == "es"
+        assert correction.version_number == 2
+
+    async def test_factory_override_correction_type(
+        self,
+        repository: TranscriptCorrectionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Factory produces corrections with overridden correction_type values."""
+        for ct in CorrectionType:
+            correction = TranscriptCorrectionFactory.build(
+                correction_type=ct.value,
+                original_text="before",
+                corrected_text="after",
+            )
+            assert correction.correction_type == ct.value

--- a/tests/unit/services/test_transcript_correction_service.py
+++ b/tests/unit/services/test_transcript_correction_service.py
@@ -1,0 +1,1549 @@
+"""
+Unit tests for TranscriptCorrectionService.apply_correction.
+
+Tests all branches of apply_correction with fully mocked repositories.
+All database I/O is mocked — these are pure unit tests that validate
+service-layer logic without any real database connection.
+
+Service contract source:
+  specs/033-transcript-corrections-audit/contracts/service-contracts.md
+
+Implementation target:
+  src/chronovista/services/transcript_correction_service.py
+
+Constitution §Cross-Feature Data Contract Verification:
+  Mock tests MUST inspect the exact arguments passed to repository methods
+  to verify that segment and transcript mutations include every expected
+  column, not merely that a method was called.
+
+References
+----------
+- TranscriptCorrectionService.apply_correction contract: service-contracts.md
+- TranscriptSegment DB model: src/chronovista/db/models.py
+- VideoTranscript DB model: src/chronovista/db/models.py
+- TranscriptCorrectionCreate Pydantic model: src/chronovista/models/transcript_correction.py
+- CorrectionType enum: src/chronovista/models/enums.py
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+from datetime import datetime, timezone
+
+import pytest
+
+from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
+from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+from chronovista.db.models import VideoTranscript as VideoTranscriptDB
+from chronovista.models.enums import CorrectionType
+from chronovista.models.transcript_correction import TranscriptCorrectionCreate
+
+# ---------------------------------------------------------------------------
+# CRITICAL: Module-level asyncio marker ensures async tests run properly
+# with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
+# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_segment(
+    segment_id: int = 1,
+    text: str = "teh quick brown fox",
+    corrected_text: str | None = None,
+    has_correction: bool = False,
+    video_id: str = "dQw4w9WgXcQ",
+    language_code: str = "en",
+) -> MagicMock:
+    """Build a mock TranscriptSegmentDB object with relevant attributes."""
+    seg = MagicMock(spec=TranscriptSegmentDB)
+    seg.id = segment_id
+    seg.video_id = video_id
+    seg.language_code = language_code
+    seg.text = text
+    seg.corrected_text = corrected_text
+    seg.has_correction = has_correction
+    return seg
+
+
+def _make_transcript(
+    video_id: str = "dQw4w9WgXcQ",
+    language_code: str = "en",
+    has_corrections: bool = False,
+    correction_count: int = 0,
+    last_corrected_at: datetime | None = None,
+) -> MagicMock:
+    """Build a mock VideoTranscriptDB object with relevant attributes."""
+    tr = MagicMock(spec=VideoTranscriptDB)
+    tr.video_id = video_id
+    tr.language_code = language_code
+    tr.has_corrections = has_corrections
+    tr.correction_count = correction_count
+    tr.last_corrected_at = last_corrected_at
+    return tr
+
+
+def _make_correction_record(
+    video_id: str = "dQw4w9WgXcQ",
+    language_code: str = "en",
+    segment_id: int = 1,
+    version_number: int = 1,
+    original_text: str = "teh quick brown fox",
+    corrected_text: str = "the quick brown fox",
+    corrected_by_user_id: str | None = "cli",
+    correction_type: str = CorrectionType.SPELLING.value,
+) -> MagicMock:
+    """Build a mock TranscriptCorrectionDB that looks like a created record."""
+    rec = MagicMock(spec=TranscriptCorrectionDB)
+    rec.id = uuid.uuid4()
+    rec.video_id = video_id
+    rec.language_code = language_code
+    rec.segment_id = segment_id
+    rec.version_number = version_number
+    rec.original_text = original_text
+    rec.corrected_text = corrected_text
+    rec.corrected_by_user_id = corrected_by_user_id
+    rec.correction_type = correction_type
+    rec.corrected_at = datetime.now(timezone.utc)
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_correction_repo() -> AsyncMock:
+    """Provide a mock TranscriptCorrectionRepository with async method stubs."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_segment_repo() -> AsyncMock:
+    """Provide a mock TranscriptSegmentRepository with async method stubs."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_transcript_repo() -> AsyncMock:
+    """Provide a mock VideoTranscriptRepository with async method stubs."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    """Provide a mock AsyncSession."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def service(
+    mock_correction_repo: AsyncMock,
+    mock_segment_repo: AsyncMock,
+    mock_transcript_repo: AsyncMock,
+) -> Any:
+    """
+    Provide a TranscriptCorrectionService instance wired with mock repos.
+
+    The constructor signature per service-contracts.md:
+        TranscriptCorrectionService(
+            correction_repo: TranscriptCorrectionRepository,
+            segment_repo: TranscriptSegmentRepository,
+            transcript_repo: VideoTranscriptRepository,
+        )
+
+    We import lazily inside fixture to allow the service to be created
+    after implementation (TDD flow — tests written before implementation).
+    """
+    from chronovista.services.transcript_correction_service import (
+        TranscriptCorrectionService,
+    )
+
+    return TranscriptCorrectionService(
+        correction_repo=mock_correction_repo,
+        segment_repo=mock_segment_repo,
+        transcript_repo=mock_transcript_repo,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestApplyCorrection
+# ---------------------------------------------------------------------------
+
+
+class TestApplyCorrection:
+    """
+    Tests for TranscriptCorrectionService.apply_correction.
+
+    Contract (service-contracts.md):
+    1. Read segment's current effective text (corrected_text if has_correction else text)
+    2. Compute next version_number via correction_repo.get_latest_version()
+    3. Create audit record → session.flush()
+    4. Update segment: corrected_text, has_correction=True → session.flush()
+    5. Update transcript: has_corrections=True, last_corrected_at=now(),
+       increment correction_count → session.flush()
+
+    Constitution §Cross-Feature Data Contract Verification:
+    Each test verifies the *exact* attributes mutated on segment and transcript
+    objects (not merely that methods were called).
+    """
+
+    async def test_first_correction_creates_audit_record(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When a segment has no prior corrections, apply_correction creates
+        an audit record with version_number=1 and original_text taken from
+        segment.text (the raw, uncorrected text).
+        """
+        segment = _make_segment(
+            segment_id=1,
+            text="teh quick brown fox",
+            corrected_text=None,
+            has_correction=False,
+        )
+        transcript = _make_transcript(correction_count=0)
+        created_record = _make_correction_record(
+            version_number=1,
+            original_text="teh quick brown fox",
+            corrected_text="the quick brown fox",
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        result = await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="the quick brown fox",
+            correction_type=CorrectionType.SPELLING,
+        )
+
+        # Verify create was called with correct version_number and original_text
+        mock_correction_repo.create.assert_called_once()
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.version_number == 1, (
+            "First correction must have version_number=1"
+        )
+        assert obj_in.original_text == "teh quick brown fox", (
+            "original_text must be segment.text when no prior correction exists"
+        )
+
+    async def test_version_chain_uses_corrected_text_as_original(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When a segment already has a correction, the new audit record's
+        original_text must be the segment's current corrected_text (the
+        effective text at the moment of the new correction), not segment.text.
+
+        This preserves the full version chain for revert operations.
+        """
+        segment = _make_segment(
+            segment_id=1,
+            text="teh quick brown fox",          # original raw text
+            corrected_text="the quick brown fox", # currently corrected
+            has_correction=True,
+        )
+        transcript = _make_transcript(correction_count=1, has_corrections=True)
+        created_record = _make_correction_record(
+            version_number=2,
+            original_text="the quick brown fox",
+            corrected_text="The quick brown fox.",
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 1
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="The quick brown fox.",
+            correction_type=CorrectionType.FORMATTING,
+        )
+
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.original_text == "the quick brown fox", (
+            "When segment already has correction, original_text must be the "
+            "current corrected_text (effective text), not segment.text"
+        )
+
+    async def test_version_number_increments(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When get_latest_version returns N, the new audit record must have
+        version_number = N + 1.
+        """
+        segment = _make_segment(
+            corrected_text="second correction",
+            has_correction=True,
+        )
+        transcript = _make_transcript(correction_count=2, has_corrections=True)
+        created_record = _make_correction_record(version_number=3)
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 2
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="third correction",
+            correction_type=CorrectionType.SPELLING,
+        )
+
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.version_number == 3, (
+            "version_number must be get_latest_version() + 1 (was 2, expected 3)"
+        )
+
+    async def test_segment_updated_with_corrected_text_and_has_correction(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Constitution §Cross-Feature: apply_correction must set segment.corrected_text
+        to the new corrected text AND segment.has_correction to True.
+
+        Verifying the specific attributes mutated on the segment object ensures
+        downstream consumers (display_text, SRT export) see the correct state.
+        """
+        segment = _make_segment(
+            text="original text",
+            corrected_text=None,
+            has_correction=False,
+        )
+        transcript = _make_transcript()
+        created_record = _make_correction_record()
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="corrected text",
+            correction_type=CorrectionType.SPELLING,
+        )
+
+        # Constitution §Cross-Feature: verify WHAT was set, not just that add() was called
+        assert segment.corrected_text == "corrected text", (
+            "segment.corrected_text must be set to the new corrected_text value"
+        )
+        assert segment.has_correction is True, (
+            "segment.has_correction must be set to True after apply_correction"
+        )
+
+    async def test_transcript_metadata_updated_has_corrections_and_count(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Constitution §Cross-Feature: apply_correction must set transcript.has_corrections=True,
+        increment transcript.correction_count, and set transcript.last_corrected_at to a
+        non-None datetime.
+
+        These three fields are read by history queries, the REST API, and the
+        frontend display — any missing mutation would silently break downstream consumers.
+        """
+        segment = _make_segment(text="original", corrected_text=None, has_correction=False)
+        transcript = _make_transcript(
+            has_corrections=False,
+            correction_count=0,
+            last_corrected_at=None,
+        )
+        # Capture the initial correction_count so we can verify it was incremented
+        initial_count = transcript.correction_count
+        created_record = _make_correction_record()
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+
+        # Constitution §Cross-Feature: verify all three required transcript fields
+        assert transcript.has_corrections is True, (
+            "transcript.has_corrections must be set to True after apply_correction"
+        )
+        assert transcript.correction_count == initial_count + 1, (
+            "transcript.correction_count must be incremented by 1"
+        )
+        assert transcript.last_corrected_at is not None, (
+            "transcript.last_corrected_at must be set to a datetime after apply_correction"
+        )
+
+    async def test_last_corrected_at_is_datetime(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        transcript.last_corrected_at must be set to a timezone-aware datetime,
+        not None and not a plain date or string.
+        """
+        segment = _make_segment(text="hello world", corrected_text=None, has_correction=False)
+        transcript = _make_transcript(last_corrected_at=None)
+        created_record = _make_correction_record()
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="hello, world",
+            correction_type=CorrectionType.FORMATTING,
+        )
+
+        assert isinstance(transcript.last_corrected_at, datetime), (
+            "transcript.last_corrected_at must be a datetime object"
+        )
+
+    async def test_raises_value_error_for_nonexistent_segment(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        apply_correction must raise ValueError when the segment does not exist.
+        The segment repo returns None to simulate a missing segment.
+        """
+        mock_segment_repo.get.return_value = None
+
+        with pytest.raises(ValueError, match="segment"):
+            await service.apply_correction(
+                mock_session,
+                video_id="dQw4w9WgXcQ",
+                language_code="en",
+                segment_id=999,
+                corrected_text="any text",
+                correction_type=CorrectionType.SPELLING,
+            )
+
+        # Ensure no audit record was created
+        mock_correction_repo.create.assert_not_called()
+
+    async def test_raises_value_error_for_identical_text_no_prior_correction(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        apply_correction must raise ValueError when corrected_text is identical
+        to the segment's current effective text (segment.text when has_correction=False).
+        This prevents no-op corrections from polluting the audit trail.
+        """
+        segment = _make_segment(
+            text="already correct",
+            corrected_text=None,
+            has_correction=False,
+        )
+        mock_segment_repo.get.return_value = segment
+
+        with pytest.raises(ValueError, match="identical|no-op|same|differ"):
+            await service.apply_correction(
+                mock_session,
+                video_id="dQw4w9WgXcQ",
+                language_code="en",
+                segment_id=1,
+                corrected_text="already correct",  # identical to segment.text
+                correction_type=CorrectionType.SPELLING,
+            )
+
+        mock_correction_repo.create.assert_not_called()
+
+    async def test_raises_value_error_for_identical_text_with_prior_correction(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When the segment has a prior correction, the effective text is
+        segment.corrected_text. apply_correction must raise ValueError if
+        the new corrected_text is identical to the current corrected_text.
+        """
+        segment = _make_segment(
+            text="original",
+            corrected_text="currently corrected",
+            has_correction=True,
+        )
+        mock_segment_repo.get.return_value = segment
+
+        with pytest.raises(ValueError, match="identical|no-op|same|differ"):
+            await service.apply_correction(
+                mock_session,
+                video_id="dQw4w9WgXcQ",
+                language_code="en",
+                segment_id=1,
+                corrected_text="currently corrected",  # same as corrected_text
+                correction_type=CorrectionType.SPELLING,
+            )
+
+        mock_correction_repo.create.assert_not_called()
+
+    async def test_corrected_by_user_id_passed_through(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The corrected_by_user_id argument must appear in the created
+        TranscriptCorrectionCreate object passed to correction_repo.create().
+        """
+        segment = _make_segment(text="original", corrected_text=None, has_correction=False)
+        transcript = _make_transcript()
+        created_record = _make_correction_record(corrected_by_user_id="api")
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="corrected",
+            correction_type=CorrectionType.SPELLING,
+            corrected_by_user_id="api",
+        )
+
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.corrected_by_user_id == "api", (
+            "corrected_by_user_id='api' must be forwarded to the audit record"
+        )
+
+    async def test_corrected_by_user_id_defaults_to_none(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When corrected_by_user_id is omitted, the audit record should
+        have corrected_by_user_id=None (anonymous/system correction).
+        """
+        segment = _make_segment(text="original", corrected_text=None, has_correction=False)
+        transcript = _make_transcript()
+        created_record = _make_correction_record(corrected_by_user_id=None)
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="corrected",
+            correction_type=CorrectionType.SPELLING,
+            # corrected_by_user_id omitted intentionally
+        )
+
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.corrected_by_user_id is None, (
+            "corrected_by_user_id must be None when not provided"
+        )
+
+    async def test_returns_created_correction(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        apply_correction must return the TranscriptCorrectionDB record
+        created by correction_repo.create(), not None or the segment.
+        """
+        segment = _make_segment(text="original", corrected_text=None, has_correction=False)
+        transcript = _make_transcript()
+        expected_record = _make_correction_record(version_number=1)
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = expected_record
+
+        result = await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+
+        assert result is expected_record, (
+            "apply_correction must return the TranscriptCorrectionDB record "
+            "returned by correction_repo.create()"
+        )
+
+    async def test_get_latest_version_called_with_correct_args(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        correction_repo.get_latest_version must be called with the session,
+        video_id, language_code, and segment_id to acquire the FOR UPDATE
+        lock and compute the next version_number (NFR-005).
+        """
+        segment = _make_segment(
+            segment_id=42,
+            text="foo",
+            corrected_text=None,
+            has_correction=False,
+            video_id="abcABC12345",
+            language_code="es",
+        )
+        transcript = _make_transcript(video_id="abcABC12345", language_code="es")
+        created_record = _make_correction_record()
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="abcABC12345",
+            language_code="es",
+            segment_id=42,
+            corrected_text="bar",
+            correction_type=CorrectionType.SPELLING,
+        )
+
+        mock_correction_repo.get_latest_version.assert_called_once()
+        call_args = mock_correction_repo.get_latest_version.call_args
+        # Verify the correct identifiers are forwarded for the FOR UPDATE lock
+        assert call_args.args[0] is mock_session or mock_session in call_args.args, (
+            "get_latest_version must receive the session"
+        )
+
+    async def test_correction_note_passed_through(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When correction_note is provided, it must appear in the created
+        TranscriptCorrectionCreate object.
+        """
+        segment = _make_segment(text="original", corrected_text=None, has_correction=False)
+        transcript = _make_transcript()
+        created_record = _make_correction_record()
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="corrected",
+            correction_type=CorrectionType.ASR_ERROR,
+            correction_note="ASR confused homophone 'teh' → 'the'",
+        )
+
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.correction_note == "ASR confused homophone 'teh' → 'the'", (
+            "correction_note must be forwarded to the audit record"
+        )
+
+    async def test_session_flush_called_for_each_mutation(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        Per FR-007a (flush-only pattern), the service must call session.flush()
+        after each of the three mutations (audit record, segment, transcript).
+        session.commit() must NEVER be called (caller owns transaction lifecycle).
+        """
+        segment = _make_segment(text="original", corrected_text=None, has_correction=False)
+        transcript = _make_transcript()
+        created_record = _make_correction_record()
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+
+        # Three flushes required: audit record + segment + transcript
+        assert mock_session.flush.call_count >= 1, (
+            "session.flush() must be called at least once per mutation step (FR-007a)"
+        )
+        # NEVER call commit — caller owns the transaction
+        mock_session.commit.assert_not_called()
+
+    async def test_correction_type_stored_correctly(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The correction_type argument must be forwarded to the TranscriptCorrectionCreate
+        object with the correct enum value.
+        """
+        segment = _make_segment(text="original", corrected_text=None, has_correction=False)
+        transcript = _make_transcript()
+        created_record = _make_correction_record(
+            correction_type=CorrectionType.CONTEXT_CORRECTION.value
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=1,
+            corrected_text="corrected",
+            correction_type=CorrectionType.CONTEXT_CORRECTION,
+        )
+
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.correction_type == CorrectionType.CONTEXT_CORRECTION, (
+            "correction_type must be forwarded to the audit record as-is"
+        )
+
+    async def test_video_id_and_language_code_in_audit_record(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The audit record must link back to the correct (video_id, language_code)
+        transcript pair. This is required for get_by_video() queries.
+        """
+        segment = _make_segment(
+            text="original",
+            corrected_text=None,
+            has_correction=False,
+            video_id="xyz123ABCDE",
+            language_code="fr",
+        )
+        transcript = _make_transcript(video_id="xyz123ABCDE", language_code="fr")
+        created_record = _make_correction_record(
+            video_id="xyz123ABCDE",
+            language_code="fr",
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="xyz123ABCDE",
+            language_code="fr",
+            segment_id=1,
+            corrected_text="corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.video_id == "xyz123ABCDE", (
+            "audit record must include the correct video_id"
+        )
+        assert obj_in.language_code == "fr", (
+            "audit record must include the correct language_code"
+        )
+
+    async def test_segment_id_in_audit_record(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The segment_id FK must be set on the audit record to allow
+        get_by_segment() queries to work correctly.
+        """
+        segment = _make_segment(
+            segment_id=77,
+            text="original",
+            corrected_text=None,
+            has_correction=False,
+        )
+        transcript = _make_transcript()
+        created_record = _make_correction_record(segment_id=77)
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_latest_version.return_value = 0
+        mock_correction_repo.create.return_value = created_record
+
+        await service.apply_correction(
+            mock_session,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+            segment_id=77,
+            corrected_text="corrected",
+            correction_type=CorrectionType.SPELLING,
+        )
+
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+        assert obj_in.segment_id == 77, (
+            "audit record must include the segment_id FK for history lookups"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestRevertCorrection
+# ---------------------------------------------------------------------------
+
+
+class TestRevertCorrection:
+    """
+    Tests for TranscriptCorrectionService.revert_correction.
+
+    Contract (service-contracts.md):
+    - Fetch V_N (latest audit record for segment by version_number)
+    - If V_N.version_number == 1: set corrected_text=None, has_correction=False
+    - If V_N.version_number > 1: set corrected_text=V_N.original_text, has_correction=True
+    - Create revert audit record: correction_type='revert',
+        original_text=V_N.corrected_text, corrected_text=V_N.original_text,
+        version_number=V_N.version_number+1
+    - If revert-to-original: decrement correction_count, recompute has_corrections
+    - If revert-to-prior: correction_count unchanged, has_corrections=True
+    - Always: update last_corrected_at=now() (FR-014c)
+    - Never call session.commit() (FR-007a)
+
+    Constitution §Cross-Feature Data Contract Verification:
+    Each test inspects the exact attributes mutated on segment and transcript,
+    and verifies the audit record fields that downstream history queries depend on.
+    """
+
+    async def test_revert_to_original_clears_corrected_text(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When a segment has exactly one correction (V_N.version_number == 1),
+        revert_correction must set segment.corrected_text = None and
+        segment.has_correction = False, restoring the segment to its original
+        uncorrected state.
+
+        Constitution §Cross-Feature: downstream consumers (display_text, SRT
+        export) rely on has_correction=False to skip corrected_text.
+        """
+        segment = _make_segment(
+            segment_id=1,
+            text="teh quick brown fox",
+            corrected_text="the quick brown fox",
+            has_correction=True,
+            video_id="dQw4w9WgXcQ",
+            language_code="en",
+        )
+        transcript = _make_transcript(
+            correction_count=1,
+            has_corrections=True,
+        )
+        # V_N: the only correction applied, version_number=1
+        v_n = _make_correction_record(
+            version_number=1,
+            original_text="teh quick brown fox",
+            corrected_text="the quick brown fox",
+        )
+        revert_record = _make_correction_record(
+            version_number=2,
+            original_text="the quick brown fox",
+            corrected_text="teh quick brown fox",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = revert_record
+        # Simulate EXISTS scan returning False (no other corrected segments)
+        _exists_result_mock = MagicMock()
+        _exists_result_mock.scalar_one.return_value = False
+        mock_session.execute.return_value = _exists_result_mock
+
+        await service.revert_correction(mock_session, segment_id=1)
+
+        # Constitution §Cross-Feature: verify WHAT was mutated on segment
+        assert segment.corrected_text is None, (
+            "After revert-to-original, segment.corrected_text must be None"
+        )
+        assert segment.has_correction is False, (
+            "After revert-to-original, segment.has_correction must be False"
+        )
+
+    async def test_revert_to_original_decrements_correction_count(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        FR-014a: When revert-to-original, transcript.correction_count must be
+        decremented by exactly 1.
+
+        Constitution §Cross-Feature: the correction_count field is read by the
+        REST API and frontend — an incorrect value would show stale data.
+        """
+        segment = _make_segment(
+            corrected_text="corrected",
+            has_correction=True,
+        )
+        transcript = _make_transcript(
+            correction_count=3,
+            has_corrections=True,
+        )
+        v_n = _make_correction_record(
+            version_number=1,
+            original_text="original",
+            corrected_text="corrected",
+        )
+        revert_record = _make_correction_record(
+            version_number=2,
+            original_text="corrected",
+            corrected_text="original",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = revert_record
+        _exists_result_mock = MagicMock()
+        _exists_result_mock.scalar_one.return_value = False
+        mock_session.execute.return_value = _exists_result_mock
+
+        await service.revert_correction(mock_session, segment_id=1)
+
+        assert transcript.correction_count == 2, (
+            "FR-014a: revert-to-original must decrement correction_count by 1 "
+            f"(was 3, expected 2, got {transcript.correction_count})"
+        )
+
+    async def test_revert_to_original_scans_has_corrections(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        FR-014b: When revert-to-original, transcript.has_corrections must be
+        recomputed by scanning other segments for remaining active corrections.
+
+        If no other segments have has_correction=True, has_corrections becomes False.
+        If another segment still has has_correction=True, has_corrections stays True.
+
+        Constitution §Cross-Feature: has_corrections is read by the history
+        query endpoint — stale True value would cause false positive "has corrections"
+        display on the frontend.
+        """
+        segment = _make_segment(
+            corrected_text="corrected",
+            has_correction=True,
+        )
+        transcript = _make_transcript(
+            correction_count=1,
+            has_corrections=True,  # was True before revert
+        )
+        v_n = _make_correction_record(
+            version_number=1,
+            original_text="original",
+            corrected_text="corrected",
+        )
+        revert_record = _make_correction_record(
+            version_number=2,
+            original_text="corrected",
+            corrected_text="original",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = revert_record
+        # EXISTS scan returns False — no other corrected segments remain
+        _exists_result_mock = MagicMock()
+        _exists_result_mock.scalar_one.return_value = False
+        mock_session.execute.return_value = _exists_result_mock
+
+        await service.revert_correction(mock_session, segment_id=1)
+
+        assert transcript.has_corrections is False, (
+            "FR-014b: has_corrections must be recomputed to False when no "
+            "other segments have active corrections after revert-to-original"
+        )
+
+    async def test_revert_to_original_has_corrections_remains_true_when_others_exist(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        FR-014b: When revert-to-original but OTHER segments still have active
+        corrections, transcript.has_corrections must remain True after the scan.
+        """
+        segment = _make_segment(
+            corrected_text="corrected",
+            has_correction=True,
+        )
+        transcript = _make_transcript(
+            correction_count=2,
+            has_corrections=True,
+        )
+        v_n = _make_correction_record(
+            version_number=1,
+            original_text="original",
+            corrected_text="corrected",
+        )
+        revert_record = _make_correction_record(
+            version_number=2,
+            original_text="corrected",
+            corrected_text="original",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = revert_record
+        # EXISTS scan returns True — another segment still has a correction
+        _exists_result_mock = MagicMock()
+        _exists_result_mock.scalar_one.return_value = True
+        mock_session.execute.return_value = _exists_result_mock
+
+        await service.revert_correction(mock_session, segment_id=1)
+
+        assert transcript.has_corrections is True, (
+            "FR-014b: has_corrections must remain True when other segments "
+            "still have active corrections after revert-to-original"
+        )
+
+    async def test_revert_to_prior_version(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When a segment has multiple corrections (V_N.version_number > 1),
+        revert_correction must set segment.corrected_text = V_N.original_text
+        and segment.has_correction remains True (the segment is still corrected,
+        just to an earlier version).
+
+        Constitution §Cross-Feature: downstream SRT export reads corrected_text
+        when has_correction=True — it must reflect the prior-version text.
+        """
+        segment = _make_segment(
+            text="teh lazy dog",              # original raw text
+            corrected_text="The lazy dog.",   # currently at v2 state
+            has_correction=True,
+        )
+        transcript = _make_transcript(
+            correction_count=2,
+            has_corrections=True,
+        )
+        # V_N is version 2: original_text = "the lazy dog" (v1 text), corrected = "The lazy dog."
+        v_n = _make_correction_record(
+            version_number=2,
+            original_text="the lazy dog",
+            corrected_text="The lazy dog.",
+        )
+        revert_record = _make_correction_record(
+            version_number=3,
+            original_text="The lazy dog.",
+            corrected_text="the lazy dog",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = revert_record
+
+        await service.revert_correction(mock_session, segment_id=1)
+
+        assert segment.corrected_text == "the lazy dog", (
+            "Revert-to-prior must set segment.corrected_text = V_N.original_text"
+        )
+        assert segment.has_correction is True, (
+            "Revert-to-prior must leave segment.has_correction=True "
+            "(segment is still corrected, just to the prior version)"
+        )
+
+    async def test_revert_to_prior_version_count_unchanged(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        FR-014a: When revert-to-prior-version, transcript.correction_count must
+        NOT be changed — the segment is still corrected, just to an earlier version.
+
+        Constitution §Cross-Feature: changing correction_count here would cause
+        the API to show incorrect correction statistics.
+        """
+        segment = _make_segment(
+            corrected_text="The lazy dog.",
+            has_correction=True,
+        )
+        transcript = _make_transcript(
+            correction_count=4,
+            has_corrections=True,
+        )
+        v_n = _make_correction_record(
+            version_number=2,
+            original_text="the lazy dog",
+            corrected_text="The lazy dog.",
+        )
+        revert_record = _make_correction_record(
+            version_number=3,
+            original_text="The lazy dog.",
+            corrected_text="the lazy dog",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = revert_record
+
+        await service.revert_correction(mock_session, segment_id=1)
+
+        assert transcript.correction_count == 4, (
+            "FR-014a: revert-to-prior must NOT change correction_count "
+            f"(expected 4, got {transcript.correction_count})"
+        )
+
+    async def test_revert_audit_record_fields(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        The revert audit record must have:
+        - correction_type = CorrectionType.REVERT
+        - version_number = V_N.version_number + 1
+        - original_text = V_N.corrected_text (state before revert)
+        - corrected_text = V_N.original_text (state restored to)
+
+        Constitution §Cross-Feature: these fields are the inputs for any
+        future re-apply or further-revert operations. Incorrect values break
+        the full version chain.
+        """
+        segment = _make_segment(
+            corrected_text="the quick brown fox",
+            has_correction=True,
+        )
+        transcript = _make_transcript(correction_count=1, has_corrections=True)
+        v_n = _make_correction_record(
+            version_number=1,
+            original_text="teh quick brown fox",
+            corrected_text="the quick brown fox",
+        )
+        revert_record = _make_correction_record(
+            version_number=2,
+            original_text="the quick brown fox",
+            corrected_text="teh quick brown fox",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = revert_record
+        _exists_result_mock = MagicMock()
+        _exists_result_mock.scalar_one.return_value = False
+        mock_session.execute.return_value = _exists_result_mock
+
+        await service.revert_correction(mock_session, segment_id=1)
+
+        # Verify the create call had the correct revert audit record fields
+        mock_correction_repo.create.assert_called_once()
+        call_kwargs = mock_correction_repo.create.call_args
+        obj_in: TranscriptCorrectionCreate = call_kwargs.kwargs["obj_in"]
+
+        assert obj_in.correction_type == CorrectionType.REVERT, (
+            "Revert audit record must have correction_type=CorrectionType.REVERT"
+        )
+        assert obj_in.version_number == 2, (
+            f"Revert audit record must have version_number=V_N.version_number+1 "
+            f"(V_N.version_number=1, expected 2, got {obj_in.version_number})"
+        )
+        assert obj_in.original_text == "the quick brown fox", (
+            "Revert audit original_text must be V_N.corrected_text "
+            "(the state the segment had BEFORE this revert)"
+        )
+        assert obj_in.corrected_text == "teh quick brown fox", (
+            "Revert audit corrected_text must be V_N.original_text "
+            "(the state the segment is being RESTORED to)"
+        )
+
+    async def test_raises_value_error_no_corrections(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        revert_correction must raise ValueError when the segment has
+        has_correction=False — there is nothing to revert.
+
+        No audit record should be created.
+        """
+        segment = _make_segment(
+            corrected_text=None,
+            has_correction=False,  # no active correction
+        )
+
+        mock_segment_repo.get.return_value = segment
+
+        with pytest.raises(ValueError, match="has_correction|correction|revert"):
+            await service.revert_correction(mock_session, segment_id=1)
+
+        mock_correction_repo.create.assert_not_called()
+
+    async def test_raises_value_error_segment_not_found(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        revert_correction must raise ValueError when the segment_id does not
+        exist in the database. No audit record should be created.
+        """
+        mock_segment_repo.get.return_value = None
+
+        with pytest.raises(ValueError, match="segment"):
+            await service.revert_correction(mock_session, segment_id=999)
+
+        mock_correction_repo.create.assert_not_called()
+
+    async def test_double_revert_fully_reverted(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        EC-DOUBLE-REVERT: After the first revert restores a segment to its
+        original uncorrected state (has_correction=False), a second call to
+        revert_correction on the same segment must raise ValueError.
+
+        The service checks segment state (has_correction), not audit history.
+        An already-reverted-to-original segment must not allow further reverts.
+        """
+        # Simulate the segment state AFTER a revert-to-original has already run
+        segment = _make_segment(
+            corrected_text=None,
+            has_correction=False,  # first revert already cleared this
+        )
+
+        mock_segment_repo.get.return_value = segment
+
+        with pytest.raises(ValueError, match="has_correction|correction|revert"):
+            await service.revert_correction(mock_session, segment_id=1)
+
+        mock_correction_repo.create.assert_not_called()
+
+    async def test_last_corrected_at_updated(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        FR-014c: revert_correction must set transcript.last_corrected_at to a
+        current timezone-aware datetime. A revert is always a correction event.
+
+        Constitution §Cross-Feature: last_corrected_at is displayed in the
+        transcript history view and must never be stale after any correction
+        or revert operation.
+        """
+        segment = _make_segment(
+            corrected_text="corrected",
+            has_correction=True,
+        )
+        transcript = _make_transcript(
+            correction_count=1,
+            has_corrections=True,
+            last_corrected_at=None,  # Start with no timestamp
+        )
+        v_n = _make_correction_record(
+            version_number=1,
+            original_text="original",
+            corrected_text="corrected",
+        )
+        revert_record = _make_correction_record(
+            version_number=2,
+            original_text="corrected",
+            corrected_text="original",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = revert_record
+        _exists_result_mock = MagicMock()
+        _exists_result_mock.scalar_one.return_value = False
+        mock_session.execute.return_value = _exists_result_mock
+
+        await service.revert_correction(mock_session, segment_id=1)
+
+        assert isinstance(transcript.last_corrected_at, datetime), (
+            "FR-014c: transcript.last_corrected_at must be set to a datetime "
+            "after revert_correction"
+        )
+        assert transcript.last_corrected_at.tzinfo is not None, (
+            "FR-014c: transcript.last_corrected_at must be timezone-aware"
+        )
+
+    async def test_session_flush_called_not_commit(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        FR-007a: revert_correction must call session.flush() for each mutation
+        step (audit record, segment, transcript) and must NEVER call
+        session.commit() — the caller owns the transaction lifecycle.
+
+        This is the same flush-only pattern enforced throughout the service.
+        """
+        segment = _make_segment(
+            corrected_text="corrected",
+            has_correction=True,
+        )
+        transcript = _make_transcript(
+            correction_count=1,
+            has_corrections=True,
+        )
+        v_n = _make_correction_record(
+            version_number=1,
+            original_text="original",
+            corrected_text="corrected",
+        )
+        revert_record = _make_correction_record(
+            version_number=2,
+            original_text="corrected",
+            corrected_text="original",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = revert_record
+        _exists_result_mock = MagicMock()
+        _exists_result_mock.scalar_one.return_value = False
+        mock_session.execute.return_value = _exists_result_mock
+
+        await service.revert_correction(mock_session, segment_id=1)
+
+        # At least one flush must be called for each mutation step
+        assert mock_session.flush.call_count >= 1, (
+            "FR-007a: session.flush() must be called at least once "
+            "(audit record + segment + transcript mutations)"
+        )
+        # NEVER commit — caller owns the transaction
+        mock_session.commit.assert_not_called()
+
+    async def test_returns_revert_audit_record(
+        self,
+        service: Any,
+        mock_correction_repo: AsyncMock,
+        mock_segment_repo: AsyncMock,
+        mock_transcript_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        revert_correction must return the TranscriptCorrectionDB record
+        created for the revert operation, not None or the segment.
+        """
+        segment = _make_segment(
+            corrected_text="corrected",
+            has_correction=True,
+        )
+        transcript = _make_transcript(
+            correction_count=1,
+            has_corrections=True,
+        )
+        v_n = _make_correction_record(
+            version_number=1,
+            original_text="original",
+            corrected_text="corrected",
+        )
+        expected_revert_record = _make_correction_record(
+            version_number=2,
+            original_text="corrected",
+            corrected_text="original",
+            correction_type=CorrectionType.REVERT.value,
+        )
+
+        mock_segment_repo.get.return_value = segment
+        mock_transcript_repo.get.return_value = transcript
+        mock_correction_repo.get_by_segment.return_value = [v_n]
+        mock_correction_repo.create.return_value = expected_revert_record
+        _exists_result_mock = MagicMock()
+        _exists_result_mock.scalar_one.return_value = False
+        mock_session.execute.return_value = _exists_result_mock
+
+        result = await service.revert_correction(mock_session, segment_id=1)
+
+        assert result is expected_revert_record, (
+            "revert_correction must return the TranscriptCorrectionDB record "
+            "returned by correction_repo.create()"
+        )

--- a/tests/unit/services/test_transcript_service.py
+++ b/tests/unit/services/test_transcript_service.py
@@ -1162,3 +1162,241 @@ class TestResolveLanguageCode:
         service._resolve_language_code("en-XX")  # Unknown English variant
         # Should not log a warning since it's English-like
         mock_logger.warning.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# US-5 / FR-015 / FR-016 — Re-download protection for corrected segments
+# ---------------------------------------------------------------------------
+
+
+class _FakeSegment:
+    """Minimal in-memory stand-in for a TranscriptSegment ORM object."""
+
+    def __init__(
+        self,
+        *,
+        id: int = 1,
+        text: str = "original raw text",
+        corrected_text: Optional[str] = None,
+        has_correction: bool = False,
+    ) -> None:
+        self.id = id
+        self.text = text
+        self.corrected_text = corrected_text
+        self.has_correction = has_correction
+
+
+class TestUpdateSegmentTextRedownloadProtection:
+    """
+    Tests for TranscriptService._update_segment_text (US-5, FR-015, FR-016).
+
+    These tests use a lightweight fake segment object to avoid any database
+    dependency.  The helper method operates purely on Python attributes.
+    """
+
+    @pytest.fixture
+    def service(self) -> TranscriptService:
+        """Return a TranscriptService with mock fallback enabled (no real API)."""
+        return TranscriptService(enable_mock_fallback=True)
+
+    # ------------------------------------------------------------------
+    # Scenario: segment has a correction, force_overwrite=False (default)
+    # ------------------------------------------------------------------
+
+    def test_corrected_segment_preserves_corrected_text(
+        self, service: TranscriptService
+    ) -> None:
+        """
+        FR-015: When has_correction=True and force_overwrite=False, a re-download
+        MUST NOT touch corrected_text.
+        """
+        segment = _FakeSegment(
+            id=42,
+            text="old raw text",
+            corrected_text="human-corrected text",
+            has_correction=True,
+        )
+
+        service._update_segment_text(segment, "new raw text from re-download")
+
+        # corrected_text must be untouched
+        assert segment.corrected_text == "human-corrected text"
+
+    def test_corrected_segment_raw_text_updated(
+        self, service: TranscriptService
+    ) -> None:
+        """
+        FR-015: Even when correction protection is active, segment.text (the raw
+        column) MUST be updated with the fresh downloaded text.
+        """
+        segment = _FakeSegment(
+            id=7,
+            text="old raw text",
+            corrected_text="human-corrected text",
+            has_correction=True,
+        )
+
+        service._update_segment_text(segment, "new raw text from re-download")
+
+        assert segment.text == "new raw text from re-download"
+
+    @patch("chronovista.services.transcript_service.logger")
+    def test_corrected_segment_logs_warning(
+        self, mock_logger: MagicMock, service: TranscriptService
+    ) -> None:
+        """
+        FR-016: A WARNING must be logged about divergence when a corrected
+        segment's raw text is updated during re-download.
+        """
+        segment = _FakeSegment(
+            id=99,
+            text="stale raw",
+            corrected_text="the correction",
+            has_correction=True,
+        )
+
+        service._update_segment_text(segment, "fresh raw text")
+
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "corrected_text preserved" in warning_msg
+
+    # ------------------------------------------------------------------
+    # Scenario: segment has a correction, force_overwrite=True
+    # ------------------------------------------------------------------
+
+    def test_force_overwrite_bypasses_protection(
+        self, service: TranscriptService
+    ) -> None:
+        """
+        US-5 AC-3: With force_overwrite=True, corrected_text is cleared and
+        has_correction is reset to False.
+        """
+        segment = _FakeSegment(
+            id=5,
+            text="old raw",
+            corrected_text="a correction that should be wiped",
+            has_correction=True,
+        )
+
+        service._update_segment_text(
+            segment, "overwritten raw text", force_overwrite=True
+        )
+
+        assert segment.text == "overwritten raw text"
+        assert segment.corrected_text is None
+        assert segment.has_correction is False
+
+    @patch("chronovista.services.transcript_service.logger")
+    def test_force_overwrite_logs_info_not_warning(
+        self, mock_logger: MagicMock, service: TranscriptService
+    ) -> None:
+        """
+        When force_overwrite=True, an INFO is logged (not a WARNING), and no
+        warning about divergence should appear.
+        """
+        segment = _FakeSegment(
+            id=3,
+            text="old",
+            corrected_text="correction",
+            has_correction=True,
+        )
+
+        service._update_segment_text(segment, "new", force_overwrite=True)
+
+        mock_logger.info.assert_called_once()
+        mock_logger.warning.assert_not_called()
+        info_msg = mock_logger.info.call_args[0][0]
+        assert "force-overwrite" in info_msg
+
+    # ------------------------------------------------------------------
+    # Scenario: segment has NO correction (happy path)
+    # ------------------------------------------------------------------
+
+    def test_uncorrected_segment_updates_normally(
+        self, service: TranscriptService
+    ) -> None:
+        """
+        US-5 AC-4: A segment with has_correction=False is updated without any
+        special handling.
+        """
+        segment = _FakeSegment(
+            id=10,
+            text="old raw text",
+            corrected_text=None,
+            has_correction=False,
+        )
+
+        service._update_segment_text(segment, "new raw text")
+
+        assert segment.text == "new raw text"
+        assert segment.corrected_text is None
+        assert segment.has_correction is False
+
+    @patch("chronovista.services.transcript_service.logger")
+    def test_uncorrected_segment_no_log_emitted(
+        self, mock_logger: MagicMock, service: TranscriptService
+    ) -> None:
+        """No warnings or info messages should be emitted for uncorrected segments."""
+        segment = _FakeSegment(has_correction=False)
+
+        service._update_segment_text(segment, "anything")
+
+        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # EC-FORCE-OVERWRITE-AUDIT: metadata recomputation after force-overwrite
+    # ------------------------------------------------------------------
+
+    def test_force_overwrite_recomputes_metadata(
+        self, service: TranscriptService
+    ) -> None:
+        """
+        EC-FORCE-OVERWRITE-AUDIT: After a force overwrite clears a segment's
+        correction, the caller must be able to recompute has_corrections /
+        correction_count by scanning remaining segments.
+
+        This test verifies the contract: after _update_segment_text with
+        force_overwrite=True, the segment's has_correction is False, so a
+        simple scan of all segments can correctly determine whether the parent
+        transcript still has active corrections.
+        """
+        # Two corrected segments
+        seg_a = _FakeSegment(id=1, text="raw a", corrected_text="fix a", has_correction=True)
+        seg_b = _FakeSegment(id=2, text="raw b", corrected_text="fix b", has_correction=True)
+
+        # Force-overwrite only segment A
+        service._update_segment_text(seg_a, "new raw a", force_overwrite=True)
+
+        # Simulate caller recomputing transcript metadata after all segments are processed
+        all_segments = [seg_a, seg_b]
+        recomputed_has_corrections = any(s.has_correction for s in all_segments)
+        recomputed_correction_count = sum(1 for s in all_segments if s.has_correction)
+
+        # seg_a is cleared; seg_b still has its correction
+        assert seg_a.has_correction is False
+        assert seg_b.has_correction is True
+        assert recomputed_has_corrections is True
+        assert recomputed_correction_count == 1
+
+    def test_force_overwrite_all_segments_clears_transcript_corrections(
+        self, service: TranscriptService
+    ) -> None:
+        """
+        EC-FORCE-OVERWRITE-AUDIT: When ALL corrected segments are force-
+        overwritten, recomputed has_corrections must be False and
+        correction_count must be 0.
+        """
+        seg_a = _FakeSegment(id=1, text="raw a", corrected_text="fix a", has_correction=True)
+        seg_b = _FakeSegment(id=2, text="raw b", corrected_text="fix b", has_correction=True)
+
+        service._update_segment_text(seg_a, "new a", force_overwrite=True)
+        service._update_segment_text(seg_b, "new b", force_overwrite=True)
+
+        all_segments = [seg_a, seg_b]
+        recomputed_has_corrections = any(s.has_correction for s in all_segments)
+        recomputed_correction_count = sum(1 for s in all_segments if s.has_correction)
+
+        assert recomputed_has_corrections is False
+        assert recomputed_correction_count == 0


### PR DESCRIPTION
## Summary

- Add append-only `transcript_corrections` audit table with UUIDv7 PKs, composite FK to `video_transcripts`, version chains, and `CorrectionType` enum (spelling, profanity_fix, context_correction, formatting, asr_error, revert)
- Implement `TranscriptCorrectionService` with `apply_correction()` and `revert_correction()` methods using flush-only transaction pattern (caller owns transaction lifecycle)
- Add re-download protection: corrected segments preserve `corrected_text` during transcript sync with `--force-overwrite` bypass
- Enforce append-only immutability via `NotImplementedError` on `update()`/`delete()` in `TranscriptCorrectionRepository`
- Add cross-feature contract integration tests verifying `display_text` property, search ILIKE on `corrected_text`, SRT export, and API responses after mutations

**ADR-005 Increment 3** — This feature provides the foundation for Increment 4 (Correction Submission API Endpoint).

## What's Included

### Database
- Alembic migration: `transcript_corrections` table with CHECK constraint (`version_number >= 1`), composite FK with RESTRICT, two indexes
- 3 new columns on `video_transcripts`: `has_corrections`, `last_corrected_at`, `correction_count`
- Migration fully reversible (downgrade drops table and removes columns)

### Domain Layer
- `CorrectionType` enum (6 values) in `models/enums.py`
- Pydantic V2 models: `TranscriptCorrectionBase`, `TranscriptCorrectionCreate`, `TranscriptCorrectionRead`
- `TranscriptCorrectionDB` ORM model with relationships to `VideoTranscriptDB` and `TranscriptSegmentDB`

### Repository
- `TranscriptCorrectionRepository` extending `BaseSQLAlchemyRepository`
- `get_by_segment()` (version DESC), `get_by_video()` (paginated), `count_by_video()`, `get_latest_version()` (FOR UPDATE row lock)
- Immutability guards: `update()` and `delete()` raise `NotImplementedError`

### Service
- `apply_correction()` — atomic: audit record + segment update + transcript metadata update
- `revert_correction()` — revert-to-original (V==1) or revert-to-prior (V>1) with EXISTS scan for `has_corrections`
- All mutations use `session.flush()` only (FR-007a)

### Re-Download Protection (US5)
- Transcript sync checks `has_correction` before overwriting
- `--force-overwrite` flag bypasses protection and recomputes metadata

## Test plan

- [x] 34 unit tests for Pydantic models (field types, enum enforcement, hypothesis strategies)
- [x] 44 unit tests for repository (CRUD, immutability guards, pagination, FOR UPDATE lock)
- [x] 31 unit tests for correction service (apply, revert, version chain, error cases)
- [x] 9 unit tests for transcript service re-download protection
- [x] 21 integration tests with real DB (apply/revert flows, cross-feature contracts)
- [x] Cross-feature contract tests: display_text after mutations, search ILIKE, SRT export, API responses
- [x] Hypothesis property-based tests for CorrectionType exhaustiveness, text edge cases, version chain integrity
- [x] 97-100% coverage on all new source files
- [x] mypy strict compliance (0 errors)
- [x] 5,632 total tests passing, 0 regressions