### PR TITLE
feat(entities): add entity CLI commands and enhance classify with description and auto-case flags (Feature 037)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [0.40.0] - 2026-03-06
+
+### Added
+
+#### Feature 037: Entity Classify Improvements (#69)
+
+Standalone named entity management CLI and improvements to the `classify` command. Adds 3 new `chronovista entities` commands for creating, listing, and backfilling entity descriptions independently of canonical tags. Enhances `classify` with `--description` flag and auto-title-case for entity-producing types. CLI only — no frontend changes, no new API endpoints, no database migrations.
+
+**3 New CLI Commands (`chronovista entities`):**
+
+| Command | Description |
+|---------|-------------|
+| `entities create <name> --type <type>` | Create a standalone named entity with aliases, description, auto-title-case, and duplicate detection |
+| `entities list` | Browse named entities in a Rich table with type, search, and limit filters |
+| `entities backfill-descriptions` | Copy classify `--reason` text into entity descriptions for entities with NULL descriptions |
+
+**Entity Create (Issue #69):**
+- Takes a canonical name and `--type` (person, organization, place, event, work, technical_term)
+- Normalizes the name via `TagNormalizationService.normalize()` for duplicate detection
+- Auto-title-cases the canonical name for entity-producing types
+- `--description` option for a human-readable entity description
+- `--alias` option (repeatable) to add additional name variants as `entity_aliases` rows
+- Creates canonical name as an alias (same pattern as `classify`)
+- Validates against `_ENTITY_PRODUCING_TYPES` — rejects topic/descriptor (tag-only types)
+- Duplicate detection: same normalized name + entity type → error
+
+**Entity List:**
+- Rich table with columns: ID (truncated), Name, Type, Description (truncated), Aliases count, Created date
+- `--type` filter restricts to a specific entity type
+- `--search` / `-q` case-insensitive canonical name search
+- `--limit` / `-l` caps results (default: 50)
+- Footer shows "Showing N of M total entities"
+
+**Backfill Descriptions:**
+- Queries `tag_operation_logs` for classify operations (operation_type='create') with a reason
+- Joins against `named_entities` where description IS NULL
+- `--dry-run` shows a preview table (Entity ID, Name, Reason) without writing
+- Normal mode updates entities and commits
+
+**Classify Improvements (Issues #60, #62):**
+- `--description` flag populates `named_entities.description` directly during classification (falls back to `--reason` when `--description` is not provided)
+- Auto-title-case: `canonical_form` is automatically title-cased for entity-producing types (person, organization, place, event, work, technical_term); `--no-auto-case` flag opts out
+- Auto-title-case prevents future lowercase person entity names caused by YouTube creators never capitalizing a tag
+
+**New Source File (1):**
+
+| File | Description |
+|------|-------------|
+| `cli/entity_commands.py` | 3 Typer commands registered as `entities` sub-app: create, list, backfill-descriptions |
+
+**Modified Files (3):**
+- `cli/main.py` — Registered `entity_app` as `entities` sub-app
+- `cli/tag_commands.py` — Added `--description` and `--no-auto-case` flags to `classify` command
+- `services/tag_management.py` — Added `description` and `auto_case` parameters to `classify()` method
+
+### Fixed
+- 4 lowercase person entity names (Camila Escalante, Dena Takruri, Lara Sheehi, Margaret Kimberley) corrected via one-time `INITCAP()` update across `canonical_tags`, `named_entities`, and `entity_aliases` tables — root cause: no YouTube creator ever title-cased those tags, so canonical form election selected lowercase
+
+### Technical
+- 42 new tests: 29 integration (entity CLI), 6 integration (tag management CLI), 7 unit (tag management service)
+- mypy strict compliance (0 errors)
+- No new dependencies, no database migrations (uses Feature 028a tables)
+
 ## [0.39.0] - 2026-03-05
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.40.0] - 2026-03-06
+
+### Added
+- **Feature 037: Entity Classify Improvements (#69)**
+  - New `chronovista entities` sub-app with 3 CLI commands for standalone named entity management
+  - `entities create <name> --type <type>` — create a standalone named entity (not linked to a canonical tag) with auto-title-case, name normalization, duplicate detection, `--description`, and `--alias` (repeatable) for additional name variants
+  - `entities list` — browse named entities in a Rich table with `--type`, `--search`, `--limit` filters showing ID, name, type, description, alias count, and created date
+  - `entities backfill-descriptions` — copy `classify --reason` text from `tag_operation_logs` into `named_entities.description` for entities with NULL descriptions, with `--dry-run` preview
+  - `classify --description` flag to directly populate `named_entities.description` during entity classification (falls back to `--reason` when not provided)
+  - Auto-title-case for `canonical_form` on entity-producing types during `classify` (person, organization, place, event, work, technical_term); `--no-auto-case` flag to opt out
+
+### Fixed
+- 4 lowercase person entity names (Camila Escalante, Dena Takruri, Lara Sheehi, Margaret Kimberley) corrected via one-time INITCAP update across `canonical_tags`, `named_entities`, and `entity_aliases` tables
+
+### Technical
+- 42 new tests (29 entity CLI + 6 tag management CLI + 7 tag management service)
+- mypy strict compliance (0 errors)
+- No new dependencies, no database migrations (uses Feature 028a tables)
+
 ## [0.39.0] - 2026-03-05
 
 ### Added

--- a/docs/user-guide/cli-overview.md
+++ b/docs/user-guide/cli-overview.md
@@ -191,6 +191,18 @@ chronovista recover [COMMAND]
 
 Video recovery also attempts to recover the associated channel's metadata when the channel is unavailable. In batch mode (`--all`), the summary report includes channel recovery statistics showing how many channels were attempted, recovered, and which fields were restored.
 
+### Entity Commands
+
+```bash
+chronovista entities [COMMAND]
+```
+
+| Command | Description |
+|---------|-------------|
+| `create` | Create a standalone named entity with aliases |
+| `list` | Browse named entities in a Rich table |
+| `backfill-descriptions` | Copy classify reason text into entity descriptions |
+
 ### Corrections Commands
 
 ```bash
@@ -724,12 +736,20 @@ With `--top N`, displays the N highest-video_count unclassified canonical tags f
 - `--top <n>` - Show top N unclassified tags by video count
 - `--force` - Reclassify an already-classified tag
 - `--reason <text>` - Reason for the classification (max 1000 chars)
+- `--description <text>` - Description for the named entity (falls back to --reason if omitted)
+- `--no-auto-case` - Disable auto-title-casing of canonical form for entity-producing types
 
 **Examples:**
 
 ```bash
 # Classify as a person (creates named entity + entity aliases)
 chronovista tags classify "aaron mate" --type person --reason "journalist, The Grayzone"
+
+# Classify with a separate description (falls back to --reason if omitted)
+chronovista tags classify "noam chomsky" --type person --description "Linguist and political commentator" --reason "MIT linguistics professor"
+
+# Disable auto-title-casing of canonical form
+chronovista tags classify "iPhone" --type technical_term --no-auto-case
 
 # Classify as a topic (no entity record created)
 chronovista tags classify "politics" --type topic --reason "general subject area"
@@ -832,6 +852,97 @@ chronovista tags undo 019c9d80-8242-70c0-88ed-537e3acd6bc4
 - For merge undo: aliases are reassigned back, source tags restored to `active`
 - For split undo: aliases moved back, created canonical tag deleted
 - For classify undo: entity_type cleared; created entity/aliases deleted (only if `discovery_method='user_created'`)
+
+### Named Entity Management
+
+#### Create Entity
+
+```bash
+chronovista entities create <NAME> --type <TYPE> [OPTIONS]
+```
+
+Creates a standalone named entity (not linked to an existing canonical tag). The name is auto-title-cased and normalized for duplicate detection.
+
+**Arguments:**
+
+- `NAME` - Canonical name for the entity (e.g., "Noam Chomsky")
+
+**Options:**
+
+- `--type <type>` - Entity type (required): `person`, `organization`, `place`, `event`, `work`, `technical_term`
+- `--description <text>` - Human-readable description of the entity
+- `--alias <name>` - Additional alias name (repeatable for multiple aliases)
+
+**Examples:**
+
+```bash
+# Create a person entity with aliases
+chronovista entities create "Edward Snowden" --type person --description "NSA whistleblower" --alias "Ed Snowden" --alias "Snowden"
+
+# Create an organization
+chronovista entities create "Electronic Frontier Foundation" --type organization --alias "EFF"
+
+# Create a place
+chronovista entities create "Gaza Strip" --type place --description "Palestinian territory"
+```
+
+**Notes:**
+
+- Only entity-producing types are allowed (topic and descriptor are tag-only types — use `tags classify` instead)
+- Duplicate detection: same normalized name + entity type → error
+- The canonical name alias is automatically created (same pattern as `tags classify`)
+
+#### List Entities
+
+```bash
+chronovista entities list [OPTIONS]
+```
+
+Lists named entities in a Rich table with columns: ID, Name, Type, Description, Alias count, Created date.
+
+**Options:**
+
+- `--type <type>` - Filter by entity type
+- `--search, -q <text>` - Search by canonical name (case-insensitive)
+- `--limit, -l <n>` - Maximum entities to show (default: 50)
+
+**Examples:**
+
+```bash
+# List all entities
+chronovista entities list
+
+# Filter by type
+chronovista entities list --type person
+
+# Search by name
+chronovista entities list --search "chomsky"
+
+# Combine filters
+chronovista entities list --type organization --limit 20
+```
+
+#### Backfill Descriptions
+
+```bash
+chronovista entities backfill-descriptions [OPTIONS]
+```
+
+Copies `classify --reason` text from `tag_operation_logs` into `named_entities.description` for entities that have NULL descriptions. Useful for retroactively populating descriptions from existing classify operations.
+
+**Options:**
+
+- `--dry-run` - Preview which entities would be updated without writing
+
+**Examples:**
+
+```bash
+# Preview what would be backfilled
+chronovista entities backfill-descriptions --dry-run
+
+# Apply the backfill
+chronovista entities backfill-descriptions
+```
 
 ### Playlist Management
 
@@ -1384,6 +1495,26 @@ curl http://localhost:8765/api/v1/videos?limit=10
 
 # 4. View interactive docs
 open http://localhost:8765/docs
+```
+
+### Entity Management
+
+```bash
+# Create a standalone entity with aliases
+chronovista entities create "Noam Chomsky" --type person --description "Linguist and political commentator" --alias "Chomsky"
+
+# List all person entities
+chronovista entities list --type person
+
+# Search entities by name
+chronovista entities list --search "chomsky"
+
+# Backfill descriptions from classify --reason text
+chronovista entities backfill-descriptions --dry-run
+chronovista entities backfill-descriptions
+
+# Classify a tag as an entity (creates entity + aliases from tag)
+chronovista tags classify "aaron mate" --type person --description "Journalist, The Grayzone" --reason "The Grayzone reporter"
 ```
 
 ### Batch Transcript Corrections

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.39.0"
+version = "0.40.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.39.0"
+__version__ = "0.40.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/cli/entity_commands.py
+++ b/src/chronovista/cli/entity_commands.py
@@ -1,0 +1,473 @@
+"""
+Entity CLI commands for chronovista.
+
+Commands for creating and browsing named entities. Entities represent
+real-world people, organizations, places, events, and other typed objects
+discovered from or associated with video tags.
+
+Feature 037 — Entity Classify Improvements (#69)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from sqlalchemy import func, select, update
+
+from chronovista.config.database import db_manager
+from chronovista.db.models import EntityAlias as EntityAliasDB
+from chronovista.db.models import NamedEntity as NamedEntityDB
+from chronovista.db.models import TagOperationLog as TagOperationLogDB
+from chronovista.models.enums import (
+    DiscoveryMethod,
+    EntityAliasType,
+    EntityType,
+)
+from chronovista.models.entity_alias import EntityAliasCreate
+from chronovista.models.named_entity import NamedEntityCreate
+from chronovista.repositories.entity_alias_repository import EntityAliasRepository
+from chronovista.repositories.named_entity_repository import NamedEntityRepository
+from chronovista.services.tag_normalization import TagNormalizationService
+
+logger = logging.getLogger(__name__)
+
+console = Console()
+
+entity_app = typer.Typer(
+    name="entities",
+    help="Named entity management",
+    no_args_is_help=True,
+)
+
+# Entity types that are valid for standalone entity creation.
+# "topic" and "descriptor" are tag-only types, not entity types.
+_ENTITY_PRODUCING_TYPES = {
+    "person",
+    "organization",
+    "place",
+    "event",
+    "work",
+    "technical_term",
+}
+
+
+@entity_app.command("create")
+def create_entity(
+    name: str = typer.Argument(
+        ..., help="Canonical name for the entity (e.g., 'Noam Chomsky')."
+    ),
+    type_str: str = typer.Option(
+        ...,
+        "--type",
+        help=(
+            "Entity type. Valid values: person, organization, place, "
+            "event, work, technical_term."
+        ),
+    ),
+    description: Optional[str] = typer.Option(
+        None,
+        "--description",
+        help="Human-readable description of the entity.",
+    ),
+    alias: Optional[List[str]] = typer.Option(
+        None,
+        "--alias",
+        help="Additional alias name (repeatable).",
+    ),
+) -> None:
+    """Create a standalone named entity (not linked to an existing canonical tag)."""
+
+    async def _run() -> None:
+        # Validate entity type
+        if type_str not in _ENTITY_PRODUCING_TYPES:
+            console.print(
+                Panel(
+                    f"[red]Entity type '{type_str}' is not valid for entities.[/red]\n"
+                    "Only entity-producing types are allowed: "
+                    "person, organization, place, event, work, technical_term",
+                    title="Invalid Type",
+                    border_style="red",
+                )
+            )
+            raise typer.Exit(code=1)
+
+        try:
+            entity_type = EntityType(type_str)
+        except ValueError:
+            valid_types = ", ".join(t.value for t in EntityType)
+            console.print(
+                Panel(
+                    f"[red]Invalid entity type '{type_str}'. "
+                    f"Valid values: {valid_types}[/red]",
+                    title="Invalid --type",
+                    border_style="red",
+                )
+            )
+            raise typer.Exit(code=1)
+
+        # Normalize the name
+        normalizer = TagNormalizationService()
+        normalized_name = normalizer.normalize(name)
+
+        if normalized_name is None:
+            console.print(
+                Panel(
+                    "[red]Name normalizes to empty string. "
+                    "Please provide a valid entity name.[/red]",
+                    title="Invalid Name",
+                    border_style="red",
+                )
+            )
+            raise typer.Exit(code=1)
+
+        # Auto-title-case canonical name for entity-producing types
+        canonical_name = name.title() if not name.istitle() else name
+
+        entity_repo = NamedEntityRepository()
+        alias_repo = EntityAliasRepository()
+
+        async for session in db_manager.get_session(echo=False):
+            # Check for duplicate: same normalized name + entity type
+            existing = await session.execute(
+                select(NamedEntityDB).where(
+                    NamedEntityDB.canonical_name_normalized == normalized_name,
+                    NamedEntityDB.entity_type == entity_type.value,
+                )
+            )
+            if existing.scalar_one_or_none() is not None:
+                console.print(
+                    Panel(
+                        f"[red]A named entity with normalized name "
+                        f"'{normalized_name}' and type '{entity_type.value}' "
+                        f"already exists.[/red]",
+                        title="Duplicate Entity",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=1)
+
+            # Create the named entity
+            entity_create = NamedEntityCreate(
+                canonical_name=canonical_name,
+                canonical_name_normalized=normalized_name,
+                entity_type=entity_type,
+                description=description,
+                discovery_method=DiscoveryMethod.USER_CREATED,
+                confidence=1.0,
+            )
+            new_entity = await entity_repo.create(
+                session, obj_in=entity_create
+            )
+
+            # Create canonical name as an alias (same pattern as classify)
+            canonical_alias_create = EntityAliasCreate(
+                entity_id=new_entity.id,
+                alias_name=canonical_name,
+                alias_name_normalized=normalized_name,
+                alias_type=EntityAliasType.NAME_VARIANT,
+                occurrence_count=0,
+            )
+            await alias_repo.create(session, obj_in=canonical_alias_create)
+
+            alias_count = 1  # canonical name alias
+
+            # Create additional aliases
+            if alias:
+                for alias_text in alias:
+                    normalized_alias = normalizer.normalize(alias_text)
+                    if normalized_alias is None:
+                        console.print(
+                            f"[yellow]Skipping alias '{alias_text}' "
+                            f"(normalizes to empty).[/yellow]"
+                        )
+                        continue
+
+                    alias_create = EntityAliasCreate(
+                        entity_id=new_entity.id,
+                        alias_name=alias_text,
+                        alias_name_normalized=normalized_alias,
+                        alias_type=EntityAliasType.NAME_VARIANT,
+                        occurrence_count=0,
+                    )
+                    await alias_repo.create(session, obj_in=alias_create)
+                    alias_count += 1
+
+            await session.commit()
+
+            # Display result
+            details = (
+                f"[bold]ID:[/bold] {new_entity.id}\n"
+                f"[bold]Name:[/bold] {new_entity.canonical_name}\n"
+                f"[bold]Type:[/bold] {new_entity.entity_type}\n"
+                f"[bold]Description:[/bold] "
+                f"{new_entity.description or '(none)'}\n"
+                f"[bold]Aliases:[/bold] {alias_count}"
+            )
+
+            console.print(
+                Panel(
+                    details,
+                    title="[green]Entity Created[/green]",
+                    border_style="green",
+                )
+            )
+
+    asyncio.run(_run())
+
+
+@entity_app.command("list")
+def list_entities(
+    type_str: Optional[str] = typer.Option(
+        None,
+        "--type",
+        help="Filter by entity type.",
+    ),
+    limit: int = typer.Option(
+        50, "--limit", "-l", help="Maximum number of entities to show."
+    ),
+    search: Optional[str] = typer.Option(
+        None,
+        "--search",
+        "-q",
+        help="Search by canonical name (case-insensitive).",
+    ),
+) -> None:
+    """List named entities in a table."""
+
+    async def _run() -> None:
+        # Validate entity type filter if provided
+        parsed_type: Optional[EntityType] = None
+        if type_str is not None:
+            try:
+                parsed_type = EntityType(type_str)
+            except ValueError:
+                valid_types = ", ".join(t.value for t in EntityType)
+                console.print(
+                    Panel(
+                        f"[red]Invalid entity type '{type_str}'. "
+                        f"Valid values: {valid_types}[/red]",
+                        title="Invalid --type",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=1)
+
+        async for session in db_manager.get_session(echo=False):
+            # Build query
+            query = select(NamedEntityDB).where(
+                NamedEntityDB.status == "active"
+            )
+
+            if parsed_type is not None:
+                query = query.where(
+                    NamedEntityDB.entity_type == parsed_type.value
+                )
+
+            if search is not None:
+                query = query.where(
+                    NamedEntityDB.canonical_name.ilike(f"%{search}%")
+                )
+
+            query = query.order_by(NamedEntityDB.canonical_name.asc())
+            query = query.limit(limit)
+
+            result = await session.execute(query)
+            entities = list(result.scalars().all())
+
+            # Total count query
+            count_query = select(func.count(NamedEntityDB.id)).where(
+                NamedEntityDB.status == "active"
+            )
+            if parsed_type is not None:
+                count_query = count_query.where(
+                    NamedEntityDB.entity_type == parsed_type.value
+                )
+            if search is not None:
+                count_query = count_query.where(
+                    NamedEntityDB.canonical_name.ilike(f"%{search}%")
+                )
+            total_result = await session.execute(count_query)
+            total_count = total_result.scalar() or 0
+
+            if not entities:
+                console.print(
+                    Panel(
+                        "[yellow]No entities found matching the criteria.[/yellow]",
+                        title="No Entities",
+                        border_style="yellow",
+                    )
+                )
+                return
+
+            # Build table
+            entity_table = Table(
+                title="Named Entities",
+                show_header=True,
+                header_style="bold blue",
+            )
+            entity_table.add_column("ID", style="dim", width=10)
+            entity_table.add_column("Name", style="cyan", width=30)
+            entity_table.add_column("Type", style="magenta", width=16)
+            entity_table.add_column("Description", style="white", width=50)
+            entity_table.add_column("Aliases", style="green", width=8)
+            entity_table.add_column("Created", style="dim", width=12)
+
+            for entity in entities:
+                # Get alias count
+                alias_count_result = await session.execute(
+                    select(func.count(EntityAliasDB.id)).where(
+                        EntityAliasDB.entity_id == entity.id
+                    )
+                )
+                alias_count = alias_count_result.scalar() or 0
+
+                # Truncate values for display
+                short_id = str(entity.id)[:8]
+                desc = entity.description or ""
+                short_desc = (desc[:47] + "...") if len(desc) > 50 else desc
+                created = (
+                    entity.created_at.strftime("%Y-%m-%d")
+                    if entity.created_at
+                    else ""
+                )
+
+                entity_table.add_row(
+                    short_id,
+                    entity.canonical_name,
+                    entity.entity_type,
+                    short_desc,
+                    str(alias_count),
+                    created,
+                )
+
+            console.print(entity_table)
+            console.print(
+                f"\nShowing {len(entities)} of {total_count} total entities"
+            )
+
+    asyncio.run(_run())
+
+
+@entity_app.command("backfill-descriptions")
+def backfill_descriptions(
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        is_flag=True,
+        help="Preview which entities would be updated without writing.",
+    ),
+) -> None:
+    """Copy classify --reason text into named_entities.description for entities with NULL descriptions."""
+
+    async def _run() -> None:
+        import uuid as uuid_mod
+
+        async for session in db_manager.get_session(echo=False):
+            # Find classify operations (operation_type='create') with a reason,
+            # where the created entity still has description = NULL.
+            # rollback_data->'created_entity_id' holds the entity UUID string.
+            query = (
+                select(
+                    TagOperationLogDB.reason,
+                    TagOperationLogDB.rollback_data["created_entity_id"].as_string().label(
+                        "entity_id_str"
+                    ),
+                )
+                .where(
+                    TagOperationLogDB.operation_type == "create",
+                    TagOperationLogDB.reason.isnot(None),
+                    TagOperationLogDB.rolled_back.is_(False),
+                    TagOperationLogDB.rollback_data["created_entity_id"].isnot(None),
+                )
+                .order_by(TagOperationLogDB.performed_at.asc())
+            )
+            result = await session.execute(query)
+            rows = list(result.all())
+
+            if not rows:
+                console.print(
+                    Panel(
+                        "[yellow]No classify operations with reasons found.[/yellow]",
+                        title="Nothing to Backfill",
+                        border_style="yellow",
+                    )
+                )
+                return
+
+            updated = 0
+            skipped = 0
+
+            if dry_run:
+                preview_table = Table(
+                    title="Backfill Preview (dry run)",
+                    show_header=True,
+                    header_style="bold blue",
+                )
+                preview_table.add_column("Entity ID", style="dim", width=10)
+                preview_table.add_column("Name", style="cyan", width=30)
+                preview_table.add_column("Reason", style="white", width=50)
+
+            for row in rows:
+                entity_id_str = row.entity_id_str
+                reason = row.reason
+
+                if not entity_id_str or entity_id_str == "null":
+                    skipped += 1
+                    continue
+
+                try:
+                    entity_id = uuid_mod.UUID(entity_id_str)
+                except ValueError:
+                    skipped += 1
+                    continue
+
+                # Check if entity exists and has NULL description
+                entity_result = await session.execute(
+                    select(NamedEntityDB).where(
+                        NamedEntityDB.id == entity_id,
+                        NamedEntityDB.description.is_(None),
+                    )
+                )
+                entity = entity_result.scalar_one_or_none()
+
+                if entity is None:
+                    skipped += 1
+                    continue
+
+                if dry_run:
+                    preview_table.add_row(
+                        str(entity.id)[:8],
+                        entity.canonical_name,
+                        reason[:50] if reason else "",
+                    )
+                else:
+                    entity.description = reason
+                    session.add(entity)
+
+                updated += 1
+
+            if dry_run:
+                console.print(preview_table)
+                console.print(
+                    f"\n[bold]Dry run:[/bold] {updated} entities would be updated, "
+                    f"{skipped} skipped"
+                )
+            else:
+                await session.commit()
+                console.print(
+                    Panel(
+                        f"[bold]Updated:[/bold] {updated} entities\n"
+                        f"[bold]Skipped:[/bold] {skipped} (already has description, "
+                        f"entity not found, or invalid ID)",
+                        title="[green]Backfill Complete[/green]",
+                        border_style="green",
+                    )
+                )
+
+    asyncio.run(_run())

--- a/src/chronovista/cli/main.py
+++ b/src/chronovista/cli/main.py
@@ -12,6 +12,7 @@ from chronovista import __version__
 from chronovista.cli.auth_commands import auth_app
 from chronovista.cli.category_commands import category_app
 from chronovista.cli.correction_commands import correction_app
+from chronovista.cli.entity_commands import entity_app
 from chronovista.cli.commands.api import api_app
 from chronovista.cli.commands.cache import app as cache_app
 from chronovista.cli.commands.enrich import app as enrich_app
@@ -44,6 +45,7 @@ app.add_typer(
 app.add_typer(
     correction_app, name="corrections", help="🔧 Batch transcript correction tools"
 )
+app.add_typer(entity_app, name="entities", help="🧑 Named entity management")
 app.add_typer(enrich_app, name="enrich", help="🔄 Enrich video metadata from YouTube API")
 app.add_typer(language_app, name="languages", help="🌐 Manage language preferences for transcripts")
 app.add_typer(playlist_app, name="playlist", help="📋 Playlist management commands")

--- a/src/chronovista/cli/tag_commands.py
+++ b/src/chronovista/cli/tag_commands.py
@@ -1099,6 +1099,18 @@ def classify_tag(
         callback=_reason_callback,
         help="Reason for the classification (max 1000 chars).",
     ),
+    description: Optional[str] = typer.Option(
+        None,
+        "--description",
+        help="Entity description (e.g., 'Mexican journalist'). "
+        "Falls back to --reason if not provided.",
+    ),
+    no_auto_case: bool = typer.Option(
+        False,
+        "--no-auto-case",
+        is_flag=True,
+        help="Skip auto-title-casing of the canonical form.",
+    ),
 ) -> None:
     """Classify a canonical tag with an entity type, or list top unclassified tags."""
 
@@ -1213,6 +1225,8 @@ def classify_tag(
                         entity_type=parsed_type,
                         force=force,
                         reason=reason,
+                        description=description,
+                        auto_case=not no_auto_case,
                     )
                     await session.commit()
 

--- a/src/chronovista/services/tag_management.py
+++ b/src/chronovista/services/tag_management.py
@@ -832,6 +832,8 @@ class TagManagementService:
         *,
         force: bool = False,
         reason: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_case: bool = True,
     ) -> ClassifyResult:
         """
         Classify a canonical tag with an entity type.
@@ -853,6 +855,11 @@ class TagManagementService:
             If True, override existing classification.
         reason : Optional[str]
             Human-readable reason for the classification.
+        description : Optional[str]
+            Entity description. If not provided, falls back to reason.
+        auto_case : bool
+            If True (default), auto-title-case the canonical form for
+            entity-producing types when it is not already title-cased.
 
         Returns
         -------
@@ -923,6 +930,11 @@ class TagManagementService:
         entity_created = False
 
         if entity_type in entity_producing_types:
+            # 3b. Auto-title-case for entity-producing types
+            if auto_case and not tag.canonical_form.istitle():
+                tag.canonical_form = tag.canonical_form.title()
+                session.add(tag)
+
             # 4. Check if a named_entity already exists with same name and type
             existing_entity_result = await session.execute(
                 select(NamedEntityDB).where(
@@ -940,10 +952,12 @@ class TagManagementService:
                 linked_existing_entity_id = existing_entity.id
             else:
                 # Create new NamedEntity
+                entity_description = description or reason
                 entity_create = NamedEntityCreate(
                     canonical_name=tag.canonical_form,
                     canonical_name_normalized=tag.normalized_form,
                     entity_type=entity_type,
+                    description=entity_description,
                     discovery_method=DiscoveryMethod.USER_CREATED,
                     confidence=1.0,
                 )

--- a/tests/integration/cli/test_entity_commands.py
+++ b/tests/integration/cli/test_entity_commands.py
@@ -1,0 +1,884 @@
+"""
+Integration tests for Entity CLI commands (Feature 037).
+
+Covers `entities create` and `entities list` commands.
+
+These tests mock the database layer, NamedEntityRepository, and
+EntityAliasRepository to verify:
+- Correct CLI argument parsing and option handling
+- Rich output contains expected human-readable strings
+- Exit codes for success (0), validation failure (1), and usage error (2)
+- Duplicate detection via session.execute scalar_one_or_none
+- Alias creation count (canonical alias + additional aliases)
+
+NOTE: The CLI commands use asyncio.run() internally. Tests remain synchronous
+and mock db_manager.get_session so no real database connection is needed.
+Pattern mirrors tests/integration/cli/test_tag_management_commands.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from typer.testing import CliRunner
+
+from chronovista.cli.main import app
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_OP_ID = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+
+def _make_get_session(mock_session: AsyncMock) -> Any:
+    """
+    Return an async generator factory that yields *mock_session* once,
+    matching the signature of db_manager.get_session(echo=False).
+    """
+
+    async def _gen(echo: bool = False) -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    return _gen()
+
+
+def _make_mock_entity(
+    name: str = "Noam Chomsky",
+    entity_type: str = "person",
+    description: str | None = None,
+    entity_id: uuid.UUID | None = None,
+) -> MagicMock:
+    """Build a MagicMock that looks like a NamedEntity ORM row."""
+    entity = MagicMock()
+    entity.id = entity_id or uuid.uuid4()
+    entity.canonical_name = name
+    entity.entity_type = entity_type
+    entity.description = description
+    entity.created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    entity.status = "active"
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# Create entity command tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateEntityCommand:
+    """Integration tests for `chronovista entities create`."""
+
+    def test_create_entity_person_exit_code_zero(self) -> None:
+        """Creating a person entity successfully returns exit code 0."""
+        mock_entity = _make_mock_entity()
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.NamedEntityRepository"
+            ) as MockEntityRepo,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            # Duplicate check returns None (no existing entity)
+            mock_execute_result = MagicMock()
+            mock_execute_result.scalar_one_or_none.return_value = None
+            mock_session.execute.return_value = mock_execute_result
+
+            mock_entity_repo = AsyncMock()
+            mock_entity_repo.create.return_value = mock_entity
+            MockEntityRepo.return_value = mock_entity_repo
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app, ["entities", "create", "Noam Chomsky", "--type", "person"]
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_create_entity_output_shows_entity_created(self) -> None:
+        """Output contains 'Entity Created', entity name, type, and ID."""
+        entity_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        mock_entity = _make_mock_entity(entity_id=entity_id)
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.NamedEntityRepository"
+            ) as MockEntityRepo,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_execute_result = MagicMock()
+            mock_execute_result.scalar_one_or_none.return_value = None
+            mock_session.execute.return_value = mock_execute_result
+
+            mock_entity_repo = AsyncMock()
+            mock_entity_repo.create.return_value = mock_entity
+            MockEntityRepo.return_value = mock_entity_repo
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app, ["entities", "create", "Noam Chomsky", "--type", "person"]
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Entity Created" in result.output
+        assert "Noam Chomsky" in result.output
+        assert "person" in result.output
+        assert str(entity_id) in result.output
+
+    def test_create_entity_with_description(self) -> None:
+        """--description is accepted and command still exits 0."""
+        mock_entity = _make_mock_entity(description="American linguist")
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.NamedEntityRepository"
+            ) as MockEntityRepo,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_execute_result = MagicMock()
+            mock_execute_result.scalar_one_or_none.return_value = None
+            mock_session.execute.return_value = mock_execute_result
+
+            mock_entity_repo = AsyncMock()
+            mock_entity_repo.create.return_value = mock_entity
+            MockEntityRepo.return_value = mock_entity_repo
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app,
+                [
+                    "entities",
+                    "create",
+                    "Noam Chomsky",
+                    "--type",
+                    "person",
+                    "--description",
+                    "American linguist",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        # Verify the description was passed to the repo create call
+        create_call_kwargs = mock_entity_repo.create.call_args[1]
+        obj_in = create_call_kwargs["obj_in"]
+        assert obj_in.description == "American linguist"
+
+    def test_create_entity_with_aliases_calls_alias_repo_three_times(self) -> None:
+        """--alias creates the canonical alias plus each additional alias (3 total)."""
+        mock_entity = _make_mock_entity()
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.NamedEntityRepository"
+            ) as MockEntityRepo,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_execute_result = MagicMock()
+            mock_execute_result.scalar_one_or_none.return_value = None
+            mock_session.execute.return_value = mock_execute_result
+
+            mock_entity_repo = AsyncMock()
+            mock_entity_repo.create.return_value = mock_entity
+            MockEntityRepo.return_value = mock_entity_repo
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app,
+                [
+                    "entities",
+                    "create",
+                    "Noam Chomsky",
+                    "--type",
+                    "person",
+                    "--alias",
+                    "N. Chomsky",
+                    "--alias",
+                    "Avram Noam Chomsky",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        # 1 canonical alias + 2 additional aliases = 3 alias repo create calls
+        assert mock_alias_repo.create.call_count == 3
+
+    def test_create_entity_duplicate_exits_code_1(self) -> None:
+        """When a duplicate entity exists (same normalized name + type), exit code is 1."""
+        existing_entity = _make_mock_entity()
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch("chronovista.cli.entity_commands.NamedEntityRepository"),
+            patch("chronovista.cli.entity_commands.EntityAliasRepository"),
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            # Duplicate check returns an existing entity
+            mock_execute_result = MagicMock()
+            mock_execute_result.scalar_one_or_none.return_value = existing_entity
+            mock_session.execute.return_value = mock_execute_result
+
+            result = runner.invoke(
+                app, ["entities", "create", "Noam Chomsky", "--type", "person"]
+            )
+
+        assert result.exit_code == 1, f"Output: {result.output}"
+        assert "Duplicate Entity" in result.output
+
+    def test_create_entity_invalid_type_topic_exits_code_1(self) -> None:
+        """--type topic is rejected as not valid for entity creation (exit code 1)."""
+        result = runner.invoke(
+            app, ["entities", "create", "Machine Learning", "--type", "topic"]
+        )
+
+        assert result.exit_code == 1, f"Output: {result.output}"
+        assert "Invalid Type" in result.output
+
+    def test_create_entity_invalid_type_descriptor_exits_code_1(self) -> None:
+        """--type descriptor is rejected as not valid for entity creation (exit code 1)."""
+        result = runner.invoke(
+            app, ["entities", "create", "Interesting", "--type", "descriptor"]
+        )
+
+        assert result.exit_code == 1, f"Output: {result.output}"
+        assert "Invalid Type" in result.output
+
+    def test_create_entity_auto_title_cases_name(self) -> None:
+        """Lowercase input name is title-cased when passed to NamedEntityCreate."""
+        mock_entity = _make_mock_entity(name="Noam Chomsky")
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.NamedEntityRepository"
+            ) as MockEntityRepo,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_execute_result = MagicMock()
+            mock_execute_result.scalar_one_or_none.return_value = None
+            mock_session.execute.return_value = mock_execute_result
+
+            mock_entity_repo = AsyncMock()
+            mock_entity_repo.create.return_value = mock_entity
+            MockEntityRepo.return_value = mock_entity_repo
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app,
+                ["entities", "create", "noam chomsky", "--type", "person"],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        create_call_kwargs = mock_entity_repo.create.call_args[1]
+        obj_in = create_call_kwargs["obj_in"]
+        # "noam chomsky".title() == "Noam Chomsky"
+        assert obj_in.canonical_name == "Noam Chomsky"
+
+    def test_create_entity_empty_normalized_name_exits_code_1(self) -> None:
+        """Name that normalizes to empty (e.g. '###') exits with code 1."""
+        result = runner.invoke(
+            app, ["entities", "create", "###", "--type", "person"]
+        )
+
+        assert result.exit_code == 1, f"Output: {result.output}"
+        assert "Invalid Name" in result.output
+
+    def test_create_entity_missing_type_flag_exits_nonzero(self) -> None:
+        """Missing required --type option exits with a non-zero code."""
+        result = runner.invoke(app, ["entities", "create", "Noam Chomsky"])
+
+        assert result.exit_code != 0
+
+    def test_create_entity_organization_type_accepted(self) -> None:
+        """--type organization is a valid entity-producing type and exits 0."""
+        mock_entity = _make_mock_entity(name="MIT", entity_type="organization")
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.NamedEntityRepository"
+            ) as MockEntityRepo,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_execute_result = MagicMock()
+            mock_execute_result.scalar_one_or_none.return_value = None
+            mock_session.execute.return_value = mock_execute_result
+
+            mock_entity_repo = AsyncMock()
+            mock_entity_repo.create.return_value = mock_entity
+            MockEntityRepo.return_value = mock_entity_repo
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app, ["entities", "create", "MIT", "--type", "organization"]
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_create_entity_output_shows_description_when_set(self) -> None:
+        """Output shows the entity description when it is not None."""
+        mock_entity = _make_mock_entity(description="American linguist and philosopher")
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.NamedEntityRepository"
+            ) as MockEntityRepo,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_execute_result = MagicMock()
+            mock_execute_result.scalar_one_or_none.return_value = None
+            mock_session.execute.return_value = mock_execute_result
+
+            mock_entity_repo = AsyncMock()
+            mock_entity_repo.create.return_value = mock_entity
+            MockEntityRepo.return_value = mock_entity_repo
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app,
+                [
+                    "entities",
+                    "create",
+                    "Noam Chomsky",
+                    "--type",
+                    "person",
+                    "--description",
+                    "American linguist and philosopher",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "American linguist and philosopher" in result.output
+
+    def test_create_entity_output_shows_none_for_missing_description(self) -> None:
+        """Output shows '(none)' when entity has no description."""
+        mock_entity = _make_mock_entity(description=None)
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.NamedEntityRepository"
+            ) as MockEntityRepo,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_execute_result = MagicMock()
+            mock_execute_result.scalar_one_or_none.return_value = None
+            mock_session.execute.return_value = mock_execute_result
+
+            mock_entity_repo = AsyncMock()
+            mock_entity_repo.create.return_value = mock_entity
+            MockEntityRepo.return_value = mock_entity_repo
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app, ["entities", "create", "Noam Chomsky", "--type", "person"]
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "(none)" in result.output
+
+    def test_create_entity_help_flag(self) -> None:
+        """--help shows usage text and exits 0."""
+        result = runner.invoke(app, ["entities", "create", "--help"])
+
+        assert result.exit_code == 0
+        assert "--type" in result.output
+        assert "--description" in result.output
+        assert "--alias" in result.output
+
+
+# ---------------------------------------------------------------------------
+# List entities command tests
+# ---------------------------------------------------------------------------
+
+
+class TestListEntitiesCommand:
+    """Integration tests for `chronovista entities list`."""
+
+    def test_list_entities_exit_code_zero(self) -> None:
+        """Listing entities when some exist returns exit code 0."""
+        mock_entity = _make_mock_entity()
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            # Call 1: main query returns entities
+            entities_result = MagicMock()
+            entities_result.scalars.return_value.all.return_value = [mock_entity]
+
+            # Call 2: count query
+            count_result = MagicMock()
+            count_result.scalar.return_value = 1
+
+            # Call 3: alias count per entity
+            alias_count_result = MagicMock()
+            alias_count_result.scalar.return_value = 2
+
+            mock_session.execute.side_effect = [
+                entities_result,
+                count_result,
+                alias_count_result,
+            ]
+
+            result = runner.invoke(app, ["entities", "list"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_list_entities_shows_table_with_entity_names(self) -> None:
+        """Listing 2 entities shows a 'Named Entities' table with their names."""
+        entity1 = _make_mock_entity(name="Noam Chomsky")
+        entity2 = _make_mock_entity(name="Edward Said", entity_type="person")
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entities_result = MagicMock()
+            entities_result.scalars.return_value.all.return_value = [entity1, entity2]
+
+            count_result = MagicMock()
+            count_result.scalar.return_value = 2
+
+            # Two alias count queries (one per entity)
+            alias_count_1 = MagicMock()
+            alias_count_1.scalar.return_value = 2
+            alias_count_2 = MagicMock()
+            alias_count_2.scalar.return_value = 1
+
+            mock_session.execute.side_effect = [
+                entities_result,
+                count_result,
+                alias_count_1,
+                alias_count_2,
+            ]
+
+            result = runner.invoke(app, ["entities", "list"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Named Entities" in result.output
+        assert "Noam Chomsky" in result.output
+        assert "Edward Said" in result.output
+
+    def test_list_entities_empty_shows_no_entities_panel(self) -> None:
+        """When no entities match the criteria, 'No Entities' panel is shown."""
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entities_result = MagicMock()
+            entities_result.scalars.return_value.all.return_value = []
+
+            count_result = MagicMock()
+            count_result.scalar.return_value = 0
+
+            mock_session.execute.side_effect = [entities_result, count_result]
+
+            result = runner.invoke(app, ["entities", "list"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "No Entities" in result.output
+
+    def test_list_entities_with_type_filter_exits_code_zero(self) -> None:
+        """--type person filter is accepted and returns exit code 0."""
+        mock_entity = _make_mock_entity()
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entities_result = MagicMock()
+            entities_result.scalars.return_value.all.return_value = [mock_entity]
+
+            count_result = MagicMock()
+            count_result.scalar.return_value = 1
+
+            alias_count_result = MagicMock()
+            alias_count_result.scalar.return_value = 1
+
+            mock_session.execute.side_effect = [
+                entities_result,
+                count_result,
+                alias_count_result,
+            ]
+
+            result = runner.invoke(app, ["entities", "list", "--type", "person"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_list_entities_with_search_exits_code_zero(self) -> None:
+        """--search chomsky filter is accepted and returns exit code 0."""
+        mock_entity = _make_mock_entity()
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entities_result = MagicMock()
+            entities_result.scalars.return_value.all.return_value = [mock_entity]
+
+            count_result = MagicMock()
+            count_result.scalar.return_value = 1
+
+            alias_count_result = MagicMock()
+            alias_count_result.scalar.return_value = 1
+
+            mock_session.execute.side_effect = [
+                entities_result,
+                count_result,
+                alias_count_result,
+            ]
+
+            result = runner.invoke(app, ["entities", "list", "--search", "chomsky"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_list_entities_invalid_type_exits_code_1(self) -> None:
+        """--type with an invalid enum value exits with code 1."""
+        result = runner.invoke(app, ["entities", "list", "--type", "invalid_type"])
+
+        assert result.exit_code == 1, f"Output: {result.output}"
+        assert "Invalid --type" in result.output
+
+    def test_list_entities_shows_count_footer(self) -> None:
+        """Output contains 'Showing N of M total entities' footer."""
+        mock_entity = _make_mock_entity()
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entities_result = MagicMock()
+            entities_result.scalars.return_value.all.return_value = [mock_entity]
+
+            count_result = MagicMock()
+            count_result.scalar.return_value = 42
+
+            alias_count_result = MagicMock()
+            alias_count_result.scalar.return_value = 3
+
+            mock_session.execute.side_effect = [
+                entities_result,
+                count_result,
+                alias_count_result,
+            ]
+
+            result = runner.invoke(app, ["entities", "list"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        # Footer: "Showing 1 of 42 total entities"
+        assert "Showing" in result.output
+        assert "total entities" in result.output
+        assert "42" in result.output
+
+    def test_list_entities_alias_count_query_is_executed_per_entity(self) -> None:
+        """The command issues an alias count query for each entity row returned.
+
+        Note: Rich truncates the Aliases column header and cell to '…' in the
+        narrow terminal width that CliRunner provides, so we verify the behaviour
+        by asserting that session.execute was called three times total:
+        main query + count query + one alias-count query per entity.
+        """
+        mock_entity = _make_mock_entity()
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entities_result = MagicMock()
+            entities_result.scalars.return_value.all.return_value = [mock_entity]
+
+            count_result = MagicMock()
+            count_result.scalar.return_value = 1
+
+            alias_count_result = MagicMock()
+            alias_count_result.scalar.return_value = 5
+
+            mock_session.execute.side_effect = [
+                entities_result,
+                count_result,
+                alias_count_result,
+            ]
+
+            result = runner.invoke(app, ["entities", "list"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Named Entities" in result.output
+        # 3 execute calls: main query + count query + 1 alias-count per entity
+        assert mock_session.execute.call_count == 3
+
+    def test_list_entities_with_limit_option(self) -> None:
+        """--limit option is accepted and returns exit code 0."""
+        mock_entity = _make_mock_entity()
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entities_result = MagicMock()
+            entities_result.scalars.return_value.all.return_value = [mock_entity]
+
+            count_result = MagicMock()
+            count_result.scalar.return_value = 1
+
+            alias_count_result = MagicMock()
+            alias_count_result.scalar.return_value = 1
+
+            mock_session.execute.side_effect = [
+                entities_result,
+                count_result,
+                alias_count_result,
+            ]
+
+            result = runner.invoke(app, ["entities", "list", "--limit", "10"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+    def test_list_entities_help_flag(self) -> None:
+        """--help shows usage text and exits 0."""
+        result = runner.invoke(app, ["entities", "list", "--help"])
+
+        assert result.exit_code == 0
+        assert "--type" in result.output
+        assert "--search" in result.output
+        assert "--limit" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Backfill descriptions command tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillDescriptionsCommand:
+    """Integration tests for `chronovista entities backfill-descriptions`.
+
+    The backfill command makes multiple session.execute() calls:
+    - First call: main query returning TagOperationLog rows (uses .all())
+    - Subsequent calls: one per row to look up the NamedEntity (uses .scalar_one_or_none())
+
+    We therefore use side_effect on mock_session.execute to drive each call
+    independently, exactly as the command issues them.
+    """
+
+    def test_backfill_dry_run_shows_preview(self) -> None:
+        """--dry-run with matching entities shows a preview table and 'would be updated'."""
+        # Build two mock log rows
+        mock_row_1 = MagicMock()
+        mock_row_1.entity_id_str = "12345678-1234-5678-1234-567812345678"
+        mock_row_1.reason = "British journalist"
+
+        mock_row_2 = MagicMock()
+        mock_row_2.entity_id_str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        mock_row_2.reason = "American linguist"
+
+        # Main query result: .all() returns both rows
+        main_result = MagicMock()
+        main_result.all.return_value = [mock_row_1, mock_row_2]
+
+        # Entity lookup results for each row
+        mock_entity_1 = MagicMock()
+        mock_entity_1.id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        mock_entity_1.canonical_name = "Vanessa Beeley"
+        mock_entity_1.description = None
+
+        entity_result_1 = MagicMock()
+        entity_result_1.scalar_one_or_none.return_value = mock_entity_1
+
+        mock_entity_2 = MagicMock()
+        mock_entity_2.id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        mock_entity_2.canonical_name = "Noam Chomsky"
+        mock_entity_2.description = None
+
+        entity_result_2 = MagicMock()
+        entity_result_2.scalar_one_or_none.return_value = mock_entity_2
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            # First execute = main query, second and third = per-row entity lookups
+            mock_session.execute.side_effect = [
+                main_result,
+                entity_result_1,
+                entity_result_2,
+            ]
+
+            result = runner.invoke(
+                app, ["entities", "backfill-descriptions", "--dry-run"]
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Backfill Preview" in result.output
+        assert "would be updated" in result.output
+
+    def test_backfill_applies_descriptions(self) -> None:
+        """Without --dry-run, entities are updated and commit is called."""
+        mock_row_1 = MagicMock()
+        mock_row_1.entity_id_str = "12345678-1234-5678-1234-567812345678"
+        mock_row_1.reason = "British journalist"
+
+        mock_row_2 = MagicMock()
+        mock_row_2.entity_id_str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        mock_row_2.reason = "American linguist"
+
+        main_result = MagicMock()
+        main_result.all.return_value = [mock_row_1, mock_row_2]
+
+        mock_entity_1 = MagicMock()
+        mock_entity_1.id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        mock_entity_1.canonical_name = "Vanessa Beeley"
+        mock_entity_1.description = None
+
+        entity_result_1 = MagicMock()
+        entity_result_1.scalar_one_or_none.return_value = mock_entity_1
+
+        mock_entity_2 = MagicMock()
+        mock_entity_2.id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        mock_entity_2.canonical_name = "Noam Chomsky"
+        mock_entity_2.description = None
+
+        entity_result_2 = MagicMock()
+        entity_result_2.scalar_one_or_none.return_value = mock_entity_2
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_session.execute.side_effect = [
+                main_result,
+                entity_result_1,
+                entity_result_2,
+            ]
+
+            result = runner.invoke(app, ["entities", "backfill-descriptions"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Backfill Complete" in result.output
+        assert "Updated" in result.output
+        mock_session.commit.assert_called_once()
+
+    def test_backfill_no_operations_found(self) -> None:
+        """When the main query returns no rows, 'Nothing to Backfill' panel is shown."""
+        main_result = MagicMock()
+        main_result.all.return_value = []
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_session.execute.return_value = main_result
+
+            result = runner.invoke(app, ["entities", "backfill-descriptions"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Nothing to Backfill" in result.output
+
+    def test_backfill_skips_entities_with_existing_description(self) -> None:
+        """When entity lookup returns None (entity not found or already has description), row is skipped."""
+        mock_row_1 = MagicMock()
+        mock_row_1.entity_id_str = "12345678-1234-5678-1234-567812345678"
+        mock_row_1.reason = "British journalist"
+
+        main_result = MagicMock()
+        main_result.all.return_value = [mock_row_1]
+
+        # Entity lookup returns None → entity has description or does not exist
+        entity_result = MagicMock()
+        entity_result.scalar_one_or_none.return_value = None
+
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            mock_session.execute.side_effect = [main_result, entity_result]
+
+            result = runner.invoke(app, ["entities", "backfill-descriptions"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        # The non-dry-run panel prints "Skipped: 1 (...)" with a capital S
+        assert "Skipped:" in result.output
+
+    def test_backfill_help_flag(self) -> None:
+        """--help shows usage text including --dry-run and exits 0."""
+        result = runner.invoke(
+            app, ["entities", "backfill-descriptions", "--help"]
+        )
+
+        assert result.exit_code == 0
+        assert "--dry-run" in result.output

--- a/tests/integration/cli/test_tag_management_commands.py
+++ b/tests/integration/cli/test_tag_management_commands.py
@@ -1946,3 +1946,222 @@ class TestInputNormalization:
         call_kwargs = mock_service.merge.call_args[1]
         assert call_kwargs["source_normalized_forms"] == ["mexico"]
         assert call_kwargs["target_normalized_form"] == "mexico"
+
+
+# ---------------------------------------------------------------------------
+# Classify --description and --no-auto-case tests (Feature 037)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyDescriptionAndAutoCase:
+    """Verify the --description and --no-auto-case flags on `tags classify`.
+
+    Feature 037 added two new options to the classify command:
+    - ``--description``: entity description forwarded directly to service.classify()
+    - ``--no-auto-case``: when set, passes ``auto_case=False`` to service.classify()
+    """
+
+    def test_classify_passes_description_to_service(self) -> None:
+        """--description is forwarded to service.classify() as description kwarg."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="vanessa beeley",
+            canonical_form="Vanessa Beeley",
+            entity_type="person",
+            entity_created=True,
+            entity_alias_count=1,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "tags",
+                    "classify",
+                    "vanessa beeley",
+                    "--type",
+                    "person",
+                    "--description",
+                    "British journalist",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        call_kwargs = mock_service.classify.call_args[1]
+        assert call_kwargs["description"] == "British journalist"
+
+    def test_classify_without_description_passes_none_to_service(self) -> None:
+        """When --description is omitted, service.classify() receives description=None."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="vanessa beeley",
+            canonical_form="Vanessa Beeley",
+            entity_type="person",
+            entity_created=True,
+            entity_alias_count=1,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "tags",
+                    "classify",
+                    "vanessa beeley",
+                    "--type",
+                    "person",
+                    "--reason",
+                    "Journalist",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        call_kwargs = mock_service.classify.call_args[1]
+        # No --description provided: service receives None
+        assert call_kwargs["description"] is None
+        # --reason is still forwarded separately
+        assert call_kwargs["reason"] == "Journalist"
+
+    def test_classify_no_auto_case_passes_false_to_service(self) -> None:
+        """--no-auto-case flag causes service.classify() to receive auto_case=False."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="noamchomsky",
+            canonical_form="noamchomsky",
+            entity_type="person",
+            entity_created=True,
+            entity_alias_count=1,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "tags",
+                    "classify",
+                    "noamchomsky",
+                    "--type",
+                    "person",
+                    "--no-auto-case",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        call_kwargs = mock_service.classify.call_args[1]
+        assert call_kwargs["auto_case"] is False
+
+    def test_classify_default_auto_case_is_true(self) -> None:
+        """Without --no-auto-case, service.classify() receives auto_case=True."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="noamchomsky",
+            canonical_form="Noamchomsky",
+            entity_type="person",
+            entity_created=True,
+            entity_alias_count=1,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "tags",
+                    "classify",
+                    "noamchomsky",
+                    "--type",
+                    "person",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        call_kwargs = mock_service.classify.call_args[1]
+        assert call_kwargs["auto_case"] is True
+
+    def test_classify_description_and_no_auto_case_together(self) -> None:
+        """--description and --no-auto-case can be combined; both are forwarded correctly."""
+        from chronovista.services.tag_management import ClassifyResult
+
+        mock_result = ClassifyResult(
+            normalized_form="vanessa beeley",
+            canonical_form="vanessa beeley",
+            entity_type="person",
+            entity_created=True,
+            entity_alias_count=1,
+            operation_id=_OP_ID,
+        )
+
+        with patch("chronovista.cli.tag_commands.db_manager") as mock_db, patch(
+            "chronovista.cli.tag_commands._create_tag_management_service"
+        ) as mock_factory:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+            mock_service = AsyncMock()
+            mock_service.classify.return_value = mock_result
+            mock_factory.return_value = mock_service
+
+            result = runner.invoke(
+                app,
+                [
+                    "tags",
+                    "classify",
+                    "vanessa beeley",
+                    "--type",
+                    "person",
+                    "--description",
+                    "British journalist and blogger",
+                    "--no-auto-case",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        call_kwargs = mock_service.classify.call_args[1]
+        assert call_kwargs["description"] == "British journalist and blogger"
+        assert call_kwargs["auto_case"] is False
+
+    def test_classify_help_shows_description_and_no_auto_case_flags(self) -> None:
+        """--help output lists --description and --no-auto-case options."""
+        result = runner.invoke(app, ["tags", "classify", "--help"])
+
+        assert result.exit_code == 0
+        assert "--description" in result.output
+        assert "--no-auto-case" in result.output

--- a/tests/unit/services/test_tag_management.py
+++ b/tests/unit/services/test_tag_management.py
@@ -3488,3 +3488,381 @@ class TestDeprecate:
 
         with pytest.raises(ValueError, match="Cannot undo deprecate"):
             await service._undo_deprecate(mock_session, log_entry)
+
+
+# ===========================================================================
+# TestClassifyDescriptionAndAutoCase
+# ===========================================================================
+
+
+class TestClassifyDescriptionAndAutoCase:
+    """
+    Tests for the ``description`` and ``auto_case`` parameters added to
+    ``TagManagementService.classify``.
+
+    Covers:
+    - ``description`` takes priority over ``reason`` when populating the entity
+      description field of ``NamedEntityCreate``.
+    - ``description=None`` falls back to ``reason``.
+    - Both None results in ``description=None`` on the created entity.
+    - ``auto_case=True`` (default) title-cases a lowercase canonical form and
+      calls ``session.add`` to persist the change.
+    - ``auto_case=False`` leaves the canonical form unchanged.
+    - Already title-cased canonical forms are not mutated by ``auto_case=True``.
+    - ``auto_case`` has no effect for tag-only entity types (topic, descriptor).
+    """
+
+    def _setup_classify_mocks(
+        self,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+        *,
+        tag_canonical_form: str = "Vanessa Beeley",
+        tag_normalized_form: str = "vanessa beeley",
+    ) -> tuple[MagicMock, MagicMock]:
+        """
+        Shared setup for classify tests that create a new NamedEntity.
+
+        Returns
+        -------
+        tuple[MagicMock, MagicMock]
+            (tag mock, new_entity mock)
+        """
+        tag = _make_canonical_tag(
+            normalized_form=tag_normalized_form,
+            canonical_form=tag_canonical_form,
+            status="active",
+        )
+        tag.entity_type = None
+        tag.entity_id = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        alias_a = _make_tag_alias(
+            raw_form=tag_canonical_form,
+            normalized_form=tag_normalized_form,
+            canonical_tag_id=tag.id,
+        )
+        new_entity = _make_named_entity(
+            normalized_form=tag_normalized_form,
+            entity_type="person",
+            discovery_method="user_created",
+        )
+        mock_named_entity_repo.create.return_value = new_entity
+
+        ea = _make_entity_alias(entity_id=new_entity.id)
+        mock_entity_alias_repo.create.return_value = ea
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="create")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # existing entity check
+                _make_scalars_result([alias_a]),                          # tag aliases
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # alias upsert check
+            ]
+        )
+        mock_session.add = MagicMock()
+
+        return tag, new_entity
+
+    async def test_classify_description_populates_entity_description(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When ``description`` is provided, it takes priority over ``reason``
+        and is stored as the entity description in ``NamedEntityCreate``.
+
+        Expected behaviour:
+        - ``NamedEntityCreate.description`` equals the ``description`` argument
+          ("British journalist"), not the ``reason`` argument ("War reporter").
+        """
+        from chronovista.models.enums import EntityType
+
+        self._setup_classify_mocks(
+            mock_canonical_tag_repo,
+            mock_named_entity_repo,
+            mock_entity_alias_repo,
+            mock_operation_log_repo,
+            mock_session,
+        )
+
+        await service.classify(
+            mock_session,
+            normalized_form="vanessa beeley",
+            entity_type=EntityType.PERSON,
+            description="British journalist",
+            reason="War reporter",
+        )
+
+        create_call = mock_named_entity_repo.create.call_args
+        obj_in = create_call.kwargs["obj_in"]
+        assert obj_in.description == "British journalist", (
+            "description argument should take priority over reason"
+        )
+
+    async def test_classify_description_falls_back_to_reason_when_none(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When ``description=None`` and ``reason`` is provided, the entity
+        description falls back to ``reason``.
+
+        Expected behaviour:
+        - ``NamedEntityCreate.description`` equals the ``reason`` value
+          ("War reporter").
+        """
+        from chronovista.models.enums import EntityType
+
+        self._setup_classify_mocks(
+            mock_canonical_tag_repo,
+            mock_named_entity_repo,
+            mock_entity_alias_repo,
+            mock_operation_log_repo,
+            mock_session,
+        )
+
+        await service.classify(
+            mock_session,
+            normalized_form="vanessa beeley",
+            entity_type=EntityType.PERSON,
+            description=None,
+            reason="War reporter",
+        )
+
+        create_call = mock_named_entity_repo.create.call_args
+        obj_in = create_call.kwargs["obj_in"]
+        assert obj_in.description == "War reporter", (
+            "description should fall back to reason when description is None"
+        )
+
+    async def test_classify_description_none_and_reason_none(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When both ``description`` and ``reason`` are None, the entity
+        description field should be None.
+
+        Expected behaviour:
+        - ``NamedEntityCreate.description`` is ``None``.
+        """
+        from chronovista.models.enums import EntityType
+
+        self._setup_classify_mocks(
+            mock_canonical_tag_repo,
+            mock_named_entity_repo,
+            mock_entity_alias_repo,
+            mock_operation_log_repo,
+            mock_session,
+        )
+
+        await service.classify(
+            mock_session,
+            normalized_form="vanessa beeley",
+            entity_type=EntityType.PERSON,
+            description=None,
+            reason=None,
+        )
+
+        create_call = mock_named_entity_repo.create.call_args
+        obj_in = create_call.kwargs["obj_in"]
+        assert obj_in.description is None, (
+            "description should be None when both description and reason are None"
+        )
+
+    async def test_classify_auto_case_title_cases_canonical_form(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When ``auto_case=True`` (the default) and the canonical form is not
+        already title-cased, the service must title-case it and persist the
+        change via ``session.add``.
+
+        Expected behaviour:
+        - ``tag.canonical_form`` is mutated to ``"Vanessa Beeley"``.
+        - ``mock_session.add`` is called with the tag object.
+        """
+        from chronovista.models.enums import EntityType
+
+        tag, _ = self._setup_classify_mocks(
+            mock_canonical_tag_repo,
+            mock_named_entity_repo,
+            mock_entity_alias_repo,
+            mock_operation_log_repo,
+            mock_session,
+            tag_canonical_form="vanessa beeley",
+            tag_normalized_form="vanessa beeley",
+        )
+
+        await service.classify(
+            mock_session,
+            normalized_form="vanessa beeley",
+            entity_type=EntityType.PERSON,
+            auto_case=True,
+        )
+
+        assert tag.canonical_form == "Vanessa Beeley", (
+            "auto_case=True should title-case a lowercase canonical_form"
+        )
+        # session.add must have been called with the tag to persist the mutation
+        mock_session.add.assert_any_call(tag)
+
+    async def test_classify_auto_case_false_preserves_canonical_form(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When ``auto_case=False``, the canonical form must not be mutated
+        regardless of its current casing.
+
+        Expected behaviour:
+        - ``tag.canonical_form`` remains ``"vanessa beeley"`` (unchanged).
+        """
+        from chronovista.models.enums import EntityType
+
+        tag, _ = self._setup_classify_mocks(
+            mock_canonical_tag_repo,
+            mock_named_entity_repo,
+            mock_entity_alias_repo,
+            mock_operation_log_repo,
+            mock_session,
+            tag_canonical_form="vanessa beeley",
+            tag_normalized_form="vanessa beeley",
+        )
+
+        await service.classify(
+            mock_session,
+            normalized_form="vanessa beeley",
+            entity_type=EntityType.PERSON,
+            auto_case=False,
+        )
+
+        assert tag.canonical_form == "vanessa beeley", (
+            "auto_case=False should leave canonical_form unchanged"
+        )
+
+    async def test_classify_auto_case_skips_already_title_cased(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When ``auto_case=True`` but the canonical form is already title-cased,
+        the service must not mutate it (``istitle()`` returns True, so the
+        title-casing branch is skipped).
+
+        Expected behaviour:
+        - ``tag.canonical_form`` remains ``"Vanessa Beeley"`` (no change).
+        - ``mock_session.add`` may still be called for other reasons (e.g.
+          updating entity_type) but the canonical_form value itself is stable.
+        """
+        from chronovista.models.enums import EntityType
+
+        tag, _ = self._setup_classify_mocks(
+            mock_canonical_tag_repo,
+            mock_named_entity_repo,
+            mock_entity_alias_repo,
+            mock_operation_log_repo,
+            mock_session,
+            tag_canonical_form="Vanessa Beeley",
+            tag_normalized_form="vanessa beeley",
+        )
+
+        await service.classify(
+            mock_session,
+            normalized_form="vanessa beeley",
+            entity_type=EntityType.PERSON,
+            auto_case=True,
+        )
+
+        assert tag.canonical_form == "Vanessa Beeley", (
+            "auto_case=True must not alter a canonical_form that is already title-cased"
+        )
+
+    async def test_classify_auto_case_no_effect_for_tag_only_types(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        For tag-only entity types (topic, descriptor) the ``auto_case``
+        parameter has no effect: no entity is created and the canonical form
+        is never mutated by the auto-case branch.
+
+        Expected behaviour:
+        - ``tag.canonical_form`` remains ``"machine learning"`` (lowercase,
+          unchanged) after classifying with ``EntityType.TOPIC``.
+        - No ``NamedEntity`` is created.
+        """
+        from chronovista.models.enums import EntityType
+        from chronovista.services.tag_management import ClassifyResult
+
+        tag = _make_canonical_tag(
+            normalized_form="machine learning",
+            canonical_form="machine learning",
+            status="active",
+        )
+        tag.entity_type = None
+        tag.entity_id = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="create")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+        mock_session.add = MagicMock()
+
+        result = await service.classify(
+            mock_session,
+            normalized_form="machine learning",
+            entity_type=EntityType.TOPIC,
+            auto_case=True,
+        )
+
+        assert isinstance(result, ClassifyResult)
+        assert tag.canonical_form == "machine learning", (
+            "auto_case must have no effect for tag-only types such as TOPIC"
+        )
+        mock_named_entity_repo.create.assert_not_called()


### PR DESCRIPTION
## Summary

- New `chronovista entities` sub-app with 3 CLI commands: `create`, `list`, and `backfill-descriptions`
- `entities create` — standalone named entity creation with `--type`, `--description`, and `--alias` (repeatable) flags, auto-title-case, and duplicate detection
- `entities list` — browse entities with `--type`, `--search`, and `--limit` filters rendered in a Rich table
- `entities backfill-descriptions` — copies `classify --reason` text into entity descriptions (supports `--dry-run`)
- `classify --description` flag to directly populate `named_entities.description` (falls back to `--reason`)
- Auto-title-case for `canonical_form` on entity-producing types; `--no-auto-case` to opt out
- Fixed 4 lowercase person entity names via INITCAP update
- Version bump 0.39.0 → 0.40.0 with updated CHANGELOG.md, docs/changelog.md, and docs/user-guide/cli-overview.md
- No new dependencies, no database migrations, mypy strict compliance

Closes #60
Closes #62
Closes #69

## Test plan

- [x] 42 new tests added (29 entity CLI + 6 tag management CLI + 7 tag management service)
- [x] Run `pytest tests/ -k "entity"` to verify all entity CLI tests pass
- [x] Run `pytest tests/ -k "tag"` to verify tag management CLI and service tests pass
- [x] Run `mypy src/` to confirm strict type compliance with no new errors
- [x] Manually test `chronovista entities create --type PERSON --alias "John" "John Doe"` and verify auto-title-case and duplicate detection
- [x] Manually test `chronovista entities list --type PERSON --search "doe" --limit 10` and verify Rich table output
- [x] Manually test `chronovista entities backfill-descriptions --dry-run` to confirm no writes occur
- [x] Manually test `chronovista tags classify <tag> --description "Some description"` and verify `named_entities.description` is populated
- [x] Verify existing `classify` and `tags` commands remain unaffected by the changes