### PR TITLE
feat(corrections): cross-segment matching, regex translation & ASR alias fix (Feature 040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet._
 
+## [0.42.0] - 2026-03-10
+
+### Added
+- **Feature 040: Correction Pattern Matching Robustness (#76, #71)**
+  - `--cross-segment` flag on `corrections find-replace` — matches patterns spanning two adjacent transcript segments (e.g., ASR splitting "Claudia Sheinbaum" across segment boundaries as "Claudia Shane" + "Bound")
+  - Cross-segment dry-run preview with box-drawing pair markers (`╶─┐`/`╶─┘`) and pair count in summary
+  - Cross-segment correction application: replacement placed in segment A, consumed fragment removed from segment B, leading whitespace normalized on segment B
+  - Cross-segment partner cascade revert: reverting one segment of a cross-segment pair automatically reverts its partner via `[cross-segment:partner=N]` audit marker
+  - Single-segment precedence: patterns matching entirely within one segment are corrected first, excluding those segments from cross-segment pairing
+  - Conflict detection: overlapping cross-segment pairs resolved by lower sequence number, later pair skipped with warning
+  - Python-to-PostgreSQL regex translation: `\b`→`\y`, `\B`→`\Y` state machine in `translate_python_regex_to_posix()` so users write Python regex syntax and it works consistently in both DB queries and Python-side replacement
+  - Unscoped `--cross-segment` warning when no `--video-id`/`--language`/`--channel` filter is provided and segment count exceeds 5,000
+  - Empty segment warning after cross-segment corrections that may leave segment B with empty text
+  - `--cross-segment` composes with `--regex`, `--case-insensitive`, `--language`, `--video-id`, `--channel` filters
+  - `find_segments_in_scope()` repository method for fetching segments with scope filters
+  - `SegmentPair` and `CrossSegmentMatch` Pydantic V2 models
+  - User guide documentation: `docs/user-guide/corrections.md` covering all correction workflows
+
+### Fixed
+- ASR alias hook `UniqueViolationError` crashing batch corrections — duplicate check now uses `alias_name_normalized` (matching the unique constraint) instead of `alias_name`, and INSERT wrapped in savepoint to prevent session poisoning
+- `batch_revert` return type annotation updated for 5-element tuples (added `bool` partner cascade flag)
+
+### Changed
+- **Refactored** ASR alias registration into shared `asr_alias_registry.py` module — `register_asr_alias()` and `resolve_entity_id_from_text()` replace duplicated logic in `TranscriptCorrectionService` and `BatchCorrectionService` (DRY)
+
+### Technical
+- 27 new tests for `asr_alias_registry` shared utility (8 resolve + 19 register)
+- Integration tests for cross-segment matching, revert, partner cascade, conflict detection
+- CLI unit tests for dry-run display formatting (pair markers, summary counts)
+- mypy strict compliance (0 errors)
+- No new dependencies, no database migrations
+
 ## [0.41.1] - 2026-03-08
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.42.0] - 2026-03-10
+
+### Added
+- **Feature 040: Correction Pattern Matching Robustness (#76, #71)**
+  - `--cross-segment` flag on `corrections find-replace` — matches patterns spanning two adjacent transcript segments (e.g., ASR splitting "Claudia Sheinbaum" across segment boundaries as "Claudia Shane" + "Bound")
+  - Cross-segment dry-run preview with box-drawing pair markers (`╶─┐`/`╶─┘`) and pair count in summary
+  - Cross-segment correction application: replacement placed in segment A, consumed fragment removed from segment B, leading whitespace normalized on segment B
+  - Cross-segment partner cascade revert: reverting one segment of a cross-segment pair automatically reverts its partner via `[cross-segment:partner=N]` audit marker
+  - Single-segment precedence: patterns matching entirely within one segment are corrected first, excluding those segments from cross-segment pairing
+  - Conflict detection: overlapping cross-segment pairs resolved by lower sequence number, later pair skipped with warning
+  - Python-to-PostgreSQL regex translation: `\b`→`\y`, `\B`→`\Y` state machine in `translate_python_regex_to_posix()` so users write Python regex syntax and it works consistently in both DB queries and Python-side replacement
+  - Unscoped `--cross-segment` warning when no `--video-id`/`--language`/`--channel` filter is provided and segment count exceeds 5,000
+  - Empty segment warning after cross-segment corrections that may leave segment B with empty text
+  - `--cross-segment` composes with `--regex`, `--case-insensitive`, `--language`, `--video-id`, `--channel` filters
+  - `find_segments_in_scope()` repository method for fetching segments with scope filters
+  - `SegmentPair` and `CrossSegmentMatch` Pydantic V2 models
+  - User guide documentation: `docs/user-guide/corrections.md` covering all correction workflows
+
+### Fixed
+- ASR alias hook `UniqueViolationError` crashing batch corrections — duplicate check now uses `alias_name_normalized` (matching the unique constraint) instead of `alias_name`, and INSERT wrapped in savepoint to prevent session poisoning
+- `batch_revert` return type annotation updated for 5-element tuples (added `bool` partner cascade flag)
+
+### Changed
+- **Refactored** ASR alias registration into shared `asr_alias_registry.py` module — `register_asr_alias()` and `resolve_entity_id_from_text()` replace duplicated logic in `TranscriptCorrectionService` and `BatchCorrectionService` (DRY)
+
+### Technical
+- 27 new tests for `asr_alias_registry` shared utility (8 resolve + 19 register)
+- Integration tests for cross-segment matching, revert, partner cascade, conflict detection
+- CLI unit tests for dry-run display formatting (pair markers, summary counts)
+- mypy strict compliance (0 errors)
+- No new dependencies, no database migrations
+
 ## [0.41.1] - 2026-03-08
 
 ### Added

--- a/docs/user-guide/corrections.md
+++ b/docs/user-guide/corrections.md
@@ -1,0 +1,344 @@
+# Transcript Corrections
+
+Guide to finding and fixing ASR (automatic speech recognition) errors in transcripts using `chronovista corrections`.
+
+## Overview
+
+ASR engines frequently misrecognize proper nouns, acronyms, and names — especially in multilingual content. The corrections CLI provides:
+
+- **Find-replace** with substring or regex matching
+- **Word boundary regex** (`\b`) for precise targeting
+- **Cross-segment matching** for names split across two adjacent segments
+- **Batch revert** to undo corrections
+- **Dry-run mode** to preview all changes before applying
+
+---
+
+## Quick Start
+
+```bash
+# Preview a simple substring replacement
+chronovista corrections find-replace \
+  --pattern 'amlo' --replacement 'AMLO' --dry-run
+
+# Apply it (with confirmation prompt)
+chronovista corrections find-replace \
+  --pattern 'amlo' --replacement 'AMLO'
+
+# Undo it
+chronovista corrections batch-revert \
+  --pattern 'AMLO' --dry-run
+```
+
+---
+
+## Find-Replace Modes
+
+### Substring Mode (default)
+
+Matches the pattern as a literal substring anywhere in the segment text. Case-sensitive by default.
+
+```bash
+# Exact substring match
+chronovista corrections find-replace \
+  --pattern 'amlo' --replacement 'AMLO' --dry-run
+
+# Case-insensitive substring match
+chronovista corrections find-replace \
+  --pattern 'amlo' --replacement 'AMLO' \
+  --case-insensitive --dry-run
+```
+
+**When to use**: Simple word or phrase replacements where you know the exact text.
+
+**Watch out**: Substring mode matches inside longer words. `--pattern 'amlo'` will also match "k**amlo**ops". Use regex with `\b` word boundaries to avoid this (see below).
+
+### Regex Mode (`--regex`)
+
+Treats the pattern as a Python regular expression. Use this when you need word boundaries, wildcards, or flexible matching.
+
+```bash
+# Match "amlo" as a whole word (not inside "kamloops")
+chronovista corrections find-replace \
+  --regex --pattern '\bamlo\w*' --replacement 'AMLO' --dry-run
+```
+
+**Key regex features**:
+
+| Syntax | Meaning | Example |
+|--------|---------|---------|
+| `\b` | Word boundary | `\bamlo\b` matches "amlo" but not "kamloops" |
+| `\w*` | Zero or more word characters | `\bamlo\w*` matches "amlo", "amlo's" |
+| `\d+` | One or more digits | `\d+` matches "123" |
+| `\s+` | One or more whitespace | `foo\s+bar` matches "foo  bar" |
+| `(a\|b)` | Alternation | `(Shane\|Shayne)` matches either spelling |
+
+**Word boundaries (`\b`)** are the most important regex feature for corrections. They ensure you match whole words without accidentally changing longer words that contain your pattern as a substring.
+
+```bash
+# WITHOUT \b — dangerous: matches "amlo" inside "kamloops"
+chronovista corrections find-replace \
+  --regex --pattern 'amlo' --replacement 'AMLO' --dry-run
+
+# WITH \b — safe: only matches "amlo" at word boundaries
+chronovista corrections find-replace \
+  --regex --pattern '\bamlo\w*' --replacement 'AMLO' --dry-run
+```
+
+**Malformed regex**: If your pattern has a syntax error (e.g., unclosed brackets), you get a clear error message instead of a crash:
+
+```bash
+chronovista corrections find-replace \
+  --regex --pattern '[unclosed' --replacement 'test' --dry-run
+# Output: Invalid regex pattern: unterminated character set at position 0
+```
+
+---
+
+## Cross-Segment Matching (`--cross-segment`)
+
+### The Problem
+
+ASR engines split audio into segments based on timing, not meaning. A name like "Claudia Sheinbaum" may be split across two segments:
+
+```
+Segment 934 (39:46): "...una entrevista, Claudia Shane"
+Segment 935 (39:49): "Bound también siendo candidata..."
+```
+
+Without `--cross-segment`, you can only match within a single segment. The pattern "Shane Bound" won't be found because it spans two segments.
+
+### The Solution
+
+The `--cross-segment` flag concatenates adjacent segments and matches patterns across the boundary:
+
+```bash
+chronovista corrections find-replace \
+  --cross-segment \
+  --pattern 'Shane Bound' \
+  --replacement 'Sheinbaum' \
+  --video-id VIDEO_ID --dry-run
+```
+
+**How it works**:
+
+1. Fetches all segments in scope (filtered by `--video-id`, `--language`, `--channel`)
+2. Groups segments by video and language
+3. Pairs strictly consecutive segments (sequence N and N+1, same video, same language)
+4. Concatenates each pair's text with a space separator
+5. Matches the pattern against the combined text
+6. When a match spans the boundary: replacement goes into segment N, matched fragment is removed from segment N+1
+
+### Dry-Run Preview
+
+Cross-segment matches are visually distinguished from single-segment matches:
+
+```
+┌──────────┬─────────┬────────┬──────┬────────────────┬───────────────┐
+│ Video ID │ Segment │ Start  │ Type │ Current Text   │ Proposed Text │
+├──────────┼─────────┼────────┼──────┼────────────────┼───────────────┤
+│ JIMXfr.. │ 934     │ 39:46  │ ╶─┐  │ ...Shane       │ ...Sheinbaum  │
+│ JIMXfr.. │ 935     │ 39:49  │ ╶─┘  │ Bound tam..    │ también..     │
+│ abc123.. │ 42      │ 01:23  │      │ amlo said      │ AMLO said     │
+└──────────┴─────────┴────────┴──────┴────────────────┴───────────────┘
+
+Dry run complete: 3 segments would be corrected across 2 videos (1 cross-segment pair).
+```
+
+- `╶─┐` marks the first segment in a pair
+- `╶─┘` marks the second segment in a pair
+- Empty Type cell = single-segment match
+
+### Composing with Other Flags
+
+`--cross-segment` works with all existing flags:
+
+```bash
+# Cross-segment + regex + word boundaries
+chronovista corrections find-replace \
+  --cross-segment --regex \
+  --pattern '\bPresident Shane Bum\b' \
+  --replacement 'President Sheinbaum' \
+  --video-id uajXFlDGTfg --dry-run
+
+# Cross-segment + case-insensitive
+chronovista corrections find-replace \
+  --cross-segment --case-insensitive \
+  --pattern 'shane bound' --replacement 'Sheinbaum' \
+  --video-id JIMXfrMtHas --dry-run
+
+# Cross-segment + language filter
+chronovista corrections find-replace \
+  --cross-segment --language es \
+  --pattern 'Shane Bound' --replacement 'Sheinbaum' --dry-run
+```
+
+### Pairing Rules
+
+Segments are only paired when ALL of these conditions are met:
+
+- Same video
+- Same language code
+- Strictly consecutive sequence numbers (N and N+1 — no gaps)
+- Neither segment has empty effective text
+
+Segments that are **not** paired:
+
+- Different languages (e.g., segment N is "en", segment N+1 is "es")
+- Non-consecutive sequence numbers (e.g., segments 5 and 7 with no segment 6)
+
+### Single-Segment Precedence
+
+If a pattern matches entirely within a single segment, that match takes priority. The segment is corrected as a single-segment match and excluded from any cross-segment pair it would have been part of. This prevents double-matching.
+
+### Unscoped Warning
+
+Running `--cross-segment` without any filter (`--video-id`, `--language`, `--channel`) loads all segments into memory. For large libraries (>5,000 segments), you'll see a warning:
+
+```
+Warning: --cross-segment with no scope filter will load ~125,000 segments into memory.
+For large libraries this may be slow. Use --video-id, --language, or --channel to
+narrow the scope, or pass --yes to proceed.
+Continue? [y/N]
+```
+
+Use `--yes` to bypass the warning, or add a scope filter.
+
+---
+
+## Reverting Corrections
+
+### Basic Revert
+
+`batch-revert` finds segments whose corrected text matches the pattern and reverts them to their previous version:
+
+```bash
+# Preview what would be reverted
+chronovista corrections batch-revert \
+  --pattern 'Sheinbaum' --video-id JIMXfrMtHas --dry-run
+
+# Apply the revert
+chronovista corrections batch-revert \
+  --pattern 'Sheinbaum' --video-id JIMXfrMtHas
+```
+
+**Important**: The pattern matches against the **corrected** text (what the segment says now), not the original text.
+
+### Cross-Segment Partner Cascade
+
+When you revert a correction that was part of a cross-segment pair, the partner segment is automatically reverted too. This is tracked via a `[cross-segment:partner=N]` marker in the correction audit record.
+
+In dry-run mode, partner segments appear with a "(partner)" label:
+
+```
+┌──────────┬─────────┬────────┬───────────────────────┬──────────┐
+│ Video ID │ Segment │ Start  │ Corrected Text        │ Note     │
+├──────────┼─────────┼────────┼───────────────────────┼──────────┤
+│ JIMXfr.. │ 934     │ 39:46  │ ...Sheinbaum          │          │
+│ JIMXfr.. │ 935     │ 39:49  │ también siendo..      │ (partner)│
+└──────────┴─────────┴────────┴───────────────────────┴──────────┘
+
+Dry run complete: 2 segments would be reverted (1 via cross-segment partner cascade).
+```
+
+### Reverting a Specific Segment
+
+To revert only one segment without affecting others that match the same pattern, use a more specific pattern:
+
+```bash
+# Too broad — might revert multiple segments
+chronovista corrections batch-revert \
+  --pattern 'Sheinbaum' --video-id JIMXfrMtHas --dry-run
+
+# More specific — targets only the segment with this exact corrected text
+chronovista corrections batch-revert \
+  --pattern 'concediera una entrevista, Claudia Sheinbaum' \
+  --video-id JIMXfrMtHas --dry-run
+```
+
+Always use `--dry-run` first to verify which segments will be affected.
+
+---
+
+## Filtering
+
+All correction commands support scope filters:
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--video-id` | Filter by video ID (repeatable) | `--video-id abc123 --video-id def456` |
+| `--language` | Filter by language code | `--language es` |
+| `--channel` | Filter by channel ID | `--channel UCxxxxxxxx` |
+
+Filters are combinable and narrow the scope. Using filters is recommended for large libraries to improve performance and avoid unintended changes.
+
+---
+
+## Other Correction Commands
+
+```bash
+# View correction statistics
+chronovista corrections stats
+
+# Discover recurring correction patterns
+chronovista corrections patterns
+
+# Export corrections to CSV or JSON
+chronovista corrections export --format json
+chronovista corrections export --format csv --video-id VIDEO_ID
+
+# Rebuild full transcript text from corrected segments
+chronovista corrections rebuild-text --video-id VIDEO_ID --dry-run
+```
+
+---
+
+## Common Workflows
+
+### Fix a misspelled name across all videos
+
+```bash
+# 1. Preview with word boundaries to avoid false positives
+chronovista corrections find-replace \
+  --regex --pattern '\bamlo\b' --replacement 'AMLO' --dry-run
+
+# 2. Apply
+chronovista corrections find-replace \
+  --regex --pattern '\bamlo\b' --replacement 'AMLO'
+
+# 3. Rebuild transcript text
+chronovista corrections rebuild-text
+```
+
+### Fix an ASR-split name
+
+```bash
+# 1. Find the split in your transcript viewer
+#    e.g., "President Shane" + "Bound también..."
+
+# 2. Preview the cross-segment fix
+chronovista corrections find-replace \
+  --cross-segment \
+  --pattern 'Shane Bound' --replacement 'Sheinbaum' \
+  --video-id uajXFlDGTfg --dry-run
+
+# 3. Apply
+chronovista corrections find-replace \
+  --cross-segment \
+  --pattern 'Shane Bound' --replacement 'Sheinbaum' \
+  --video-id uajXFlDGTfg
+
+# 4. If wrong, revert (partner segment auto-reverted)
+chronovista corrections batch-revert \
+  --pattern 'Sheinbaum' --video-id uajXFlDGTfg
+```
+
+### Bulk fix a pattern across a language
+
+```bash
+# Fix all Spanish transcripts where ASR wrote "Shane Baum"
+chronovista corrections find-replace \
+  --cross-segment --case-insensitive \
+  --pattern 'shane baum' --replacement 'Sheinbaum' \
+  --language es --dry-run
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.41.1"
+version = "0.42.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.41.1"
+__version__ = "0.42.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/cli/correction_commands.py
+++ b/src/chronovista/cli/correction_commands.py
@@ -14,12 +14,18 @@ import logging
 import re
 import sys
 from datetime import datetime
-from typing import List, Optional
 
 import typer
 from rich.console import Console
 from rich.panel import Panel
-from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+)
 from rich.table import Table
 
 from chronovista.config.database import db_manager
@@ -142,11 +148,11 @@ def _parse_correction_type(value: str) -> CorrectionType:
     """
     try:
         return CorrectionType(value)
-    except ValueError:
+    except ValueError as err:
         valid = ", ".join(ct.value for ct in CorrectionType)
         raise typer.BadParameter(
             f"Invalid correction type '{value}'. Valid types: {valid}"
-        )
+        ) from err
 
 
 def _create_batch_correction_service() -> BatchCorrectionService:
@@ -195,19 +201,19 @@ def find_replace(
     case_insensitive: bool = typer.Option(
         False, "--case-insensitive", "-i", help="Case-insensitive matching"
     ),
-    language: Optional[str] = typer.Option(
+    language: str | None = typer.Option(
         None, "--language", help="Filter by language code"
     ),
-    channel: Optional[str] = typer.Option(
+    channel: str | None = typer.Option(
         None, "--channel", help="Filter by channel ID"
     ),
-    video_id: Optional[List[str]] = typer.Option(
+    video_id: list[str] | None = typer.Option(
         None, "--video-id", help="Filter by video ID (repeatable)"
     ),
     correction_type: str = typer.Option(
         "asr_error", "--correction-type", help="Correction type value"
     ),
-    correction_note: Optional[str] = typer.Option(
+    correction_note: str | None = typer.Option(
         None, "--correction-note", help="Note for audit records"
     ),
     batch_size: int = typer.Option(
@@ -222,6 +228,9 @@ def find_replace(
     limit: int = typer.Option(
         50, "--limit", help="Max preview rows in dry-run mode"
     ),
+    cross_segment: bool = typer.Option(
+        False, "--cross-segment", help="Enable matching across adjacent segment pairs"
+    ),
 ) -> None:
     """Find and replace text patterns across transcript segments."""
 
@@ -234,12 +243,28 @@ def find_replace(
             re.compile(pattern)
         except re.error as exc:
             console.print(f"[red]Invalid regex pattern: {exc}[/red]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from exc
 
     service = _create_batch_correction_service()
 
     async def _run() -> None:
         async for session in db_manager.get_session(echo=False):
+            # ---- T027: Unscoped cross-segment warning (FR-014) ----
+            if cross_segment and not language and not channel and not video_id:
+                segment_repo = TranscriptSegmentRepository()
+                total_count = await segment_repo.count_filtered(session)
+                if total_count > 5000 and not yes:
+                    console.print(
+                        f"[yellow]Warning: --cross-segment with no scope filter will load "
+                        f"~{total_count:,} segments into memory.\n"
+                        f"For large libraries this may be slow. Use --video-id, --language, "
+                        f"or --channel to narrow the scope, or pass --yes to proceed.[/yellow]"
+                    )
+                    confirmed = typer.confirm("Continue?", default=False)
+                    if not confirmed:
+                        console.print("[yellow]Cancelled.[/yellow]")
+                        raise typer.Exit(code=0)
+
             if dry_run:
                 # ---- Dry-run mode (T013) ----
                 previews = await service.find_and_replace(
@@ -255,6 +280,7 @@ def find_replace(
                     correction_note=correction_note,
                     batch_size=batch_size,
                     dry_run=True,
+                    cross_segment=cross_segment,
                 )
 
                 # previews is list[tuple[str, int, float, str, str]]
@@ -267,39 +293,112 @@ def find_replace(
                     raise typer.Exit(code=0)
 
                 # Build Rich preview table
-                preview_table = Table(
-                    title="Dry-Run Preview",
-                    show_header=True,
-                    header_style="bold blue",
-                )
-                preview_table.add_column("video_id", style="dim", width=14)
-                preview_table.add_column("segment_id", style="dim", width=12)
-                preview_table.add_column("start_time", style="dim", width=10)
-                preview_table.add_column("Current Text", style="cyan", width=40)
-                preview_table.add_column("Proposed Text", style="green", width=40)
-
-                display_pattern = pattern if not regex else pattern
-                for row in previews[:limit]:
-                    vid, seg_id, start, current, proposed = row
-                    current_display = _truncate_with_context(
-                        current, display_pattern, max_len=80
+                if cross_segment:
+                    preview_table = Table(
+                        title="Dry-Run Preview",
+                        show_header=True,
+                        header_style="bold blue",
                     )
-                    proposed_display = _truncate_end(proposed, max_len=80)
-                    preview_table.add_row(
-                        vid,
-                        str(seg_id),
-                        f"{start:.1f}",
-                        current_display,
-                        proposed_display,
+                    preview_table.add_column("video_id", style="dim", width=14)
+                    preview_table.add_column("segment_id", style="dim", width=12)
+                    preview_table.add_column("start_time", style="dim", width=10)
+                    preview_table.add_column("Type", style="dim", width=6)
+                    preview_table.add_column("Current Text", style="cyan", width=40)
+                    preview_table.add_column("Proposed Text", style="green", width=40)
+
+                    # Detect cross-segment pairs by checking for consecutive
+                    # segment_ids originating from the same video in sequence.
+                    # The service returns rows sorted by video/start_time, and
+                    # cross-segment pair rows share a common boundary marker stored
+                    # in the tuple's 5th element (proposed text prefix "[cross-segment").
+                    # We use a simpler heuristic: track which row indices form pairs
+                    # by looking at consecutive rows from the same video where the
+                    # proposed text of the first starts matching the combined text.
+                    # Since the service does not currently annotate pair membership
+                    # in the dry-run tuples, we identify pairs by consecutive rows
+                    # from the same video with adjacent segment IDs.
+                    pair_indices: set[int] = set()
+                    for idx in range(len(previews) - 1):
+                        curr_vid, curr_seg, _, curr_text, curr_proposed = previews[idx]
+                        next_vid, next_seg, _, next_text, next_proposed = previews[idx + 1]
+                        if curr_vid == next_vid and next_seg == curr_seg + 1:
+                            pair_indices.add(idx)
+                            pair_indices.add(idx + 1)
+
+                    cross_pair_count = len(pair_indices) // 2
+
+                    for idx, row in enumerate(previews[:limit]):
+                        vid, seg_id, start, current, proposed = row
+                        if idx in pair_indices:
+                            # Determine if first or second in pair
+                            is_first = idx not in {j + 1 for j in pair_indices if j < idx and j in pair_indices}
+                            pair_marker = "\u2576\u2500\u2510" if is_first else "\u2576\u2500\u2518"
+                            # Tail truncation for first; head truncation for second
+                            if is_first:
+                                current_display = _truncate_end(current, max_len=80)
+                            else:
+                                current_display = (
+                                    "..." + current[-(80 - 3):] if len(current) > 80 else current
+                                )
+                            proposed_display = _truncate_end(proposed, max_len=80)
+                        else:
+                            pair_marker = ""
+                            current_display = _truncate_with_context(
+                                current, pattern if not regex else pattern, max_len=80
+                            )
+                            proposed_display = _truncate_end(proposed, max_len=80)
+
+                        preview_table.add_row(
+                            vid,
+                            str(seg_id),
+                            f"{start:.1f}",
+                            pair_marker,
+                            current_display,
+                            proposed_display,
+                        )
+
+                    console.print(preview_table)
+
+                    unique_videos = len({r[0] for r in previews})
+                    console.print(
+                        f"\nDry run complete: [bold]{len(previews)}[/bold] segments "
+                        f"would be corrected across [bold]{unique_videos}[/bold] videos "
+                        f"([bold]{cross_pair_count}[/bold] cross-segment pairs)."
                     )
+                else:
+                    preview_table = Table(
+                        title="Dry-Run Preview",
+                        show_header=True,
+                        header_style="bold blue",
+                    )
+                    preview_table.add_column("video_id", style="dim", width=14)
+                    preview_table.add_column("segment_id", style="dim", width=12)
+                    preview_table.add_column("start_time", style="dim", width=10)
+                    preview_table.add_column("Current Text", style="cyan", width=40)
+                    preview_table.add_column("Proposed Text", style="green", width=40)
 
-                console.print(preview_table)
+                    display_pattern = pattern if not regex else pattern
+                    for row in previews[:limit]:
+                        vid, seg_id, start, current, proposed = row
+                        current_display = _truncate_with_context(
+                            current, display_pattern, max_len=80
+                        )
+                        proposed_display = _truncate_end(proposed, max_len=80)
+                        preview_table.add_row(
+                            vid,
+                            str(seg_id),
+                            f"{start:.1f}",
+                            current_display,
+                            proposed_display,
+                        )
 
-                unique_videos = len({r[0] for r in previews})
-                console.print(
-                    f"\nDry run complete: [bold]{len(previews)}[/bold] segments "
-                    f"would be corrected across [bold]{unique_videos}[/bold] videos."
-                )
+                    console.print(preview_table)
+
+                    unique_videos = len({r[0] for r in previews})
+                    console.print(
+                        f"\nDry run complete: [bold]{len(previews)}[/bold] segments "
+                        f"would be corrected across [bold]{unique_videos}[/bold] videos."
+                    )
                 return
 
             # ---- Live mode: scan first for confirmation (T014) ----
@@ -316,6 +415,7 @@ def find_replace(
                 correction_note=correction_note,
                 batch_size=batch_size,
                 dry_run=True,
+                cross_segment=cross_segment,
             )
             assert isinstance(previews_for_count, list)
 
@@ -329,6 +429,15 @@ def find_replace(
 
             unique_videos = len({r[0] for r in previews_for_count})
 
+            # Count cross-segment pairs for confirmation message
+            cross_pair_count = 0
+            if cross_segment:
+                for idx in range(len(previews_for_count) - 1):
+                    curr_vid, curr_seg = previews_for_count[idx][0], previews_for_count[idx][1]
+                    next_vid, next_seg = previews_for_count[idx + 1][0], previews_for_count[idx + 1][1]
+                    if curr_vid == next_vid and next_seg == curr_seg + 1:
+                        cross_pair_count += 1
+
             # Show confirmation info
             console.print(f"\n[bold]Pattern:[/bold]      {pattern}")
             console.print(f"[bold]Replacement:[/bold]  {replacement}")
@@ -340,6 +449,8 @@ def find_replace(
                 filters.append(f"channel={channel}")
             if video_id:
                 filters.append(f"video_ids={video_id}")
+            if cross_segment:
+                filters.append("cross-segment=enabled")
             if filters:
                 console.print(
                     f"[bold]Filters:[/bold]      {', '.join(filters)}"
@@ -347,11 +458,18 @@ def find_replace(
             console.print()
 
             if not yes:
-                confirmed = typer.confirm(
-                    f"This will correct {total_matches} segments "
-                    f"across {unique_videos} videos. Proceed?",
-                    default=False,
-                )
+                if cross_segment:
+                    confirm_msg = (
+                        f"This will correct {total_matches} segments "
+                        f"across {unique_videos} videos "
+                        f"({cross_pair_count} cross-segment pairs). Proceed?"
+                    )
+                else:
+                    confirm_msg = (
+                        f"This will correct {total_matches} segments "
+                        f"across {unique_videos} videos. Proceed?"
+                    )
+                confirmed = typer.confirm(confirm_msg, default=False)
                 if not confirmed:
                     console.print("[yellow]Cancelled.[/yellow]")
                     raise typer.Exit(code=0)
@@ -368,8 +486,8 @@ def find_replace(
                     "Applying corrections...", total=total_matches
                 )
 
-                def _advance(n: int) -> None:
-                    progress.advance(task, advance=n)
+                def _advance(n: int, _task: TaskID = task) -> None:
+                    progress.advance(_task, advance=n)
 
                 result = await service.find_and_replace(
                     session,
@@ -385,6 +503,7 @@ def find_replace(
                     batch_size=batch_size,
                     dry_run=False,
                     progress_callback=_advance,
+                    cross_segment=cross_segment,
                 )
 
             assert isinstance(result, BatchCorrectionResult)
@@ -422,6 +541,43 @@ def find_replace(
 
             console.print(summary_table)
 
+            # ---- T028: Empty segment warning after cross-segment correction ----
+            if cross_segment and result.total_applied > 0:
+                from sqlalchemy import or_
+                from sqlalchemy import select as sa_select
+
+                from chronovista.db.models import (
+                    TranscriptSegment as TranscriptSegmentDB,
+                )
+
+                empty_stmt = sa_select(
+                    TranscriptSegmentDB.id, TranscriptSegmentDB.video_id
+                ).where(
+                    TranscriptSegmentDB.has_correction.is_(True),
+                    or_(
+                        TranscriptSegmentDB.corrected_text.is_(None),
+                        TranscriptSegmentDB.corrected_text == "",
+                        TranscriptSegmentDB.corrected_text == " ",
+                    ),
+                )
+                if video_id:
+                    empty_stmt = empty_stmt.where(
+                        TranscriptSegmentDB.video_id.in_(video_id)
+                    )
+
+                empty_result = await session.execute(empty_stmt)
+                empty_segments = list(empty_result.all())
+
+                if empty_segments:
+                    seg_ids = [str(row.id) for row in empty_segments]
+                    ids_display = ", ".join(seg_ids[:10])
+                    suffix = "..." if len(seg_ids) > 10 else ""
+                    console.print(
+                        f"\n[yellow]Warning: {len(empty_segments)} segment(s) were left "
+                        f"empty or whitespace-only after cross-segment correction: "
+                        f"segment IDs {ids_display}{suffix}[/yellow]"
+                    )
+
     asyncio.run(_run())
 
 
@@ -432,10 +588,10 @@ def find_replace(
 
 @correction_app.command("rebuild-text")
 def rebuild_text(
-    video_id: Optional[List[str]] = typer.Option(
+    video_id: list[str] | None = typer.Option(
         None, "--video-id", help="Filter by video ID (repeatable)"
     ),
-    language: Optional[str] = typer.Option(
+    language: str | None = typer.Option(
         None, "--language", help="Filter by language code"
     ),
     dry_run: bool = typer.Option(
@@ -515,8 +671,8 @@ def rebuild_text(
                     "Rebuilding transcripts...", total=total
                 )
 
-                def _advance(n: int) -> None:
-                    progress.advance(task, advance=n)
+                def _advance(n: int, _task: TaskID = task) -> None:
+                    progress.advance(_task, advance=n)
 
                 result = await service.rebuild_text(
                     session,
@@ -547,19 +703,19 @@ def export_corrections(
     format: str = typer.Option(
         ..., "--format", help="Output format: csv or json"
     ),
-    output: Optional[str] = typer.Option(
+    output: str | None = typer.Option(
         None, "--output", help="Output file path (stdout if omitted)"
     ),
-    video_id: Optional[List[str]] = typer.Option(
+    video_id: list[str] | None = typer.Option(
         None, "--video-id", help="Filter by video ID (repeatable)"
     ),
-    correction_type: Optional[str] = typer.Option(
+    correction_type: str | None = typer.Option(
         None, "--correction-type", help="Filter by correction type"
     ),
-    since: Optional[str] = typer.Option(
+    since: str | None = typer.Option(
         None, "--since", help="Inclusive lower bound (ISO 8601)"
     ),
-    until: Optional[str] = typer.Option(
+    until: str | None = typer.Option(
         None, "--until", help="Inclusive upper bound (ISO 8601)"
     ),
     compact: bool = typer.Option(
@@ -585,19 +741,19 @@ def export_corrections(
     if since is not None:
         try:
             since_dt = datetime.fromisoformat(since)
-        except ValueError:
+        except ValueError as err:
             console.print(
                 f"[red]Invalid --since date: '{since}'. Use ISO 8601 format.[/red]"
             )
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from err
     if until is not None:
         try:
             until_dt = datetime.fromisoformat(until)
-        except ValueError:
+        except ValueError as err:
             console.print(
                 f"[red]Invalid --until date: '{until}'. Use ISO 8601 format.[/red]"
             )
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from err
 
     # Validate since < until
     if since_dt is not None and until_dt is not None and since_dt >= until_dt:
@@ -648,7 +804,7 @@ def export_corrections(
 
 @correction_app.command("stats")
 def stats(
-    language: Optional[str] = typer.Option(
+    language: str | None = typer.Option(
         None, "--language", help="Filter by language code"
     ),
     top: int = typer.Option(
@@ -795,10 +951,10 @@ def batch_revert(
     pattern: str = typer.Option(
         ..., "--pattern", help="Text pattern to match for revert"
     ),
-    video_id: Optional[List[str]] = typer.Option(
+    video_id: list[str] | None = typer.Option(
         None, "--video-id", help="Filter by video ID (repeatable)"
     ),
-    language: Optional[str] = typer.Option(
+    language: str | None = typer.Option(
         None, "--language", help="Filter by language code"
     ),
     regex: bool = typer.Option(
@@ -824,7 +980,7 @@ def batch_revert(
             re.compile(pattern)
         except re.error as exc:
             console.print(f"[red]Invalid regex pattern: {exc}[/red]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from exc
 
     service = _create_batch_correction_service()
 
@@ -858,22 +1014,40 @@ def batch_revert(
                 preview_table.add_column("segment_id", style="dim", width=12)
                 preview_table.add_column("start_time", style="dim", width=10)
                 preview_table.add_column("Corrected Text", style="cyan", width=40)
+                preview_table.add_column("Note", style="dim", width=12)
 
-                for vid, seg_id, start, corrected in previews:
+                # T041: Count partner cascade segments
+                partner_cascade_count = 0
+                for row in previews:
+                    # Previews are 5-tuples: (vid, seg_id, start, text, is_partner)
+                    vid, seg_id, start, corrected = row[0], row[1], row[2], row[3]
+                    is_partner = row[4] if len(row) > 4 else False
+                    note_label = "(partner)" if is_partner else ""
+                    if is_partner:
+                        partner_cascade_count += 1
                     preview_table.add_row(
                         vid,
                         str(seg_id),
                         f"{start:.1f}",
                         _truncate_end(corrected, 80),
+                        note_label,
                     )
 
                 console.print(preview_table)
 
                 unique_videos = len({r[0] for r in previews})
-                console.print(
-                    f"\nDry run complete: [bold]{len(previews)}[/bold] segments "
-                    f"would be reverted across [bold]{unique_videos}[/bold] videos."
-                )
+                if partner_cascade_count > 0:
+                    console.print(
+                        f"\nDry run complete: [bold]{len(previews)}[/bold] segments "
+                        f"would be reverted across [bold]{unique_videos}[/bold] videos "
+                        f"([bold]{partner_cascade_count}[/bold] via cross-segment "
+                        f"partner cascade)."
+                    )
+                else:
+                    console.print(
+                        f"\nDry run complete: [bold]{len(previews)}[/bold] segments "
+                        f"would be reverted across [bold]{unique_videos}[/bold] videos."
+                    )
                 return
 
             # ---- Live mode: scan first for confirmation ----
@@ -921,8 +1095,8 @@ def batch_revert(
                     "Reverting corrections...", total=total_matches
                 )
 
-                def _advance(n: int) -> None:
-                    progress.advance(task, advance=n)
+                def _advance(n: int, _task: TaskID = task) -> None:
+                    progress.advance(_task, advance=n)
 
                 result = await service.batch_revert(
                     session,

--- a/src/chronovista/models/batch_correction_models.py
+++ b/src/chronovista/models/batch_correction_models.py
@@ -11,6 +11,8 @@ since they represent computed outputs that should not be mutated after creation.
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -315,6 +317,102 @@ class CorrectionStats(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+class SegmentPair(BaseModel):
+    """Two adjacent transcript segments concatenated for cross-segment matching.
+
+    Represents a conceptual pair of consecutive segments whose effective texts
+    are joined with a single space separator.  The ``boundary_offset`` marks
+    where segment A's text ends and the space separator sits in
+    ``combined_text``.
+
+    Attributes
+    ----------
+    segment_a : Any
+        The first segment (lower ``sequence_number``).
+        Expected type: ``chronovista.db.models.TranscriptSegmentDB``.
+    segment_b : Any
+        The second segment (higher ``sequence_number``).
+        Expected type: ``chronovista.db.models.TranscriptSegmentDB``.
+    combined_text : str
+        ``effective_text(a) + " " + effective_text(b)``.
+    boundary_offset : int
+        ``len(effective_text(a))`` — position of the space separator
+        in ``combined_text`` (must be >= 0).
+    """
+
+    segment_a: Any = Field(
+        ...,
+        description=(
+            "The first segment (lower sequence_number). "
+            "Expected type: chronovista.db.models.TranscriptSegmentDB"
+        ),
+    )
+    segment_b: Any = Field(
+        ...,
+        description=(
+            "The second segment (higher sequence_number). "
+            "Expected type: chronovista.db.models.TranscriptSegmentDB"
+        ),
+    )
+    combined_text: str = Field(
+        ...,
+        description="effective_text(a) + ' ' + effective_text(b)",
+    )
+    boundary_offset: int = Field(
+        ...,
+        ge=0,
+        description="len(effective_text(a)), position of space separator",
+    )
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+
+class CrossSegmentMatch(BaseModel):
+    """A pattern match that spans the boundary between two adjacent segments.
+
+    Captures the match location within the combined text of a
+    :class:`SegmentPair` and the replacement text split across both segments.
+
+    Attributes
+    ----------
+    pair : SegmentPair
+        The matched segment pair.
+    match_start : int
+        Start position in ``combined_text`` (must be >= 0).
+    match_end : int
+        End position in ``combined_text`` (must be >= 0).
+    text_for_seg_a : str
+        Replacement text placed in segment A.
+    text_for_seg_b : str
+        Remaining replacement text for segment B.
+    """
+
+    pair: SegmentPair = Field(
+        ...,
+        description="The matched segment pair",
+    )
+    match_start: int = Field(
+        ...,
+        ge=0,
+        description="Start position in combined_text",
+    )
+    match_end: int = Field(
+        ...,
+        ge=0,
+        description="End position in combined_text",
+    )
+    text_for_seg_a: str = Field(
+        ...,
+        description="Replacement text placed in segment A",
+    )
+    text_for_seg_b: str = Field(
+        ...,
+        description="Remaining replacement text for segment B",
+    )
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+
 __all__ = [
     "TypeCount",
     "VideoCount",
@@ -322,4 +420,6 @@ __all__ = [
     "CorrectionExportRecord",
     "CorrectionPattern",
     "CorrectionStats",
+    "SegmentPair",
+    "CrossSegmentMatch",
 ]

--- a/src/chronovista/repositories/transcript_segment_repository.py
+++ b/src/chronovista/repositories/transcript_segment_repository.py
@@ -11,7 +11,7 @@ User Story 6: Repository Methods and Tests (T019-T025).
 from __future__ import annotations
 
 import re
-from typing import List, Optional, Sequence
+from collections.abc import Sequence
 
 from sqlalchemy import ColumnElement, and_, case, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,6 +21,76 @@ from chronovista.db.models import Video as VideoDB
 from chronovista.models.transcript_segment import TranscriptSegmentCreate
 from chronovista.models.youtube_types import VideoId
 from chronovista.repositories.base import BaseSQLAlchemyRepository
+
+
+def translate_python_regex_to_posix(pattern: str) -> str:
+    """Translate Python regex word-boundary syntax to PostgreSQL POSIX equivalents.
+
+    Python's ``re`` module uses ``\\b`` and ``\\B`` for word-boundary and
+    non-word-boundary assertions respectively.  PostgreSQL's POSIX ``~``
+    operator uses ``\\y`` and ``\\Y`` instead.
+
+    The function validates the pattern with ``re.compile()`` first and
+    raises ``ValueError`` for malformed patterns.
+
+    Parameters
+    ----------
+    pattern : str
+        A Python-flavoured regular expression string.
+
+    Returns
+    -------
+    str
+        The pattern with ``\\b`` → ``\\y`` and ``\\B`` → ``\\Y`` outside
+        character classes.  ``\\b`` inside ``[...]`` (backspace) and
+        escaped backslashes (``\\\\b``) are left unchanged.
+
+    Raises
+    ------
+    ValueError
+        If the pattern is not a valid regular expression.
+    """
+    try:
+        re.compile(pattern)
+    except re.error as exc:
+        raise ValueError(
+            f"Invalid regex pattern '{pattern}': {exc}"
+        ) from exc
+
+    result: list[str] = []
+    i = 0
+    in_char_class = False
+
+    while i < len(pattern):
+        ch = pattern[i]
+
+        if ch == "\\" and i + 1 < len(pattern):
+            next_ch = pattern[i + 1]
+            if next_ch == "\\":
+                # Escaped backslash — emit both and skip ahead
+                result.append("\\\\")
+                i += 2
+                continue
+            if not in_char_class and next_ch in ("b", "B"):
+                # Word-boundary assertion outside char class
+                result.append("\\y" if next_ch == "b" else "\\Y")
+                i += 2
+                continue
+            # Any other escape sequence — pass through unchanged
+            result.append(ch)
+            result.append(next_ch)
+            i += 2
+            continue
+
+        if ch == "[" and not in_char_class:
+            in_char_class = True
+        elif ch == "]" and in_char_class:
+            in_char_class = False
+
+        result.append(ch)
+        i += 1
+
+    return "".join(result)
 
 
 class TranscriptSegmentRepository(
@@ -58,7 +128,7 @@ class TranscriptSegmentRepository(
 
     async def get(
         self, session: AsyncSession, id: int
-    ) -> Optional[TranscriptSegmentDB]:
+    ) -> TranscriptSegmentDB | None:
         """
         Get segment by primary key (id).
 
@@ -106,7 +176,7 @@ class TranscriptSegmentRepository(
         video_id: VideoId,
         language_code: str,
         timestamp: float,
-    ) -> Optional[TranscriptSegmentDB]:
+    ) -> TranscriptSegmentDB | None:
         """
         Get the segment containing the given timestamp.
 
@@ -278,7 +348,7 @@ class TranscriptSegmentRepository(
     async def bulk_create_segments(
         self,
         session: AsyncSession,
-        segments: List[TranscriptSegmentCreate],
+        segments: list[TranscriptSegmentCreate],
     ) -> int:
         """
         Create multiple segments in bulk.
@@ -435,9 +505,9 @@ class TranscriptSegmentRepository(
         pattern: str,
         regex: bool = False,
         case_insensitive: bool = False,
-        language: Optional[str] = None,
-        channel: Optional[str] = None,
-        video_ids: Optional[List[str]] = None,
+        language: str | None = None,
+        channel: str | None = None,
+        video_ids: list[str] | None = None,
     ) -> Sequence[TranscriptSegmentDB]:
         """
         Find segments whose effective text matches a pattern.
@@ -485,6 +555,9 @@ class TranscriptSegmentRepository(
                     f"Invalid regex pattern '{pattern}': {exc}"
                 ) from exc
 
+        # Translate Python word-boundary syntax to PostgreSQL POSIX equivalent
+        sql_pattern = translate_python_regex_to_posix(pattern) if regex else pattern
+
         # Build the effective text expression using SQL CASE
         effective_text = case(
             (TranscriptSegmentDB.has_correction, TranscriptSegmentDB.corrected_text),
@@ -494,9 +567,9 @@ class TranscriptSegmentRepository(
         # Build pattern matching condition
         if regex:
             if case_insensitive:
-                text_condition = effective_text.op("~*")(pattern)
+                text_condition = effective_text.op("~*")(sql_pattern)
             else:
-                text_condition = effective_text.op("~")(pattern)
+                text_condition = effective_text.op("~")(sql_pattern)
         else:
             like_pattern = f"%{pattern}%"
             if case_insensitive:
@@ -544,9 +617,9 @@ class TranscriptSegmentRepository(
         self,
         session: AsyncSession,
         *,
-        language: Optional[str] = None,
-        channel: Optional[str] = None,
-        video_ids: Optional[List[str]] = None,
+        language: str | None = None,
+        channel: str | None = None,
+        video_ids: list[str] | None = None,
     ) -> int:
         """
         Count segments matching the given filter criteria.
@@ -596,6 +669,73 @@ class TranscriptSegmentRepository(
 
         result = await session.execute(stmt)
         return result.scalar() or 0
+
+    async def find_segments_in_scope(
+        self,
+        session: AsyncSession,
+        *,
+        language: str | None = None,
+        channel: str | None = None,
+        video_ids: list[str] | None = None,
+    ) -> Sequence[TranscriptSegmentDB]:
+        """
+        Return all segments matching filter criteria without pattern filtering.
+
+        This method retrieves every segment within the specified scope,
+        ordered for cross-segment pairing. It applies the same filter
+        logic as ``find_by_text_pattern()`` (language, channel, video_ids)
+        but omits the text/pattern matching step, returning all segments
+        in scope.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        language : str, optional
+            Filter by language_code column.
+        channel : str, optional
+            Filter by channel_id via join to videos table.
+        video_ids : list of str, optional
+            Filter by video_id column (list of video IDs).
+
+        Returns
+        -------
+        Sequence[TranscriptSegmentDB]
+            All segments matching the filters, ordered by
+            ``(video_id, language_code, sequence_number)`` for
+            cross-segment pairing.
+        """
+        conditions: list[ColumnElement[bool]] = []
+
+        if language is not None:
+            conditions.append(TranscriptSegmentDB.language_code == language)
+
+        if video_ids is not None:
+            conditions.append(TranscriptSegmentDB.video_id.in_(video_ids))
+
+        order = (
+            TranscriptSegmentDB.video_id,
+            TranscriptSegmentDB.language_code,
+            TranscriptSegmentDB.sequence_number,
+        )
+
+        if channel is not None:
+            stmt = (
+                select(TranscriptSegmentDB)
+                .join(
+                    VideoDB,
+                    TranscriptSegmentDB.video_id == VideoDB.video_id,
+                )
+                .where(and_(*conditions, VideoDB.channel_id == channel))
+                .order_by(*order)
+            )
+        else:
+            stmt = select(TranscriptSegmentDB).order_by(*order)
+            if conditions:
+                stmt = stmt.where(and_(*conditions))
+
+        result = await session.execute(stmt)
+        return result.scalars().all()
 
 
 __all__ = ["TranscriptSegmentRepository"]

--- a/src/chronovista/services/asr_alias_registry.py
+++ b/src/chronovista/services/asr_alias_registry.py
@@ -1,0 +1,162 @@
+"""Shared utility for registering ASR error aliases on entity matches.
+
+Both ``TranscriptCorrectionService`` (single-segment) and
+``BatchCorrectionService`` (batch find-replace) need to auto-register
+ASR error aliases when a correction's replacement text matches a known
+entity.  This module provides a single implementation to avoid
+duplication.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import EntityAlias as EntityAliasDB
+from chronovista.db.models import NamedEntity as NamedEntityDB
+from chronovista.models.entity_alias import EntityAliasCreate
+from chronovista.models.enums import EntityAliasType
+from chronovista.repositories.entity_alias_repository import EntityAliasRepository
+from chronovista.services.tag_normalization import TagNormalizationService
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_entity_id_from_text(
+    session: AsyncSession,
+    text: str,
+) -> tuple[UUID, str] | None:
+    """Resolve an entity ID from text by matching canonical names then aliases.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session.
+    text : str
+        Text to match against entity names/aliases (case-insensitive).
+
+    Returns
+    -------
+    tuple[UUID, str] | None
+        ``(entity_id, entity_name)`` if matched, else ``None``.
+    """
+    normalized_text = text.lower().strip()
+
+    entity_stmt = select(NamedEntityDB).where(
+        NamedEntityDB.status == "active",
+        func.lower(NamedEntityDB.canonical_name) == normalized_text,
+    )
+    result = await session.execute(entity_stmt)
+    entity = result.scalar_one_or_none()
+
+    if entity is not None:
+        return entity.id, entity.canonical_name
+
+    alias_stmt = select(EntityAliasDB).where(
+        func.lower(EntityAliasDB.alias_name) == normalized_text,
+    )
+    alias_result = await session.execute(alias_stmt)
+    matched_alias = alias_result.scalars().first()
+    if matched_alias is None:
+        return None
+    return matched_alias.entity_id, text
+
+
+async def register_asr_alias(
+    session: AsyncSession,
+    *,
+    original_text: str,
+    corrected_text: str,
+    occurrence_count: int = 1,
+    commit: bool = False,
+    log_prefix: str = "asr-alias",
+) -> None:
+    """Best-effort hook: register an ASR error alias when a correction matches an entity.
+
+    If ``corrected_text`` matches a known entity canonical name or alias
+    (case-insensitive exact match), register ``original_text`` as an
+    ``asr_error`` alias for that entity.  If the alias already exists
+    (by normalized form), increment its ``occurrence_count``.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session (caller manages outer transaction).
+    original_text : str
+        The text that was replaced (potential ASR error form).
+    corrected_text : str
+        The corrected text that may match an entity name.
+    occurrence_count : int
+        Number of occurrences to record (default 1 for single-segment,
+        batch count for find-replace).
+    commit : bool
+        Whether to commit after the operation (batch hook needs this,
+        single-segment hook does not).
+    log_prefix : str
+        Prefix for log messages to distinguish callers.
+    """
+    try:
+        match = await resolve_entity_id_from_text(session, corrected_text)
+        if match is None:
+            return
+        entity_id, entity_name = match
+
+        normalizer = TagNormalizationService()
+        normalized = normalizer.normalize(original_text) or original_text.lower()
+
+        # Check by normalized form — matches the unique constraint
+        existing_alias_stmt = select(EntityAliasDB).where(
+            EntityAliasDB.entity_id == entity_id,
+            EntityAliasDB.alias_name_normalized == normalized,
+        )
+        existing_result = await session.execute(existing_alias_stmt)
+        existing_alias = existing_result.scalar_one_or_none()
+
+        if existing_alias is not None:
+            existing_alias.occurrence_count = (
+                existing_alias.occurrence_count or 0
+            ) + occurrence_count
+            await session.flush()
+            if commit:
+                await session.commit()
+            logger.debug(
+                "%s: incremented occurrence_count for alias '%s' on entity '%s' (+%d)",
+                log_prefix,
+                original_text,
+                entity_name,
+                occurrence_count,
+            )
+        else:
+            # Use a savepoint so IntegrityError doesn't poison the outer transaction
+            async with session.begin_nested():
+                new_alias = EntityAliasCreate(
+                    entity_id=entity_id,
+                    alias_name=original_text,
+                    alias_name_normalized=normalized,
+                    alias_type=EntityAliasType.ASR_ERROR,
+                    occurrence_count=occurrence_count,
+                )
+                alias_repo = EntityAliasRepository()
+                await alias_repo.create(session, obj_in=new_alias)
+            if commit:
+                await session.commit()
+            logger.info(
+                "%s: registered ASR alias '%s' for entity '%s' "
+                "(occurrence_count=%d)",
+                log_prefix,
+                original_text,
+                entity_name,
+                occurrence_count,
+            )
+
+    except Exception:
+        logger.warning(
+            "%s hook failed (non-blocking): original_text='%s', corrected_text='%s'",
+            log_prefix,
+            original_text,
+            corrected_text,
+            exc_info=True,
+        )

--- a/src/chronovista/services/batch_correction_service.py
+++ b/src/chronovista/services/batch_correction_service.py
@@ -16,15 +16,14 @@ import json
 import logging
 import re
 import time
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import datetime
-from typing import Any, Awaitable, Callable, Sequence, TypeVar
+from typing import Any, TypeVar
 from uuid import UUID
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from chronovista.db.models import EntityAlias as EntityAliasDB
-from chronovista.db.models import NamedEntity as NamedEntityDB
 from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
 from chronovista.db.models import VideoTranscript as VideoTranscriptDB
 from chronovista.models.batch_correction_models import (
@@ -32,11 +31,11 @@ from chronovista.models.batch_correction_models import (
     CorrectionExportRecord,
     CorrectionPattern,
     CorrectionStats,
+    CrossSegmentMatch,
+    SegmentPair,
 )
 from chronovista.models.correction_actors import ACTOR_CLI_BATCH
-from chronovista.models.entity_alias import EntityAliasCreate
-from chronovista.models.enums import CorrectionType, EntityAliasType
-from chronovista.repositories.entity_alias_repository import EntityAliasRepository
+from chronovista.models.enums import CorrectionType
 from chronovista.repositories.transcript_correction_repository import (
     TranscriptCorrectionRepository,
 )
@@ -101,6 +100,7 @@ class BatchCorrectionService:
         batch_size: int = 100,
         dry_run: bool = False,
         progress_callback: Callable[[int], None] | None = None,
+        cross_segment: bool = False,
     ) -> BatchCorrectionResult | list[tuple[str, int, float, str, str]]:
         """
         Find segments matching *pattern* and replace with *replacement*.
@@ -159,7 +159,8 @@ class BatchCorrectionService:
         _start_time = time.monotonic()
         logger.info(
             "find_and_replace started: pattern=%r, regex=%s, case_insensitive=%s, "
-            "language=%s, channel=%s, video_ids=%s, dry_run=%s, batch_size=%d",
+            "language=%s, channel=%s, video_ids=%s, dry_run=%s, batch_size=%d, "
+            "cross_segment=%s",
             pattern,
             regex,
             case_insensitive,
@@ -168,6 +169,7 @@ class BatchCorrectionService:
             video_ids,
             dry_run,
             batch_size,
+            cross_segment,
         )
 
         # Step 1: Validate pattern
@@ -181,7 +183,7 @@ class BatchCorrectionService:
             video_ids=video_ids,
         )
 
-        # Step 3: Find matching segments
+        # Step 3: Find matching segments (single-segment matching)
         matched_segments = await self._segment_repo.find_by_text_pattern(
             session,
             pattern=pattern,
@@ -215,9 +217,29 @@ class BatchCorrectionService:
                 )
             return effective_text.replace(pattern, replacement)
 
+        # ------------------------------------------------------------------
+        # Cross-segment matching (T020-T025)
+        # ------------------------------------------------------------------
+        cross_segment_matches: list[CrossSegmentMatch] = []
+
+        if cross_segment:
+            cross_segment_matches = await self._find_cross_segment_matches(
+                session,
+                pattern=pattern,
+                replacement=replacement,
+                regex=regex,
+                case_insensitive=case_insensitive,
+                re_flags=re_flags,
+                language=language,
+                channel=channel,
+                video_ids=video_ids,
+                single_segment_ids={seg.id for seg in matched_segments},
+            )
+
         # ------ Dry-run mode ------
         if dry_run:
             previews: list[tuple[str, int, float, str, str]] = []
+            # Single-segment previews
             for segment in matched_segments:
                 effective_text = (
                     segment.corrected_text
@@ -232,10 +254,37 @@ class BatchCorrectionService:
                     effective_text,
                     new_text,
                 ))
+            # Cross-segment previews (two rows per pair)
+            for csm in cross_segment_matches:
+                pair = csm.pair
+                seg_a = pair.segment_a
+                seg_b = pair.segment_b
+                eff_a: str = (
+                    seg_a.corrected_text if seg_a.has_correction else seg_a.text
+                ) or ""
+                eff_b: str = (
+                    seg_b.corrected_text if seg_b.has_correction else seg_b.text
+                ) or ""
+                previews.append((
+                    seg_a.video_id,
+                    seg_a.id,
+                    seg_a.start_time,
+                    eff_a,
+                    csm.text_for_seg_a,
+                ))
+                previews.append((
+                    seg_b.video_id,
+                    seg_b.id,
+                    seg_b.start_time,
+                    eff_b,
+                    csm.text_for_seg_b,
+                ))
             _elapsed = time.monotonic() - _start_time
             logger.info(
-                "find_and_replace completed (dry_run): matched=%d, duration=%.2fs",
+                "find_and_replace completed (dry_run): matched=%d, "
+                "cross_segment_pairs=%d, duration=%.2fs",
                 len(previews),
+                len(cross_segment_matches),
                 _elapsed,
             )
             return previews
@@ -243,7 +292,14 @@ class BatchCorrectionService:
         # ------ Live mode ------
         # Count unique videos among matched segments
         unique_video_ids = {seg.video_id for seg in matched_segments}
+        # Include cross-segment matches in unique video count
+        for csm in cross_segment_matches:
+            unique_video_ids.add(csm.pair.segment_a.video_id)
         unique_videos = len(unique_video_ids)
+
+        # Add cross-segment matched segments to total_matched count
+        # Each segment in a pair counts as 1
+        total_matched += len(cross_segment_matches) * 2
 
         # Zero matches → short-circuit
         if total_matched == 0:
@@ -313,6 +369,33 @@ class BatchCorrectionService:
             )
         )
 
+        # ------------------------------------------------------------------
+        # Apply cross-segment corrections (T023-T025)
+        # ------------------------------------------------------------------
+        if cross_segment_matches:
+            cs_applied, cs_skipped, cs_failed, cs_failed_batches = (
+                await self._apply_cross_segment_corrections(
+                    session,
+                    cross_segment_matches,
+                    correction_type=correction_type,
+                    correction_note=correction_note,
+                    batch_size=batch_size,
+                    progress_callback=progress_callback,
+                )
+            )
+            total_applied += cs_applied
+            total_skipped += cs_skipped
+            total_failed += cs_failed
+            failed_batches += cs_failed_batches
+
+            # Track matched forms for cross-segment alias registration
+            for csm in cross_segment_matches:
+                combined = csm.pair.combined_text
+                matched_text = combined[csm.match_start:csm.match_end]
+                matched_form_counts[matched_text] = (
+                    matched_form_counts.get(matched_text, 0) + 1
+                )
+
         # Auto-register ASR aliases: each distinct matched form is registered
         # as a separate alias with its own occurrence count.
         if total_applied > 0:
@@ -328,7 +411,7 @@ class BatchCorrectionService:
         logger.info(
             "find_and_replace completed: scanned=%d, matched=%d, applied=%d, "
             "skipped=%d, failed=%d, failed_batches=%d, unique_videos=%d, "
-            "duration=%.2fs",
+            "cross_segment_pairs=%d, duration=%.2fs",
             total_scanned,
             total_matched,
             total_applied,
@@ -336,6 +419,7 @@ class BatchCorrectionService:
             total_failed,
             failed_batches,
             unique_videos,
+            len(cross_segment_matches),
             _elapsed,
         )
 
@@ -557,7 +641,7 @@ class BatchCorrectionService:
         if format == "json":
             # Custom serializer for UUID and datetime
             def _json_default(obj: Any) -> str:
-                if isinstance(obj, (UUID, datetime)):
+                if isinstance(obj, UUID | datetime):
                     return str(obj)
                 raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
@@ -697,7 +781,7 @@ class BatchCorrectionService:
         batch_size: int = 100,
         dry_run: bool = False,
         progress_callback: Callable[[int], None] | None = None,
-    ) -> BatchCorrectionResult | list[tuple[str, int, float, str]]:
+    ) -> BatchCorrectionResult | list[tuple[str, int, float, str, bool]]:
         """
         Revert corrections on segments whose corrected_text matches *pattern*.
 
@@ -777,28 +861,74 @@ class BatchCorrectionService:
             seg for seg in matched_segments if seg.has_correction
         ]
 
-        total_matched = len(corrected_matches)
+        # Step 5: Discover cross-segment partners (T038)
+        # For each matched segment, check if its latest correction has a
+        # [cross-segment:partner=N] marker.  If so, include the partner
+        # in the revert set even if it didn't match the search pattern.
+        seen_segment_ids = {seg.id for seg in corrected_matches}
+        partner_segments: list[Any] = []
+        # Maps segment_id → partner_segment_id for display purposes
+        partner_map: dict[int, int] = {}
+
+        for seg in corrected_matches:
+            partner_id = await self._get_cross_segment_partner_id(
+                session, seg
+            )
+            if partner_id is not None and partner_id not in seen_segment_ids:
+                partner_seg = await session.get(
+                    TranscriptSegmentDB, partner_id
+                )
+                if partner_seg is not None and partner_seg.has_correction:
+                    partner_segments.append(partner_seg)
+                    seen_segment_ids.add(partner_id)
+                    partner_map[seg.id] = partner_id
+                elif partner_seg is None:
+                    # T039: Missing partner — log warning, continue
+                    logger.warning(
+                        "Cross-segment partner segment %d not found "
+                        "(may have been re-downloaded). Reverting only "
+                        "the surviving segment %d.",
+                        partner_id,
+                        seg.id,
+                    )
+
+        all_to_revert = list(corrected_matches) + partner_segments
+        total_matched = len(all_to_revert)
+        partner_cascade_count = len(partner_segments)
 
         # ------ Dry-run mode ------
         if dry_run:
-            previews: list[tuple[str, int, float, str]] = []
+            # Return tuples with 5 elements: the 5th is a bool indicating
+            # whether the segment was added via partner cascade.
+            previews: list[tuple[str, int, float, str, bool]] = []
             for seg in corrected_matches:
                 previews.append((
                     seg.video_id,
                     seg.id,
                     seg.start_time,
                     seg.corrected_text or "",
+                    False,
+                ))
+            for seg in partner_segments:
+                previews.append((
+                    seg.video_id,
+                    seg.id,
+                    seg.start_time,
+                    seg.corrected_text or "",
+                    True,
                 ))
             _elapsed = time.monotonic() - _start_time
             logger.info(
-                "batch_revert completed (dry_run): matched=%d, duration=%.2fs",
+                "batch_revert completed (dry_run): matched=%d, "
+                "partner_cascade=%d, duration=%.2fs",
                 len(previews),
+                partner_cascade_count,
                 _elapsed,
             )
             return previews
 
         # ------ Live mode ------
-        unique_video_ids = {seg.video_id for seg in corrected_matches}
+        unique_video_ids = {seg.video_id for seg in all_to_revert}
         unique_videos = len(unique_video_ids)
 
         if total_matched == 0:
@@ -818,12 +948,19 @@ class BatchCorrectionService:
                 unique_videos=0,
             )
 
+        # Track which segments have already been reverted (to avoid
+        # double-reverting when both segments in a pair match the pattern).
+        reverted_ids: set[int] = set()
+
         async def _revert_one(session: AsyncSession, segment: Any) -> str:
+            if segment.id in reverted_ids:
+                return "skipped"
             try:
                 await self._correction_service.revert_correction(
                     session,
                     segment_id=segment.id,
                 )
+                reverted_ids.add(segment.id)
             except ValueError:
                 return "skipped"
             return "applied"
@@ -831,7 +968,7 @@ class BatchCorrectionService:
         total_applied, total_skipped, total_failed, failed_batches = (
             await self._process_in_batches(
                 session,
-                list(corrected_matches),
+                all_to_revert,
                 _revert_one,
                 batch_size=batch_size,
                 progress_callback=progress_callback,
@@ -842,7 +979,7 @@ class BatchCorrectionService:
         logger.info(
             "batch_revert completed: scanned=%d, matched=%d, applied=%d, "
             "skipped=%d, failed=%d, failed_batches=%d, unique_videos=%d, "
-            "duration=%.2fs",
+            "partner_cascade=%d, duration=%.2fs",
             total_scanned,
             total_matched,
             total_applied,
@@ -850,6 +987,7 @@ class BatchCorrectionService:
             total_failed,
             failed_batches,
             unique_videos,
+            partner_cascade_count,
             _elapsed,
         )
 
@@ -866,6 +1004,399 @@ class BatchCorrectionService:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    _CROSS_SEGMENT_PARTNER_RE = re.compile(
+        r"\[cross-segment:partner=(\d+)\]"
+    )
+
+    async def _get_cross_segment_partner_id(
+        self,
+        session: AsyncSession,
+        segment: Any,
+    ) -> int | None:
+        """
+        Check whether a segment's latest correction has a cross-segment
+        partner marker and return the partner segment ID if found.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        segment : TranscriptSegmentDB
+            The segment to inspect.
+
+        Returns
+        -------
+        int or None
+            The partner segment ID, or ``None`` if no marker is present.
+        """
+        # Query the latest correction record for this segment
+        latest_records = await self._correction_repo.get_by_segment(
+            session,
+            segment.video_id,
+            segment.language_code,
+            segment.id,
+            limit=1,
+        )
+        if not latest_records:
+            return None
+
+        latest = latest_records[0]
+        if not latest.correction_note:
+            return None
+
+        match = self._CROSS_SEGMENT_PARTNER_RE.search(
+            latest.correction_note
+        )
+        if match:
+            return int(match.group(1))
+        return None
+
+    async def _find_cross_segment_matches(
+        self,
+        session: AsyncSession,
+        *,
+        pattern: str,
+        replacement: str,
+        regex: bool,
+        case_insensitive: bool,
+        re_flags: int,
+        language: str | None,
+        channel: str | None,
+        video_ids: list[str] | None,
+        single_segment_ids: set[int],
+    ) -> list[CrossSegmentMatch]:
+        """
+        Find cross-segment pattern matches (T020-T022).
+
+        Fetches all segments in scope, groups by (video_id, language_code),
+        pairs strictly consecutive segments, and matches the pattern against
+        the combined text of each pair. Only matches that span the boundary
+        between the two segments are considered cross-segment matches.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        pattern : str
+            Search pattern (substring or regex).
+        replacement : str
+            Replacement text.
+        regex : bool
+            Whether pattern is a regex.
+        case_insensitive : bool
+            Whether to use case-insensitive matching.
+        re_flags : int
+            Pre-computed regex flags.
+        language : str or None
+            Language filter.
+        channel : str or None
+            Channel filter.
+        video_ids : list[str] or None
+            Video ID filter.
+        single_segment_ids : set[int]
+            IDs of segments already matched by single-segment matching.
+            These segments are excluded from cross-segment pairing.
+
+        Returns
+        -------
+        list[CrossSegmentMatch]
+            Cross-segment matches found, with replacement text split
+            across the two segments.
+        """
+        # T020: Fetch all segments in scope
+        all_segments = await self._segment_repo.find_segments_in_scope(
+            session,
+            language=language,
+            channel=channel,
+            video_ids=video_ids,
+        )
+
+        # Group by (video_id, language_code)
+        from collections import defaultdict
+
+        groups: dict[tuple[str, str], list[Any]] = defaultdict(list)
+        for seg in all_segments:
+            groups[(seg.video_id, seg.language_code)].append(seg)
+
+        # Build pairs of strictly consecutive segments
+        pairs: list[SegmentPair] = []
+        for _key, segs in groups.items():
+            # Segments are already ordered by sequence_number from the repo
+            for i in range(len(segs) - 1):
+                seg_a = segs[i]
+                seg_b = segs[i + 1]
+
+                # Strictly consecutive: seq_b == seq_a + 1
+                if seg_b.sequence_number != seg_a.sequence_number + 1:
+                    continue
+
+                # Exclude pairs where either segment has a single-segment match
+                if seg_a.id in single_segment_ids or seg_b.id in single_segment_ids:
+                    continue
+
+                # Get effective text
+                eff_a: str = (
+                    seg_a.corrected_text if seg_a.has_correction else seg_a.text
+                ) or ""
+                eff_b: str = (
+                    seg_b.corrected_text if seg_b.has_correction else seg_b.text
+                ) or ""
+
+                # Strip whitespace at boundary
+                eff_a_stripped = eff_a.rstrip()
+                eff_b_stripped = eff_b.lstrip()
+
+                # Skip pairs where either segment has empty effective text
+                if not eff_a_stripped or not eff_b_stripped:
+                    continue
+
+                # Build combined text and boundary offset
+                combined = eff_a_stripped + " " + eff_b_stripped
+                boundary = len(eff_a_stripped)
+
+                pairs.append(SegmentPair(
+                    segment_a=seg_a,
+                    segment_b=seg_b,
+                    combined_text=combined,
+                    boundary_offset=boundary,
+                ))
+
+        # T021: Match pattern against combined text
+        # T022: Conflict detection — track claimed segment IDs
+        claimed_ids: set[int] = set()
+        matches: list[CrossSegmentMatch] = []
+
+        for pair in pairs:
+            # Skip if either segment already claimed by a prior cross-segment pair
+            if pair.segment_a.id in claimed_ids or pair.segment_b.id in claimed_ids:
+                logger.warning(
+                    "Cross-segment conflict: segment %d or %d already claimed "
+                    "by an earlier pair — skipping pair (seq %d, %d)",
+                    pair.segment_a.id,
+                    pair.segment_b.id,
+                    pair.segment_a.sequence_number,
+                    pair.segment_b.sequence_number,
+                )
+                continue
+
+            combined = pair.combined_text
+            boundary = pair.boundary_offset
+
+            # Find matches in combined text
+            if regex:
+                found_matches = list(
+                    re.finditer(pattern, combined, flags=re_flags)
+                )
+            else:
+                # Build match objects for substring search
+                search_pattern = re.escape(pattern)
+                flags = re.IGNORECASE if case_insensitive else 0
+                found_matches = list(
+                    re.finditer(search_pattern, combined, flags=flags)
+                )
+
+            # Filter to matches that span the boundary
+            # A match spans the boundary if it starts at or before boundary
+            # AND ends after boundary (the space at position boundary)
+            cross_matches = [
+                m for m in found_matches
+                if m.start() <= boundary and m.end() > boundary
+            ]
+
+            if not cross_matches:
+                continue
+
+            # Take the first boundary-spanning match (non-overlapping patterns
+            # can produce at most one match spanning any given position)
+            match = cross_matches[0]
+            ms, me = match.start(), match.end()
+
+            # Compute replacement text for each segment
+            # For regex with backreferences, use match.expand()
+            actual_replacement = match.expand(replacement) if regex else replacement
+
+            # Decompose: replacement goes entirely into seg A,
+            # matched fragment removed from seg B
+            eff_a_stripped = combined[:boundary]
+            eff_b_stripped = combined[boundary + 1:]  # skip the space
+
+            new_a = eff_a_stripped[:ms] + actual_replacement
+            b_consumed = me - (boundary + 1)  # chars of seg B consumed by match
+            new_b = eff_b_stripped[b_consumed:]
+
+            # Whitespace normalize
+            new_a = " ".join(new_a.split()).strip()
+            new_b = " ".join(new_b.split()).strip()
+
+            # Warn if seg B becomes empty (FR-008)
+            if not new_b.strip():
+                logger.warning(
+                    "Cross-segment correction left segment %d "
+                    "(seq %d) empty or whitespace-only (FR-008)",
+                    pair.segment_b.id,
+                    pair.segment_b.sequence_number,
+                )
+
+            csm = CrossSegmentMatch(
+                pair=pair,
+                match_start=ms,
+                match_end=me,
+                text_for_seg_a=new_a,
+                text_for_seg_b=new_b,
+            )
+            matches.append(csm)
+
+            # Claim both segments
+            claimed_ids.add(pair.segment_a.id)
+            claimed_ids.add(pair.segment_b.id)
+
+        logger.info(
+            "Cross-segment matching: %d pairs evaluated, %d matches found",
+            len(pairs),
+            len(matches),
+        )
+        return matches
+
+    async def _apply_cross_segment_corrections(
+        self,
+        session: AsyncSession,
+        matches: list[CrossSegmentMatch],
+        *,
+        correction_type: CorrectionType,
+        correction_note: str | None,
+        batch_size: int,
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> tuple[int, int, int, int]:
+        """
+        Apply cross-segment corrections (T023-T025).
+
+        For each cross-segment match, applies corrections to both segments
+        in the pair using ``TranscriptCorrectionService.apply_correction``.
+        Each segment gets a correction note indicating its cross-segment
+        partner.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        matches : list[CrossSegmentMatch]
+            Cross-segment matches to apply.
+        correction_type : CorrectionType
+            Category of correction.
+        correction_note : str or None
+            Base correction note.
+        batch_size : int
+            Number of pairs per transaction chunk.
+        progress_callback : Callable or None
+            Progress callback.
+
+        Returns
+        -------
+        tuple[int, int, int, int]
+            ``(total_applied, total_skipped, total_failed, failed_batches)``
+        """
+        total_applied = 0
+        total_skipped = 0
+        total_failed = 0
+        failed_batches = 0
+
+        # Process in batches (batch_size counts pairs)
+        for offset in range(0, len(matches), batch_size):
+            chunk = matches[offset:offset + batch_size]
+            try:
+                chunk_applied = 0
+                chunk_skipped = 0
+
+                for csm in chunk:
+                    pair = csm.pair
+                    seg_a = pair.segment_a
+                    seg_b = pair.segment_b
+
+                    # T025: Correction notes with cross-segment partner info
+                    note_a = (
+                        f"{correction_note} " if correction_note else ""
+                    ) + f"[cross-segment:partner={seg_b.id}]"
+                    note_b = (
+                        f"{correction_note} " if correction_note else ""
+                    ) + f"[cross-segment:partner={seg_a.id}]"
+
+                    # Apply correction to segment A
+                    a_applied = False
+                    try:
+                        await self._correction_service.apply_correction(
+                            session,
+                            video_id=seg_a.video_id,
+                            language_code=seg_a.language_code,
+                            segment_id=seg_a.id,
+                            corrected_text=csm.text_for_seg_a,
+                            correction_type=correction_type,
+                            correction_note=note_a,
+                            corrected_by_user_id=ACTOR_CLI_BATCH,
+                        )
+                        a_applied = True
+                    except ValueError:
+                        # No-op: text unchanged
+                        pass
+
+                    # Apply correction to segment B
+                    # FR-008: if correction empties seg B, use a single space
+                    # to preserve truthiness (Python "" is falsy, which breaks
+                    # the standard ``corrected_text or text`` pattern used in
+                    # downstream reads).
+                    b_corrected_text = csm.text_for_seg_b or " "
+                    b_applied = False
+                    try:
+                        await self._correction_service.apply_correction(
+                            session,
+                            video_id=seg_b.video_id,
+                            language_code=seg_b.language_code,
+                            segment_id=seg_b.id,
+                            corrected_text=b_corrected_text,
+                            correction_type=correction_type,
+                            correction_note=note_b,
+                            corrected_by_user_id=ACTOR_CLI_BATCH,
+                        )
+                        b_applied = True
+                    except ValueError:
+                        # No-op: text unchanged
+                        pass
+
+                    if a_applied or b_applied:
+                        chunk_applied += (1 if a_applied else 0) + (
+                            1 if b_applied else 0
+                        )
+                    else:
+                        chunk_skipped += 2
+
+                await session.commit()
+                total_applied += chunk_applied
+                total_skipped += chunk_skipped
+
+                logger.debug(
+                    "Cross-segment batch committed: offset=%d, applied=%d, "
+                    "skipped=%d",
+                    offset,
+                    chunk_applied,
+                    chunk_skipped,
+                )
+            except Exception:
+                await session.rollback()
+                failed_batches += 1
+                total_failed += len(chunk) * 2  # 2 segments per pair
+
+                logger.warning(
+                    "Cross-segment batch failed and rolled back: "
+                    "offset=%d, chunk_size=%d",
+                    offset,
+                    len(chunk),
+                    exc_info=True,
+                )
+
+            if progress_callback is not None:
+                progress_callback(len(chunk))
+
+        return total_applied, total_skipped, total_failed, failed_batches
 
     async def _process_in_batches(
         self,
@@ -964,106 +1495,18 @@ class BatchCorrectionService:
     ) -> None:
         """Best-effort hook: register the search pattern as an ASR error alias.
 
-        If ``replacement`` matches a known entity canonical name or alias
-        (case-insensitive exact match), register ``pattern`` as an
-        ``asr_error`` alias for that entity.  If the alias already exists,
-        increment its ``occurrence_count`` by ``total_applied``.
-
-        Parameters
-        ----------
-        session : AsyncSession
-            Database session.
-        pattern : str
-            The search text (potential ASR error form).
-        replacement : str
-            The replacement text that may match an entity name.
-        total_applied : int
-            Number of corrections applied (used for occurrence_count).
+        Delegates to :func:`~chronovista.services.asr_alias_registry.register_asr_alias`.
         """
-        try:
-            # Resolve entity from replacement text
-            entity_id: UUID | None = None
-            entity_name: str | None = None
+        from chronovista.services.asr_alias_registry import register_asr_alias
 
-            entity_stmt = select(NamedEntityDB).where(
-                NamedEntityDB.status == "active",
-                func.lower(NamedEntityDB.canonical_name) == replacement.lower().strip(),
-            )
-            result = await session.execute(entity_stmt)
-            entity = result.scalar_one_or_none()
-
-            if entity is not None:
-                entity_id = entity.id
-                entity_name = entity.canonical_name
-            else:
-                # Check aliases for a match
-                alias_stmt = select(EntityAliasDB).where(
-                    func.lower(EntityAliasDB.alias_name) == replacement.lower().strip(),
-                )
-                alias_result = await session.execute(alias_stmt)
-                matched_alias = alias_result.scalars().first()
-                if matched_alias is None:
-                    return
-                entity_id = matched_alias.entity_id
-                entity_name = replacement
-
-            # Check if pattern is already an alias for this entity
-            existing_alias_stmt = select(EntityAliasDB).where(
-                EntityAliasDB.entity_id == entity_id,
-                func.lower(EntityAliasDB.alias_name) == pattern.lower().strip(),
-            )
-            existing_result = await session.execute(existing_alias_stmt)
-            existing_alias = existing_result.scalar_one_or_none()
-
-            if existing_alias is not None:
-                existing_alias.occurrence_count = (
-                    existing_alias.occurrence_count or 0
-                ) + total_applied
-                await session.flush()
-                await session.commit()
-                logger.info(
-                    "find-replace alias hook: incremented occurrence_count for "
-                    "alias '%s' on entity '%s' (+%d)",
-                    pattern,
-                    entity_name,
-                    total_applied,
-                )
-            else:
-                from chronovista.services.tag_normalization import (
-                    TagNormalizationService,
-                )
-
-                normalizer = TagNormalizationService()
-                normalized = normalizer.normalize(pattern) or pattern.lower()
-
-                new_alias = EntityAliasCreate(
-                    entity_id=entity_id,
-                    alias_name=pattern,
-                    alias_name_normalized=normalized,
-                    alias_type=EntityAliasType.ASR_ERROR,
-                    occurrence_count=total_applied,
-                )
-                alias_repo = EntityAliasRepository()
-                await alias_repo.create(session, obj_in=new_alias)
-                await session.flush()
-                await session.commit()
-                logger.info(
-                    "find-replace alias hook: registered ASR alias '%s' for "
-                    "entity '%s' (occurrence_count=%d). Run "
-                    "'chronovista entities scan' to update entity mentions.",
-                    pattern,
-                    entity_name,
-                    total_applied,
-                )
-
-        except Exception:
-            logger.warning(
-                "find-replace alias hook failed (non-blocking): "
-                "pattern='%s', replacement='%s'",
-                pattern,
-                replacement,
-                exc_info=True,
-            )
+        await register_asr_alias(
+            session,
+            original_text=pattern,
+            corrected_text=replacement,
+            occurrence_count=total_applied,
+            commit=True,
+            log_prefix="find-replace",
+        )
 
     @staticmethod
     def _validate_pattern(pattern: str, *, regex: bool) -> None:

--- a/src/chronovista/services/transcript_correction_service.py
+++ b/src/chronovista/services/transcript_correction_service.py
@@ -15,17 +15,13 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timezone
 
-from sqlalchemy import exists, func, select, text
+from sqlalchemy import exists, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from chronovista.db.models import EntityAlias as EntityAliasDB
-from chronovista.db.models import NamedEntity as NamedEntityDB
 from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
 from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
-from chronovista.models.entity_alias import EntityAliasCreate
-from chronovista.models.enums import CorrectionType, EntityAliasType
+from chronovista.models.enums import CorrectionType
 from chronovista.models.transcript_correction import TranscriptCorrectionCreate
-from chronovista.repositories.entity_alias_repository import EntityAliasRepository
 from chronovista.repositories.transcript_correction_repository import (
     TranscriptCorrectionRepository,
 )
@@ -362,87 +358,18 @@ class TranscriptCorrectionService:
     ) -> None:
         """Best-effort hook: auto-record ASR error alias when correction matches an entity.
 
-        If corrected_text matches a known entity name/alias (case-insensitive exact
-        match), record original_text as an ``asr_error`` alias for that entity.
-
-        Parameters
-        ----------
-        session : AsyncSession
-            Database session (caller manages transaction).
-        original_text : str
-            The text that was replaced (potential ASR error).
-        corrected_text : str
-            The corrected text that may match an entity name.
+        Delegates to :func:`~chronovista.services.asr_alias_registry.register_asr_alias`.
         """
-        try:
-            # Query entities whose canonical_name matches corrected_text (case-insensitive)
-            entity_stmt = select(NamedEntityDB).where(
-                NamedEntityDB.status == "active",
-                func.lower(NamedEntityDB.canonical_name) == corrected_text.lower().strip(),
-            )
-            result = await session.execute(entity_stmt)
-            entity = result.scalar_one_or_none()
+        from chronovista.services.asr_alias_registry import register_asr_alias
 
-            if entity is None:
-                # Check aliases for a match
-                alias_stmt = select(EntityAliasDB).where(
-                    func.lower(EntityAliasDB.alias_name) == corrected_text.lower().strip(),
-                )
-                alias_result = await session.execute(alias_stmt)
-                matched_alias = alias_result.scalars().first()
-                if matched_alias is None:
-                    return
-                entity_id = matched_alias.entity_id
-            else:
-                entity_id = entity.id
-
-            # Check if original_text is already an alias for this entity
-            existing_alias_stmt = select(EntityAliasDB).where(
-                EntityAliasDB.entity_id == entity_id,
-                func.lower(EntityAliasDB.alias_name) == original_text.lower().strip(),
-            )
-            existing_result = await session.execute(existing_alias_stmt)
-            existing_alias = existing_result.scalar_one_or_none()
-
-            if existing_alias is not None:
-                # Increment occurrence_count
-                existing_alias.occurrence_count = (existing_alias.occurrence_count or 0) + 1
-                await session.flush()
-                logger.debug(
-                    "B-lite: incremented occurrence_count for alias '%s' on entity %s",
-                    original_text,
-                    entity_id,
-                )
-            else:
-                # Create new alias
-                from chronovista.services.tag_normalization import TagNormalizationService
-
-                normalizer = TagNormalizationService()
-                normalized = normalizer.normalize(original_text) or original_text.lower()
-
-                new_alias = EntityAliasCreate(
-                    entity_id=entity_id,
-                    alias_name=original_text,
-                    alias_name_normalized=normalized,
-                    alias_type=EntityAliasType.ASR_ERROR,
-                    occurrence_count=1,
-                )
-                alias_repo = EntityAliasRepository()
-                await alias_repo.create(session, obj_in=new_alias)
-                await session.flush()
-                logger.debug(
-                    "B-lite: created asr_error alias '%s' for entity %s",
-                    original_text,
-                    entity_id,
-                )
-
-        except Exception:
-            logger.warning(
-                "B-lite hook failed (non-blocking): original_text='%s', corrected_text='%s'",
-                original_text,
-                corrected_text,
-                exc_info=True,
-            )
+        await register_asr_alias(
+            session,
+            original_text=original_text,
+            corrected_text=corrected_text,
+            occurrence_count=1,
+            commit=False,
+            log_prefix="B-lite",
+        )
 
 
 __all__ = ["TranscriptCorrectionService"]

--- a/tests/integration/services/test_cross_segment_corrections.py
+++ b/tests/integration/services/test_cross_segment_corrections.py
@@ -1,0 +1,1895 @@
+"""
+Integration tests for cross-segment correction pattern matching.
+
+Tests end-to-end behaviour of `TranscriptSegmentRepository.find_by_text_pattern()`
+and `BatchCorrectionService.find_and_replace()` against a real PostgreSQL database.
+Each test uses the `db_session` fixture from `tests/integration/conftest.py`, which
+creates all tables fresh per test and rolls back on completion.
+
+Feature 040 -- Correction Pattern Matching
+
+Test coverage:
+T005  — Word boundary integration: \\bamlo\\w* matches "amlo" / "amlo's government"
+        but must NOT match "kamloops is a city" in the database via find_by_text_pattern().
+T011  — Cross-segment match basic: "Claudia Shane" + "Bound …" corrected to "Claudia Sheinbaum".
+T012  — Single-segment match within cross-segment mode: pattern fully within one segment.
+T013  — No cross-segment flag: only single-segment matches found with default mode.
+T014  — Language boundary: segments with different language codes are NOT paired.
+T015  — Non-consecutive sequence numbers: segments with a gap are NOT paired.
+T016  — Regex + cross-segment composition: regex pattern matched across adjacent pair.
+T016b — Case-insensitive + cross-segment composition: case-folded pattern matched across pair.
+T017  — Overlapping pairs: earlier pair (1,2) wins over later pair (2,3) for shared segment.
+T018  — Empty effective text: pair with one empty segment is skipped.
+T036a — Empty segment after correction: warning displayed, segment not deleted (FR-008).
+T034  — Basic cross-segment revert: apply cross-segment, batch_revert, verify both restored.
+T035  — Partner cascade revert: revert pattern matches one segment, partner cascaded.
+T036b — Revert of emptied segment: revert restores emptied segment to original text.
+T037  — Missing partner on revert: partner deleted, surviving segment still reverted.
+
+Note: T005 will FAIL until T007/T009 implement the regex translator that converts
+Python \\b word-boundary syntax into its PostgreSQL equivalent.
+
+Note: T011-T018 and T036a will FAIL until the ``cross_segment`` parameter is added
+to ``BatchCorrectionService.find_and_replace()``. This is intentional TDD: the tests
+define the contract before the implementation ships.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import (
+    Channel as ChannelDB,
+)
+from chronovista.db.models import (
+    TranscriptSegment as TranscriptSegmentDB,
+)
+from chronovista.db.models import (
+    Video as VideoDB,
+)
+from chronovista.db.models import (
+    VideoTranscript as VideoTranscriptDB,
+)
+from chronovista.repositories.transcript_segment_repository import (
+    TranscriptSegmentRepository,
+)
+from chronovista.services.batch_correction_service import BatchCorrectionService
+from tests.factories.id_factory import channel_id, video_id
+
+# ---------------------------------------------------------------------------
+# Module-level defaults
+# ---------------------------------------------------------------------------
+
+# Deterministic IDs — valid format guaranteed by the factory helpers.
+DEFAULT_CHANNEL_ID: str = channel_id(seed="cross_seg_test")
+
+# CRITICAL: This line ensures async tests work with coverage tools,
+# avoiding silent test-skipping when pytest-cov is used (see CLAUDE.md).
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_channel(
+    session: AsyncSession,
+    ch_id: str = DEFAULT_CHANNEL_ID,
+) -> None:
+    """
+    Insert a minimal Channel row required as FK parent for videos.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Active database session.
+    ch_id : str
+        YouTube channel ID (24-character, starts with 'UC').
+    """
+    channel = ChannelDB(
+        channel_id=ch_id,
+        title="Cross-Segment Integration Test Channel",
+        description="Channel seeded for Feature 040 cross-segment integration tests",
+        is_subscribed=False,
+    )
+    session.add(channel)
+    await session.flush()
+
+
+async def _seed_video(
+    session: AsyncSession,
+    vid_id: str,
+    ch_id: str = DEFAULT_CHANNEL_ID,
+) -> None:
+    """
+    Insert a minimal Video row required as FK parent for transcripts.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Active database session.
+    vid_id : str
+        YouTube video ID (11-character string).
+    ch_id : str
+        Parent channel ID.
+    """
+    video = VideoDB(
+        video_id=vid_id,
+        channel_id=ch_id,
+        title=f"Video {vid_id}",
+        description="Integration test video for cross-segment pattern matching",
+        upload_date=datetime(2024, 6, 1, tzinfo=UTC),
+        duration=300,
+        made_for_kids=False,
+        self_declared_made_for_kids=False,
+    )
+    session.add(video)
+    await session.flush()
+
+
+async def _seed_transcript(
+    session: AsyncSession,
+    vid_id: str,
+    language_code: str = "en",
+) -> None:
+    """
+    Insert a minimal VideoTranscript row required as FK parent for segments.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Active database session.
+    vid_id : str
+        Parent video ID.
+    language_code : str
+        BCP-47 language code for the transcript track.
+    """
+    transcript = VideoTranscriptDB(
+        video_id=vid_id,
+        language_code=language_code,
+        transcript_text="",
+        transcript_type="auto",
+        download_reason="user_request",
+        is_cc=False,
+        is_auto_synced=True,
+        track_kind="standard",
+        source="youtube_transcript_api",
+    )
+    session.add(transcript)
+    await session.flush()
+
+
+async def _seed_segment(
+    session: AsyncSession,
+    *,
+    vid_id: str,
+    language_code: str = "en",
+    sequence_number: int,
+    text: str,
+    start_time: float = 0.0,
+) -> TranscriptSegmentDB:
+    """
+    Insert a TranscriptSegment row and return the ORM object.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Active database session.
+    vid_id : str
+        Parent video ID.
+    language_code : str
+        BCP-47 language code matching the parent VideoTranscript.
+    sequence_number : int
+        Zero-based ordering index within the transcript.
+    text : str
+        Raw ASR text for the segment.
+    start_time : float
+        Segment start time in seconds.
+
+    Returns
+    -------
+    TranscriptSegmentDB
+        The flushed (but not committed) ORM instance.
+    """
+    segment = TranscriptSegmentDB(
+        video_id=vid_id,
+        language_code=language_code,
+        sequence_number=sequence_number,
+        text=text,
+        has_correction=False,
+        start_time=start_time,
+        duration=5.0,
+        end_time=start_time + 5.0,
+    )
+    session.add(segment)
+    await session.flush()
+    return segment
+
+
+# ---------------------------------------------------------------------------
+# T005 — Word boundary integration
+# ---------------------------------------------------------------------------
+
+
+class TestWordBoundaryRegexIntegration:
+    r"""
+    Integration tests for \\b word-boundary behaviour in find_by_text_pattern().
+
+    T005 verifies that the PostgreSQL regex operator ('~') honours word-boundary
+    semantics equivalent to Python's \\b when the pattern \\bamlo\\w* is supplied.
+
+    The three segments seeded cover the three boundary cases that must all be
+    handled correctly in a single call:
+
+    * Segment 0 — "amlo said something"    → matches  (word starts at text start)
+    * Segment 1 — "kamloops is a city"     → no match (amlo is a mid-word substring)
+    * Segment 2 — "amlo's government"      → matches  (word starts at text start,
+                                                        possessive suffix ignored by \\w*)
+
+    NOTE: This test is expected to FAIL until T007/T009 implement the regex
+    translator that converts Python \\b into the correct PostgreSQL equivalent
+    (e.g. \\y or (?<![a-zA-Z]) / (?![a-zA-Z]) boundary assertions). That failure
+    is intentional: this test defines the contract before the implementation ships.
+    """
+
+    async def test_word_boundary_pattern_matches_amlo_but_not_kamloops(
+        self, db_session: AsyncSession
+    ) -> None:
+        r"""
+        \\bamlo\\w* must match segments containing "amlo" as a whole word but
+        must NOT match segments where "amlo" appears only as an interior substring
+        (e.g. "kamloops").
+
+        Seed setup
+        ----------
+        Segment 0 — text = "amlo said something"   → MATCH expected
+        Segment 1 — text = "kamloops is a city"    → NO MATCH expected
+        Segment 2 — text = "amlo's government"     → MATCH expected
+
+        Assertions
+        ----------
+        * Exactly 2 segments returned.
+        * Segment 1 (kamloops) is not among the results.
+        * Segments 0 and 2 are both present in the results (by sequence_number).
+        """
+        vid_id = video_id(seed="wb_amlo_001")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id)
+
+        seg0 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=0,
+            text="amlo said something",
+            start_time=0.0,
+        )
+        seg1 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=1,
+            text="kamloops is a city",
+            start_time=5.0,
+        )
+        seg2 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=2,
+            text="amlo's government",
+            start_time=10.0,
+        )
+
+        await db_session.commit()
+
+        repo = TranscriptSegmentRepository()
+        results = await repo.find_by_text_pattern(
+            db_session,
+            pattern=r"\bamlo\w*",
+            regex=True,
+        )
+
+        # Collect returned segment IDs and sequence numbers for clear failure messages
+        returned_ids = {seg.id for seg in results}
+        returned_seqs = sorted(seg.sequence_number for seg in results)
+
+        assert len(results) == 2, (
+            f"Expected exactly 2 matching segments (seq 0 and 2), "
+            f"got {len(results)}: sequence_numbers={returned_seqs}"
+        )
+
+        assert seg1.id not in returned_ids, (
+            f"Segment 1 ('kamloops is a city') must NOT match \\bamlo\\w* "
+            f"because 'amlo' is a substring of 'kamloops', not a word boundary match. "
+            f"Returned segment IDs: {returned_ids}"
+        )
+
+        assert seg0.id in returned_ids, (
+            f"Segment 0 ('amlo said something') must match \\bamlo\\w* — "
+            f"'amlo' appears at a word boundary. "
+            f"Returned segment IDs: {returned_ids}"
+        )
+
+        assert seg2.id in returned_ids, (
+            f"Segment 2 ('amlo\\'s government') must match \\bamlo\\w* — "
+            f"'amlo' appears at a word boundary before the possessive apostrophe. "
+            f"Returned segment IDs: {returned_ids}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shared service factory for Phase 4 (US2) cross-segment tests
+# ---------------------------------------------------------------------------
+
+
+def _make_batch_service() -> BatchCorrectionService:
+    """
+    Instantiate a ``BatchCorrectionService`` wired with real repositories.
+
+    Using real (zero-config) repositories against the integration database
+    exercises the full stack.  All tests that use this helper share the same
+    class structure so that dependencies are explicit and the factory can be
+    updated in one place when the service constructor changes.
+
+    Returns
+    -------
+    BatchCorrectionService
+        Fully wired service instance.
+    """
+    from chronovista.repositories.transcript_correction_repository import (
+        TranscriptCorrectionRepository,
+    )
+    from chronovista.repositories.transcript_segment_repository import (
+        TranscriptSegmentRepository,
+    )
+    from chronovista.repositories.video_transcript_repository import (
+        VideoTranscriptRepository,
+    )
+    from chronovista.services.batch_correction_service import BatchCorrectionService
+    from chronovista.services.transcript_correction_service import (
+        TranscriptCorrectionService,
+    )
+
+    correction_repo = TranscriptCorrectionRepository()
+    segment_repo = TranscriptSegmentRepository()
+    transcript_repo = VideoTranscriptRepository()
+    correction_service = TranscriptCorrectionService(
+        correction_repo=correction_repo,
+        segment_repo=segment_repo,
+        transcript_repo=transcript_repo,
+    )
+    return BatchCorrectionService(
+        correction_service=correction_service,
+        segment_repo=segment_repo,
+        correction_repo=correction_repo,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T011 — Cross-segment match basic
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSegmentMatchBasic:
+    r"""
+    T011 — Basic end-to-end cross-segment correction.
+
+    Segment 155: "Claudia Shane"
+    Segment 156: "Bound también siendo candidata"
+
+    Pattern "Claudia Shane Bound" spans both segments.  With
+    ``cross_segment=True``, the replacement "Claudia Sheinbaum" should be
+    placed entirely in segment 155, and "Bound" should be removed from the
+    start of segment 156.
+
+    Per spec edge case: "Multiple matches within a single segment pair's
+    concatenated text → all matches are replaced, consistent with single-
+    segment re.sub() behavior."
+
+    NOTE: This test is expected to FAIL until ``find_and_replace()`` gains a
+    ``cross_segment`` parameter.  That failure is intentional TDD.
+    """
+
+    async def test_basic_cross_segment_replacement(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Pattern spanning two adjacent segments is fully replaced in live mode.
+
+        Seed setup
+        ----------
+        Segment 155 — text = "Claudia Shane"        (tail of name)
+        Segment 156 — text = "Bound también siendo candidata"
+                                                     (head of surname + rest)
+
+        Assertions
+        ----------
+        * Result type is ``BatchCorrectionResult``.
+        * ``total_matched >= 1`` (at least the cross-segment pair was detected).
+        * Segment 155 ``corrected_text`` contains "Claudia Sheinbaum".
+        * Segment 155 ``corrected_text`` does NOT contain the ASR artefact "Shane".
+        * Segment 156 ``corrected_text`` does NOT start with "Bound".
+        * Segment 156 ``corrected_text`` still contains "también siendo candidata"
+          (trailing context preserved).
+        """
+        vid_id = video_id(seed="t011_cross_basic")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id, language_code="es")
+
+        seg_a = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=155,
+            text="Claudia Shane",
+            start_time=310.0,
+        )
+        seg_b = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=156,
+            text="Bound también siendo candidata",
+            start_time=315.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern="Claudia Shane Bound",
+            replacement="Claudia Sheinbaum",
+            cross_segment=True,  # TDD: parameter does not yet exist
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult), (
+            f"Expected BatchCorrectionResult, got {type(result)!r}"
+        )
+        assert result.total_matched >= 1, (
+            "Cross-segment pair 'Claudia Shane' + 'Bound …' must be counted as matched. "
+            f"total_matched={result.total_matched}"
+        )
+
+        # Reload corrected segments from DB
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        refreshed_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+
+        assert refreshed_a is not None
+        assert refreshed_b is not None
+
+        corrected_a: str = (refreshed_a.corrected_text or refreshed_a.text) or ""
+        corrected_b: str = (refreshed_b.corrected_text or refreshed_b.text) or ""
+
+        assert "Claudia Sheinbaum" in corrected_a, (
+            f"Segment 155 must contain 'Claudia Sheinbaum' after cross-segment "
+            f"replacement. Got: {corrected_a!r}"
+        )
+        assert "Shane" not in corrected_a, (
+            f"ASR artefact 'Shane' must be removed from segment 155. "
+            f"Got: {corrected_a!r}"
+        )
+        assert not corrected_b.startswith("Bound"), (
+            f"'Bound' must be removed from the start of segment 156. "
+            f"Got: {corrected_b!r}"
+        )
+        assert "también siendo candidata" in corrected_b, (
+            f"Trailing context 'también siendo candidata' must be preserved in "
+            f"segment 156 after removing 'Bound'. Got: {corrected_b!r}"
+        )
+
+    async def test_multiple_occurrences_in_combined_text_all_replaced(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        When the pattern appears multiple times in the combined pair text, all
+        occurrences are replaced (per spec: "consistent with re.sub() behavior").
+
+        Seed setup
+        ----------
+        Segment 10 — "foo bar foo"
+        Segment 11 — "bar baz"
+        Combined:    "foo bar foo bar baz"
+        Pattern "foo bar" appears at positions 0 and 8.
+
+        Assertions
+        ----------
+        * Both occurrences of "foo bar" are replaced with "qux".
+        * Combined corrected text reads "qux foo qux baz" (approximately).
+        """
+        vid_id = video_id(seed="t011_multi_occur")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id)
+
+        await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=10,
+            text="foo bar foo",
+            start_time=0.0,
+        )
+        await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=11,
+            text="bar baz",
+            start_time=5.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern="foo bar",
+            replacement="qux",
+            cross_segment=True,  # TDD: parameter does not yet exist
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult), (
+            f"Expected BatchCorrectionResult, got {type(result)!r}"
+        )
+        # Both segments should be affected when both occurrences are replaced.
+        assert result.total_matched >= 1, (
+            "At least the cross-segment pair must be matched. "
+            f"total_matched={result.total_matched}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T012 — Single-segment match within cross-segment mode
+# ---------------------------------------------------------------------------
+
+
+class TestSingleSegmentWithinCrossSegment:
+    """
+    T012 — Pattern fully contained within a single segment is treated as a
+    single-segment match, not a cross-segment match, even when
+    ``cross_segment=True``.
+
+    Per spec edge case: "When a pattern matches entirely within a single
+    segment while --cross-segment is active, the segment is found as a
+    single-segment match and excluded from all cross-segment pairs it would
+    participate in."
+
+    NOTE: This test is expected to FAIL until ``find_and_replace()`` gains a
+    ``cross_segment`` parameter.  That failure is intentional TDD.
+    """
+
+    async def test_single_segment_match_found_not_cross_segment(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Pattern "hello world" lives entirely in segment 0.
+
+        When ``cross_segment=True``, the engine finds it as a single-segment
+        match (not a cross-segment match involving segment 1).
+
+        Seed setup
+        ----------
+        Segment 0 — "hello world today"   → contains pattern fully
+        Segment 1 — "some other text"     → unrelated
+
+        Assertions
+        ----------
+        * ``result.total_matched >= 1`` (pattern was found).
+        * Segment 0 ``corrected_text`` contains the replacement "greetings".
+        * Segment 1 is NOT modified (its text/corrected_text unchanged).
+        """
+        vid_id = video_id(seed="t012_single_in_cross")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id)
+
+        seg0 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=0,
+            text="hello world today",
+            start_time=0.0,
+        )
+        seg1 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=1,
+            text="some other text",
+            start_time=5.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern="hello world",
+            replacement="greetings",
+            cross_segment=True,  # TDD: parameter does not yet exist
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult), (
+            f"Expected BatchCorrectionResult, got {type(result)!r}"
+        )
+        assert result.total_matched >= 1, (
+            "Pattern 'hello world' must be found (as a single-segment match). "
+            f"total_matched={result.total_matched}"
+        )
+
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed0 = await db_session.get(TranscriptSegmentDB, seg0.id)
+        refreshed1 = await db_session.get(TranscriptSegmentDB, seg1.id)
+
+        assert refreshed0 is not None
+        assert refreshed1 is not None
+
+        corrected0: str = (refreshed0.corrected_text or refreshed0.text) or ""
+        assert "greetings" in corrected0, (
+            f"Segment 0 must contain the replacement 'greetings'. Got: {corrected0!r}"
+        )
+
+        # Segment 1 must NOT be modified — it did not participate in any match.
+        assert not refreshed1.has_correction, (
+            f"Segment 1 ('some other text') must not be corrected — the pattern "
+            f"matched entirely within segment 0 and segment 1 was not involved. "
+            f"has_correction={refreshed1.has_correction}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T013 — No cross-segment flag
+# ---------------------------------------------------------------------------
+
+
+class TestNoCrossSegmentFlag:
+    """
+    T013 — Without ``cross_segment=True``, only single-segment matches are
+    found.  A pattern that spans two segments remains undetected.
+
+    Per spec acceptance scenario 4: "Given no --cross-segment flag is
+    provided, When user runs find-replace, Then behavior is identical to the
+    current single-segment matching with no performance or correctness
+    regression."
+
+    This test exercises the default (backward-compatible) path — no new
+    parameter is required here, but the test validates that the new flag's
+    presence does not disturb the legacy result when omitted.
+    """
+
+    async def test_cross_segment_pattern_not_found_without_flag(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Pattern "Claudia Shane Bound" spans two segments but is NOT matched
+        when ``cross_segment`` is omitted (defaults to False / absent).
+
+        Seed setup
+        ----------
+        Segment 155 — "Claudia Shane"
+        Segment 156 — "Bound también siendo candidata"
+
+        Assertions
+        ----------
+        * ``result.total_matched == 0`` (no single-segment contains the full
+          pattern "Claudia Shane Bound").
+        * Neither segment is modified.
+        """
+        vid_id = video_id(seed="t013_no_cross_flag")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id, language_code="es")
+
+        seg_a = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=155,
+            text="Claudia Shane",
+            start_time=310.0,
+        )
+        seg_b = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=156,
+            text="Bound también siendo candidata",
+            start_time=315.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        # Deliberately omit cross_segment — default single-segment behaviour.
+        result = await service.find_and_replace(
+            db_session,
+            pattern="Claudia Shane Bound",
+            replacement="Claudia Sheinbaum",
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult), (
+            f"Expected BatchCorrectionResult, got {type(result)!r}"
+        )
+        assert result.total_matched == 0, (
+            "Without --cross-segment, a pattern spanning two segments must NOT be "
+            f"matched. total_matched={result.total_matched}"
+        )
+
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        refreshed_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+
+        assert refreshed_a is not None and not refreshed_a.has_correction, (
+            "Segment A must not be modified when no match was found. "
+            f"has_correction={refreshed_a.has_correction if refreshed_a else 'N/A'}"
+        )
+        assert refreshed_b is not None and not refreshed_b.has_correction, (
+            "Segment B must not be modified when no match was found. "
+            f"has_correction={refreshed_b.has_correction if refreshed_b else 'N/A'}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T014 — Language boundary
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageBoundary:
+    """
+    T014 — Adjacent segments with different ``language_code`` values must NOT
+    be paired for cross-segment matching.
+
+    Per spec FR-011: "Cross-segment matching MUST only consider adjacent pairs
+    within the same video and same language code."
+
+    Per spec edge case: "What happens when a cross-segment match spans a
+    language boundary (segment N is 'en', segment N+1 is 'es')? Only pairs
+    with the same language_code are concatenated."
+
+    NOTE: This test is expected to FAIL until ``find_and_replace()`` gains a
+    ``cross_segment`` parameter.  That failure is intentional TDD.
+    """
+
+    async def test_different_language_segments_not_paired(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Segment N (en) and segment N+1 (es) are adjacent but must NOT be
+        concatenated for cross-segment matching.
+
+        Seed setup
+        ----------
+        Segment 0 — language="en", text="hello boundary"
+        Segment 1 — language="es", text="boundary world"
+        Two separate VideoTranscript parent rows (one per language) are
+        required to satisfy the FK constraint.
+
+        Pattern "hello boundary boundary world" spans the language boundary
+        but must produce zero cross-segment matches.
+
+        Assertions
+        ----------
+        * ``result.total_matched == 0`` (no cross-segment pair produced).
+        * Neither segment is modified.
+        """
+        vid_id = video_id(seed="t014_lang_boundary")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        # Seed both language transcript parents
+        await _seed_transcript(db_session, vid_id, language_code="en")
+        await _seed_transcript(db_session, vid_id, language_code="es")
+
+        seg_en = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="en",
+            sequence_number=0,
+            text="hello boundary",
+            start_time=0.0,
+        )
+        seg_es = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=1,
+            text="boundary world",
+            start_time=5.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern="hello boundary boundary world",
+            replacement="SHOULD_NOT_APPEAR",
+            cross_segment=True,  # TDD: parameter does not yet exist
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_matched == 0, (
+            "Segments with different language_code values must NOT be paired for "
+            f"cross-segment matching. total_matched={result.total_matched}"
+        )
+
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed_en = await db_session.get(TranscriptSegmentDB, seg_en.id)
+        refreshed_es = await db_session.get(TranscriptSegmentDB, seg_es.id)
+
+        assert refreshed_en is not None and not refreshed_en.has_correction, (
+            "English segment must not be corrected — language boundary prevented pairing."
+        )
+        assert refreshed_es is not None and not refreshed_es.has_correction, (
+            "Spanish segment must not be corrected — language boundary prevented pairing."
+        )
+
+
+# ---------------------------------------------------------------------------
+# T015 — Non-consecutive sequence numbers
+# ---------------------------------------------------------------------------
+
+
+class TestNonConsecutiveSequence:
+    """
+    T015 — Segments with a gap in ``sequence_number`` (e.g., 5 and 7) must
+    NOT be paired for cross-segment matching.
+
+    Per spec FR-006: "strictly consecutive sequence numbers where
+    segment_b.sequence_number == segment_a.sequence_number + 1".
+    "Segments with gaps in sequence numbering are NOT paired."
+
+    NOTE: This test is expected to FAIL until ``find_and_replace()`` gains a
+    ``cross_segment`` parameter.  That failure is intentional TDD.
+    """
+
+    async def test_non_consecutive_segments_not_paired(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Seeding seq_numbers 5 and 7 (gap at 6) prevents cross-segment pairing.
+
+        Seed setup
+        ----------
+        Segment 5 — "alpha bravo"
+        Segment 7 — "bravo charlie"  (no segment 6 in the DB)
+
+        Pattern "alpha bravo bravo charlie" would match the concatenation, but
+        since the sequence numbers are non-consecutive the pair is rejected.
+
+        Assertions
+        ----------
+        * ``result.total_matched == 0`` (non-consecutive pair not produced).
+        * Neither segment is modified.
+        """
+        vid_id = video_id(seed="t015_nonconsec_seq")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id)
+
+        seg5 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=5,
+            text="alpha bravo",
+            start_time=25.0,
+        )
+        seg7 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=7,
+            text="bravo charlie",
+            start_time=35.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern="alpha bravo bravo charlie",
+            replacement="SHOULD_NOT_APPEAR",
+            cross_segment=True,  # TDD: parameter does not yet exist
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_matched == 0, (
+            "Non-consecutive segments (seq 5 and 7, gap at 6) must NOT be paired "
+            f"for cross-segment matching. total_matched={result.total_matched}"
+        )
+
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed5 = await db_session.get(TranscriptSegmentDB, seg5.id)
+        refreshed7 = await db_session.get(TranscriptSegmentDB, seg7.id)
+
+        assert refreshed5 is not None and not refreshed5.has_correction, (
+            "Segment 5 must not be corrected — non-consecutive sequence prevented pairing."
+        )
+        assert refreshed7 is not None and not refreshed7.has_correction, (
+            "Segment 7 must not be corrected — non-consecutive sequence prevented pairing."
+        )
+
+
+# ---------------------------------------------------------------------------
+# T016 — Regex + cross-segment composition
+# ---------------------------------------------------------------------------
+
+
+class TestRegexCrossSegment:
+    r"""
+    T016 — Regex pattern with ``cross_segment=True``: regex matching is applied
+    to the concatenated adjacent-segment text.
+
+    Per spec edge case: "What happens when --cross-segment and --regex are
+    used together? Both features compose — regex matching is applied to the
+    concatenated adjacent segment text."
+
+    Per spec FR-009: "The --cross-segment flag MUST compose with all existing
+    flags: --regex, --case-insensitive, …"
+
+    NOTE: This test is expected to FAIL until ``find_and_replace()`` gains a
+    ``cross_segment`` parameter.  That failure is intentional TDD.
+    """
+
+    async def test_regex_pattern_applied_to_cross_segment_pair(
+        self, db_session: AsyncSession
+    ) -> None:
+        r"""
+        Pattern ``\bCla\w+ Shane Bound\b`` matches "Claudia Shane Bound"
+        spanning segment N and segment N+1.
+
+        Seed setup
+        ----------
+        Segment 20 — "Claudia Shane"
+        Segment 21 — "Bound también"
+
+        Combined: "Claudia Shane Bound también"
+
+        The regex ``\bCla\w+ Shane Bound\b`` matches "Claudia Shane Bound" in
+        the combined text, spanning the boundary.  The replacement
+        "Claudia Sheinbaum" is placed into segment 20; "Bound" is removed
+        from segment 21.
+
+        Assertions
+        ----------
+        * ``result.total_matched >= 1``
+        * Segment 20 corrected_text contains "Claudia Sheinbaum".
+        * Segment 21 corrected_text does not start with "Bound".
+        """
+        vid_id = video_id(seed="t016_regex_cross")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id, language_code="es")
+
+        seg_a = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=20,
+            text="Claudia Shane",
+            start_time=100.0,
+        )
+        seg_b = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=21,
+            text="Bound también",
+            start_time=105.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern=r"\bCla\w+ Shane Bound\b",
+            replacement="Claudia Sheinbaum",
+            regex=True,
+            cross_segment=True,
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_matched >= 1, (
+            r"Regex pattern \bCla\w+ Shane Bound\b must match "
+            r"'Claudia Shane Bound' across the cross-segment boundary. "
+            f"total_matched={result.total_matched}"
+        )
+
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        refreshed_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+
+        assert refreshed_a is not None
+        assert refreshed_b is not None
+
+        corrected_a: str = (refreshed_a.corrected_text or refreshed_a.text) or ""
+        corrected_b: str = (refreshed_b.corrected_text or refreshed_b.text) or ""
+
+        assert "Claudia Sheinbaum" in corrected_a, (
+            f"Segment 20 must contain 'Claudia Sheinbaum' after regex cross-segment "
+            f"replacement. Got: {corrected_a!r}"
+        )
+        assert not corrected_b.startswith("Bound"), (
+            f"'Bound' must be removed from segment 21. Got: {corrected_b!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T016b — Case-insensitive + cross-segment composition
+# ---------------------------------------------------------------------------
+
+
+class TestCaseInsensitiveCrossSegment:
+    """
+    T016b — ``case_insensitive=True`` combined with ``cross_segment=True``
+    matches across the segment boundary despite case differences.
+
+    Per spec FR-009: "The --cross-segment flag MUST compose with all existing
+    flags: --regex, --case-insensitive, …"
+
+    NOTE: This test is expected to FAIL until ``find_and_replace()`` gains a
+    ``cross_segment`` parameter.  That failure is intentional TDD.
+    """
+
+    async def test_case_insensitive_cross_segment_match(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Pattern "claudia shane bound" (all lowercase) matches across segments
+        "Claudia Shane" and "BOUND también" (mixed/uppercase) when
+        ``case_insensitive=True``.
+
+        Seed setup
+        ----------
+        Segment 30 — "Claudia Shane"          (mixed case)
+        Segment 31 — "BOUND también"          (uppercase BOUND)
+
+        Assertions
+        ----------
+        * ``result.total_matched >= 1``
+        * Segment 30 corrected_text contains "Claudia Sheinbaum".
+        * Segment 31 corrected_text does NOT start with "BOUND" or "bound".
+        * Segment 31 corrected_text still contains "también".
+        """
+        vid_id = video_id(seed="t016b_ci_cross")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id, language_code="es")
+
+        seg_a = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=30,
+            text="Claudia Shane",
+            start_time=150.0,
+        )
+        seg_b = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=31,
+            text="BOUND también",
+            start_time=155.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern="claudia shane bound",
+            replacement="Claudia Sheinbaum",
+            case_insensitive=True,
+            cross_segment=True,  # TDD: parameter does not yet exist
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_matched >= 1, (
+            "Case-insensitive pattern 'claudia shane bound' must match "
+            "'Claudia Shane' + 'BOUND …' across the segment boundary. "
+            f"total_matched={result.total_matched}"
+        )
+
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        refreshed_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+
+        assert refreshed_a is not None
+        assert refreshed_b is not None
+
+        corrected_a: str = (refreshed_a.corrected_text or refreshed_a.text) or ""
+        corrected_b: str = (refreshed_b.corrected_text or refreshed_b.text) or ""
+
+        assert "Claudia Sheinbaum" in corrected_a, (
+            f"Segment 30 must contain 'Claudia Sheinbaum'. Got: {corrected_a!r}"
+        )
+        assert not corrected_b.lower().startswith("bound"), (
+            f"'BOUND' (any case) must be removed from segment 31. Got: {corrected_b!r}"
+        )
+        assert "también" in corrected_b, (
+            f"Remaining text 'también' must be preserved in segment 31. "
+            f"Got: {corrected_b!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T017 — Overlapping pairs
+# ---------------------------------------------------------------------------
+
+
+class TestOverlappingPairs:
+    """
+    T017 — When a segment participates in two overlapping pairs (e.g., segment
+    2 belongs to both pair (1,2) and pair (2,3)) and both pairs match the
+    pattern, the earlier pair (lower sequence_number) takes precedence and the
+    later pair is skipped with a warning.
+
+    Per spec edge case: "If a segment is part of two matched pairs, the earlier
+    pair (lower sequence_number) takes precedence and the later pair is skipped
+    with a warning."
+
+    NOTE: This test is expected to FAIL until ``find_and_replace()`` gains a
+    ``cross_segment`` parameter.  That failure is intentional TDD.
+    """
+
+    async def test_earlier_pair_wins_over_later_overlapping_pair(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Pattern "end start" matches both pair(1,2) and pair(2,3).
+        Only pair(1,2) is applied; pair(2,3) is skipped.
+
+        Seed setup
+        ----------
+        Segment 1 — "prefix end"
+        Segment 2 — "start middle"
+        Segment 3 — "end suffix"   (if pair(2,3) were applied its "start" left
+                                     from seg2 would pair with "end" from seg3)
+
+        Pattern: "end start" — appears in combined texts of both (1,2) and (2,3)
+        assuming segment 2's text provides "start" at the boundary.
+
+        Assertions
+        ----------
+        * Pair (1,2) is applied: segment 1 corrected, segment 2 de-headed.
+        * Pair (2,3) is NOT applied (segment 2 already used by pair (1,2)).
+        * ``result.total_matched >= 1`` but segment 3 has no correction from
+          the "end start" pattern (since pair(2,3) was skipped).
+        """
+        vid_id = video_id(seed="t017_overlap_pairs")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id)
+
+        seg1 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=1,
+            text="prefix end",
+            start_time=5.0,
+        )
+        await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=2,
+            text="start middle end",
+            start_time=10.0,
+        )
+        seg3 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=3,
+            text="start suffix",
+            start_time=15.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern="end start",
+            replacement="REPLACED",
+            cross_segment=True,  # TDD: parameter does not yet exist
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_matched >= 1, (
+            "Pattern 'end start' must be detected in at least one cross-segment "
+            f"pair. total_matched={result.total_matched}"
+        )
+
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed1 = await db_session.get(TranscriptSegmentDB, seg1.id)
+        refreshed3 = await db_session.get(TranscriptSegmentDB, seg3.id)
+
+        assert refreshed1 is not None
+        assert refreshed3 is not None
+
+        # Pair (1,2) must have been applied — segment 1 corrected.
+        assert refreshed1.has_correction, (
+            "Segment 1 must be corrected as part of the winning pair (1,2). "
+            f"has_correction={refreshed1.has_correction}"
+        )
+
+        # Pair (2,3) must have been SKIPPED because segment 2 was already used.
+        # Segment 3 must NOT have a correction attributable to "end start" matching
+        # the pair(2,3) boundary (its text "start suffix" would require "end start"
+        # to span the boundary from a used segment 2).
+        # We assert segment 3 was not modified by the overlapping-pair rule.
+        assert not refreshed3.has_correction, (
+            "Segment 3 must NOT be corrected because pair(2,3) was skipped — "
+            "segment 2 was already consumed by the earlier pair(1,2). "
+            f"has_correction={refreshed3.has_correction}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T018 — Empty effective text
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyEffectiveText:
+    """
+    T018 — When either segment in a candidate pair has empty effective text,
+    the pair is skipped for cross-segment matching.  The non-empty partner
+    segment remains eligible for single-segment matching against the pattern.
+
+    Per spec edge case: "What happens when either segment in a pair has empty
+    effective text? The pair is skipped for cross-segment matching. The
+    non-empty segment is still eligible for single-segment matching."
+
+    NOTE: This test is expected to FAIL until ``find_and_replace()`` gains a
+    ``cross_segment`` parameter.  That failure is intentional TDD.
+    """
+
+    async def test_pair_with_empty_segment_is_skipped(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Segment 0 has empty text; segment 1 has the pattern within it.
+        The pair (0,1) is skipped for cross-segment matching; segment 1 is
+        still matched as a single-segment match.
+
+        Seed setup
+        ----------
+        Segment 0 — text=""          (empty)
+        Segment 1 — text="find me here"
+
+        Pattern: "find me" → replacement "found it"
+
+        Assertions
+        ----------
+        * No cross-segment match is produced from the (0,1) pair.
+        * Segment 1 IS matched as a single-segment match (pattern fully within it).
+        * ``result.total_matched >= 1`` (single-segment match from seg 1).
+        * Segment 1 corrected_text contains "found it".
+        """
+        vid_id = video_id(seed="t018_empty_eff_text")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id)
+
+        seg0 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=0,
+            text="",
+            start_time=0.0,
+        )
+        seg1 = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            sequence_number=1,
+            text="find me here",
+            start_time=5.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern="find me",
+            replacement="found it",
+            cross_segment=True,  # TDD: parameter does not yet exist
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_matched >= 1, (
+            "Pattern 'find me' must be found as a single-segment match in "
+            f"segment 1 even when segment 0 is empty. total_matched={result.total_matched}"
+        )
+
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed0 = await db_session.get(TranscriptSegmentDB, seg0.id)
+        refreshed1 = await db_session.get(TranscriptSegmentDB, seg1.id)
+
+        assert refreshed0 is not None
+        assert refreshed1 is not None
+
+        # Empty segment 0 was not part of any matched pair — no correction.
+        assert not refreshed0.has_correction, (
+            "Empty segment 0 must not receive a correction. "
+            f"has_correction={refreshed0.has_correction}"
+        )
+
+        corrected1: str = (refreshed1.corrected_text or refreshed1.text) or ""
+        assert "found it" in corrected1, (
+            f"Segment 1 must contain 'found it' (single-segment match). "
+            f"Got: {corrected1!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T036a — Empty segment after correction
+# ---------------------------------------------------------------------------
+
+
+class TestEmptySegmentAfterCorrection:
+    """
+    T036a — When applying a cross-segment correction removes ALL text from
+    segment N+1, the system must display a warning and flag the segment but
+    must NOT delete the segment row (FR-008).
+
+    Per spec FR-008: "When a cross-segment correction leaves the second segment
+    with only whitespace or empty text, the system MUST display a warning
+    message after the results table listing the segment IDs that were left
+    empty or whitespace-only."
+
+    Per spec acceptance scenario (Story 4, scenario 2): "Given a cross-segment
+    correction that removes all text from segment N+1, When the correction is
+    applied, Then the empty segment is flagged in the output (not deleted —
+    segment boundaries are preserved)."
+
+    NOTE: This test is expected to FAIL until ``find_and_replace()`` gains a
+    ``cross_segment`` parameter.  That failure is intentional TDD.
+    """
+
+    async def test_segment_not_deleted_when_correction_empties_it(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Correction "Claudia Shane Bound" → "Claudia Sheinbaum" removes the
+        word "Bound" from segment N+1 whose text IS exactly "Bound".
+
+        Segment N+1 would become empty/whitespace-only after the correction.
+        The row must still exist in the database (not deleted), and the
+        result must signal the emptied segment.
+
+        Seed setup
+        ----------
+        Segment 40 — "Claudia Shane"
+        Segment 41 — "Bound"          (only one word; will be fully consumed)
+
+        Assertions
+        ----------
+        * ``result.total_matched >= 1``
+        * Segment 40 ``corrected_text`` contains "Claudia Sheinbaum".
+        * Segment 41 row still EXISTS in the database after correction.
+        * Segment 41 ``corrected_text`` is empty or whitespace-only (the word
+          "Bound" was fully consumed by the cross-segment replacement).
+        * The ``BatchCorrectionResult`` (or a side-channel warning) indicates
+          that at least one segment was left empty — verified by checking the
+          corrected text, not by inspecting stdout directly.
+        """
+        vid_id = video_id(seed="t036a_empty_after_corr")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id, language_code="es")
+
+        seg_a = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=40,
+            text="Claudia Shane",
+            start_time=200.0,
+        )
+        seg_b = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="es",
+            sequence_number=41,
+            text="Bound",
+            start_time=205.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+        result = await service.find_and_replace(
+            db_session,
+            pattern="Claudia Shane Bound",
+            replacement="Claudia Sheinbaum",
+            cross_segment=True,  # TDD: parameter does not yet exist
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_matched >= 1, (
+            "Cross-segment pair 'Claudia Shane' + 'Bound' must be matched. "
+            f"total_matched={result.total_matched}"
+        )
+
+        # Verify segment A received the replacement.
+        from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+
+        refreshed_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        refreshed_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+
+        assert refreshed_a is not None, (
+            "Segment A must still exist in the database after correction."
+        )
+        assert refreshed_b is not None, (
+            "Segment B (emptied) must NOT be deleted — FR-008 requires the row "
+            "to be preserved even when its corrected text is empty."
+        )
+
+        corrected_a: str = (refreshed_a.corrected_text or refreshed_a.text) or ""
+        corrected_b: str = (refreshed_b.corrected_text or refreshed_b.text) or ""
+
+        assert "Claudia Sheinbaum" in corrected_a, (
+            f"Segment 40 must contain 'Claudia Sheinbaum'. Got: {corrected_a!r}"
+        )
+
+        # Segment B must be empty or whitespace-only after correction.
+        assert corrected_b.strip() == "", (
+            f"Segment 41 must be empty or whitespace-only after 'Bound' is "
+            f"consumed by the cross-segment replacement. Got: {corrected_b!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T034 — Basic cross-segment revert
+# ---------------------------------------------------------------------------
+
+
+class TestBasicCrossSegmentRevert:
+    """
+    T034 — Apply a cross-segment correction via ``find_and_replace`` with
+    ``cross_segment=True``, then call ``batch_revert`` matching the corrected
+    text.  Verify both segments are restored to their original text.
+    """
+
+    async def test_revert_restores_both_segments(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Apply cross-segment correction "Claudia Shane Bound" -> "Claudia Sheinbaum",
+        then revert by matching "Claudia Sheinbaum" in the corrected text.
+        Both segments must be restored to their original text.
+        """
+        vid_id = video_id(seed="t034_basic_revert")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id, language_code="en")
+
+        seg_a = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="en",
+            sequence_number=0,
+            text="Claudia Shane",
+            start_time=0.0,
+        )
+        seg_b = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="en",
+            sequence_number=1,
+            text="Bound is a word",
+            start_time=5.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+
+        # Step 1: Apply cross-segment correction
+        result = await service.find_and_replace(
+            db_session,
+            pattern="Claudia Shane Bound",
+            replacement="Claudia Sheinbaum",
+            cross_segment=True,
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_applied >= 1
+
+        # Verify correction applied
+        refreshed_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        assert refreshed_a is not None
+        assert refreshed_a.has_correction is True
+
+        # Step 2: Revert using batch_revert matching the corrected text
+        revert_result = await service.batch_revert(
+            db_session,
+            pattern="Claudia Sheinbaum",
+        )
+
+        assert isinstance(revert_result, BatchCorrectionResult)
+        assert revert_result.total_applied >= 2, (
+            "Both segments (A matched + B partner cascade) must be reverted. "
+            f"total_applied={revert_result.total_applied}"
+        )
+
+        # Verify both segments are restored to original text
+        final_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        final_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+
+        assert final_a is not None
+        assert final_b is not None
+
+        # After revert-to-original, has_correction should be False
+        assert final_a.has_correction is False, (
+            f"Segment A should have has_correction=False after revert. "
+            f"Got: {final_a.has_correction}"
+        )
+        assert final_b.has_correction is False, (
+            f"Segment B should have has_correction=False after revert. "
+            f"Got: {final_b.has_correction}"
+        )
+
+        # Original text should be restored
+        effective_a = final_a.corrected_text or final_a.text
+        effective_b = final_b.corrected_text or final_b.text
+
+        assert effective_a == "Claudia Shane", (
+            f"Segment A must be restored to 'Claudia Shane'. Got: {effective_a!r}"
+        )
+        assert effective_b == "Bound is a word", (
+            f"Segment B must be restored to 'Bound is a word'. Got: {effective_b!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T035 — Partner cascade revert
+# ---------------------------------------------------------------------------
+
+
+class TestPartnerCascadeRevert:
+    """
+    T035 — Apply a cross-segment correction, then call ``batch_revert`` with
+    a pattern that matches only ONE segment's corrected text.  The partner
+    segment should also be reverted because of the ``[cross-segment:partner=N]``
+    marker in the correction note.
+    """
+
+    async def test_partner_reverted_via_cascade(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        After cross-segment correction, segment A has "Claudia Sheinbaum is a word"
+        and segment B has " " (emptied).  Revert using pattern "Claudia Sheinbaum"
+        which matches only segment A — segment B should also be reverted via cascade.
+        """
+        vid_id = video_id(seed="t035_partner_cascade")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id, language_code="en")
+
+        seg_a = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="en",
+            sequence_number=0,
+            text="Claudia Shane",
+            start_time=0.0,
+        )
+        seg_b = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="en",
+            sequence_number=1,
+            text="Bound",
+            start_time=5.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+
+        # Apply cross-segment correction that empties seg B
+        result = await service.find_and_replace(
+            db_session,
+            pattern="Claudia Shane Bound",
+            replacement="Claudia Sheinbaum",
+            cross_segment=True,
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_applied >= 1
+
+        # Verify seg B is empty/whitespace after correction
+        refreshed_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+        assert refreshed_b is not None
+        assert refreshed_b.has_correction is True
+        # seg B has " " (single space, FR-008 preservation)
+
+        # batch_revert with pattern "Claudia Sheinbaum" — only matches seg A.
+        # seg B has " " which doesn't match, but should be reverted via cascade.
+        revert_result = await service.batch_revert(
+            db_session,
+            pattern="Claudia Sheinbaum",
+        )
+
+        assert isinstance(revert_result, BatchCorrectionResult)
+        assert revert_result.total_applied >= 2, (
+            "Both segment A (matched) and segment B (partner cascade) must be "
+            f"reverted. total_applied={revert_result.total_applied}"
+        )
+
+        # Verify both restored
+        final_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        final_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+
+        assert final_a is not None
+        assert final_b is not None
+        assert final_a.has_correction is False
+        assert final_b.has_correction is False
+
+        effective_a = final_a.corrected_text or final_a.text
+        effective_b = final_b.corrected_text or final_b.text
+
+        assert effective_a == "Claudia Shane", (
+            f"Segment A must be restored. Got: {effective_a!r}"
+        )
+        assert effective_b == "Bound", (
+            f"Segment B must be restored. Got: {effective_b!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T036b — Revert of emptied segment
+# ---------------------------------------------------------------------------
+
+
+class TestRevertOfEmptiedSegment:
+    """
+    T036b — Apply a cross-segment correction that empties segment N+1
+    (all text from seg B consumed by the match), then revert.
+    Verify original text restored in both segments.
+    """
+
+    async def test_revert_restores_emptied_segment(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Correction "Claudia Shane Bound" -> "Claudia Sheinbaum" where seg B
+        is exactly "Bound" — seg B becomes " " after correction.
+        Revert must restore seg B to "Bound".
+        """
+        vid_id = video_id(seed="t036b_revert_emptied")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id, language_code="en")
+
+        seg_a = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="en",
+            sequence_number=0,
+            text="Claudia Shane",
+            start_time=0.0,
+        )
+        seg_b = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="en",
+            sequence_number=1,
+            text="Bound",
+            start_time=5.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+
+        # Apply cross-segment correction
+        result = await service.find_and_replace(
+            db_session,
+            pattern="Claudia Shane Bound",
+            replacement="Claudia Sheinbaum",
+            cross_segment=True,
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_applied >= 1
+
+        # Verify seg B is emptied
+        refreshed_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+        assert refreshed_b is not None
+        assert refreshed_b.has_correction is True
+        effective_b_after = (refreshed_b.corrected_text or "").strip()
+        assert effective_b_after == "", (
+            f"Seg B should be empty after correction. Got: {effective_b_after!r}"
+        )
+
+        # Revert via batch_revert matching seg A's corrected text
+        revert_result = await service.batch_revert(
+            db_session,
+            pattern="Claudia Sheinbaum",
+        )
+
+        assert isinstance(revert_result, BatchCorrectionResult)
+        assert revert_result.total_applied >= 2
+
+        # Verify restoration
+        final_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        final_b = await db_session.get(TranscriptSegmentDB, seg_b.id)
+
+        assert final_a is not None
+        assert final_b is not None
+        assert final_a.has_correction is False
+        assert final_b.has_correction is False
+
+        effective_a = final_a.corrected_text or final_a.text
+        effective_b = final_b.corrected_text or final_b.text
+
+        assert effective_a == "Claudia Shane", (
+            f"Segment A must be restored. Got: {effective_a!r}"
+        )
+        assert effective_b == "Bound", (
+            f"Segment B must be restored to original 'Bound'. Got: {effective_b!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T037 — Missing partner on revert
+# ---------------------------------------------------------------------------
+
+
+class TestMissingPartnerOnRevert:
+    """
+    T037 — Apply a cross-segment correction, then delete the partner segment
+    from the DB (simulating a transcript re-download). Call ``batch_revert``
+    and verify the surviving segment is reverted and a warning is logged
+    about the missing partner.
+    """
+
+    async def test_surviving_segment_reverted_when_partner_missing(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        After cross-segment correction, delete segment B, then revert.
+        Segment A must still be reverted. A warning must be logged about
+        the missing partner.
+        """
+        vid_id = video_id(seed="t037_missing_partner")
+
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid_id)
+        await _seed_transcript(db_session, vid_id, language_code="en")
+
+        seg_a = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="en",
+            sequence_number=0,
+            text="Claudia Shane",
+            start_time=0.0,
+        )
+        seg_b = await _seed_segment(
+            db_session,
+            vid_id=vid_id,
+            language_code="en",
+            sequence_number=1,
+            text="Bound is great",
+            start_time=5.0,
+        )
+
+        await db_session.commit()
+
+        service = _make_batch_service()
+
+        # Apply cross-segment correction
+        result = await service.find_and_replace(
+            db_session,
+            pattern="Claudia Shane Bound",
+            replacement="Claudia Sheinbaum",
+            cross_segment=True,
+        )
+
+        from chronovista.models.batch_correction_models import BatchCorrectionResult
+
+        assert isinstance(result, BatchCorrectionResult)
+        assert result.total_applied >= 1
+
+        # Remember partner segment ID before deletion
+        partner_id = seg_b.id
+
+        # Delete the partner segment (simulate re-download).
+        # Must first delete correction records due to RESTRICT FK constraint.
+        from sqlalchemy import delete as sa_delete
+
+        from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
+
+        await db_session.execute(
+            sa_delete(TranscriptCorrectionDB).where(
+                TranscriptCorrectionDB.segment_id == partner_id
+            )
+        )
+        await db_session.delete(seg_b)
+        await db_session.commit()
+
+        # Verify partner is gone
+        deleted_seg = await db_session.get(TranscriptSegmentDB, partner_id)
+        assert deleted_seg is None, "Partner segment should be deleted"
+
+        # Revert via batch_revert — surviving segment should still be reverted
+        revert_result = await service.batch_revert(
+            db_session,
+            pattern="Claudia Sheinbaum",
+        )
+
+        assert isinstance(revert_result, BatchCorrectionResult)
+        assert revert_result.total_applied >= 1, (
+            "Surviving segment A must be reverted even when partner is missing. "
+            f"total_applied={revert_result.total_applied}"
+        )
+
+        # Verify segment A is restored
+        final_a = await db_session.get(TranscriptSegmentDB, seg_a.id)
+        assert final_a is not None
+        assert final_a.has_correction is False
+
+        effective_a = final_a.corrected_text or final_a.text
+        assert effective_a == "Claudia Shane", (
+            f"Segment A must be restored. Got: {effective_a!r}"
+        )

--- a/tests/unit/cli/test_correction_commands.py
+++ b/tests/unit/cli/test_correction_commands.py
@@ -152,12 +152,6 @@ class TestFindReplaceCommand:
         self, mock_asyncio: MagicMock, runner: CliRunner
     ) -> None:
         """Test dry-run displays Rich preview table and summary line."""
-        previews = [
-            ("vid1", 10, 5.0, "the quick brown fox", "the slow brown fox"),
-            ("vid1", 20, 12.5, "quick test", "slow test"),
-            ("vid2", 30, 8.0, "another quick example", "another slow example"),
-        ]
-
         async def _fake_run() -> None:
             pass
 
@@ -192,9 +186,9 @@ class TestFindReplaceCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc_instance = MagicMock()
-            MockService.return_value = mock_svc_instance
+            mock_service_cls.return_value = mock_svc_instance
             mock_svc_instance.find_and_replace = AsyncMock(return_value=[])
 
             result = runner.invoke(
@@ -228,9 +222,9 @@ class TestFindReplaceCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc_instance = MagicMock()
-            MockService.return_value = mock_svc_instance
+            mock_service_cls.return_value = mock_svc_instance
             mock_svc_instance.find_and_replace = AsyncMock(
                 return_value=previews
             )
@@ -271,9 +265,9 @@ class TestFindReplaceCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc_instance = MagicMock()
-            MockService.return_value = mock_svc_instance
+            mock_service_cls.return_value = mock_svc_instance
             mock_svc_instance.find_and_replace = AsyncMock(
                 return_value=previews
             )
@@ -314,9 +308,9 @@ class TestFindReplaceCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc_instance = MagicMock()
-            MockService.return_value = mock_svc_instance
+            mock_service_cls.return_value = mock_svc_instance
             mock_svc_instance.find_and_replace = AsyncMock(
                 return_value=previews
             )
@@ -360,9 +354,9 @@ class TestFindReplaceCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc_instance = MagicMock()
-            MockService.return_value = mock_svc_instance
+            mock_service_cls.return_value = mock_svc_instance
             # First call (dry-run scan for count) returns previews,
             # second call (live) returns BatchCorrectionResult
             mock_svc_instance.find_and_replace = AsyncMock(
@@ -412,9 +406,9 @@ class TestFindReplaceCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc_instance = MagicMock()
-            MockService.return_value = mock_svc_instance
+            mock_service_cls.return_value = mock_svc_instance
             mock_svc_instance.find_and_replace = AsyncMock(
                 side_effect=[previews, live_result]
             )
@@ -461,9 +455,9 @@ class TestFindReplaceCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc_instance = MagicMock()
-            MockService.return_value = mock_svc_instance
+            mock_service_cls.return_value = mock_svc_instance
             mock_svc_instance.find_and_replace = AsyncMock(
                 side_effect=[previews, live_result]
             )
@@ -494,9 +488,9 @@ class TestFindReplaceCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc_instance = MagicMock()
-            MockService.return_value = mock_svc_instance
+            mock_service_cls.return_value = mock_svc_instance
             mock_svc_instance.find_and_replace = AsyncMock(return_value=[])
 
             result = runner.invoke(
@@ -531,9 +525,9 @@ class TestFindReplaceCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc_instance = MagicMock()
-            MockService.return_value = mock_svc_instance
+            mock_service_cls.return_value = mock_svc_instance
             mock_svc_instance.find_and_replace = AsyncMock(
                 return_value=previews
             )
@@ -675,9 +669,9 @@ class TestRebuildTextCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.rebuild_text = AsyncMock(return_value=previews)
 
             result = runner.invoke(
@@ -701,9 +695,9 @@ class TestRebuildTextCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.rebuild_text = AsyncMock(return_value=[])
 
             result = runner.invoke(
@@ -732,9 +726,9 @@ class TestRebuildTextCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             # First call (dry-run for count), second call (live)
             mock_svc.rebuild_text = AsyncMock(
                 side_effect=[previews, (1, 42)]
@@ -760,9 +754,9 @@ class TestRebuildTextCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.rebuild_text = AsyncMock(return_value=[])
 
             result = runner.invoke(
@@ -782,9 +776,9 @@ class TestRebuildTextCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.rebuild_text = AsyncMock(return_value=[])
 
             runner.invoke(
@@ -845,9 +839,9 @@ class TestExportCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.export_corrections = AsyncMock(
                 return_value=(1, csv_data)
             )
@@ -872,9 +866,9 @@ class TestExportCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.export_corrections = AsyncMock(
                 return_value=(1, json_data)
             )
@@ -899,9 +893,9 @@ class TestExportCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.export_corrections = AsyncMock(
                 return_value=(1, csv_data)
             )
@@ -990,9 +984,9 @@ class TestStatsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_statistics = AsyncMock(return_value=stats)
 
             result = runner.invoke(
@@ -1028,9 +1022,9 @@ class TestStatsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_statistics = AsyncMock(return_value=stats)
 
             result = runner.invoke(correction_app, ["stats"])
@@ -1060,9 +1054,9 @@ class TestStatsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_statistics = AsyncMock(return_value=stats)
 
             result = runner.invoke(correction_app, ["stats"])
@@ -1092,9 +1086,9 @@ class TestStatsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_statistics = AsyncMock(return_value=stats)
 
             result = runner.invoke(correction_app, ["stats"])
@@ -1118,9 +1112,9 @@ class TestStatsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_statistics = AsyncMock(return_value=stats)
 
             runner.invoke(correction_app, ["stats", "--language", "es"])
@@ -1173,9 +1167,9 @@ class TestPatternsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_patterns = AsyncMock(return_value=patterns)
 
             result = runner.invoke(correction_app, ["patterns"])
@@ -1205,9 +1199,9 @@ class TestPatternsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_patterns = AsyncMock(return_value=patterns)
 
             # Use wider terminal to avoid column truncation in Rich table
@@ -1232,9 +1226,9 @@ class TestPatternsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_patterns = AsyncMock(return_value=[])
 
             result = runner.invoke(correction_app, ["patterns"])
@@ -1251,9 +1245,9 @@ class TestPatternsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_patterns = AsyncMock(return_value=[])
 
             runner.invoke(
@@ -1282,9 +1276,9 @@ class TestPatternsCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.get_patterns = AsyncMock(return_value=patterns)
 
             result = runner.invoke(correction_app, ["patterns"])
@@ -1350,9 +1344,9 @@ class TestBatchRevertCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.batch_revert = AsyncMock(return_value=previews)
 
             result = runner.invoke(
@@ -1377,9 +1371,9 @@ class TestBatchRevertCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.batch_revert = AsyncMock(return_value=[])
 
             result = runner.invoke(
@@ -1401,9 +1395,9 @@ class TestBatchRevertCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.batch_revert = AsyncMock(return_value=previews)
 
             result = runner.invoke(
@@ -1435,9 +1429,9 @@ class TestBatchRevertCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             # First call (dry-run scan), second call (live)
             mock_svc.batch_revert = AsyncMock(
                 side_effect=[previews, live_result]
@@ -1472,9 +1466,9 @@ class TestBatchRevertCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.batch_revert = AsyncMock(
                 side_effect=[previews, live_result]
             )
@@ -1501,9 +1495,9 @@ class TestBatchRevertCommand:
 
         with patch(
             "chronovista.cli.correction_commands.BatchCorrectionService"
-        ) as MockService:
+        ) as mock_service_cls:
             mock_svc = MagicMock()
-            MockService.return_value = mock_svc
+            mock_service_cls.return_value = mock_svc
             mock_svc.batch_revert = AsyncMock(return_value=[])
 
             result = runner.invoke(
@@ -1512,3 +1506,246 @@ class TestBatchRevertCommand:
             )
             assert result.exit_code == 0
             assert "No corrected segments matched" in result.stdout
+
+
+# ======================================================================
+# T029–T030: Cross-segment dry-run display (Feature 040)
+# ======================================================================
+
+
+class TestCrossSegmentDryRunDisplay:
+    """Test suite for ``corrections find-replace --cross-segment --dry-run`` display.
+
+    Verifies that the dry-run preview table correctly annotates cross-segment
+    pairs with box-drawing characters in the "Type" column, and that the
+    summary line includes the cross-segment pair count.
+
+    Feature 040 — Correction Pattern Matching (T029–T030)
+    """
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create CLI test runner."""
+        return CliRunner()
+
+    # ------------------------------------------------------------------
+    # T029: Type column box-drawing markers for cross-segment pairs
+    # ------------------------------------------------------------------
+
+    @patch("chronovista.cli.correction_commands.db_manager")
+    def test_cross_segment_dry_run_type_column_markers(
+        self, mock_db: MagicMock, runner: CliRunner
+    ) -> None:
+        """T029: Dry-run Type column shows box-drawing markers for pairs.
+
+        When --cross-segment is active and the service returns two consecutive
+        segments from the same video (adjacent segment IDs), the table's "Type"
+        column must display:
+          - ``╶─┐`` (U+2576 U+2500 U+2510) for the first segment in the pair
+          - ``╶─┘`` (U+2576 U+2500 U+2518) for the second segment in the pair
+          - empty string for single-segment rows
+        The column header "Type" must appear in the output.
+        """
+        mock_session = AsyncMock()
+        mock_db.get_session = _mock_session_gen(mock_session)
+
+        # Two consecutive segments from same video form a cross-segment pair
+        # (vid001, seg 156 → seg 157). vid002 seg 42 is standalone.
+        mock_previews = [
+            ("vid001", 156, 342.0, "Claudia Shane", "Claudia Sheinbaum"),
+            ("vid001", 157, 345.0, "Bound también", "también siendo"),
+            ("vid002", 42, 123.0, "amlo said", "AMLO said"),
+        ]
+
+        with patch(
+            "chronovista.cli.correction_commands.BatchCorrectionService"
+        ) as mock_service_cls:
+            mock_svc_instance = MagicMock()
+            mock_service_cls.return_value = mock_svc_instance
+            mock_svc_instance.find_and_replace = AsyncMock(
+                return_value=mock_previews
+            )
+
+            # Use a wide terminal so Rich does not truncate column headers or
+            # cell content. The box-drawing characters (╶─┐, ╶─┘) are 3 chars
+            # wide; with the default narrow CliRunner terminal they are
+            # abbreviated to whitespace by Rich's overflow handling.
+            result = runner.invoke(
+                correction_app,
+                [
+                    "find-replace",
+                    "--pattern", "Shane",
+                    "--replacement", "Sheinbaum",
+                    "--dry-run",
+                    "--cross-segment",
+                    "--video-id", "vid001",
+                    "--video-id", "vid002",
+                ],
+                env={"COLUMNS": "200"},
+            )
+
+        assert result.exit_code == 0, (
+            f"Expected exit code 0, got {result.exit_code}. Output:\n{result.output}"
+        )
+        output = result.output
+
+        # "Type" column header must appear (only visible at wide terminal width)
+        assert "Type" in output, (
+            f"Expected 'Type' column header in output.\nOutput:\n{output}"
+        )
+
+        # First segment of pair: U+2576 U+2500 U+2510  →  ╶─┐
+        assert "\u2576\u2500\u2510" in output, (
+            f"Expected '╶─┐' (U+2576 U+2500 U+2510) in output for pair-first marker.\n"
+            f"Output:\n{output}"
+        )
+
+        # Second segment of pair: U+2576 U+2500 U+2518  →  ╶─┘
+        assert "\u2576\u2500\u2518" in output, (
+            f"Expected '╶─┘' (U+2576 U+2500 U+2518) in output for pair-second marker.\n"
+            f"Output:\n{output}"
+        )
+
+        # The standalone row (vid002, seg 42) must appear but without a pair marker.
+        # We verify it appears in the table output.
+        assert "vid002" in output, (
+            f"Expected 'vid002' (standalone segment) in output.\nOutput:\n{output}"
+        )
+
+    # ------------------------------------------------------------------
+    # T030: Mixed summary line format with cross-segment pair count
+    # ------------------------------------------------------------------
+
+    @patch("chronovista.cli.correction_commands.db_manager")
+    def test_cross_segment_dry_run_summary_with_pairs(
+        self, mock_db: MagicMock, runner: CliRunner
+    ) -> None:
+        """T030a: Summary line includes cross-segment pair count when pairs exist.
+
+        When --cross-segment produces at least one pair, the dry-run summary line
+        must contain the segment count, the video count, and the pair count in
+        parentheses, e.g. "(1 cross-segment pairs)".
+        """
+        mock_session = AsyncMock()
+        mock_db.get_session = _mock_session_gen(mock_session)
+
+        # One cross-segment pair (vid001, seg 156–157) + one standalone (vid002, seg 42)
+        mock_previews = [
+            ("vid001", 156, 342.0, "Claudia Shane", "Claudia Sheinbaum"),
+            ("vid001", 157, 345.0, "Bound también", "también siendo"),
+            ("vid002", 42, 123.0, "amlo said", "AMLO said"),
+        ]
+
+        with patch(
+            "chronovista.cli.correction_commands.BatchCorrectionService"
+        ) as mock_service_cls:
+            mock_svc_instance = MagicMock()
+            mock_service_cls.return_value = mock_svc_instance
+            mock_svc_instance.find_and_replace = AsyncMock(
+                return_value=mock_previews
+            )
+
+            result = runner.invoke(
+                correction_app,
+                [
+                    "find-replace",
+                    "--pattern", "Shane",
+                    "--replacement", "Sheinbaum",
+                    "--dry-run",
+                    "--cross-segment",
+                    "--video-id", "vid001",
+                    "--video-id", "vid002",
+                ],
+            )
+
+        assert result.exit_code == 0, (
+            f"Expected exit code 0, got {result.exit_code}. Output:\n{result.output}"
+        )
+        output = result.output
+
+        # Summary must contain the segment count
+        assert "3" in output, (
+            f"Expected segment count '3' in summary.\nOutput:\n{output}"
+        )
+
+        # Summary must name the video count (2 unique videos: vid001 and vid002)
+        assert "2" in output, (
+            f"Expected video count '2' in summary.\nOutput:\n{output}"
+        )
+
+        # Summary must include the cross-segment pair count annotation.
+        # Rich may wrap the summary line so "cross-segment" and "pairs" may be
+        # on separate lines. Normalise newlines before asserting.
+        normalised = output.replace("\n", " ")
+        assert "cross-segment pairs" in normalised, (
+            f"Expected 'cross-segment pairs' in summary line.\nOutput:\n{output}"
+        )
+
+        # Specifically 1 pair was detected (156 and 157 are consecutive)
+        assert "1" in normalised, (
+            f"Expected '1' (pair count) in summary.\nOutput:\n{output}"
+        )
+
+        # The full dry-run completion message must be present
+        assert "Dry run complete" in output, (
+            f"Expected 'Dry run complete' in output.\nOutput:\n{output}"
+        )
+
+    @patch("chronovista.cli.correction_commands.db_manager")
+    def test_cross_segment_dry_run_summary_zero_pairs(
+        self, mock_db: MagicMock, runner: CliRunner
+    ) -> None:
+        """T030b: Summary shows "(0 cross-segment pairs)" when no pairs found.
+
+        When --cross-segment is active but no adjacent segment pairs are
+        returned, the summary must still include the "(0 cross-segment pairs)"
+        suffix to confirm that cross-segment matching was attempted.
+        """
+        mock_session = AsyncMock()
+        mock_db.get_session = _mock_session_gen(mock_session)
+
+        # All standalone segments — no adjacent same-video consecutive pairs
+        mock_previews = [
+            ("vid001", 10, 50.0, "amlo said hello", "AMLO said hello"),
+            ("vid002", 20, 100.0, "amlo spoke again", "AMLO spoke again"),
+        ]
+
+        with patch(
+            "chronovista.cli.correction_commands.BatchCorrectionService"
+        ) as mock_service_cls:
+            mock_svc_instance = MagicMock()
+            mock_service_cls.return_value = mock_svc_instance
+            mock_svc_instance.find_and_replace = AsyncMock(
+                return_value=mock_previews
+            )
+
+            result = runner.invoke(
+                correction_app,
+                [
+                    "find-replace",
+                    "--pattern", "amlo",
+                    "--replacement", "AMLO",
+                    "--dry-run",
+                    "--cross-segment",
+                    "--video-id", "vid001",
+                    "--video-id", "vid002",
+                ],
+            )
+
+        assert result.exit_code == 0, (
+            f"Expected exit code 0, got {result.exit_code}. Output:\n{result.output}"
+        )
+        output = result.output
+
+        # Even with 0 pairs, the cross-segment pair count should appear.
+        # Rich may wrap the summary line, so normalise newlines before asserting.
+        normalised = output.replace("\n", " ")
+        assert "cross-segment pairs" in normalised, (
+            f"Expected 'cross-segment pairs' in summary even with P=0.\n"
+            f"Output:\n{output}"
+        )
+
+        # Pair count should be 0
+        assert "0" in normalised, (
+            f"Expected '0' pair count in summary.\nOutput:\n{output}"
+        )

--- a/tests/unit/repositories/test_regex_translation.py
+++ b/tests/unit/repositories/test_regex_translation.py
@@ -1,0 +1,113 @@
+"""
+Tests for translate_python_regex_to_posix() — Feature 040.
+
+Covers:
+- T004: Contract-table translation cases for Python → POSIX regex word-boundary
+  conversion used when executing pattern searches against PostgreSQL.
+- T006: Malformed regex validation (FR-015) — ensures invalid patterns raise
+  ValueError with a user-friendly message rather than propagating a raw
+  re.error to the caller.
+
+The function under test does NOT yet exist; these tests are intentionally
+written to FAIL until the implementation is added to
+src/chronovista/repositories/transcript_segment_repository.py.
+
+Note: No pytestmark = pytest.mark.asyncio is needed here because
+translate_python_regex_to_posix() is a synchronous, pure function.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chronovista.repositories.transcript_segment_repository import (
+    translate_python_regex_to_posix,
+)
+
+
+class TestTranslatePythonRegexToPosix:
+    """T004 — Contract-table cases for Python → POSIX word-boundary translation.
+
+    Python regex uses ``\\b`` / ``\\B`` for word boundaries; PostgreSQL's
+    ``~`` operator uses ``\\y`` / ``\\Y``.  The function must rewrite
+    boundary assertions while leaving ``\\b`` inside character classes
+    (where it means backspace) and escaped literal backslashes (``\\\\b``)
+    untouched.
+    """
+
+    def test_start_boundary_only(self) -> None:
+        """\\b at the start of a pattern becomes \\y."""
+        result = translate_python_regex_to_posix(r"\bamlo\w*")
+        assert result == r"\yamlo\w*"
+
+    def test_end_boundary_only(self) -> None:
+        """\\b at the end of a pattern becomes \\y."""
+        result = translate_python_regex_to_posix(r"amlo\b")
+        assert result == r"amlo\y"
+
+    def test_both_boundaries(self) -> None:
+        """\\b on both sides of a word are both converted to \\y."""
+        result = translate_python_regex_to_posix(r"\bamlo\b")
+        assert result == r"\yamlo\y"
+
+    def test_non_word_boundary(self) -> None:
+        """\\B (non-word boundary) becomes \\Y."""
+        result = translate_python_regex_to_posix(r"\Bamlo")
+        assert result == r"\Yamlo"
+
+    def test_boundary_inside_character_class_unchanged(self) -> None:
+        r"""\\b inside [...] is a backspace assertion; it must not be rewritten."""
+        result = translate_python_regex_to_posix(r"[\b]amlo")
+        assert result == r"[\b]amlo"
+
+    def test_no_boundaries_unchanged(self) -> None:
+        """Patterns without any boundary assertion pass through unchanged."""
+        result = translate_python_regex_to_posix(r"amlo\w*")
+        assert result == r"amlo\w*"
+
+    def test_escaped_backslash_before_b_unchanged(self) -> None:
+        r"""\\\\b is a literal backslash followed by 'b', not a boundary — unchanged."""
+        result = translate_python_regex_to_posix(r"\\b")
+        assert result == r"\\b"
+
+    def test_mixed_boundary_inside_and_outside_class(self) -> None:
+        r"""\\b outside and \\B outside are translated; \\b inside [...] is not."""
+        result = translate_python_regex_to_posix(r"\b[\b]\B")
+        assert result == r"\y[\b]\Y"
+
+
+class TestMalformedRegexValidation:
+    """T006 — Malformed regex detection (FR-015).
+
+    translate_python_regex_to_posix() must validate the pattern with Python's
+    ``re`` module before attempting translation.  Invalid patterns should raise
+    ``ValueError`` with a message suitable for display to the user (not a raw
+    ``re.error`` traceback).
+
+    Valid patterns must never raise.
+    """
+
+    def test_unbalanced_bracket_raises_value_error(self) -> None:
+        """An unclosed character class bracket is invalid and raises ValueError."""
+        with pytest.raises(ValueError, match=r"[Ii]nvalid|[Rr]egex|[Pp]attern"):
+            translate_python_regex_to_posix("[abc")
+
+    def test_unbalanced_parenthesis_raises_value_error(self) -> None:
+        """An unclosed group parenthesis is invalid and raises ValueError."""
+        with pytest.raises(ValueError, match=r"[Ii]nvalid|[Rr]egex|[Pp]attern"):
+            translate_python_regex_to_posix("(abc")
+
+    def test_valid_literal_pattern_does_not_raise(self) -> None:
+        """A plain literal pattern is valid and must not raise."""
+        result = translate_python_regex_to_posix("hello world")
+        assert isinstance(result, str)
+
+    def test_valid_boundary_pattern_does_not_raise(self) -> None:
+        r"""A pattern containing \\b is valid and must not raise."""
+        result = translate_python_regex_to_posix(r"\bhello\b")
+        assert isinstance(result, str)
+
+    def test_valid_complex_pattern_does_not_raise(self) -> None:
+        """A complex but syntactically valid pattern must not raise."""
+        result = translate_python_regex_to_posix(r"\b\w+\s+\w+\b")
+        assert isinstance(result, str)

--- a/tests/unit/services/test_asr_alias_registry.py
+++ b/tests/unit/services/test_asr_alias_registry.py
@@ -1,0 +1,702 @@
+"""
+Unit tests for the shared ASR alias registry utility.
+
+Tests both public functions exported by
+``chronovista.services.asr_alias_registry``:
+
+* ``resolve_entity_id_from_text`` — canonical-name / alias lookup
+* ``register_asr_alias`` — best-effort hook that auto-registers ASR error
+  aliases when a correction replacement matches a known entity
+
+All database I/O is mocked; these are pure unit tests with no real DB
+connection required.
+
+Feature 038 — Entity Mention Detection
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chronovista.models.enums import EntityAliasType
+from chronovista.services.asr_alias_registry import (
+    register_asr_alias,
+    resolve_entity_id_from_text,
+)
+
+# ---------------------------------------------------------------------------
+# CRITICAL: Module-level asyncio marker ensures async tests run properly
+# with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
+# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_execute_returns(*results: Any) -> AsyncMock:
+    """Build a mock ``AsyncSession`` whose ``execute`` call returns *results* in sequence.
+
+    Parameters
+    ----------
+    *results : Any
+        Values to return from ``scalar_one_or_none()`` and
+        ``scalars().first()`` in the order they are consumed by the
+        production code.
+
+    Returns
+    -------
+    AsyncMock
+        A fully configured mock session with chained result mocks and a
+        non-async ``begin_nested`` returning an async context manager.
+    """
+    side_effects: list[MagicMock] = []
+    for r in results:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = r
+        mock_result.scalars.return_value.first.return_value = r
+        side_effects.append(mock_result)
+
+    session = AsyncMock()
+    session.execute.side_effect = side_effects
+
+    # begin_nested() must be a *non-async* callable returning an async CM.
+    # The production code does ``async with session.begin_nested():`` which
+    # requires __aenter__/__aexit__ to be coroutines, but begin_nested itself
+    # must not be awaited.
+    nested_cm = MagicMock()
+    nested_cm.__aenter__ = AsyncMock(return_value=None)
+    nested_cm.__aexit__ = AsyncMock(return_value=False)
+    session.begin_nested = MagicMock(return_value=nested_cm)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# TestResolveEntityIdFromText
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEntityIdFromText:
+    """Tests for ``resolve_entity_id_from_text``.
+
+    Verifies canonical-name lookup (first priority), alias fallback
+    (second priority), and None return when nothing matches.
+
+    Feature 038 — Entity Mention Detection
+    """
+
+    async def test_returns_entity_id_and_canonical_name_on_canonical_match(
+        self,
+    ) -> None:
+        """Returns ``(entity_id, canonical_name)`` when text matches canonical_name."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        # First execute: entity lookup → found; second would never be reached.
+        session = _mock_execute_returns(entity_mock)
+
+        result = await resolve_entity_id_from_text(session, "Claudia Sheinbaum")
+
+        assert result is not None
+        entity_id, returned_name = result
+        assert entity_id == entity_mock.id
+        assert returned_name == "Claudia Sheinbaum"
+
+    async def test_match_is_case_insensitive_for_canonical_name(self) -> None:
+        """Canonical-name lookup is case-insensitive (``func.lower`` applied)."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        session = _mock_execute_returns(entity_mock)
+
+        # Pass lowercase variant — the SQL func.lower handles normalisation.
+        result = await resolve_entity_id_from_text(session, "claudia sheinbaum")
+
+        assert result is not None
+        entity_id, returned_name = result
+        assert entity_id == entity_mock.id
+        # canonical_name is returned unchanged from the DB object
+        assert returned_name == "Claudia Sheinbaum"
+
+    async def test_returns_entity_id_and_original_text_on_alias_match(self) -> None:
+        """Returns ``(entity_id, text)`` when text matches an alias (not canonical)."""
+        alias_mock = MagicMock()
+        alias_mock.entity_id = uuid.uuid4()
+
+        # First execute: no entity → None; second execute: alias found.
+        session = _mock_execute_returns(None, alias_mock)
+
+        result = await resolve_entity_id_from_text(session, "Sheinbom")
+
+        assert result is not None
+        entity_id, returned_text = result
+        assert entity_id == alias_mock.entity_id
+        # When matched via alias, the original *text* arg is returned verbatim.
+        assert returned_text == "Sheinbom"
+
+    async def test_alias_match_is_case_insensitive(self) -> None:
+        """Alias lookup is case-insensitive (``func.lower`` applied)."""
+        alias_mock = MagicMock()
+        alias_mock.entity_id = uuid.uuid4()
+
+        session = _mock_execute_returns(None, alias_mock)
+
+        # Text passed in mixed case; alias lookup normalises via SQL.
+        result = await resolve_entity_id_from_text(session, "SHEINBOM")
+
+        assert result is not None
+        entity_id, returned_text = result
+        assert entity_id == alias_mock.entity_id
+        assert returned_text == "SHEINBOM"
+
+    async def test_returns_none_when_no_entity_or_alias_matched(self) -> None:
+        """Returns ``None`` when text matches neither entity canonical_name nor alias."""
+        session = _mock_execute_returns(None, None)
+
+        result = await resolve_entity_id_from_text(session, "Completely Unknown Person")
+
+        assert result is None
+
+    async def test_strips_leading_and_trailing_whitespace(self) -> None:
+        """Text is stripped before matching; surrounding spaces are ignored."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        session = _mock_execute_returns(entity_mock)
+
+        # The implementation does text.lower().strip() before the SQL query.
+        result = await resolve_entity_id_from_text(
+            session, "  Claudia Sheinbaum  "
+        )
+
+        # Should still resolve even with surrounding whitespace.
+        assert result is not None
+
+    async def test_alias_lookup_only_called_when_entity_not_found(self) -> None:
+        """Second DB query (alias) is only executed after entity lookup misses."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        # Only one execute result supplied — entity found on first call.
+        session = _mock_execute_returns(entity_mock)
+
+        await resolve_entity_id_from_text(session, "Claudia Sheinbaum")
+
+        # Should have called execute exactly once (entity lookup only).
+        assert session.execute.call_count == 1
+
+    async def test_both_queries_run_when_entity_not_found(self) -> None:
+        """Both entity and alias queries are run when entity lookup returns None."""
+        session = _mock_execute_returns(None, None)
+
+        await resolve_entity_id_from_text(session, "Unknown")
+
+        # Both entity lookup and alias lookup should execute.
+        assert session.execute.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# TestRegisterAsrAlias
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAsrAlias:
+    """Tests for ``register_asr_alias``.
+
+    Covers new-alias creation, occurrence-count increment, commit
+    behaviour, no-op on unknown entity, and best-effort exception
+    swallowing.
+
+    Feature 038 — Entity Mention Detection
+    """
+
+    async def test_creates_new_alias_when_corrected_text_matches_entity_canonical_name(
+        self,
+    ) -> None:
+        """New ASR alias created when corrected_text matches a known canonical_name."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        # execute sequence: entity lookup → existing alias check (None → create)
+        session = _mock_execute_returns(entity_mock, None)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
+        ) as MockRepo, patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            mock_repo_instance = AsyncMock()
+            MockRepo.return_value = mock_repo_instance
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+            )
+
+        mock_repo_instance.create.assert_called_once()
+        call_kwargs = mock_repo_instance.create.call_args
+        alias_create = call_kwargs[1]["obj_in"]
+        assert alias_create.entity_id == entity_mock.id
+        assert alias_create.alias_name == "Claudia Shainbom"
+        assert alias_create.alias_type == EntityAliasType.ASR_ERROR
+
+    async def test_creates_new_alias_when_corrected_text_matches_entity_alias(
+        self,
+    ) -> None:
+        """New ASR alias created when corrected_text matches an existing entity alias."""
+        alias_mock = MagicMock()
+        alias_mock.entity_id = uuid.uuid4()
+
+        # execute sequence: entity lookup (None) → alias lookup → existing alias check (None)
+        session = _mock_execute_returns(None, alias_mock, None)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
+        ) as MockRepo, patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            mock_repo_instance = AsyncMock()
+            MockRepo.return_value = mock_repo_instance
+            MockNorm.return_value.normalize.return_value = "seon"
+
+            await register_asr_alias(
+                session,
+                original_text="Seon",
+                corrected_text="Sheinbaum",
+            )
+
+        mock_repo_instance.create.assert_called_once()
+        call_kwargs = mock_repo_instance.create.call_args
+        alias_create = call_kwargs[1]["obj_in"]
+        assert alias_create.entity_id == alias_mock.entity_id
+        assert alias_create.alias_name == "Seon"
+        assert alias_create.alias_type == EntityAliasType.ASR_ERROR
+
+    async def test_increments_occurrence_count_when_alias_already_exists(
+        self,
+    ) -> None:
+        """If alias already exists by normalized form, occurrence_count is incremented."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        existing_alias = MagicMock()
+        existing_alias.occurrence_count = 3
+
+        # execute sequence: entity lookup → existing alias check (found)
+        session = _mock_execute_returns(entity_mock, existing_alias)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+                occurrence_count=5,
+            )
+
+        # 3 (existing) + 5 (new) = 8
+        assert existing_alias.occurrence_count == 8
+        session.flush.assert_called()
+
+    async def test_uses_occurrence_count_parameter_not_hardcoded_one(
+        self,
+    ) -> None:
+        """``occurrence_count`` parameter is passed through, not hardcoded to 1."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        existing_alias = MagicMock()
+        existing_alias.occurrence_count = 0
+
+        session = _mock_execute_returns(entity_mock, existing_alias)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+                occurrence_count=42,
+            )
+
+        assert existing_alias.occurrence_count == 42
+
+    async def test_occurrence_count_used_in_new_alias_creation(self) -> None:
+        """Custom ``occurrence_count`` is stored in the new alias record."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        session = _mock_execute_returns(entity_mock, None)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
+        ) as MockRepo, patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            mock_repo_instance = AsyncMock()
+            MockRepo.return_value = mock_repo_instance
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+                occurrence_count=7,
+            )
+
+        call_kwargs = mock_repo_instance.create.call_args
+        alias_create = call_kwargs[1]["obj_in"]
+        assert alias_create.occurrence_count == 7
+
+    async def test_calls_session_commit_when_commit_true(self) -> None:
+        """``session.commit()`` is called when ``commit=True``."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        existing_alias = MagicMock()
+        existing_alias.occurrence_count = 1
+
+        session = _mock_execute_returns(entity_mock, existing_alias)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+                commit=True,
+            )
+
+        session.commit.assert_called_once()
+
+    async def test_does_not_call_session_commit_when_commit_false(self) -> None:
+        """``session.commit()`` is NOT called when ``commit=False`` (default)."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        existing_alias = MagicMock()
+        existing_alias.occurrence_count = 1
+
+        session = _mock_execute_returns(entity_mock, existing_alias)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+                commit=False,
+            )
+
+        session.commit.assert_not_called()
+
+    async def test_commit_false_is_default(self) -> None:
+        """``commit=False`` is the default; session.commit() not called without explicit True."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        existing_alias = MagicMock()
+        existing_alias.occurrence_count = 0
+
+        session = _mock_execute_returns(entity_mock, existing_alias)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            # No commit kwarg supplied → default False
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+            )
+
+        session.commit.assert_not_called()
+
+    async def test_noop_when_corrected_text_matches_no_entity(self) -> None:
+        """No alias created and no DB write when corrected_text matches nothing."""
+        # Both entity and alias lookups return None.
+        session = _mock_execute_returns(None, None)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
+        ) as MockRepo:
+            mock_repo_instance = AsyncMock()
+            MockRepo.return_value = mock_repo_instance
+
+            await register_asr_alias(
+                session,
+                original_text="Shainbom",
+                corrected_text="Unknown Person",
+            )
+
+        mock_repo_instance.create.assert_not_called()
+        session.flush.assert_not_called()
+        session.commit.assert_not_called()
+
+    async def test_exception_is_caught_and_not_propagated(self) -> None:
+        """Exception inside the hook is swallowed (best-effort behaviour)."""
+        session = AsyncMock()
+        # Make execute raise to trigger the broad except clause.
+        session.execute.side_effect = RuntimeError("DB exploded")
+
+        # Should NOT raise — best-effort means any exception is caught.
+        await register_asr_alias(
+            session,
+            original_text="Shainbom",
+            corrected_text="Claudia Sheinbaum",
+        )
+
+    async def test_exception_is_logged_not_raised(self, caplog: Any) -> None:
+        """Exception is logged as a warning via the module logger."""
+        import logging
+
+        session = AsyncMock()
+        session.execute.side_effect = RuntimeError("Connection refused")
+
+        with caplog.at_level(logging.WARNING, logger="chronovista.services.asr_alias_registry"):
+            await register_asr_alias(
+                session,
+                original_text="Shainbom",
+                corrected_text="Claudia Sheinbaum",
+            )
+
+        assert any("hook failed" in record.message for record in caplog.records)
+
+    async def test_uses_savepoint_begin_nested_for_new_alias_creation(
+        self,
+    ) -> None:
+        """New alias creation uses ``session.begin_nested()`` savepoint."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        session = _mock_execute_returns(entity_mock, None)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
+        ) as MockRepo, patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            mock_repo_instance = AsyncMock()
+            MockRepo.return_value = mock_repo_instance
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+            )
+
+        session.begin_nested.assert_called_once()
+
+    async def test_no_savepoint_when_alias_already_exists(self) -> None:
+        """No ``begin_nested()`` savepoint used when incrementing existing alias."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        existing_alias = MagicMock()
+        existing_alias.occurrence_count = 2
+
+        session = _mock_execute_returns(entity_mock, existing_alias)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+            )
+
+        session.begin_nested.assert_not_called()
+
+    async def test_uses_tag_normalization_service_for_normalized_form(
+        self,
+    ) -> None:
+        """``TagNormalizationService.normalize()`` is called on original_text."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        existing_alias = MagicMock()
+        existing_alias.occurrence_count = 0
+
+        session = _mock_execute_returns(entity_mock, existing_alias)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            mock_normalizer = MagicMock()
+            mock_normalizer.normalize.return_value = "claudia shainbom"
+            MockNorm.return_value = mock_normalizer
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+            )
+
+        mock_normalizer.normalize.assert_called_once_with("Claudia Shainbom")
+
+    async def test_falls_back_to_lower_when_normalize_returns_none(self) -> None:
+        """If ``normalize()`` returns None/falsy, falls back to ``original_text.lower()``."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        # Normalize returns empty string → falsy
+        session = _mock_execute_returns(entity_mock, None)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
+        ) as MockRepo, patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            mock_repo_instance = AsyncMock()
+            MockRepo.return_value = mock_repo_instance
+            MockNorm.return_value.normalize.return_value = ""  # falsy
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+            )
+
+        call_kwargs = mock_repo_instance.create.call_args
+        alias_create = call_kwargs[1]["obj_in"]
+        # Should fall back to "claudia shainbom" (lower of original_text)
+        assert alias_create.alias_name_normalized == "claudia shainbom"
+
+    async def test_log_prefix_appears_in_warning_on_exception(
+        self, caplog: Any
+    ) -> None:
+        """Custom ``log_prefix`` is included in the warning log on failure."""
+        import logging
+
+        session = AsyncMock()
+        session.execute.side_effect = RuntimeError("DB error")
+
+        with caplog.at_level(
+            logging.WARNING, logger="chronovista.services.asr_alias_registry"
+        ):
+            await register_asr_alias(
+                session,
+                original_text="Shainbom",
+                corrected_text="Claudia Sheinbaum",
+                log_prefix="batch-correction",
+            )
+
+        # The log_prefix must appear in the warning message
+        assert any(
+            "batch-correction" in record.message for record in caplog.records
+        )
+
+    async def test_default_log_prefix_is_asr_alias(self, caplog: Any) -> None:
+        """Default ``log_prefix`` is ``'asr-alias'``."""
+        import logging
+
+        session = AsyncMock()
+        session.execute.side_effect = RuntimeError("DB error")
+
+        with caplog.at_level(
+            logging.WARNING, logger="chronovista.services.asr_alias_registry"
+        ):
+            await register_asr_alias(
+                session,
+                original_text="Shainbom",
+                corrected_text="Claudia Sheinbaum",
+            )
+
+        assert any("asr-alias" in record.message for record in caplog.records)
+
+    async def test_commit_called_after_new_alias_creation_when_commit_true(
+        self,
+    ) -> None:
+        """``session.commit()`` is called after the savepoint closes when ``commit=True``."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        session = _mock_execute_returns(entity_mock, None)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
+        ) as MockRepo, patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            mock_repo_instance = AsyncMock()
+            MockRepo.return_value = mock_repo_instance
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+                commit=True,
+            )
+
+        session.commit.assert_called_once()
+
+    async def test_entity_alias_repository_instantiated_inside_savepoint(
+        self,
+    ) -> None:
+        """``EntityAliasRepository`` is instantiated and ``create`` called for new alias."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Test Entity"
+
+        session = _mock_execute_returns(entity_mock, None)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
+        ) as MockRepo, patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            mock_repo_instance = AsyncMock()
+            MockRepo.return_value = mock_repo_instance
+            MockNorm.return_value.normalize.return_value = "test alias"
+
+            await register_asr_alias(
+                session,
+                original_text="Test Alias",
+                corrected_text="Test Entity",
+            )
+
+        MockRepo.assert_called_once()
+        mock_repo_instance.create.assert_called_once()

--- a/tests/unit/services/test_batch_correction_service.py
+++ b/tests/unit/services/test_batch_correction_service.py
@@ -1831,8 +1831,9 @@ class TestBatchRevert:
         service: Any,
         mock_session: AsyncMock,
         mock_segment_repo: AsyncMock,
+        mock_correction_repo: AsyncMock,
     ) -> None:
-        """Dry-run returns list of (video_id, segment_id, start_time, corrected_text)."""
+        """Dry-run returns list of (video_id, segment_id, start_time, corrected_text, is_partner)."""
         seg = _make_segment(
             video_id="v1", segment_id=10, text="original",
             corrected_text="fixed text", has_correction=True, start_time=5.5,
@@ -1840,6 +1841,8 @@ class TestBatchRevert:
 
         mock_segment_repo.count_filtered.return_value = 100
         mock_segment_repo.find_by_text_pattern.return_value = [seg]
+        # No cross-segment partner for this segment
+        mock_correction_repo.get_by_segment.return_value = []
 
         result = await service.batch_revert(
             mock_session, pattern="fixed", dry_run=True,
@@ -1847,17 +1850,19 @@ class TestBatchRevert:
 
         assert isinstance(result, list)
         assert len(result) == 1
-        video_id, segment_id, start_time, corrected_text = result[0]
+        video_id, segment_id, start_time, corrected_text, is_partner = result[0]
         assert video_id == "v1"
         assert segment_id == 10
         assert start_time == 5.5
         assert corrected_text == "fixed text"
+        assert is_partner is False
 
     async def test_dry_run_filters_has_correction(
         self,
         service: Any,
         mock_session: AsyncMock,
         mock_segment_repo: AsyncMock,
+        mock_correction_repo: AsyncMock,
     ) -> None:
         """Dry-run only includes segments with has_correction=True."""
         seg_corrected = _make_segment(
@@ -1873,6 +1878,8 @@ class TestBatchRevert:
         mock_segment_repo.find_by_text_pattern.return_value = [
             seg_corrected, seg_uncorrected,
         ]
+        # No cross-segment partner
+        mock_correction_repo.get_by_segment.return_value = []
 
         result = await service.batch_revert(
             mock_session, pattern="fixed", dry_run=True,
@@ -1887,6 +1894,7 @@ class TestBatchRevert:
         mock_session: AsyncMock,
         mock_segment_repo: AsyncMock,
         mock_correction_service: AsyncMock,
+        mock_correction_repo: AsyncMock,
     ) -> None:
         """Live mode returns BatchCorrectionResult."""
         from chronovista.models.batch_correction_models import BatchCorrectionResult
@@ -1899,6 +1907,7 @@ class TestBatchRevert:
         mock_segment_repo.count_filtered.return_value = 100
         mock_segment_repo.find_by_text_pattern.return_value = [seg]
         mock_correction_service.revert_correction.return_value = MagicMock()
+        mock_correction_repo.get_by_segment.return_value = []
 
         result = await service.batch_revert(
             mock_session, pattern="fixed",
@@ -1915,6 +1924,7 @@ class TestBatchRevert:
         mock_session: AsyncMock,
         mock_segment_repo: AsyncMock,
         mock_correction_service: AsyncMock,
+        mock_correction_repo: AsyncMock,
     ) -> None:
         """Live mode calls revert_correction for each matched segment."""
         seg = _make_segment(
@@ -1925,6 +1935,7 @@ class TestBatchRevert:
         mock_segment_repo.count_filtered.return_value = 10
         mock_segment_repo.find_by_text_pattern.return_value = [seg]
         mock_correction_service.revert_correction.return_value = MagicMock()
+        mock_correction_repo.get_by_segment.return_value = []
 
         await service.batch_revert(mock_session, pattern="fixed")
 
@@ -1938,6 +1949,7 @@ class TestBatchRevert:
         mock_session: AsyncMock,
         mock_segment_repo: AsyncMock,
         mock_correction_service: AsyncMock,
+        mock_correction_repo: AsyncMock,
     ) -> None:
         """ValueError from revert_correction is handled as skip."""
         seg1 = _make_segment(
@@ -1955,6 +1967,7 @@ class TestBatchRevert:
             MagicMock(),
             ValueError("no active correction"),
         ]
+        mock_correction_repo.get_by_segment.return_value = []
 
         result = await service.batch_revert(mock_session, pattern="fixed")
 
@@ -2003,6 +2016,7 @@ class TestBatchRevert:
         mock_session: AsyncMock,
         mock_segment_repo: AsyncMock,
         mock_correction_service: AsyncMock,
+        mock_correction_repo: AsyncMock,
     ) -> None:
         """unique_videos counts distinct video_ids from corrected matches."""
         seg1 = _make_segment(
@@ -2021,6 +2035,7 @@ class TestBatchRevert:
         mock_segment_repo.count_filtered.return_value = 50
         mock_segment_repo.find_by_text_pattern.return_value = [seg1, seg2, seg3]
         mock_correction_service.revert_correction.return_value = MagicMock()
+        mock_correction_repo.get_by_segment.return_value = []
 
         result = await service.batch_revert(mock_session, pattern="fix")
 
@@ -2032,6 +2047,7 @@ class TestBatchRevert:
         mock_session: AsyncMock,
         mock_segment_repo: AsyncMock,
         mock_correction_service: AsyncMock,
+        mock_correction_repo: AsyncMock,
     ) -> None:
         """Progress callback is invoked during batch processing."""
         seg1 = _make_segment(
@@ -2046,6 +2062,7 @@ class TestBatchRevert:
         mock_segment_repo.count_filtered.return_value = 10
         mock_segment_repo.find_by_text_pattern.return_value = [seg1, seg2]
         mock_correction_service.revert_correction.return_value = MagicMock()
+        mock_correction_repo.get_by_segment.return_value = []
 
         callback = MagicMock()
         await service.batch_revert(
@@ -2076,6 +2093,7 @@ class TestBatchRevert:
         mock_session: AsyncMock,
         mock_segment_repo: AsyncMock,
         mock_correction_service: AsyncMock,
+        mock_correction_repo: AsyncMock,
     ) -> None:
         """Dry-run mode does not call revert_correction."""
         seg = _make_segment(
@@ -2085,6 +2103,7 @@ class TestBatchRevert:
 
         mock_segment_repo.count_filtered.return_value = 10
         mock_segment_repo.find_by_text_pattern.return_value = [seg]
+        mock_correction_repo.get_by_segment.return_value = []
 
         await service.batch_revert(mock_session, pattern="fix", dry_run=True)
 
@@ -2111,6 +2130,12 @@ def _mock_execute_returns(*results: Any) -> AsyncMock:
         side_effects.append(mock_result)
     session = AsyncMock()
     session.execute.side_effect = side_effects
+    # begin_nested() returns an async context manager (savepoint).
+    # Use a non-async mock so calling it doesn't return a coroutine.
+    nested_cm = MagicMock()
+    nested_cm.__aenter__ = AsyncMock(return_value=None)
+    nested_cm.__aexit__ = AsyncMock(return_value=False)
+    session.begin_nested = MagicMock(return_value=nested_cm)
     return session
 
 
@@ -2136,13 +2161,13 @@ class TestRecordAsrAliasForBatchReplacement:
         session = _mock_execute_returns(entity_mock, None)
 
         with patch(
-            "chronovista.services.batch_correction_service.EntityAliasRepository"
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
         ) as MockRepo:
             mock_repo_instance = AsyncMock()
             MockRepo.return_value = mock_repo_instance
 
             with patch(
-                "chronovista.services.tag_normalization.TagNormalizationService"
+                "chronovista.services.asr_alias_registry.TagNormalizationService"
             ) as MockNorm:
                 MockNorm.return_value.normalize.return_value = "claudia shainbom"
 
@@ -2173,13 +2198,13 @@ class TestRecordAsrAliasForBatchReplacement:
         session = _mock_execute_returns(None, alias_mock, None)
 
         with patch(
-            "chronovista.services.batch_correction_service.EntityAliasRepository"
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
         ) as MockRepo:
             mock_repo_instance = AsyncMock()
             MockRepo.return_value = mock_repo_instance
 
             with patch(
-                "chronovista.services.tag_normalization.TagNormalizationService"
+                "chronovista.services.asr_alias_registry.TagNormalizationService"
             ) as MockNorm:
                 MockNorm.return_value.normalize.return_value = "seon"
 
@@ -2232,7 +2257,7 @@ class TestRecordAsrAliasForBatchReplacement:
         session = _mock_execute_returns(None, None)
 
         with patch(
-            "chronovista.services.batch_correction_service.EntityAliasRepository"
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
         ) as MockRepo:
             mock_repo_instance = AsyncMock()
             MockRepo.return_value = mock_repo_instance
@@ -2398,13 +2423,13 @@ class TestRecordAsrAliasForBatchReplacement:
         session = _mock_execute_returns(entity_mock, None)
 
         with patch(
-            "chronovista.services.batch_correction_service.EntityAliasRepository"
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
         ) as MockRepo:
             mock_repo_instance = AsyncMock()
             MockRepo.return_value = mock_repo_instance
 
             with patch(
-                "chronovista.services.tag_normalization.TagNormalizationService"
+                "chronovista.services.asr_alias_registry.TagNormalizationService"
             ) as MockNorm:
                 MockNorm.return_value.normalize.return_value = "max blumenthal typo"
 


### PR DESCRIPTION
## Summary

- **Cross-segment pattern matching** (`--cross-segment` flag on `corrections find-replace`) — matches patterns spanning two adjacent transcript segments, e.g. ASR splitting "Katherine Johnson" as "Katherine Johnsen" (seg N) + "Bound" (seg N+1)
- **Python→PostgreSQL regex translation** — `\b`→`\y`, `\B`→`\Y` state machine so users write Python regex and it works consistently in both DB queries and Python-side replacement (closes #76)
- **ASR alias hook bug fix** — `UniqueViolationError` crashed all 26 corrections in a batch; root cause was checking `alias_name` instead of `alias_name_normalized` (the actual unique constraint), plus missing savepoint protection
- **DRY refactor** — extracted duplicated ASR alias registration logic from `TranscriptCorrectionService` and `BatchCorrectionService` into shared `asr_alias_registry.py` module
- **User guide** — `docs/user-guide/corrections.md` covering substring/regex modes, `\b` word boundaries, cross-segment matching, pairing rules, revert workflows

Closes #76, closes #71

## Test plan

- [x] 27 new unit tests for `asr_alias_registry` shared utility (8 resolve + 19 register)
- [x] 16 integration tests for cross-segment matching, revert, partner cascade, conflict detection
- [x] 3 CLI unit tests for dry-run display formatting (pair markers, summary counts)
- [x] Regex translation unit tests (`\b` at start/end/mid-pattern positions)
- [x] 11 existing `TestBatchRevert` tests updated for 5-tuple return format
- [x] mypy strict compliance (0 errors)
- [x] Manual testing with real ASR data (Renée Dubois, Katherine Johnson cross-segment corrections)