### PR TITLE
feat(entities): add add-alias CLI command (Feature 039)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [0.41.1] - 2026-03-08
+
+### Added
+- `entities add-alias` CLI command — add one or more aliases to an existing named entity without recreating it (Feature 039)
+
 ## [0.41.0] - 2026-03-08
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.41.1] - 2026-03-08
+
+### Added
+- `entities add-alias` CLI command — add one or more aliases to an existing named entity without recreating it
+
 ## [0.41.0] - 2026-03-08
 
 ### Added

--- a/docs/user-guide/cli-overview.md
+++ b/docs/user-guide/cli-overview.md
@@ -200,6 +200,7 @@ chronovista entities [COMMAND]
 | Command | Description |
 |---------|-------------|
 | `create` | Create a standalone named entity with aliases |
+| `add-alias` | Add one or more aliases to an existing entity |
 | `list` | Browse named entities in a Rich table |
 | `scan` | Scan transcript segments for entity mentions |
 | `stats` | Display aggregate entity mention statistics |
@@ -893,6 +894,34 @@ chronovista entities create "Gaza Strip" --type place --description "Palestinian
 - Only entity-producing types are allowed (topic and descriptor are tag-only types — use `tags classify` instead)
 - Duplicate detection: same normalized name + entity type → error
 - The canonical name alias is automatically created (same pattern as `tags classify`)
+
+#### Add Alias (v0.41.1+)
+
+```bash
+chronovista entities add-alias <ENTITY_NAME> --alias <ALIAS> [--alias <ALIAS> ...]
+```
+
+Adds one or more aliases to an existing named entity. Useful when ASR produces new misspellings or you discover alternate names for an entity already in the system.
+
+**Options:**
+
+- `--alias <name>` - Alias name to add (repeatable, required)
+
+**Examples:**
+
+```bash
+# Add a single alias
+chronovista entities add-alias "Jairo Calixto" --alias "Jairo Calixto Albarrán"
+
+# Add multiple aliases at once
+chronovista entities add-alias "Jairo Calixto" --alias "Jairo Calixto Albarrán" --alias "Jairo Calixtro"
+```
+
+**Notes:**
+
+- Entity is matched by normalized canonical name
+- Duplicate aliases are skipped with a warning
+- Aliases that normalize to empty are skipped
 
 #### List Entities
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.41.0"
+version = "0.41.1"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.41.0"
+__version__ = "0.41.1"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/cli/entity_commands.py
+++ b/src/chronovista/cli/entity_commands.py
@@ -225,6 +225,120 @@ def create_entity(
     asyncio.run(_run())
 
 
+@entity_app.command("add-alias")
+def add_alias(
+    entity_name: str = typer.Argument(
+        ..., help="Canonical name of the entity to add alias to."
+    ),
+    alias: List[str] = typer.Option(
+        ...,
+        "--alias",
+        help="Alias name to add (repeatable).",
+    ),
+) -> None:
+    """Add one or more aliases to an existing named entity."""
+
+    async def _run() -> None:
+        normalizer = TagNormalizationService()
+        alias_repo = EntityAliasRepository()
+
+        normalized_entity = normalizer.normalize(entity_name)
+        if normalized_entity is None:
+            console.print(
+                Panel(
+                    "[red]Entity name normalizes to empty string.[/red]",
+                    title="Invalid Name",
+                    border_style="red",
+                )
+            )
+            raise typer.Exit(code=1)
+
+        async for session in db_manager.get_session(echo=False):
+            # Look up entity by normalized name
+            result = await session.execute(
+                select(NamedEntityDB).where(
+                    NamedEntityDB.canonical_name_normalized == normalized_entity,
+                )
+            )
+            entity = result.scalar_one_or_none()
+
+            if entity is None:
+                console.print(
+                    Panel(
+                        f"[red]No entity found with name '{entity_name}'.[/red]",
+                        title="Entity Not Found",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(code=1)
+
+            added = 0
+            skipped = 0
+
+            for alias_text in alias:
+                normalized_alias = normalizer.normalize(alias_text)
+                if normalized_alias is None:
+                    console.print(
+                        f"[yellow]Skipping alias '{alias_text}' "
+                        f"(normalizes to empty).[/yellow]"
+                    )
+                    skipped += 1
+                    continue
+
+                # Check for duplicate alias on this entity
+                existing = await session.execute(
+                    select(EntityAliasDB).where(
+                        EntityAliasDB.entity_id == entity.id,
+                        EntityAliasDB.alias_name_normalized == normalized_alias,
+                    )
+                )
+                if existing.scalar_one_or_none() is not None:
+                    console.print(
+                        f"[yellow]Alias '{alias_text}' already exists "
+                        f"for '{entity.canonical_name}', skipping.[/yellow]"
+                    )
+                    skipped += 1
+                    continue
+
+                alias_create = EntityAliasCreate(
+                    entity_id=entity.id,
+                    alias_name=alias_text,
+                    alias_name_normalized=normalized_alias,
+                    alias_type=EntityAliasType.NAME_VARIANT,
+                    occurrence_count=0,
+                )
+                await alias_repo.create(session, obj_in=alias_create)
+                added += 1
+
+            await session.commit()
+
+            details = (
+                f"[bold]Entity:[/bold] {entity.canonical_name}\n"
+                f"[bold]Type:[/bold] {entity.entity_type}\n"
+                f"[bold]Aliases added:[/bold] {added}\n"
+                f"[bold]Skipped:[/bold] {skipped}"
+            )
+
+            if added > 0:
+                console.print(
+                    Panel(
+                        details,
+                        title="[green]Alias(es) Added[/green]",
+                        border_style="green",
+                    )
+                )
+            else:
+                console.print(
+                    Panel(
+                        details,
+                        title="[yellow]No Aliases Added[/yellow]",
+                        border_style="yellow",
+                    )
+                )
+
+    asyncio.run(_run())
+
+
 @entity_app.command("list")
 def list_entities(
     type_str: Optional[str] = typer.Option(

--- a/tests/integration/cli/test_entity_commands.py
+++ b/tests/integration/cli/test_entity_commands.py
@@ -883,3 +883,203 @@ class TestBackfillDescriptionsCommand:
 
         assert result.exit_code == 0
         assert "--dry-run" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Add alias command tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddAliasCommand:
+    """Integration tests for `chronovista entities add-alias`."""
+
+    def test_add_alias_exit_code_zero(self) -> None:
+        """Adding an alias to an existing entity returns exit code 0."""
+        mock_entity = _make_mock_entity()
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            # First execute: entity lookup returns entity
+            entity_result = MagicMock()
+            entity_result.scalar_one_or_none.return_value = mock_entity
+
+            # Second execute: duplicate alias check returns None
+            dup_check_result = MagicMock()
+            dup_check_result.scalar_one_or_none.return_value = None
+
+            mock_session.execute.side_effect = [entity_result, dup_check_result]
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app,
+                ["entities", "add-alias", "Noam Chomsky", "--alias", "N. Chomsky"],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Alias" in result.output
+        assert "Added" in result.output
+
+    def test_add_alias_output_shows_entity_name_and_count(self) -> None:
+        """Output contains entity name and alias added count."""
+        mock_entity = _make_mock_entity(name="Jairo Calixto")
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entity_result = MagicMock()
+            entity_result.scalar_one_or_none.return_value = mock_entity
+
+            dup_check_result = MagicMock()
+            dup_check_result.scalar_one_or_none.return_value = None
+
+            mock_session.execute.side_effect = [entity_result, dup_check_result]
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app,
+                [
+                    "entities",
+                    "add-alias",
+                    "Jairo Calixto",
+                    "--alias",
+                    "Jairo Calixto Albarrán",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Jairo Calixto" in result.output
+        assert "Aliases added" in result.output
+
+    def test_add_alias_multiple_aliases(self) -> None:
+        """Multiple --alias flags add multiple aliases."""
+        mock_entity = _make_mock_entity()
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entity_result = MagicMock()
+            entity_result.scalar_one_or_none.return_value = mock_entity
+
+            # Two duplicate checks, both return None (no duplicates)
+            dup_check_1 = MagicMock()
+            dup_check_1.scalar_one_or_none.return_value = None
+            dup_check_2 = MagicMock()
+            dup_check_2.scalar_one_or_none.return_value = None
+
+            mock_session.execute.side_effect = [
+                entity_result,
+                dup_check_1,
+                dup_check_2,
+            ]
+
+            mock_alias_repo = AsyncMock()
+            mock_alias_repo.create.return_value = MagicMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app,
+                [
+                    "entities",
+                    "add-alias",
+                    "Noam Chomsky",
+                    "--alias",
+                    "N. Chomsky",
+                    "--alias",
+                    "Prof. Chomsky",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert mock_alias_repo.create.call_count == 2
+
+    def test_add_alias_entity_not_found_exits_code_1(self) -> None:
+        """When entity does not exist, exits with code 1."""
+        with patch("chronovista.cli.entity_commands.db_manager") as mock_db:
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entity_result = MagicMock()
+            entity_result.scalar_one_or_none.return_value = None
+            mock_session.execute.return_value = entity_result
+
+            result = runner.invoke(
+                app,
+                ["entities", "add-alias", "Nonexistent Entity", "--alias", "foo"],
+            )
+
+        assert result.exit_code == 1, f"Output: {result.output}"
+        assert "Entity Not Found" in result.output
+
+    def test_add_alias_duplicate_skipped(self) -> None:
+        """An alias that already exists is skipped with a warning."""
+        mock_entity = _make_mock_entity()
+        existing_alias = MagicMock()
+
+        with (
+            patch("chronovista.cli.entity_commands.db_manager") as mock_db,
+            patch(
+                "chronovista.cli.entity_commands.EntityAliasRepository"
+            ) as MockAliasRepo,
+        ):
+            mock_session = AsyncMock()
+            mock_db.get_session.return_value = _make_get_session(mock_session)
+
+            entity_result = MagicMock()
+            entity_result.scalar_one_or_none.return_value = mock_entity
+
+            # Duplicate check returns existing alias
+            dup_check_result = MagicMock()
+            dup_check_result.scalar_one_or_none.return_value = existing_alias
+
+            mock_session.execute.side_effect = [entity_result, dup_check_result]
+
+            mock_alias_repo = AsyncMock()
+            MockAliasRepo.return_value = mock_alias_repo
+
+            result = runner.invoke(
+                app,
+                [
+                    "entities",
+                    "add-alias",
+                    "Noam Chomsky",
+                    "--alias",
+                    "Noam Chomsky",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "already exists" in result.output
+        assert "No Aliases Added" in result.output
+        mock_alias_repo.create.assert_not_called()
+
+    def test_add_alias_help_flag(self) -> None:
+        """--help shows usage text and exits 0."""
+        result = runner.invoke(app, ["entities", "add-alias", "--help"])
+
+        assert result.exit_code == 0
+        assert "--alias" in result.output


### PR DESCRIPTION
## Summary

- Add `entities add-alias` CLI command to attach new aliases to existing named entities without recreating them
- Supports multiple `--alias` flags, duplicate detection, and empty-normalization skipping
- Version bump: backend 0.41.0 → 0.41.1

## Examples

```bash
# Single alias
chronovista entities add-alias "Renée Dubois" --alias "Renée Dubois Laurent"

# Multiple aliases
chronovista entities add-alias "Renée Dubois" --alias "Renée Dubois Laurent" --alias "Renée Calixtro"
```

## Test plan

- [x] 6 new CLI tests (exit code, output, multiple aliases, entity not found, duplicate skipped, help flag)
- [x] All 35 entity CLI tests pass
- [x] Verified against live database — alias inserted correctly with proper normalization