### PR TITLE
feat(frontend): frontend polish & video detail UX (Feature 042)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.43.1] - 2026-03-12
+
+### Fixed
+- **Feature 042: Frontend Polish & Video Detail UX**
+  - Channel search now eagerly loads all pages before filtering — previously only searched the first 25 channels, causing "No channels match" on fast typing
+  - "Searching all channels..." banner with `aria-live="polite"` while pages load during search
+  - Transcript virtualization threshold lowered from 500 to 50 segments — fixes scroll reset at ~25 minute mark when switching from standard to virtualized list mid-scroll
+  - Transcript segment search now eagerly loads all pages — previously showed "0 of 0" because search only ran against loaded segments
+  - Scroll-to-match moved from TranscriptPanel to TranscriptSegments using `containerRef.scrollTop` calculation — fixes scroll failing silently for off-screen virtualized segments where DOM refs are null
+  - Added `prevActiveSegmentIndexRef` guard to prevent scroll yanking back to active match during eager-fetch page loads
+  - Suppressed `PaginationStatus` during active channel search to avoid confusing "Showing 25 of 800" while filtering
+
+### Technical
+- Eager-fetch pattern: `useEffect` calling `fetchNextPage()` when search is active and `hasNextPage && !isFetchingNextPage` — TanStack Query cascades naturally until all pages load
+- Applied to both `ChannelsPage` and `TranscriptSegments` for consistent search-over-paginated-data behavior
+- Frontend version: 0.13.0 → 0.14.0
+- 2,491 frontend tests passing (0 failures)
+- TypeScript strict mode (0 errors)
+- No new dependencies, no backend changes
+
 ## [0.43.0] - 2026-03-11
 
 ### Added

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chronovista-frontend",
-  "version": "0.7.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chronovista-frontend",
-      "version": "0.7.0",
+      "version": "0.13.0",
       "dependencies": {
         "@tanstack/react-query": "^5.64.0",
         "@tanstack/react-virtual": "^3.13.18",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -30,6 +30,9 @@ export const BATCH_PREVIEW_TIMEOUT = 30000;
 
 /**
  * Classifies an error into a specific error type.
+ *
+ * FR-001: HTTP 401/403 responses are classified as "auth" — distinct from
+ * generic server errors — so callers can trigger an auth recovery flow.
  */
 function classifyError(error: unknown, response?: Response): ApiErrorType {
   if (error instanceof TypeError && error.message.includes("fetch")) {
@@ -38,11 +41,17 @@ function classifyError(error: unknown, response?: Response): ApiErrorType {
   if (error instanceof DOMException && error.name === "AbortError") {
     return "timeout";
   }
-  if (response && response.status >= 500) {
-    return "server";
-  }
-  if (response && response.status >= 400) {
-    return "server";
+  if (response) {
+    // FR-001: Classify 401 Unauthorized and 403 Forbidden as auth errors.
+    if (response.status === 401 || response.status === 403) {
+      return "auth";
+    }
+    if (response.status >= 500) {
+      return "server";
+    }
+    if (response.status >= 400) {
+      return "server";
+    }
   }
   return "unknown";
 }
@@ -54,6 +63,7 @@ function createApiError(error: unknown, response?: Response): ApiError {
   const type = classifyError(error, response);
 
   const messages: Record<ApiErrorType, string> = {
+    auth: "You are not authorized to access this resource. Please check your credentials.",
     network:
       "Cannot reach the API server. Make sure the backend is running on port 8765.",
     timeout: "The server took too long to respond.",
@@ -69,18 +79,28 @@ function createApiError(error: unknown, response?: Response): ApiError {
 }
 
 /**
- * Extended fetch options that include an optional timeout override.
+ * Extended fetch options that include an optional timeout override and an
+ * optional external AbortSignal for caller-controlled cancellation.
  */
 export interface ApiFetchOptions extends RequestInit {
   /** Timeout in milliseconds. Defaults to API_TIMEOUT (10s). */
   timeout?: number;
+  /**
+   * External AbortSignal supplied by the caller (e.g. from React's use() or
+   * TanStack Query's signal). Combined with the internal timeout signal via
+   * AbortSignal.any() so that whichever fires first wins.
+   *
+   * FR-006: When this signal fires, the resulting AbortError must NOT trigger
+   * an error state or retry — the query was deliberately cancelled.
+   */
+  externalSignal?: AbortSignal;
 }
 
 /**
- * Fetch wrapper with timeout and error handling.
+ * Fetch wrapper with timeout, cancellation, and error handling.
  *
  * @param endpoint - API endpoint path (without base URL)
- * @param options - Fetch options with optional timeout override
+ * @param options - Fetch options with optional timeout override and external signal
  * @returns Parsed JSON response
  * @throws ApiError on failure
  */
@@ -88,16 +108,25 @@ export async function apiFetch<T>(
   endpoint: string,
   options: ApiFetchOptions = {}
 ): Promise<T> {
-  const { timeout, ...fetchOptions } = options;
+  const { timeout, externalSignal, ...fetchOptions } = options;
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout ?? API_TIMEOUT);
+
+  // Combine the internal timeout signal with any caller-supplied signal.
+  // AbortSignal.any() resolves as soon as the first signal fires.
+  // This lets TanStack Query (or React) cancel in-flight requests while the
+  // timeout guard remains independently active.
+  const combinedSignal: AbortSignal =
+    externalSignal !== undefined
+      ? AbortSignal.any([controller.signal, externalSignal])
+      : controller.signal;
 
   const url = `${API_BASE_URL}${endpoint}`;
 
   try {
     const response = await fetch(url, {
       ...fetchOptions,
-      signal: controller.signal,
+      signal: combinedSignal,
       headers: {
         "Content-Type": "application/json",
         ...fetchOptions.headers,

--- a/frontend/src/components/AuthErrorState.tsx
+++ b/frontend/src/components/AuthErrorState.tsx
@@ -1,0 +1,113 @@
+/**
+ * AuthErrorState component — full-page session-expired overlay.
+ *
+ * Implements:
+ * - FR-002: Consistent "Session Expired" UI shown on any page where a 401/403
+ *           is detected by the global QueryCache interceptor.
+ * - FR-022: Focus moves to the "Refresh Page" button on mount so keyboard
+ *           and screen-reader users are immediately aware of the error state.
+ * - NFR-001: 44×44 px minimum touch target on the action button.
+ */
+
+import { useEffect, useRef } from "react";
+
+/**
+ * AuthErrorState renders a centered session-expired message with a
+ * "Refresh Page" button that auto-receives focus on mount (FR-022).
+ *
+ * Place this as a full-page replacement rather than an inline error so that
+ * the user always sees the same UI regardless of which page triggered the
+ * auth failure (FR-002).
+ *
+ * @example
+ * ```tsx
+ * // Inside AppShell, conditionally replacing <Outlet />
+ * if (isAuthError) return <AuthErrorState />;
+ * ```
+ */
+export function AuthErrorState() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // FR-022: Move focus to the action button when this state is rendered.
+  // useEffect runs after paint so the element is guaranteed to be in the DOM.
+  useEffect(() => {
+    buttonRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center"
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+    >
+      {/* Lock icon */}
+      <div className="mx-auto w-16 h-16 mb-5 text-amber-600 bg-amber-100 rounded-full p-3 flex items-center justify-center">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
+          />
+        </svg>
+      </div>
+
+      {/* Label */}
+      <p className="text-sm font-semibold text-amber-800 uppercase tracking-wider mb-2">
+        Session Expired
+      </p>
+
+      {/* Primary message */}
+      <h2 className="text-xl font-bold text-slate-900 mb-3">
+        Your authentication token has expired
+      </h2>
+
+      {/* Help text */}
+      <p className="text-slate-600 max-w-sm mb-2">
+        Please refresh the page to restore your session.
+      </p>
+
+      {/* Terminal help text */}
+      <p className="text-sm text-slate-500 max-w-sm mb-8">
+        Or run{" "}
+        <code className="px-1.5 py-0.5 bg-slate-100 rounded font-mono text-xs text-slate-700">
+          chronovista auth login
+        </code>{" "}
+        in your terminal to re-authenticate.
+      </p>
+
+      {/* Refresh Page button — NFR-001: min 44×44px touch target */}
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => window.location.reload()}
+        className="inline-flex items-center gap-2 px-6 py-3 min-h-[44px] bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
+        aria-label="Refresh page to re-authenticate"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="w-5 h-5"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
+          />
+        </svg>
+        Refresh Page
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ErrorState.tsx
+++ b/frontend/src/components/ErrorState.tsx
@@ -20,6 +20,7 @@ interface ErrorStateProps {
  * Error messages for each error type.
  */
 const errorMessages: Record<ApiErrorType, string> = {
+  auth: "You are not authorized to access this resource. Please check your credentials.",
   network:
     "Cannot reach the API server. Make sure the backend is running on port 8765.",
   timeout: "The server took too long to respond.",
@@ -94,6 +95,8 @@ export function ErrorState({ error, message: providedMessage, title, onRetry }: 
   // Use provided title or generate from error type
   const errorTitle = title || (() => {
     switch (errorType) {
+      case "auth":
+        return "Authentication Error";
       case "network":
         return "Connection Error";
       case "timeout":

--- a/frontend/src/components/SearchErrorState.tsx
+++ b/frontend/src/components/SearchErrorState.tsx
@@ -1,51 +1,36 @@
 /**
  * SearchErrorState Component
  *
- * Implements FR-016, FR-024, EC-011-EC-016: Error state display for search failures.
+ * Implements FR-016: Error state display for search failures.
  *
- * Features:
- * - Friendly error message
- * - Retry button to allow recovery
- * - Authentication error detection (401/403)
- * - Session expired handling with refresh button
- * - Accessible error announcement
+ * FR-003: Authentication errors (401/403) are handled globally by the
+ * QueryCache interceptor in `src/lib/queryClient.ts`, which calls
+ * `setAuthError()` and causes AppShell to render `AuthErrorState` instead of
+ * this component. This component therefore only renders generic (non-auth)
+ * errors and no longer contains per-component 401/403 handling.
  *
  * @see FR-016: Display error state with retry option
- * @see FR-024: Authentication error handling
- * @see EC-011-EC-016: Session expiration and recovery
+ * @see FR-003: Global auth interception — no per-page 401 handling
  */
-
-import type { ApiError } from "../types/video";
 
 interface SearchErrorStateProps {
   /** Optional custom error message (defaults to generic message) */
   message?: string;
   /** Callback to retry the failed search */
   onRetry: () => void;
-  /** Optional HTTP status code for authentication detection */
-  status?: number;
-  /** Optional full error object for detailed error handling */
-  error?: unknown;
 }
 
 /**
- * Error state component for search failures.
+ * Error state component for search failures (non-auth errors only).
  *
- * Displays when a search request fails due to network issues, server errors,
- * authentication issues, or other unexpected problems. Provides appropriate
- * recovery mechanisms based on error type.
+ * Auth errors are intercepted globally via the QueryCache and rendered by
+ * AppShell as `AuthErrorState`. This component handles network failures,
+ * server errors, and other unexpected problems with a retry button.
  *
  * @example
  * ```tsx
- * // Generic error
  * <SearchErrorState
  *   message="Network error: Unable to reach server"
- *   onRetry={() => refetch()}
- * />
- *
- * // Authentication error
- * <SearchErrorState
- *   status={401}
  *   onRetry={() => refetch()}
  * />
  * ```
@@ -53,70 +38,7 @@ interface SearchErrorStateProps {
 export function SearchErrorState({
   message = "Something went wrong. Please try again.",
   onRetry,
-  status,
-  error,
 }: SearchErrorStateProps) {
-  // EC-011-EC-016: Detect authentication errors (401/403)
-  const isAuthError = status === 401 || status === 403;
-
-  // Extract status from ApiError if available
-  const apiError = error as ApiError | undefined;
-  const effectiveStatus = status ?? apiError?.status;
-  const isAuthErrorFromApi = effectiveStatus === 401 || effectiveStatus === 403;
-
-  const showAuthError = isAuthError || isAuthErrorFromApi;
-
-  if (showAuthError) {
-    return (
-      <div
-        className="flex flex-col items-center justify-center py-16 px-4 text-center"
-        role="alert"
-        aria-live="assertive"
-      >
-        {/* Lock icon for auth errors */}
-        <div className="w-16 h-16 mb-4 rounded-full bg-yellow-100 dark:bg-yellow-900/30 flex items-center justify-center">
-          <svg
-            className="w-8 h-8 text-yellow-600 dark:text-yellow-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-            />
-          </svg>
-        </div>
-
-        {/* Auth error message (EC-011) */}
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
-          Session expired
-        </h2>
-        <p className="text-gray-600 dark:text-gray-400 max-w-md mb-2">
-          Session expired. Please refresh the page.
-        </p>
-
-        {/* Secondary help text (EC-015) */}
-        <p className="text-sm text-gray-500 dark:text-gray-500 max-w-md mb-6">
-          Or run <code className="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-800 rounded font-mono text-xs">chronovista auth login</code> in your terminal
-        </p>
-
-        {/* Refresh button (EC-012, EC-013) */}
-        <button
-          onClick={() => window.location.reload()}
-          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-          aria-label="Refresh page to re-authenticate"
-        >
-          Refresh Page
-        </button>
-      </div>
-    );
-  }
-
-  // Generic error display
   return (
     <div
       className="flex flex-col items-center justify-center py-16 px-4 text-center"
@@ -124,9 +46,9 @@ export function SearchErrorState({
       aria-live="assertive"
     >
       {/* Error icon */}
-      <div className="w-16 h-16 mb-4 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+      <div className="w-16 h-16 mb-4 rounded-full bg-red-100 flex items-center justify-center">
         <svg
-          className="w-8 h-8 text-red-600 dark:text-red-400"
+          className="w-8 h-8 text-red-600"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -142,17 +64,18 @@ export function SearchErrorState({
       </div>
 
       {/* Error message */}
-      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+      <h2 className="text-xl font-semibold text-gray-900 mb-2">
         Error loading search results
       </h2>
-      <p className="text-gray-600 dark:text-gray-400 max-w-md mb-6">
+      <p className="text-gray-600 max-w-md mb-6">
         {message}
       </p>
 
       {/* Retry button */}
       <button
+        type="button"
         onClick={onRetry}
-        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         aria-label="Retry search"
       >
         Try Again

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -9,15 +9,20 @@
  * - T040: localStorage hydration UX with backend polling
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { Link, Outlet } from "react-router-dom";
 
 import { ErrorBoundary } from "../ErrorBoundary";
+import { AuthErrorState } from "../AuthErrorState";
 import { Header } from "./Header";
 import { Sidebar } from "./Sidebar";
 import { useRecoveryStore } from "../../stores/recoveryStore";
 import type { RecoverySession } from "../../stores/recoveryStore";
 import { apiFetch } from "../../api/config";
+import {
+  subscribeToAuthError,
+  getAuthErrorSnapshot,
+} from "../../lib/queryClient";
 
 /**
  * Toast notification for recovery completion/failure.
@@ -58,6 +63,15 @@ export function AppShell() {
   const hasActiveRecovery = useRecoveryStore((s) => s.hasActiveRecovery());
   // Don't subscribe to activeSessions in render - causes infinite loops with persist middleware
   // Instead, use getActiveSessions() directly when needed
+
+  // FR-001 / FR-023: Subscribe to global auth error state.
+  // useSyncExternalStore deduplicates simultaneous 401s — setAuthError() is
+  // idempotent and only transitions false → true once, so a single render
+  // is triggered regardless of how many concurrent queries received a 401.
+  const isAuthError = useSyncExternalStore(
+    subscribeToAuthError,
+    getAuthErrorSnapshot
+  );
 
   // Toast state (T039)
   const [toasts, setToasts] = useState<Toast[]>([]);
@@ -324,10 +338,17 @@ export function AppShell() {
           </div>
         )}
 
-        <main className="flex-1 overflow-auto bg-slate-50">
-          <ErrorBoundary>
-            <Outlet />
-          </ErrorBoundary>
+        {/* FR-002 / FR-023: Replace children with session-expired UI when auth error is set.
+            AuthErrorState is rendered outside the ErrorBoundary so a boundary reset
+            cannot accidentally hide the auth error message. */}
+        <main className="flex-1 overflow-auto bg-slate-50" id="main-content">
+          {isAuthError ? (
+            <AuthErrorState />
+          ) : (
+            <ErrorBoundary>
+              <Outlet />
+            </ErrorBoundary>
+          )}
         </main>
       </div>
     </div>

--- a/frontend/src/components/transcript/TextHighlighter.tsx
+++ b/frontend/src/components/transcript/TextHighlighter.tsx
@@ -1,0 +1,161 @@
+/**
+ * TextHighlighter component for rendering text with search match highlights.
+ *
+ * Implements:
+ * - FR-012: Highlight with bold/underline + background color (not color alone)
+ * - NFR-003: Not color alone — uses bold + underline in addition to background
+ * - NFR-005: WCAG 1.4.3 contrast ratio 4.5:1 for highlights on light background
+ *
+ * @module components/transcript/TextHighlighter
+ */
+
+import type React from "react";
+import type { TranscriptSearchMatch } from "../../hooks/useTranscriptSearch";
+
+/**
+ * A highlight region within a text string.
+ */
+interface HighlightRegion {
+  /** Character offset where the highlight starts */
+  startOffset: number;
+  /** Length of the highlighted string */
+  length: number;
+  /** Whether this is the currently active (focused) match */
+  isActive: boolean;
+}
+
+/**
+ * Props for the TextHighlighter component.
+ */
+export interface TextHighlighterProps {
+  /** The full text to render */
+  text: string;
+  /** All search matches for this text's segment */
+  matches: TranscriptSearchMatch[];
+  /** Index of the segment in the segments array (used to filter relevant matches) */
+  segmentIndex: number;
+  /**
+   * The global index of the currently active match.
+   * Matches are stored globally across all segments; this is compared against
+   * the match's position in the full matches array.
+   */
+  activeMatchIndex: number;
+  /** All matches across all segments (needed to calculate if a match is active) */
+  allMatches: TranscriptSearchMatch[];
+}
+
+/**
+ * TextHighlighter renders text with search result highlights.
+ *
+ * - Non-active matches: amber-200 background, bold, underline (NFR-003, NFR-005)
+ * - Active match: amber-400 background with ring outline, bold, underline
+ * - Uses `<mark>` element for semantic correctness
+ * - Achieves ≥4.5:1 contrast ratio (NFR-005):
+ *   - amber-200 (#FDE68A) with gray-900 (#111827): ~8.5:1
+ *   - amber-400 (#FBBF24) with gray-900 (#111827): ~7.2:1
+ *
+ * @example
+ * ```tsx
+ * <TextHighlighter
+ *   text="Hello world, hello again"
+ *   matches={matchesForThisSegment}
+ *   segmentIndex={2}
+ *   activeMatchIndex={currentIndex}
+ *   allMatches={allMatches}
+ * />
+ * ```
+ */
+export function TextHighlighter({
+  text,
+  matches,
+  segmentIndex,
+  activeMatchIndex,
+  allMatches,
+}: TextHighlighterProps) {
+  // Filter matches that belong to this segment
+  const segmentMatches = matches.filter((m) => m.segmentIndex === segmentIndex);
+
+  // If no matches in this segment, render plain text
+  if (segmentMatches.length === 0) {
+    return <>{text}</>;
+  }
+
+  // Build highlight regions, noting which global match index each corresponds to
+  const regions: HighlightRegion[] = segmentMatches.map((match) => {
+    // Find the global index of this match in allMatches
+    const globalIndex = allMatches.findIndex(
+      (m) =>
+        m.segmentIndex === match.segmentIndex &&
+        m.startOffset === match.startOffset &&
+        m.length === match.length
+    );
+    return {
+      startOffset: match.startOffset,
+      length: match.length,
+      isActive: globalIndex === activeMatchIndex,
+    };
+  });
+
+  // Sort regions by startOffset (ascending) to process left-to-right
+  regions.sort((a, b) => a.startOffset - b.startOffset);
+
+  // Split text into alternating plain and highlighted segments
+  const parts: React.ReactNode[] = [];
+  let cursor = 0;
+
+  for (let i = 0; i < regions.length; i++) {
+    const region = regions[i];
+    if (!region) continue;
+
+    // Plain text before this match
+    if (region.startOffset > cursor) {
+      parts.push(
+        <span key={`plain-${i}`}>
+          {text.slice(cursor, region.startOffset)}
+        </span>
+      );
+    }
+
+    // Highlighted match
+    const matchText = text.slice(
+      region.startOffset,
+      region.startOffset + region.length
+    );
+
+    if (region.isActive) {
+      // Active match: amber-400 background + ring outline
+      // NFR-003: bold + underline (not color alone)
+      // NFR-005: amber-400 (#FBBF24) on white gives ~7.2:1 with gray-900 text
+      parts.push(
+        <mark
+          key={`match-${i}`}
+          className="bg-amber-400 font-bold underline ring-2 ring-amber-600 ring-offset-0 rounded-sm"
+          aria-current="true"
+        >
+          {matchText}
+        </mark>
+      );
+    } else {
+      // Non-active match: amber-200 background
+      // NFR-003: bold + underline (not color alone)
+      // NFR-005: amber-200 (#FDE68A) on white gives ~8.5:1 with gray-900 text
+      parts.push(
+        <mark
+          key={`match-${i}`}
+          className="bg-amber-200 font-bold underline rounded-sm"
+        >
+          {matchText}
+        </mark>
+      );
+    }
+
+    cursor = region.startOffset + region.length;
+  }
+
+  // Remaining plain text after the last match
+  if (cursor < text.length) {
+    parts.push(<span key="plain-end">{text.slice(cursor)}</span>);
+  }
+
+  return <>{parts}</>;
+}

--- a/frontend/src/components/transcript/TranscriptPanel.tsx
+++ b/frontend/src/components/transcript/TranscriptPanel.tsx
@@ -14,11 +14,12 @@
  * @module components/transcript/TranscriptPanel
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent } from "react";
 
 import { usePrefersReducedMotion } from "../../hooks/usePrefersReducedMotion";
 import { useTranscriptLanguages } from "../../hooks/useTranscriptLanguages";
-import type { TranscriptLanguage, TranscriptType } from "../../types/transcript";
+import { useTranscriptSearch } from "../../hooks/useTranscriptSearch";
+import type { TranscriptLanguage, TranscriptType, TranscriptSegment } from "../../types/transcript";
 import { LanguageSelector } from "./LanguageSelector";
 import { TranscriptFullText } from "./TranscriptFullText";
 import { TranscriptSegments } from "./TranscriptSegments";
@@ -175,6 +176,28 @@ export function TranscriptPanel({
   // Language fallback notice when deep link language is unavailable (FR-012)
   const [languageFallbackNotice, setLanguageFallbackNotice] = useState<string>("");
 
+  // Loaded segments from TranscriptSegments (for client-side search, Feature 042 US4)
+  const [loadedSegments, setLoadedSegments] = useState<TranscriptSegment[]>([]);
+
+  // Raw (un-debounced) search input value for the controlled input
+  const [searchInputValue, setSearchInputValue] = useState<string>("");
+
+  // Saved scroll position — restored when search is cleared (T025)
+  const savedScrollTopRef = useRef<number>(0);
+
+  // Whether search was active (used to detect clear event for scroll restore)
+  const wasSearchActiveRef = useRef<boolean>(false);
+
+  // Ref for the active match container — used for scrollIntoView (T025)
+  const activeMatchContainerRef = useRef<HTMLDivElement>(null);
+
+  // Debounced search announcement (FR-021: 500ms debounce on aria-live)
+  const [searchAnnouncement, setSearchAnnouncement] = useState<string>("");
+  const searchAnnouncementTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Search input ref for keyboard navigation focus detection (T026)
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
   // Refs for focus management (NFR-A01, NFR-A02)
   const toggleButtonRef = useRef<HTMLButtonElement>(null);
   const languageSelectorRef = useRef<HTMLDivElement>(null);
@@ -185,6 +208,18 @@ export function TranscriptPanel({
 
   // State for aria-live announcements
   const [announcement, setAnnouncement] = useState<string>("");
+
+  // Client-side transcript search (Feature 042 US4, FR-011, FR-020)
+  const {
+    matches: searchMatches,
+    currentIndex: searchCurrentIndex,
+    total: searchTotal,
+    next: searchNext,
+    prev: searchPrev,
+    query: searchQuery,
+    setQuery: setSearchQuery,
+    reset: resetSearch,
+  } = useTranscriptSearch(loadedSegments, "");
 
   // Initialize selected language when languages load
   useEffect(() => {
@@ -215,6 +250,132 @@ export function TranscriptPanel({
       setViewMode("segments");
     }
   }, [targetSegmentId, targetTimestamp]);
+
+  // Save scroll position when search first activates (for restore on clear — T025).
+  // Actual scroll-to-match is handled by TranscriptSegments via activeSegmentIndex,
+  // which avoids re-scrolling on every page load during eager-fetch and correctly
+  // handles off-screen virtual segments that aren't in the DOM yet.
+  useEffect(() => {
+    if (searchMatches.length > 0 && !wasSearchActiveRef.current) {
+      wasSearchActiveRef.current = true;
+      if (transcriptContentRef.current) {
+        savedScrollTopRef.current = transcriptContentRef.current.scrollTop;
+      }
+    }
+  }, [searchMatches]);
+
+  // Restore scroll when search is cleared (T025)
+  useEffect(() => {
+    if (searchQuery === "" && wasSearchActiveRef.current) {
+      wasSearchActiveRef.current = false;
+      if (transcriptContentRef.current) {
+        transcriptContentRef.current.scrollTop = savedScrollTopRef.current;
+      }
+    }
+  }, [searchQuery]);
+
+  // Reset scroll position and clear active search when language or view mode changes (T027, T028).
+  // FR-015: Reset scroll to top on language/view mode switch.
+  // FR-025: Clear search highlights and search text on language/view mode switch.
+  //
+  // Scroll reset is immediate (no animation) per FR-015.
+  // The effect skips the very first value of selectedLanguage ("" → first language) by
+  // checking that selectedLanguage is non-empty before acting, which means the reset only
+  // fires on user-initiated language changes, not the initial auto-selection on mount.
+  // Deep-link scroll (FR-016) is preserved because TranscriptSegments performs its own
+  // scrollIntoView after data loads, which runs after this effect and takes precedence.
+  useEffect(() => {
+    // Do not act on the initial empty-string placeholder for selectedLanguage.
+    if (!selectedLanguage) return;
+
+    // Reset scroll container to top immediately (FR-015).
+    if (transcriptContentRef.current) {
+      transcriptContentRef.current.scrollTop = 0;
+    }
+
+    // Also reset the saved scroll position ref so a subsequent search-clear
+    // does not restore a stale pre-language-switch position (T027).
+    savedScrollTopRef.current = 0;
+    wasSearchActiveRef.current = false;
+
+    // Clear active search state (FR-025, T028).
+    setSearchInputValue("");
+    resetSearch();
+  }, [selectedLanguage, viewMode, resetSearch]);
+
+  // Update debounced aria-live search announcement (T024, FR-021: 500ms debounce)
+  useEffect(() => {
+    if (searchAnnouncementTimeoutRef.current !== null) {
+      clearTimeout(searchAnnouncementTimeoutRef.current);
+    }
+
+    if (searchQuery && searchTotal > 0) {
+      searchAnnouncementTimeoutRef.current = setTimeout(() => {
+        setSearchAnnouncement(
+          `${searchTotal} match${searchTotal !== 1 ? "es" : ""} found. Showing ${searchCurrentIndex + 1} of ${searchTotal}.`
+        );
+      }, 500);
+    } else if (searchQuery && searchTotal === 0) {
+      searchAnnouncementTimeoutRef.current = setTimeout(() => {
+        setSearchAnnouncement("No matches found.");
+      }, 500);
+    } else {
+      setSearchAnnouncement("");
+    }
+
+    return () => {
+      if (searchAnnouncementTimeoutRef.current !== null) {
+        clearTimeout(searchAnnouncementTimeoutRef.current);
+      }
+    };
+  }, [searchQuery, searchTotal, searchCurrentIndex]);
+
+  /**
+   * Handles search input change.
+   * Updates raw input state and forwards to debounced hook setter.
+   */
+  const handleSearchInput = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setSearchInputValue(value);
+      setSearchQuery(value);
+    },
+    [setSearchQuery]
+  );
+
+  /**
+   * Handles keyboard navigation from the search input (T026).
+   * Enter → next match, Shift+Enter → previous match.
+   */
+  const handleSearchKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (e.shiftKey) {
+          searchPrev();
+        } else {
+          searchNext();
+        }
+      }
+    },
+    [searchNext, searchPrev]
+  );
+
+  /**
+   * Resets the search field and restores scroll position.
+   */
+  const handleSearchReset = useCallback(() => {
+    setSearchInputValue("");
+    resetSearch();
+    // Restore scroll handled by effect watching searchQuery
+  }, [resetSearch]);
+
+  /**
+   * Handles segments loaded from TranscriptSegments (used for search indexing).
+   */
+  const handleSegmentsChange = useCallback((segments: TranscriptSegment[]) => {
+    setLoadedSegments(segments);
+  }, []);
 
   /**
    * Handles expand/collapse toggle.
@@ -453,6 +614,154 @@ export function TranscriptPanel({
                 />
               </div>
 
+              {/* Search field — visible only in expanded segments view (FR-011, T023) */}
+              {viewMode === "segments" && (
+                <div className="pb-3">
+                  <div className="flex items-center gap-2">
+                    {/* Search input (NFR-002: accessible label) */}
+                    <label
+                      htmlFor="transcript-search-input"
+                      className="sr-only"
+                    >
+                      Search transcript
+                    </label>
+                    <input
+                      ref={searchInputRef}
+                      id="transcript-search-input"
+                      type="search"
+                      value={searchInputValue}
+                      onChange={handleSearchInput}
+                      onKeyDown={handleSearchKeyDown}
+                      placeholder="Search transcript…"
+                      aria-label="Search transcript"
+                      aria-controls="transcript-content"
+                      className="
+                        flex-1 min-w-0 px-3 py-1.5 text-sm
+                        border border-gray-300 rounded-md
+                        bg-white text-gray-900
+                        placeholder:text-gray-400
+                        focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:border-blue-500
+                      "
+                    />
+
+                    {/* Match counter "N of M" (FR-013) */}
+                    {searchQuery && (
+                      <span
+                        className="flex-shrink-0 text-xs text-gray-500 tabular-nums"
+                        aria-live="off"
+                      >
+                        {searchTotal === 0
+                          ? "0 of 0"
+                          : `${searchCurrentIndex + 1} of ${searchTotal}`}
+                      </span>
+                    )}
+
+                    {/* Previous button — NFR-001: min 44×44px touch target */}
+                    {searchTotal > 0 && (
+                      <button
+                        type="button"
+                        onClick={searchPrev}
+                        aria-label="Previous match"
+                        title="Previous match (Shift+Enter)"
+                        disabled={searchTotal === 0}
+                        className="
+                          flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center rounded
+                          text-gray-600 hover:text-gray-900 hover:bg-gray-100
+                          focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
+                          disabled:opacity-40 disabled:cursor-not-allowed
+                        "
+                      >
+                        {/* Up chevron */}
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M5 15l7-7 7 7"
+                          />
+                        </svg>
+                      </button>
+                    )}
+
+                    {/* Next button — NFR-001: min 44×44px touch target */}
+                    {searchTotal > 0 && (
+                      <button
+                        type="button"
+                        onClick={searchNext}
+                        aria-label="Next match"
+                        title="Next match (Enter)"
+                        disabled={searchTotal === 0}
+                        className="
+                          flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center rounded
+                          text-gray-600 hover:text-gray-900 hover:bg-gray-100
+                          focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
+                          disabled:opacity-40 disabled:cursor-not-allowed
+                        "
+                      >
+                        {/* Down chevron */}
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 9l-7 7-7-7"
+                          />
+                        </svg>
+                      </button>
+                    )}
+
+                    {/* Clear/reset button — NFR-001: min 44×44px touch target */}
+                    {searchInputValue && (
+                      <button
+                        type="button"
+                        onClick={handleSearchReset}
+                        aria-label="Clear search"
+                        className="
+                          flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center rounded
+                          text-gray-500 hover:text-gray-700 hover:bg-gray-100
+                          focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
+                        "
+                      >
+                        {/* X icon */}
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M6 18L18 6M6 6l12 12"
+                          />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
+
+                  {/* "No matches" hint (shown when query exists but nothing found) */}
+                  {searchQuery && searchTotal === 0 && (
+                    <p className="mt-1 text-xs text-gray-500" role="status">
+                      No matches found
+                    </p>
+                  )}
+                </div>
+              )}
+
               {/* Transcript Content */}
               <div
                 ref={transcriptContentRef}
@@ -469,6 +778,19 @@ export function TranscriptPanel({
                     targetTimestamp={targetTimestamp}
                     onDeepLinkComplete={onDeepLinkComplete}
                     isExpanded={isExpanded}
+                    searchProps={{
+                      matches: searchMatches,
+                      activeMatchIndex: searchCurrentIndex,
+                      onSegmentsChange: handleSegmentsChange,
+                      activeMatchContainerRef,
+                      searchQuery,
+                      // Segment-level index for the active match — used by
+                      // TranscriptSegments to scroll the virtual container
+                      // without relying on DOM refs that fail for off-screen
+                      // segments (bug fix: T025 scroll-to-match).
+                      activeSegmentIndex:
+                        searchMatches[searchCurrentIndex]?.segmentIndex,
+                    }}
                   />
                 ) : (
                   <TranscriptFullText
@@ -488,8 +810,20 @@ export function TranscriptPanel({
         aria-live="polite"
         aria-atomic="true"
         className="sr-only"
+        data-testid="panel-announcement"
       >
         {announcement}
+      </div>
+
+      {/* Screen reader announcement for search match count (T024, FR-021: 500ms debounce) */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="search-announcement"
+      >
+        {searchAnnouncement}
       </div>
 
       {/* Screen reader summary when collapsed */}

--- a/frontend/src/components/transcript/TranscriptSegments.tsx
+++ b/frontend/src/components/transcript/TranscriptSegments.tsx
@@ -43,6 +43,8 @@ import type {
   CorrectionType,
   CorrectionAuditRecord,
 } from "../../types/corrections";
+import type { TranscriptSearchMatch } from "../../hooks/useTranscriptSearch";
+import { TextHighlighter } from "./TextHighlighter";
 import {
   CorrectionBadge,
   SegmentEditForm,
@@ -68,6 +70,43 @@ export interface TranscriptSegmentsProps {
   onDeepLinkComplete?: (() => void) | undefined;
   /** Whether the parent panel is expanded (for deep link abort on collapse) */
   isExpanded?: boolean | undefined;
+  /**
+   * Search props for client-side transcript search (Feature 042 US4).
+   * When provided, segment text is rendered through TextHighlighter.
+   */
+  searchProps?: {
+    /** All search matches across all segments */
+    matches: TranscriptSearchMatch[];
+    /** Index of the currently active match (global, across all segments) */
+    activeMatchIndex: number;
+    /** Callback to expose loaded segments to the parent for search indexing */
+    onSegmentsChange: (segments: TranscriptSegment[]) => void;
+    /** Ref for the active match DOM element, used by parent for scrollIntoView */
+    activeMatchContainerRef: React.RefObject<HTMLDivElement | null>;
+    /** Current debounced search query — triggers eager page fetching when non-empty */
+    searchQuery: string;
+    /**
+     * Segment index (into the loaded segments array) of the active match.
+     * Used by TranscriptSegments to imperatively scroll the container to the
+     * match using scrollTop — avoids DOM-ref failures for off-screen virtual segments.
+     * undefined when there is no active match.
+     */
+    activeSegmentIndex: number | undefined;
+  } | undefined;
+}
+
+/**
+ * Search rendering props for a single segment, derived from parent searchProps.
+ */
+interface SegmentSearchProps {
+  /** All matches across all segments */
+  allMatches: TranscriptSearchMatch[];
+  /** Index of the globally active match */
+  activeMatchIndex: number;
+  /** Index of this segment in the segments array */
+  segmentIndex: number;
+  /** Ref to attach to the segment row when it contains the active match */
+  activeMatchContainerRef: React.RefObject<HTMLDivElement | null>;
 }
 
 /**
@@ -106,12 +145,14 @@ interface EditModeProps {
  *
  * Supports optional highlight state for deep link navigation (FR-008, FR-009, FR-015).
  * Supports inline edit mode (Feature 035): shows SegmentEditForm when this segment is active.
+ * Supports search highlighting (Feature 042 US4): renders text through TextHighlighter.
  */
 function SegmentItem({
   segment,
   isVirtualized,
   isHighlighted,
   highlightTransitionClass,
+  segmentSearchProps,
   editState,
   isPending,
   correctionError,
@@ -136,6 +177,7 @@ function SegmentItem({
   isVirtualized: boolean;
   isHighlighted?: boolean;
   highlightTransitionClass?: string;
+  segmentSearchProps?: SegmentSearchProps | undefined;
 } & EditModeProps) {
   const isEditing =
     editState.mode === "editing" && editState.segmentId === segment.id;
@@ -149,10 +191,19 @@ function SegmentItem({
     ? "bg-yellow-100 border-l-4 border-yellow-400"
     : "border-l-4 border-transparent";
 
+  // Determine if this segment contains the active search match (Feature 042 US4)
+  const activeMatch = segmentSearchProps?.allMatches[segmentSearchProps.activeMatchIndex];
+  const isActiveMatchSegment =
+    segmentSearchProps !== undefined &&
+    activeMatch !== undefined &&
+    activeMatch.segmentIndex === segmentSearchProps.segmentIndex;
+
   return (
     <div>
       {/* Segment row */}
       <div
+        // Attach ref when this segment row contains the active search match (T025)
+        ref={isActiveMatchSegment ? segmentSearchProps.activeMatchContainerRef : undefined}
         className={`group flex gap-4 py-2 hover:bg-slate-50 ${isVirtualized ? "px-2" : ""} ${highlightClasses} ${highlightTransitionClass ?? ""}`}
         data-segment-id={segment.id}
         // FR-015: Make highlighted segment focusable for programmatic focus
@@ -196,7 +247,17 @@ function SegmentItem({
               <p
                 className={`flex-1 ${CONTRAST_SAFE_COLORS.bodyText} ${RESPONSIVE_CONFIG.segmentTextSize.mobile} lg:${RESPONSIVE_CONFIG.segmentTextSize.desktop}`}
               >
-                {segment.text}
+                {segmentSearchProps && segmentSearchProps.allMatches.length > 0 ? (
+                  <TextHighlighter
+                    text={segment.text}
+                    matches={segmentSearchProps.allMatches}
+                    segmentIndex={segmentSearchProps.segmentIndex}
+                    activeMatchIndex={segmentSearchProps.activeMatchIndex}
+                    allMatches={segmentSearchProps.allMatches}
+                  />
+                ) : (
+                  segment.text
+                )}
               </p>
 
               {/* Correction badge — renders only when segment has an active correction (Feature 035) */}
@@ -417,6 +478,7 @@ function VirtualizedSegmentList({
   highlightedSegmentId,
   highlightTransitionClass,
   editModeProps,
+  searchProps,
 }: {
   segments: TranscriptSegment[];
   containerRef: React.RefObject<HTMLDivElement | null>;
@@ -424,6 +486,7 @@ function VirtualizedSegmentList({
   highlightedSegmentId: number | null;
   highlightTransitionClass: string;
   editModeProps: EditModeProps;
+  searchProps?: TranscriptSegmentsProps["searchProps"];
 }) {
   const virtualizer = useVirtualizer({
     count: segments.length,
@@ -448,6 +511,14 @@ function VirtualizedSegmentList({
         if (!segment) return null;
 
         const isHighlighted = segment.id === highlightedSegmentId;
+        const segmentSearchProps: SegmentSearchProps | undefined = searchProps
+          ? {
+              allMatches: searchProps.matches,
+              activeMatchIndex: searchProps.activeMatchIndex,
+              segmentIndex: virtualItem.index,
+              activeMatchContainerRef: searchProps.activeMatchContainerRef,
+            }
+          : undefined;
 
         return (
           <div
@@ -469,6 +540,7 @@ function VirtualizedSegmentList({
               isVirtualized={true}
               isHighlighted={isHighlighted}
               highlightTransitionClass={isHighlighted ? highlightTransitionClass : ""}
+              segmentSearchProps={segmentSearchProps}
               {...editModeProps}
             />
           </div>
@@ -486,16 +558,26 @@ function StandardSegmentList({
   highlightedSegmentId,
   highlightTransitionClass,
   editModeProps,
+  searchProps,
 }: {
   segments: TranscriptSegment[];
   highlightedSegmentId: number | null;
   highlightTransitionClass: string;
   editModeProps: EditModeProps;
+  searchProps?: TranscriptSegmentsProps["searchProps"];
 }) {
   return (
     <>
-      {segments.map((segment) => {
+      {segments.map((segment, segmentIndex) => {
         const isHighlighted = segment.id === highlightedSegmentId;
+        const segmentSearchProps: SegmentSearchProps | undefined = searchProps
+          ? {
+              allMatches: searchProps.matches,
+              activeMatchIndex: searchProps.activeMatchIndex,
+              segmentIndex,
+              activeMatchContainerRef: searchProps.activeMatchContainerRef,
+            }
+          : undefined;
         return (
           <SegmentItem
             key={segment.id}
@@ -503,6 +585,7 @@ function StandardSegmentList({
             isVirtualized={false}
             isHighlighted={isHighlighted}
             highlightTransitionClass={isHighlighted ? highlightTransitionClass : ""}
+            segmentSearchProps={segmentSearchProps}
             {...editModeProps}
           />
         );
@@ -578,6 +661,7 @@ export function TranscriptSegments({
   targetTimestamp,
   onDeepLinkComplete,
   isExpanded = true,
+  searchProps,
 }: TranscriptSegmentsProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
@@ -659,7 +743,26 @@ export function TranscriptSegments({
   } = useTranscriptSegments(videoId, languageCode);
 
   // Determine if virtualization should be used (NFR-P12)
-  const useVirtualization = segments.length > VIRTUALIZATION_CONFIG.threshold;
+  const useVirtualization = segments.length >= INFINITE_SCROLL_CONFIG.initialBatchSize;
+
+  // Notify parent of loaded segments so it can run client-side search (Feature 042 US4)
+  const onSegmentsChange = searchProps?.onSegmentsChange;
+  useEffect(() => {
+    if (onSegmentsChange && segments.length > 0) {
+      onSegmentsChange(segments);
+    }
+  }, [segments, onSegmentsChange]);
+
+  // Eager-fetch all remaining pages when a search query is active so the full
+  // transcript is available for client-side searching (Feature 042 — same pattern
+  // as ChannelsPage eager-load). Without this, only the initially-loaded 50
+  // segments are searched and later matches won't appear until the user scrolls.
+  const searchQuery = searchProps?.searchQuery ?? "";
+  useEffect(() => {
+    if (searchQuery.trim() && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [searchQuery, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   // Highlight transition: fade-out unless reduced motion (FR-009)
   const highlightTransitionClass = prefersReducedMotion
@@ -676,6 +779,39 @@ export function TranscriptSegments({
       previousLanguageRef.current = languageCode;
     }
   }, [languageCode, onScrollPositionReset]);
+
+  // Track the previously-scrolled activeSegmentIndex so we only scroll when
+  // the user navigates to a *different* match (not when new pages load and
+  // searchMatches changes while currentIndex stays the same).
+  const prevActiveSegmentIndexRef = useRef<number | undefined>(undefined);
+
+  // Scroll the virtualizer container to the active search match when the user
+  // navigates (next / prev). Uses containerRef.scrollTop instead of DOM
+  // scrollIntoView so it works even when the target segment is outside the
+  // virtual window and hasn't been rendered yet (fixes the "scroll fails for
+  // off-screen virtual segments" problem described in the bug report).
+  const activeSegmentIndex = searchProps?.activeSegmentIndex;
+  useEffect(() => {
+    if (activeSegmentIndex === undefined) {
+      prevActiveSegmentIndexRef.current = undefined;
+      return;
+    }
+
+    // Skip — same segment as last time (e.g. new pages loaded but user didn't
+    // press next/prev, so the active match index is unchanged).
+    if (activeSegmentIndex === prevActiveSegmentIndexRef.current) return;
+    prevActiveSegmentIndexRef.current = activeSegmentIndex;
+
+    if (!containerRef.current) return;
+
+    // Center the target segment in the viewport by calculating its approximate
+    // pixel position from the top of the list.
+    const containerHeight = containerRef.current.clientHeight;
+    const targetTop = activeSegmentIndex * VIRTUALIZATION_CONFIG.estimatedHeight;
+    const centeredTop = Math.max(0, targetTop - containerHeight / 2);
+
+    containerRef.current.scrollTop = centeredTop;
+  }, [activeSegmentIndex]);
 
   /**
    * Handles the deep link scroll, highlight, focus, and cleanup sequence.
@@ -1173,6 +1309,7 @@ export function TranscriptSegments({
           highlightedSegmentId={highlightedSegmentId}
           highlightTransitionClass={highlightTransitionClass}
           editModeProps={editModeProps}
+          searchProps={searchProps}
         />
       ) : (
         <StandardSegmentList
@@ -1180,6 +1317,7 @@ export function TranscriptSegments({
           highlightedSegmentId={highlightedSegmentId}
           highlightTransitionClass={highlightTransitionClass}
           editModeProps={editModeProps}
+          searchProps={searchProps}
         />
       )}
 

--- a/frontend/src/components/transcript/__tests__/TranscriptSegments.deeplink.test.tsx
+++ b/frontend/src/components/transcript/__tests__/TranscriptSegments.deeplink.test.tsx
@@ -958,8 +958,8 @@ describe("TranscriptSegments - Deep Link Navigation", () => {
 
   describe("Integration with standard segment list", () => {
     it("should work correctly with standard (non-virtualized) list", () => {
-      // Use fewer than 100 segments to avoid virtualization
-      const segments = createTestSegments(50);
+      // Use fewer than 50 segments to avoid virtualization (threshold is initialBatchSize = 50)
+      const segments = createTestSegments(49);
       const targetSegment = segments[25]!;
 
       vi.mocked(useTranscriptSegments).mockReturnValue(
@@ -1337,7 +1337,7 @@ describe("TranscriptSegments - Deep Link Navigation", () => {
       });
       expect(mockFetchNextPage).toHaveBeenCalledTimes(1);
 
-      currentCount += 25;
+      currentCount += 10;
       updateMock(false);
       rerender(
         <TranscriptSegments

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -64,7 +64,9 @@ interface UseCategoriesReturn {
 export function useCategories(): UseCategoriesReturn {
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["categories"],
-    queryFn: ({ signal }) => apiFetch<CategoriesResponse>("/categories", { signal }),
+    // FR-004/FR-005: Pass TanStack Query signal as externalSignal so it is
+    // combined with the internal timeout guard via AbortSignal.any().
+    queryFn: ({ signal }) => apiFetch<CategoriesResponse>("/categories", { externalSignal: signal }),
     staleTime: 30 * 60 * 1000, // 30 minutes (categories rarely change)
     gcTime: 60 * 60 * 1000, // 60 minutes
     retry: 3,

--- a/frontend/src/hooks/useChannelDetail.ts
+++ b/frontend/src/hooks/useChannelDetail.ts
@@ -12,9 +12,13 @@ import type { ApiError } from "../types/video";
  * Fetches a channel's details from the API.
  */
 async function fetchChannelDetail(
-  channelId: string
+  channelId: string,
+  signal?: AbortSignal
 ): Promise<ChannelDetailResponse> {
-  return apiFetch<ChannelDetailResponse>(`/channels/${channelId}`);
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
+  return apiFetch<ChannelDetailResponse>(`/channels/${channelId}`, {
+    ...(signal !== undefined ? { externalSignal: signal } : {}),
+  });
 }
 
 interface UseChannelDetailReturn {
@@ -56,11 +60,12 @@ export function useChannelDetail(
     refetch,
   } = useQuery({
     queryKey: ["channel", channelId],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       if (!channelId) {
         throw new Error("Channel ID is required");
       }
-      return fetchChannelDetail(channelId);
+      // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+      return fetchChannelDetail(channelId, signal);
     },
     enabled: Boolean(channelId),
     staleTime: 5 * 60 * 1000, // 5 minutes

--- a/frontend/src/hooks/useChannelVideos.ts
+++ b/frontend/src/hooks/useChannelVideos.ts
@@ -29,7 +29,8 @@ async function fetchChannelVideos(
   includeUnavailable: boolean,
   sortBy?: ChannelVideoSortField,
   sortOrder?: SortOrder,
-  likedOnly?: boolean
+  likedOnly?: boolean,
+  signal?: AbortSignal
 ): Promise<VideoListResponse> {
   const params = new URLSearchParams({
     offset: offset.toString(),
@@ -47,8 +48,10 @@ async function fetchChannelVideos(
     params.set("liked_only", "true");
   }
 
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
   return apiFetch<VideoListResponse>(
-    `/channels/${channelId}/videos?${params.toString()}`
+    `/channels/${channelId}/videos?${params.toString()}`,
+    { ...(signal !== undefined ? { externalSignal: signal } : {}) }
   );
 }
 
@@ -136,11 +139,12 @@ export function useChannelVideos(
     refetch,
   } = useInfiniteQuery({
     queryKey: ["channel-videos", channelId, limit, includeUnavailable, sortBy, sortOrder, likedOnly],
-    queryFn: async ({ pageParam }) => {
+    queryFn: async ({ pageParam, signal }) => {
       if (!channelId) {
         throw new Error("Channel ID is required");
       }
-      return fetchChannelVideos(channelId, pageParam, limit, includeUnavailable, sortBy, sortOrder, likedOnly);
+      // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+      return fetchChannelVideos(channelId, pageParam, limit, includeUnavailable, sortBy, sortOrder, likedOnly, signal);
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {

--- a/frontend/src/hooks/useChannels.ts
+++ b/frontend/src/hooks/useChannels.ts
@@ -37,7 +37,8 @@ async function fetchChannels(
   limit: number,
   sortBy: ChannelSortField,
   sortOrder: SortOrder,
-  isSubscribed: SubscriptionFilter
+  isSubscribed: SubscriptionFilter,
+  signal?: AbortSignal
 ): Promise<ChannelListResponse> {
   const params = new URLSearchParams({
     offset: offset.toString(),
@@ -54,7 +55,10 @@ async function fetchChannels(
   }
   // For "all", omit the is_subscribed parameter
 
-  return apiFetch<ChannelListResponse>(`/channels?${params.toString()}`);
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
+  return apiFetch<ChannelListResponse>(`/channels?${params.toString()}`, {
+    ...(signal !== undefined ? { externalSignal: signal } : {}),
+  });
 }
 
 interface UseChannelsOptions {
@@ -140,8 +144,9 @@ export function useChannels(options: UseChannelsOptions = {}): UseChannelsReturn
     refetch,
   } = useInfiniteQuery({
     queryKey: ["channels", sortBy, sortOrder, isSubscribed, limit],
-    queryFn: async ({ pageParam }) => {
-      return fetchChannels(pageParam, limit, sortBy, sortOrder, isSubscribed);
+    queryFn: async ({ pageParam, signal }) => {
+      // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+      return fetchChannels(pageParam, limit, sortBy, sortOrder, isSubscribed, signal);
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {

--- a/frontend/src/hooks/useEntityMentions.ts
+++ b/frontend/src/hooks/useEntityMentions.ts
@@ -60,7 +60,8 @@ export function useVideoEntities(
 ): UseVideoEntitiesReturn {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["video-entities", videoId, languageCode ?? null],
-    queryFn: () => fetchVideoEntities(videoId, languageCode),
+    // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+    queryFn: ({ signal }) => fetchVideoEntities(videoId, languageCode, signal),
     enabled: Boolean(videoId),
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000,
@@ -142,12 +143,13 @@ export function useEntityVideos(
     fetchNextPage,
   } = useInfiniteQuery({
     queryKey: ["entity-videos", entityId, params.language_code ?? null, limit],
-    queryFn: ({ pageParam }) =>
+    // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+    queryFn: ({ pageParam, signal }) =>
       fetchEntityVideos(entityId, {
         ...params,
         limit,
         offset: pageParam,
-      }),
+      }, signal),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage.pagination.has_more) return undefined;
@@ -277,12 +279,13 @@ export function useEntities(
       params.sort ?? null,
       limit,
     ],
-    queryFn: ({ pageParam }) =>
+    // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+    queryFn: ({ pageParam, signal }) =>
       fetchEntities({
         ...params,
         limit,
         offset: pageParam,
-      }),
+      }, signal),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (!lastPage.pagination.has_more) return undefined;

--- a/frontend/src/hooks/usePlaylistDetail.ts
+++ b/frontend/src/hooks/usePlaylistDetail.ts
@@ -12,12 +12,17 @@ import type { ApiError } from "../types/video";
  * Fetches a playlist's details from the API.
  *
  * @param playlistId - The playlist ID to fetch
+ * @param signal - Optional AbortSignal for cancellation (FR-005)
  * @returns PlaylistDetailResponse with data field
  */
 async function fetchPlaylistDetail(
-  playlistId: string
+  playlistId: string,
+  signal?: AbortSignal
 ): Promise<PlaylistDetailResponse> {
-  return apiFetch<PlaylistDetailResponse>(`/playlists/${playlistId}`);
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
+  return apiFetch<PlaylistDetailResponse>(`/playlists/${playlistId}`, {
+    ...(signal !== undefined ? { externalSignal: signal } : {}),
+  });
 }
 
 /**
@@ -70,11 +75,12 @@ export function usePlaylistDetail(playlistId: string): UsePlaylistDetailReturn {
     refetch,
   } = useQuery<PlaylistDetailResponse, ApiError>({
     queryKey: ["playlist", playlistId],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       if (!playlistId) {
         throw new Error("Playlist ID is required");
       }
-      return fetchPlaylistDetail(playlistId);
+      // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+      return fetchPlaylistDetail(playlistId, signal);
     },
     enabled: Boolean(playlistId),
     staleTime: 5 * 60 * 1000, // 5 minutes

--- a/frontend/src/hooks/usePlaylistVideos.ts
+++ b/frontend/src/hooks/usePlaylistVideos.ts
@@ -37,7 +37,8 @@ async function fetchPlaylistVideos(
   sortOrder?: SortOrder,
   likedOnly?: boolean,
   hasTranscript?: boolean,
-  unavailableOnly?: boolean
+  unavailableOnly?: boolean,
+  signal?: AbortSignal
 ): Promise<PlaylistVideoListResponse> {
   const params = new URLSearchParams({
     offset: offset.toString(),
@@ -61,8 +62,10 @@ async function fetchPlaylistVideos(
     params.set("unavailable_only", "true");
   }
 
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
   return apiFetch<PlaylistVideoListResponse>(
-    `/playlists/${playlistId}/videos?${params.toString()}`
+    `/playlists/${playlistId}/videos?${params.toString()}`,
+    { ...(signal !== undefined ? { externalSignal: signal } : {}) }
   );
 }
 
@@ -171,7 +174,8 @@ export function usePlaylistVideos(
       hasTranscript,
       unavailableOnly,
     ],
-    queryFn: async ({ pageParam }) => {
+    queryFn: async ({ pageParam, signal }) => {
+      // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
       return fetchPlaylistVideos(
         playlistId,
         pageParam,
@@ -181,7 +185,8 @@ export function usePlaylistVideos(
         sortOrder,
         likedOnly,
         hasTranscript,
-        unavailableOnly
+        unavailableOnly,
+        signal
       );
     },
     initialPageParam: 0,

--- a/frontend/src/hooks/usePlaylists.ts
+++ b/frontend/src/hooks/usePlaylists.ts
@@ -32,7 +32,8 @@ async function fetchPlaylists(
   limit: number,
   filter: PlaylistFilterType,
   sortBy: PlaylistSortField,
-  sortOrder: SortOrder
+  sortOrder: SortOrder,
+  signal?: AbortSignal
 ): Promise<PlaylistListResponse> {
   const params = new URLSearchParams({
     offset: offset.toString(),
@@ -49,7 +50,10 @@ async function fetchPlaylists(
   }
   // For "all", omit the linked parameter
 
-  return apiFetch<PlaylistListResponse>(`/playlists?${params.toString()}`);
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
+  return apiFetch<PlaylistListResponse>(`/playlists?${params.toString()}`, {
+    ...(signal !== undefined ? { externalSignal: signal } : {}),
+  });
 }
 
 interface UsePlaylistsOptions {
@@ -132,8 +136,9 @@ export function usePlaylists(
     refetch,
   } = useInfiniteQuery({
     queryKey: ["playlists", filter, sortBy, sortOrder, limit],
-    queryFn: async ({ pageParam }) => {
-      return fetchPlaylists(pageParam, limit, filter, sortBy, sortOrder);
+    queryFn: async ({ pageParam, signal }) => {
+      // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+      return fetchPlaylists(pageParam, limit, filter, sortBy, sortOrder, signal);
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {

--- a/frontend/src/hooks/useSearchDescriptions.ts
+++ b/frontend/src/hooks/useSearchDescriptions.ts
@@ -100,9 +100,11 @@ export function useSearchDescriptions({
         params.set("include_unavailable", "true");
       }
 
+      // FR-004/FR-005: Pass TanStack Query signal as externalSignal so it is
+      // combined with the internal timeout guard via AbortSignal.any().
       return apiFetch<DescriptionSearchResponse>(
         `${SEARCH_CONFIG.DESCRIPTION_SEARCH_ENDPOINT}?${params}`,
-        { signal }
+        { ...(signal !== undefined ? { externalSignal: signal } : {}) }
       );
     },
     enabled: enabled && query.length >= SEARCH_CONFIG.MIN_QUERY_LENGTH,

--- a/frontend/src/hooks/useSearchSegments.ts
+++ b/frontend/src/hooks/useSearchSegments.ts
@@ -115,9 +115,12 @@ export function useSearchSegments({
         params.set("include_unavailable", "true");
       }
 
-      // T057: Pass signal for request cancellation (EC-019)
-      // TanStack Query automatically cancels when queryKey changes
-      return apiFetch<SearchResponse>(`/search/segments?${params}`, { signal });
+      // T057/FR-004/FR-005: Pass TanStack Query signal as externalSignal so it is
+      // combined with the internal timeout guard via AbortSignal.any().
+      // TanStack Query automatically cancels when queryKey changes.
+      return apiFetch<SearchResponse>(`/search/segments?${params}`, {
+        ...(signal !== undefined ? { externalSignal: signal } : {}),
+      });
     },
     getNextPageParam: (lastPage) => {
       // T059: Safely handle malformed backend response (EC-017)

--- a/frontend/src/hooks/useSearchTitles.ts
+++ b/frontend/src/hooks/useSearchTitles.ts
@@ -100,9 +100,11 @@ export function useSearchTitles({
         params.set("include_unavailable", "true");
       }
 
+      // FR-004/FR-005: Pass TanStack Query signal as externalSignal so it is
+      // combined with the internal timeout guard via AbortSignal.any().
       return apiFetch<TitleSearchResponse>(
         `${SEARCH_CONFIG.TITLE_SEARCH_ENDPOINT}?${params}`,
-        { signal }
+        { ...(signal !== undefined ? { externalSignal: signal } : {}) }
       );
     },
     enabled: enabled && query.length >= SEARCH_CONFIG.MIN_QUERY_LENGTH,

--- a/frontend/src/hooks/useSidebarCategories.ts
+++ b/frontend/src/hooks/useSidebarCategories.ts
@@ -37,8 +37,11 @@ interface SidebarCategoriesResponse {
  * Returns categories ordered by video_count descending,
  * including only categories with at least one video by default.
  */
-async function fetchSidebarCategories(): Promise<SidebarCategoriesResponse> {
-  return apiFetch<SidebarCategoriesResponse>("/sidebar/categories");
+async function fetchSidebarCategories(signal?: AbortSignal): Promise<SidebarCategoriesResponse> {
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
+  return apiFetch<SidebarCategoriesResponse>("/sidebar/categories", {
+    ...(signal !== undefined ? { externalSignal: signal } : {}),
+  });
 }
 
 interface UseSidebarCategoriesReturn {
@@ -77,7 +80,8 @@ interface UseSidebarCategoriesReturn {
 export function useSidebarCategories(): UseSidebarCategoriesReturn {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["sidebar", "categories"],
-    queryFn: fetchSidebarCategories,
+    // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+    queryFn: ({ signal }) => fetchSidebarCategories(signal),
     staleTime: 30 * 60 * 1000, // 30 minutes
     gcTime: 60 * 60 * 1000, // 60 minutes
   });

--- a/frontend/src/hooks/useTags.ts
+++ b/frontend/src/hooks/useTags.ts
@@ -81,7 +81,9 @@ export function useTags(options: UseTagsOptions = {}): UseTagsReturn {
       const params = new URLSearchParams();
       if (debouncedSearch) params.set("q", debouncedSearch);
 
-      return apiFetch<TagsResponse>(`/tags?${params.toString()}`, { signal });
+      // FR-004/FR-005: Pass TanStack Query signal as externalSignal so it is
+      // combined with the internal timeout guard via AbortSignal.any().
+      return apiFetch<TagsResponse>(`/tags?${params.toString()}`, { externalSignal: signal });
     },
     enabled: debouncedSearch.length > 0,
     staleTime: 5 * 60 * 1000, // 5 minutes

--- a/frontend/src/hooks/useTopics.ts
+++ b/frontend/src/hooks/useTopics.ts
@@ -78,8 +78,10 @@ export function useTopics(options: UseTopicsOptions = {}): UseTopicsReturn {
 
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["topics", "hierarchy"],
+    // FR-004/FR-005: Pass TanStack Query signal as externalSignal so it is
+    // combined with the internal timeout guard via AbortSignal.any().
     queryFn: ({ signal }) =>
-      apiFetch<TopicsHierarchyResponse>("/topics/hierarchy", { signal }),
+      apiFetch<TopicsHierarchyResponse>("/topics/hierarchy", { externalSignal: signal }),
     staleTime: 10 * 60 * 1000, // 10 minutes
     gcTime: 30 * 60 * 1000, // 30 minutes
     retry: 3,

--- a/frontend/src/hooks/useTranscript.ts
+++ b/frontend/src/hooks/useTranscript.ts
@@ -18,14 +18,18 @@ import type { Transcript, TranscriptResponse } from "../types/transcript";
  *
  * @param videoId - The YouTube video ID
  * @param languageCode - The BCP-47 language code
+ * @param signal - Optional AbortSignal for cancellation (FR-005)
  * @returns Transcript data
  */
 async function fetchTranscript(
   videoId: string,
-  languageCode: string
+  languageCode: string,
+  signal?: AbortSignal
 ): Promise<Transcript> {
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
   const response = await apiFetch<TranscriptResponse>(
-    `/videos/${videoId}/transcript?language=${encodeURIComponent(languageCode)}`
+    `/videos/${videoId}/transcript?language=${encodeURIComponent(languageCode)}`,
+    { ...(signal !== undefined ? { externalSignal: signal } : {}) }
   );
   return response.data;
 }
@@ -56,7 +60,7 @@ export function useTranscript(
 ): UseQueryResult<Transcript, ApiError> {
   return useQuery<Transcript, ApiError>({
     queryKey: ["transcript", videoId, languageCode],
-    queryFn: () => fetchTranscript(videoId, languageCode),
+    queryFn: ({ signal }) => fetchTranscript(videoId, languageCode, signal),
     staleTime: 10 * 1000, // 10 seconds (NFR-P01)
     enabled: !!videoId && !!languageCode, // Only run if both parameters are truthy
   });

--- a/frontend/src/hooks/useTranscriptLanguages.ts
+++ b/frontend/src/hooks/useTranscriptLanguages.ts
@@ -15,13 +15,17 @@ import type {
  * Fetches available transcript languages for a video from the API.
  *
  * @param videoId - The YouTube video ID to fetch languages for
+ * @param signal - Optional AbortSignal for cancellation (FR-005)
  * @returns Array of TranscriptLanguage data
  */
 async function fetchTranscriptLanguages(
-  videoId: string
+  videoId: string,
+  signal?: AbortSignal
 ): Promise<TranscriptLanguage[]> {
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
   const response = await apiFetch<TranscriptLanguagesResponse>(
-    `/videos/${videoId}/transcript/languages?include_unavailable=true`
+    `/videos/${videoId}/transcript/languages?include_unavailable=true`,
+    { ...(signal !== undefined ? { externalSignal: signal } : {}) }
   );
   return response.data;
 }
@@ -56,7 +60,7 @@ export function useTranscriptLanguages(
 ): UseQueryResult<TranscriptLanguage[], ApiError> {
   return useQuery<TranscriptLanguage[], ApiError>({
     queryKey: ["transcriptLanguages", videoId],
-    queryFn: () => fetchTranscriptLanguages(videoId),
+    queryFn: ({ signal }) => fetchTranscriptLanguages(videoId, signal),
     staleTime: 5 * 60 * 1000, // 5 minutes
     enabled: !!videoId, // Only run if videoId is truthy
   });

--- a/frontend/src/hooks/useTranscriptSearch.ts
+++ b/frontend/src/hooks/useTranscriptSearch.ts
@@ -1,0 +1,201 @@
+/**
+ * useTranscriptSearch hook for client-side transcript segment search.
+ *
+ * Implements:
+ * - FR-011: Client-side search field in transcript panel
+ * - FR-013: Auto-scroll to first match, Previous/Next with "N of M" counter
+ * - FR-020: 300ms debounce on search input
+ *
+ * @module hooks/useTranscriptSearch
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { TranscriptSegment } from "../types/transcript";
+import { DEBOUNCE_CONFIG } from "../styles/tokens";
+
+/**
+ * Represents a single search match within a transcript segment.
+ */
+export interface TranscriptSearchMatch {
+  /** Index of the segment in the segments array that contains this match */
+  segmentIndex: number;
+  /** Character offset where the match starts in the segment text */
+  startOffset: number;
+  /** Length of the matched string */
+  length: number;
+}
+
+/**
+ * Return type for the useTranscriptSearch hook.
+ */
+export interface UseTranscriptSearchResult {
+  /** All matches across all segments */
+  matches: TranscriptSearchMatch[];
+  /** Index of the currently active/highlighted match (0-based) */
+  currentIndex: number;
+  /** Total number of matches */
+  total: number;
+  /** Navigate to the next match (wraps from last to first) */
+  next: () => void;
+  /** Navigate to the previous match (wraps from first to last) */
+  prev: () => void;
+  /** The debounced query string currently applied */
+  query: string;
+  /** Set a new search query (debounced 300ms per FR-020) */
+  setQuery: (q: string) => void;
+  /** Clear the search query and reset navigation state */
+  reset: () => void;
+}
+
+/**
+ * Hook for searching transcript segments client-side.
+ *
+ * Features:
+ * - Case-insensitive search using String.toLowerCase().indexOf()
+ * - 300ms debounce on input (FR-020)
+ * - Wraparound navigation: last→first and first→last
+ * - Empty query returns no matches
+ *
+ * @param segments - Array of transcript segments to search within
+ * @param initialQuery - Optional initial search query
+ * @returns UseTranscriptSearchResult with match state and navigation functions
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   matches,
+ *   currentIndex,
+ *   total,
+ *   next,
+ *   prev,
+ *   query,
+ *   setQuery,
+ *   reset,
+ * } = useTranscriptSearch(segments);
+ * ```
+ */
+export function useTranscriptSearch(
+  segments: TranscriptSegment[],
+  initialQuery: string = ""
+): UseTranscriptSearchResult {
+  // Raw (un-debounced) query from user input
+  const [rawQuery, setRawQuery] = useState<string>(initialQuery);
+  // Debounced query that drives actual matching
+  const [query, setDebouncedQuery] = useState<string>(initialQuery);
+  // Index of the currently active match
+  const [currentIndex, setCurrentIndex] = useState<number>(0);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Apply 300ms debounce when rawQuery changes (FR-020)
+  useEffect(() => {
+    if (debounceRef.current !== null) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      setDebouncedQuery(rawQuery);
+      // Reset navigation to first match when query changes
+      setCurrentIndex(0);
+    }, DEBOUNCE_CONFIG.searchInput);
+
+    return () => {
+      if (debounceRef.current !== null) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [rawQuery]);
+
+  // Compute all matches whenever the debounced query or segments change
+  const matches = useMemo<TranscriptSearchMatch[]>(() => {
+    if (!query.trim()) {
+      return [];
+    }
+
+    const lowerQuery = query.toLowerCase();
+    const results: TranscriptSearchMatch[] = [];
+
+    for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
+      const segment = segments[segmentIndex];
+      if (!segment) continue;
+
+      const lowerText = segment.text.toLowerCase();
+      let searchFrom = 0;
+
+      while (searchFrom < lowerText.length) {
+        const matchStart = lowerText.indexOf(lowerQuery, searchFrom);
+        if (matchStart === -1) break;
+
+        results.push({
+          segmentIndex,
+          startOffset: matchStart,
+          length: lowerQuery.length,
+        });
+
+        // Advance past this match to find subsequent matches in same segment
+        searchFrom = matchStart + lowerQuery.length;
+      }
+    }
+
+    return results;
+  }, [query, segments]);
+
+  // Clamp currentIndex whenever matches array changes
+  useEffect(() => {
+    setCurrentIndex((prev) => {
+      if (matches.length === 0) return 0;
+      // Keep current position if still within bounds
+      return prev < matches.length ? prev : 0;
+    });
+  }, [matches]);
+
+  /**
+   * Navigate to the next match with wraparound (last→first).
+   */
+  const next = useCallback(() => {
+    if (matches.length === 0) return;
+    setCurrentIndex((prev) => (prev + 1) % matches.length);
+  }, [matches.length]);
+
+  /**
+   * Navigate to the previous match with wraparound (first→last).
+   */
+  const prev = useCallback(() => {
+    if (matches.length === 0) return;
+    setCurrentIndex((prev) => (prev - 1 + matches.length) % matches.length);
+  }, [matches.length]);
+
+  /**
+   * Set a new search query. The actual search is debounced by 300ms.
+   */
+  const setQuery = useCallback((q: string) => {
+    setRawQuery(q);
+  }, []);
+
+  /**
+   * Clear the search and reset all navigation state immediately (no debounce).
+   */
+  const reset = useCallback(() => {
+    // Cancel any pending debounce
+    if (debounceRef.current !== null) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setRawQuery("");
+    setDebouncedQuery("");
+    setCurrentIndex(0);
+  }, []);
+
+  return {
+    matches,
+    currentIndex,
+    total: matches.length,
+    next,
+    prev,
+    query,
+    setQuery,
+    reset,
+  };
+}

--- a/frontend/src/hooks/useTranscriptSegments.ts
+++ b/frontend/src/hooks/useTranscriptSegments.ts
@@ -89,18 +89,22 @@ async function fetchSegments(
 
   const endpoint = `/videos/${videoId}/transcript/segments?${params.toString()}`;
 
-  // Create a timeout-specific AbortController for 5s timeout (NFR-P02)
+  // NFR-P02: 5s timeout for segment batch loads — stricter than the global 10s.
+  // FR-004/FR-005: The TanStack Query signal and the 5s timeout are combined via
+  // AbortSignal.any() inside apiFetch when both are passed as externalSignal.
+  // We use AbortSignal.any() here to merge the two external signals before
+  // passing them, keeping apiFetch's own timeout guard as the fallback.
   const timeoutController = new AbortController();
   const timeoutId = setTimeout(() => timeoutController.abort(), 5000);
 
-  // Combine signals if we have an external abort signal
-  const combinedSignal = signal
-    ? combineAbortSignals(signal, timeoutController.signal)
+  // Merge the 5s segment timeout with the TanStack Query signal (if present).
+  const mergedExternal: AbortSignal = signal
+    ? AbortSignal.any([signal, timeoutController.signal])
     : timeoutController.signal;
 
   try {
     const response = await apiFetch<SegmentListResponse>(endpoint, {
-      signal: combinedSignal,
+      externalSignal: mergedExternal,
     });
     clearTimeout(timeoutId);
     return response;
@@ -108,23 +112,6 @@ async function fetchSegments(
     clearTimeout(timeoutId);
     throw error;
   }
-}
-
-/**
- * Combines multiple AbortSignals into one.
- */
-function combineAbortSignals(...signals: AbortSignal[]): AbortSignal {
-  const controller = new AbortController();
-
-  for (const signal of signals) {
-    if (signal.aborted) {
-      controller.abort();
-      break;
-    }
-    signal.addEventListener("abort", () => controller.abort(), { once: true });
-  }
-
-  return controller.signal;
 }
 
 /**

--- a/frontend/src/hooks/useVideoDetail.ts
+++ b/frontend/src/hooks/useVideoDetail.ts
@@ -11,10 +11,14 @@ import type { ApiError, VideoDetail, VideoDetailResponse } from "../types/video"
  * Fetches video details from the API.
  *
  * @param videoId - The YouTube video ID to fetch
+ * @param signal - Optional AbortSignal for cancellation (FR-005)
  * @returns VideoDetail data
  */
-async function fetchVideoDetail(videoId: string): Promise<VideoDetail> {
-  const response = await apiFetch<VideoDetailResponse>(`/videos/${videoId}`);
+async function fetchVideoDetail(videoId: string, signal?: AbortSignal): Promise<VideoDetail> {
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
+  const response = await apiFetch<VideoDetailResponse>(`/videos/${videoId}`, {
+    ...(signal !== undefined ? { externalSignal: signal } : {}),
+  });
   return response.data;
 }
 
@@ -40,7 +44,7 @@ async function fetchVideoDetail(videoId: string): Promise<VideoDetail> {
 export function useVideoDetail(videoId: string): UseQueryResult<VideoDetail, ApiError> {
   return useQuery<VideoDetail, ApiError>({
     queryKey: ["video", videoId],
-    queryFn: () => fetchVideoDetail(videoId),
+    queryFn: ({ signal }) => fetchVideoDetail(videoId, signal),
     staleTime: 10 * 1000, // 10 seconds (NFR-P01)
     enabled: !!videoId, // Only run if videoId is truthy
   });

--- a/frontend/src/hooks/useVideoPlaylists.ts
+++ b/frontend/src/hooks/useVideoPlaylists.ts
@@ -14,13 +14,17 @@ import type {
  * Fetches the playlists that contain a specific video.
  *
  * @param videoId - The YouTube video ID to fetch playlists for
+ * @param signal - Optional AbortSignal for cancellation (FR-005)
  * @returns Array of VideoPlaylistMembership objects
  */
 async function fetchVideoPlaylists(
-  videoId: string
+  videoId: string,
+  signal?: AbortSignal
 ): Promise<VideoPlaylistMembership[]> {
+  // FR-004/FR-005: externalSignal combines with the internal timeout guard.
   const response = await apiFetch<VideoPlaylistsResponse>(
-    `/videos/${videoId}/playlists`
+    `/videos/${videoId}/playlists`,
+    { ...(signal !== undefined ? { externalSignal: signal } : {}) }
   );
   return response.data;
 }
@@ -89,7 +93,7 @@ export function useVideoPlaylists(
 
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["videoPlaylists", videoId],
-    queryFn: () => fetchVideoPlaylists(videoId),
+    queryFn: ({ signal }) => fetchVideoPlaylists(videoId, signal),
     enabled: enabled && !!videoId, // Only run if enabled and videoId is truthy
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -144,7 +144,9 @@ export function useVideos(options: UseVideosOptions = {}): UseVideosReturn {
       if (likedOnly) params.set('liked_only', 'true');
       if (hasTranscript) params.set('has_transcript', 'true');
 
-      return apiFetch<VideoListResponse>(`/videos?${params.toString()}`, { signal });
+      // FR-004/FR-005: Pass TanStack Query signal as externalSignal so it is
+      // combined with the internal timeout guard via AbortSignal.any().
+      return apiFetch<VideoListResponse>(`/videos?${params.toString()}`, { externalSignal: signal });
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {

--- a/frontend/src/pages/ChannelsPage.tsx
+++ b/frontend/src/pages/ChannelsPage.tsx
@@ -7,12 +7,24 @@
  * - Dynamic channel count header reflecting filtered results
  * - ARIA live region for count announcement
  * - Pagination reset on filter/sort change
+ *
+ * Feature 042, US6 (T030-T033):
+ * - Client-side channel name search with case-insensitive substring matching
+ * - "No channels match" empty state for zero filtered results (FR-018)
+ * - Disabled search field with "Loading channels..." placeholder during load (FR-024)
+ * - Escape key clears search field (FR-026)
+ * - Auto-focus search on mount (FR-026)
+ * - Search resets on page navigation (component-local state, natural unmount reset)
+ *
+ * Feature 042, US7 (T034, T037):
+ * - SkipLink to main content area (FR-019, NFR-004, NFR-006)
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { ChannelCard } from "../components/ChannelCard";
+import { SkipLink } from "../components/SkipLink";
 import { SortDropdown } from "../components/SortDropdown";
 import { useChannels } from "../hooks/useChannels";
 import type { SubscriptionFilter } from "../hooks/useChannels";
@@ -37,6 +49,9 @@ const SUBSCRIPTION_TABS: Array<{
   { value: "subscribed", label: "Subscribed" },
   { value: "not_subscribed", label: "Not Subscribed" },
 ];
+
+/** Stable ID used by SkipLink and main content container (T034, T037). */
+const MAIN_CONTENT_ID = "channels-main-content";
 
 /**
  * Skeleton card for channel loading state.
@@ -212,6 +227,48 @@ function ChannelEmptyState({ subscriptionFilter }: ChannelEmptyStateProps) {
 }
 
 /**
+ * Empty state shown when the channel search filter returns zero results (FR-018).
+ */
+interface ChannelSearchEmptyStateProps {
+  searchQuery: string;
+}
+
+function ChannelSearchEmptyState({ searchQuery }: ChannelSearchEmptyStateProps) {
+  return (
+    <div
+      className="bg-white border border-gray-200 rounded-xl shadow-lg p-12 text-center flex flex-col items-center justify-center min-h-[300px]"
+      role="status"
+      aria-label="No channels match search"
+    >
+      <div className="mx-auto w-16 h-16 mb-5 text-gray-400 bg-gray-100 rounded-full p-4">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          />
+        </svg>
+      </div>
+      <h3 className="text-lg font-semibold text-gray-900 mb-2">
+        No channels match
+      </h3>
+      <p className="text-gray-600 max-w-xs">
+        No channels found matching{" "}
+        <strong className="font-medium">&ldquo;{searchQuery}&rdquo;</strong>.
+        Try a different search term.
+      </p>
+    </div>
+  );
+}
+
+/**
  * Subscription filter tabs component (page-specific, NOT shared per Rule of Three).
  */
 interface SubscriptionFilterTabsProps {
@@ -251,8 +308,101 @@ function SubscriptionFilterTabs({
 }
 
 /**
+ * Channel search input above the channel grid (T030, T031, T032).
+ *
+ * - Accessible label via sr-only <label> (NFR-002)
+ * - Disabled with "Loading channels..." placeholder while data loads (FR-024)
+ * - Clear (×) button resets the filter
+ * - Escape key handler clears the field (FR-026)
+ */
+interface ChannelSearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onClear: () => void;
+  disabled: boolean;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+}
+
+function ChannelSearchInput({
+  value,
+  onChange,
+  onClear,
+  disabled,
+  inputRef,
+}: ChannelSearchInputProps) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      onClear();
+    }
+  };
+
+  return (
+    <div className="relative mb-4">
+      <label htmlFor="channel-search" className="sr-only">
+        Search channels by name
+      </label>
+      {/* Search icon */}
+      <div className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="w-4 h-4 text-gray-400"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11ZM2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9Z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+
+      <input
+        ref={inputRef}
+        id="channel-search"
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        placeholder={disabled ? "Loading channels..." : "Search channels by name..."}
+        aria-label="Search channels by name"
+        className={`w-full pl-9 pr-10 py-2.5 text-sm border rounded-lg bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors ${
+          disabled
+            ? "border-gray-200 bg-gray-50 text-gray-400 cursor-not-allowed"
+            : "border-gray-300 hover:border-gray-400"
+        }`}
+      />
+
+      {/* Clear button — shown only when there is a value and input is enabled */}
+      {/* NFR-001: min 44×44px touch target via min-w/min-h */}
+      {value && !disabled && (
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label="Clear channel search"
+          className="absolute inset-y-0 right-0 flex items-center justify-center min-w-[44px] min-h-[44px] text-gray-400 hover:text-gray-600 focus:outline-none focus:text-gray-600"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-4 h-4"
+            aria-hidden="true"
+          >
+            <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
  * ChannelsPage displays channels with loading, error, and empty states.
- * Includes sort dropdown, subscription filter tabs, and infinite scroll.
+ * Includes sort dropdown, subscription filter tabs, channel name search,
+ * and infinite scroll.
  */
 export function ChannelsPage() {
   // URL params for filter and sort
@@ -274,6 +424,13 @@ export function ChannelsPage() {
     ["asc", "desc"].includes(sortOrderParam) ? sortOrderParam : "desc"
   ) as SortOrder;
 
+  // Client-side channel name search (T031, T033).
+  // Component-local state: automatically resets on unmount/remount (page navigation).
+  const [channelSearch, setChannelSearch] = useState("");
+
+  // Ref for auto-focusing the search input on page load (T032).
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+
   // Fetch channels with current sort and filter
   const {
     channels,
@@ -284,9 +441,19 @@ export function ChannelsPage() {
     error,
     hasNextPage,
     isFetchingNextPage,
+    fetchNextPage,
     retry,
     loadMoreRef,
   } = useChannels({ sortBy, sortOrder, isSubscribed: subscriptionFilter });
+
+  // Eagerly fetch all remaining pages when the user is actively searching (FR-017 fix).
+  // Client-side filtering can only work against loaded data, so we must ensure the full
+  // dataset is in memory before declaring "no results found".
+  useEffect(() => {
+    if (channelSearch.trim() && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [channelSearch, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   // Set page title
   useEffect(() => {
@@ -294,6 +461,11 @@ export function ChannelsPage() {
     return () => {
       document.title = "ChronoVista";
     };
+  }, []);
+
+  // Auto-focus search input on mount (T032, FR-026).
+  useEffect(() => {
+    searchInputRef.current?.focus();
   }, []);
 
   // Scroll to top when filter or sort changes (FR-031)
@@ -314,7 +486,14 @@ export function ChannelsPage() {
     });
   };
 
-  // Channel count header text
+  // Client-side filter: case-insensitive substring match on channel name (FR-017, T031).
+  const filteredChannels = channelSearch.trim()
+    ? channels.filter((ch) =>
+        ch.title.toLowerCase().includes(channelSearch.toLowerCase())
+      )
+    : channels;
+
+  // Channel count header text (reflects server total, not client-filtered count)
   const countText =
     total !== null
       ? `${total} channel${total !== 1 ? "s" : ""}`
@@ -339,11 +518,26 @@ export function ChannelsPage() {
   // Initial loading state
   if (isLoading) {
     return (
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Channels</h1>
-        {toolbar}
-        <ChannelLoadingState count={8} />
-      </main>
+      <>
+        <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="container mx-auto px-4 py-8"
+        >
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Channels</h1>
+          {toolbar}
+          {/* Disabled search field with "Loading channels..." placeholder (FR-024) */}
+          <ChannelSearchInput
+            value={channelSearch}
+            onChange={setChannelSearch}
+            onClear={() => setChannelSearch("")}
+            disabled={true}
+            inputRef={searchInputRef}
+          />
+          <ChannelLoadingState count={8} />
+        </main>
+      </>
     );
   }
 
@@ -355,162 +549,226 @@ export function ChannelsPage() {
       : 'An error occurred while loading channels';
 
     return (
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Channels</h1>
-        {toolbar}
-        <div
-          className="bg-gradient-to-br from-red-50 to-amber-50 border border-red-200 rounded-xl shadow-lg p-8 text-center"
-          role="alert"
-          aria-live="polite"
+      <>
+        <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="container mx-auto px-4 py-8"
         >
-          {/* Error Icon */}
-          <div className="mx-auto w-16 h-16 mb-5 text-red-500 bg-red-100 rounded-full p-3">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
-              />
-            </svg>
-          </div>
-
-          {/* Error Title */}
-          <p className="text-sm font-semibold text-red-800 uppercase tracking-wider mb-2">
-            Could not load channels
-          </p>
-
-          {/* Error Message */}
-          <p className="text-red-700 mb-8 max-w-md mx-auto">{errorMessage}</p>
-
-          {/* Retry Button */}
-          <button
-            type="button"
-            onClick={retry}
-            className="inline-flex items-center px-6 py-3 bg-red-600 text-white font-semibold rounded-lg shadow-md hover:bg-red-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-all duration-200"
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Channels</h1>
+          {toolbar}
+          <ChannelSearchInput
+            value={channelSearch}
+            onChange={setChannelSearch}
+            onClear={() => setChannelSearch("")}
+            disabled={true}
+            inputRef={searchInputRef}
+          />
+          <div
+            className="bg-gradient-to-br from-red-50 to-amber-50 border border-red-200 rounded-xl shadow-lg p-8 text-center"
+            role="alert"
+            aria-live="polite"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="w-5 h-5 mr-2"
-              aria-hidden="true"
+            {/* Error Icon */}
+            <div className="mx-auto w-16 h-16 mb-5 text-red-500 bg-red-100 rounded-full p-3">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+                />
+              </svg>
+            </div>
+
+            {/* Error Title */}
+            <p className="text-sm font-semibold text-red-800 uppercase tracking-wider mb-2">
+              Could not load channels
+            </p>
+
+            {/* Error Message */}
+            <p className="text-red-700 mb-8 max-w-md mx-auto">{errorMessage}</p>
+
+            {/* Retry Button */}
+            <button
+              type="button"
+              onClick={retry}
+              className="inline-flex items-center px-6 py-3 bg-red-600 text-white font-semibold rounded-lg shadow-md hover:bg-red-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-all duration-200"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
-              />
-            </svg>
-            Retry
-          </button>
-        </div>
-      </main>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-5 h-5 mr-2"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
+                />
+              </svg>
+              Retry
+            </button>
+          </div>
+        </main>
+      </>
     );
   }
 
-  // Empty state
+  // Empty state (no channels at all from server)
   if (channels.length === 0) {
     return (
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Channels</h1>
-        {toolbar}
-        <ChannelEmptyState subscriptionFilter={subscriptionFilter} />
-      </main>
+      <>
+        <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="container mx-auto px-4 py-8"
+        >
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Channels</h1>
+          {toolbar}
+          <ChannelSearchInput
+            value={channelSearch}
+            onChange={setChannelSearch}
+            onClear={() => setChannelSearch("")}
+            disabled={false}
+            inputRef={searchInputRef}
+          />
+          <ChannelEmptyState subscriptionFilter={subscriptionFilter} />
+        </main>
+      </>
     );
   }
 
   // Channels list with pagination
   return (
-    <main className="container mx-auto px-4 py-8">
-      <div className="flex items-baseline justify-between mb-6">
-        <h1 className="text-3xl font-bold text-gray-900">Channels</h1>
-        {/* Dynamic channel count header (FR-030) - visible only */}
-        {countText && (
-          <span className="text-sm text-gray-500 ml-3" aria-hidden="true">
-            {countText}
-          </span>
-        )}
-      </div>
-
-      {/* Toolbar: filter tabs + sort dropdown */}
-      {toolbar}
-
-      {/* ARIA live region announcing filtered count (FR-005) */}
-      {total !== null && (
-        <div role="status" aria-live="polite" className="sr-only">
-          Showing {total} channel{total !== 1 ? "s" : ""}
-        </div>
-      )}
-
-      <div className="space-y-4">
-        {/* Pagination Status - Top (only show if more to load) */}
-        {hasNextPage && <PaginationStatus loadedCount={loadedCount} total={total} />}
-
-        {/* Channel Cards Grid */}
-        <div
-          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
-          role="list"
-          aria-label="Channel list"
-        >
-          {channels.map((channel) => (
-            <div key={channel.channel_id} role="listitem">
-              <ChannelCard channel={channel} />
-            </div>
-          ))}
+    <>
+      <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+      <main
+        id={MAIN_CONTENT_ID}
+        tabIndex={-1}
+        className="container mx-auto px-4 py-8"
+      >
+        <div className="flex items-baseline justify-between mb-6">
+          <h1 className="text-3xl font-bold text-gray-900">Channels</h1>
+          {/* Dynamic channel count header (FR-030) - visible only */}
+          {countText && (
+            <span className="text-sm text-gray-500 ml-3" aria-hidden="true">
+              {countText}
+            </span>
+          )}
         </div>
 
-        {/* Loading more indicator */}
-        {isFetchingNextPage && (
-          <div aria-live="polite">
-            <p className="text-sm text-gray-500 text-center py-2">Loading more channels...</p>
-            <ChannelLoadingState count={4} />
+        {/* Toolbar: filter tabs + sort dropdown */}
+        {toolbar}
+
+        {/* Channel name search input (T030, T031, T032) */}
+        <ChannelSearchInput
+          value={channelSearch}
+          onChange={setChannelSearch}
+          onClear={() => setChannelSearch("")}
+          disabled={false}
+          inputRef={searchInputRef}
+        />
+
+        {/* ARIA live region announcing filtered count (FR-005) */}
+        {total !== null && (
+          <div role="status" aria-live="polite" className="sr-only">
+            Showing {total} channel{total !== 1 ? "s" : ""}
           </div>
         )}
 
-        {/* Inline error when channels are loaded but next page fails */}
-        {isError && channels.length > 0 && (
-          <div
-            className="bg-red-50 border border-red-200 rounded-lg p-4 text-center"
-            role="alert"
-          >
-            <p className="text-red-800 font-medium mb-2">
-              {typeof error === 'object' && error !== null && 'message' in error
-                ? (error as { message: string }).message
-                : 'Failed to load more channels'}
-            </p>
-            <button
-              type="button"
-              onClick={retry}
-              className="inline-flex items-center px-4 py-2 bg-red-600 text-white font-medium rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+        {/* Search-filtered empty state (FR-018).
+            Only shown once ALL pages have been fetched — prevents a false "no results"
+            flash while background pages are still loading in during a fast search. */}
+        {channelSearch.trim() && filteredChannels.length === 0 && !hasNextPage && !isFetchingNextPage ? (
+          <ChannelSearchEmptyState searchQuery={channelSearch} />
+        ) : (
+          <div className="space-y-4">
+            {/* While search is active and we're still fetching pages, show a brief
+                banner so the user knows the result list will grow. This prevents the
+                confusing experience of flickering results as pages arrive. */}
+            {channelSearch.trim() && (hasNextPage || isFetchingNextPage) && (
+              <p
+                role="status"
+                aria-live="polite"
+                className="text-sm text-gray-500 text-center py-1"
+              >
+                Searching all channels&hellip;
+              </p>
+            )}
+
+            {/* Pagination Status - Top (only show if more to load and search is inactive) */}
+            {hasNextPage && !channelSearch.trim() && <PaginationStatus loadedCount={loadedCount} total={total} />}
+
+            {/* Channel Cards Grid */}
+            <div
+              className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
+              role="list"
+              aria-label="Channel list"
             >
-              Retry
-            </button>
+              {filteredChannels.map((channel) => (
+                <div key={channel.channel_id} role="listitem">
+                  <ChannelCard channel={channel} />
+                </div>
+              ))}
+            </div>
+
+            {/* Loading more indicator */}
+            {isFetchingNextPage && (
+              <div aria-live="polite">
+                <p className="text-sm text-gray-500 text-center py-2">Loading more channels...</p>
+                <ChannelLoadingState count={4} />
+              </div>
+            )}
+
+            {/* Inline error when channels are loaded but next page fails */}
+            {isError && channels.length > 0 && (
+              <div
+                className="bg-red-50 border border-red-200 rounded-lg p-4 text-center"
+                role="alert"
+              >
+                <p className="text-red-800 font-medium mb-2">
+                  {typeof error === 'object' && error !== null && 'message' in error
+                    ? (error as { message: string }).message
+                    : 'Failed to load more channels'}
+                </p>
+                <button
+                  type="button"
+                  onClick={retry}
+                  className="inline-flex items-center px-4 py-2 bg-red-600 text-white font-medium rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+
+            {/* Intersection Observer Trigger Element */}
+            {!isError && (
+              <div
+                ref={loadMoreRef}
+                className="h-4"
+                aria-hidden="true"
+              />
+            )}
+
+            {/* All Loaded Message */}
+            {!hasNextPage && !isError && total !== null && total > 0 && (
+              <AllLoadedMessage total={total} />
+            )}
           </div>
         )}
-
-        {/* Intersection Observer Trigger Element */}
-        {!isError && (
-          <div
-            ref={loadMoreRef}
-            className="h-4"
-            aria-hidden="true"
-          />
-        )}
-
-        {/* All Loaded Message */}
-        {!hasNextPage && !isError && total !== null && total > 0 && (
-          <AllLoadedMessage total={total} />
-        )}
-      </div>
-    </main>
+      </main>
+    </>
   );
 }

--- a/frontend/src/pages/EntitiesPage.tsx
+++ b/frontend/src/pages/EntitiesPage.tsx
@@ -11,13 +11,20 @@
  * - Click navigates to /entities/:entityId
  * - Infinite scroll pagination
  * - Loading skeleton, empty state, error state
+ *
+ * Feature 042, US7 (T036, T037):
+ * - SkipLink to main content area (FR-019, NFR-004, NFR-006)
  */
 
 import { useEffect, useCallback } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 
+import { SkipLink } from "../components/SkipLink";
 import { useEntities } from "../hooks/useEntityMentions";
 import type { EntityListItem } from "../api/entityMentions";
+
+/** Stable ID used by SkipLink and main content container (T036, T037). */
+const MAIN_CONTENT_ID = "entities-main-content";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -531,18 +538,31 @@ export function EntitiesPage() {
   // Initial loading state
   if (isLoading) {
     return (
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Entities</h1>
-        {toolbar}
-        <EntityLoadingState count={8} />
-      </main>
+      <>
+        <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="container mx-auto px-4 py-8"
+        >
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Entities</h1>
+          {toolbar}
+          <EntityLoadingState count={8} />
+        </main>
+      </>
     );
   }
 
   // Error state (only if no entities loaded)
   if (isError && entities.length === 0) {
     return (
-      <main className="container mx-auto px-4 py-8">
+      <>
+        <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="container mx-auto px-4 py-8"
+        >
         <h1 className="text-3xl font-bold text-gray-900 mb-6">Entities</h1>
         {toolbar}
         <div
@@ -598,28 +618,42 @@ export function EntitiesPage() {
             Retry
           </button>
         </div>
-      </main>
+        </main>
+      </>
     );
   }
 
   // Empty state
   if (entities.length === 0) {
     return (
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Entities</h1>
-        {toolbar}
-        <EntitiesEmptyState
-          typeFilter={typeFilter}
-          hasMentions={hasMentions}
-          search={search}
-        />
-      </main>
+      <>
+        <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="container mx-auto px-4 py-8"
+        >
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Entities</h1>
+          {toolbar}
+          <EntitiesEmptyState
+            typeFilter={typeFilter}
+            hasMentions={hasMentions}
+            search={search}
+          />
+        </main>
+      </>
     );
   }
 
   // Entities list with pagination
   return (
-    <main className="container mx-auto px-4 py-8">
+    <>
+      <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+      <main
+        id={MAIN_CONTENT_ID}
+        tabIndex={-1}
+        className="container mx-auto px-4 py-8"
+      >
       <div className="flex items-baseline justify-between mb-6">
         <h1 className="text-3xl font-bold text-gray-900">Entities</h1>
         {countText && (
@@ -696,6 +730,7 @@ export function EntitiesPage() {
           <AllLoadedMessage total={total} />
         )}
       </div>
-    </main>
+      </main>
+    </>
   );
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -12,6 +12,7 @@ import { VideoList } from "../components/VideoList";
 import { VideoFilters } from "../components/VideoFilters";
 import { SortDropdown } from "../components/SortDropdown";
 import { FilterToggle } from "../components/FilterToggle";
+import { SkipLink } from "../components/SkipLink";
 import { useVideos } from "../hooks/useVideos";
 import type { VideoSortField, SortOrder, SortOption } from "../types/filters";
 
@@ -77,6 +78,9 @@ export function HomePage() {
 
   return (
     <div className="p-6 lg:p-8">
+      {/* NFR-006: Skip link targeting the main content area */}
+      <SkipLink targetId="main-content" label="Skip to content" />
+
       {/* Page Header */}
       <div className="mb-8">
         <h2 className="text-2xl font-bold text-slate-900">Videos</h2>

--- a/frontend/src/pages/PlaylistsPage.tsx
+++ b/frontend/src/pages/PlaylistsPage.tsx
@@ -9,6 +9,9 @@
  * - CHK052: Error state with retry
  * - CHK053: Empty state with filter-aware messaging
  * - CHK054: Infinite scroll support
+ *
+ * Feature 042, US7 (T035, T037):
+ * - SkipLink to main content area (FR-019, NFR-004, NFR-006)
  */
 
 import { useEffect } from "react";
@@ -16,6 +19,7 @@ import { useSearchParams } from "react-router-dom";
 
 import { PlaylistCard } from "../components/PlaylistCard";
 import { PlaylistFilterTabs } from "../components/PlaylistFilterTabs";
+import { SkipLink } from "../components/SkipLink";
 import { SortDropdown } from "../components/SortDropdown";
 import { ErrorState } from "../components/ErrorState";
 import { usePlaylists } from "../hooks/usePlaylists";
@@ -24,6 +28,9 @@ import type {
   PlaylistSortField,
 } from "../types/playlist";
 import type { SortOrder, SortOption } from "../types/filters";
+
+/** Stable ID used by SkipLink and main content container (T035, T037). */
+const MAIN_CONTENT_ID = "playlists-main-content";
 
 /**
  * Sort options for playlists (Feature 027).
@@ -290,72 +297,99 @@ export function PlaylistsPage() {
   // Initial loading state (CHK051)
   if (isLoading) {
     return (
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Playlists</h1>
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-          <PlaylistFilterTabs
-            currentFilter={filter}
-            onFilterChange={handleFilterChange}
-          />
-          <SortDropdown
-            options={PLAYLIST_SORT_OPTIONS}
-            defaultField="video_count"
-            defaultOrder="desc"
-            label="Sort by"
-          />
-        </div>
-        <PlaylistLoadingState count={12} />
-      </main>
+      <>
+        <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="container mx-auto px-4 py-8"
+        >
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Playlists</h1>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+            <PlaylistFilterTabs
+              currentFilter={filter}
+              onFilterChange={handleFilterChange}
+            />
+            <SortDropdown
+              options={PLAYLIST_SORT_OPTIONS}
+              defaultField="video_count"
+              defaultOrder="desc"
+              label="Sort by"
+            />
+          </div>
+          <PlaylistLoadingState count={12} />
+        </main>
+      </>
     );
   }
 
   // Error state (only if no playlists loaded) (CHK052)
   if (isError && playlists.length === 0) {
     return (
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Playlists</h1>
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-          <PlaylistFilterTabs
-            currentFilter={filter}
-            onFilterChange={handleFilterChange}
-          />
-          <SortDropdown
-            options={PLAYLIST_SORT_OPTIONS}
-            defaultField="video_count"
-            defaultOrder="desc"
-            label="Sort by"
-          />
-        </div>
-        <ErrorState error={error} onRetry={retry} />
-      </main>
+      <>
+        <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="container mx-auto px-4 py-8"
+        >
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Playlists</h1>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+            <PlaylistFilterTabs
+              currentFilter={filter}
+              onFilterChange={handleFilterChange}
+            />
+            <SortDropdown
+              options={PLAYLIST_SORT_OPTIONS}
+              defaultField="video_count"
+              defaultOrder="desc"
+              label="Sort by"
+            />
+          </div>
+          <ErrorState error={error} onRetry={retry} />
+        </main>
+      </>
     );
   }
 
   // Empty state (CHK053)
   if (playlists.length === 0) {
     return (
-      <main className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Playlists</h1>
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-          <PlaylistFilterTabs
-            currentFilter={filter}
-            onFilterChange={handleFilterChange}
-          />
-          <SortDropdown
-            options={PLAYLIST_SORT_OPTIONS}
-            defaultField="video_count"
-            defaultOrder="desc"
-            label="Sort by"
-          />
-        </div>
-        <PlaylistEmptyState filter={filter} />
-      </main>
+      <>
+        <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+        <main
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="container mx-auto px-4 py-8"
+        >
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Playlists</h1>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+            <PlaylistFilterTabs
+              currentFilter={filter}
+              onFilterChange={handleFilterChange}
+            />
+            <SortDropdown
+              options={PLAYLIST_SORT_OPTIONS}
+              defaultField="video_count"
+              defaultOrder="desc"
+              label="Sort by"
+            />
+          </div>
+          <PlaylistEmptyState filter={filter} />
+        </main>
+      </>
     );
   }
 
   // Playlists list with pagination (CHK050, CHK054)
   return (
-    <main className="container mx-auto px-4 py-8">
+    <>
+      <SkipLink targetId={MAIN_CONTENT_ID} label="Skip to content" />
+      <main
+        id={MAIN_CONTENT_ID}
+        tabIndex={-1}
+        className="container mx-auto px-4 py-8"
+      >
       <h1 className="text-3xl font-bold text-gray-900 mb-6">Playlists</h1>
 
       {/* Filter Tabs and Sort Dropdown (CHK048) */}
@@ -435,6 +469,7 @@ export function PlaylistsPage() {
           <AllLoadedMessage total={total} />
         )}
       </div>
-    </main>
+      </main>
+    </>
   );
 }

--- a/frontend/src/tests/components/AuthErrorState.test.tsx
+++ b/frontend/src/tests/components/AuthErrorState.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for AuthErrorState Component
+ *
+ * Covers:
+ * - FR-002: Consistent "Session Expired" UI
+ * - FR-022: Focus moves to "Refresh Page" button on mount
+ * - NFR-001: 44×44 px minimum touch target on the button
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AuthErrorState } from "../../components/AuthErrorState";
+
+describe("AuthErrorState", () => {
+  beforeEach(() => {
+    // Reset any window.location mock before each test
+    vi.restoreAllMocks();
+  });
+
+  describe("Content rendering", () => {
+    it("should render a lock icon (aria-hidden SVG)", () => {
+      render(<AuthErrorState />);
+
+      // The icon SVG has aria-hidden so it won't be in the accessibility tree,
+      // but we can verify the container rendered by checking the parent div class.
+      // Use the role="alert" container as an anchor.
+      const alert = screen.getByRole("alert");
+      expect(alert).toBeInTheDocument();
+
+      // The SVG element itself should carry aria-hidden="true"
+      const svgs = alert.querySelectorAll('svg[aria-hidden="true"]');
+      expect(svgs.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should display 'Your authentication token has expired' heading", () => {
+      render(<AuthErrorState />);
+
+      expect(
+        screen.getByText("Your authentication token has expired")
+      ).toBeInTheDocument();
+    });
+
+    it("should display a 'Refresh Page' button", () => {
+      render(<AuthErrorState />);
+
+      const button = screen.getByRole("button", { name: /refresh page/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("should display 'chronovista auth login' as inline code help text", () => {
+      render(<AuthErrorState />);
+
+      const codeEl = screen.getByText("chronovista auth login");
+      expect(codeEl.tagName.toLowerCase()).toBe("code");
+    });
+
+    it("should show 'Session Expired' label text", () => {
+      render(<AuthErrorState />);
+
+      expect(screen.getByText("Session Expired")).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("should have role='alert' with aria-live='assertive'", () => {
+      render(<AuthErrorState />);
+
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveAttribute("aria-live", "assertive");
+    });
+
+    it("should have aria-atomic='true' on the alert container", () => {
+      render(<AuthErrorState />);
+
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveAttribute("aria-atomic", "true");
+    });
+
+    it("button should have an accessible label referencing re-authentication", () => {
+      render(<AuthErrorState />);
+
+      const button = screen.getByRole("button", {
+        name: /refresh page to re-authenticate/i,
+      });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("button should meet NFR-001 min-height of 44px via Tailwind class", () => {
+      render(<AuthErrorState />);
+
+      const button = screen.getByRole("button", { name: /refresh page/i });
+      // Verify the min-h-[44px] class is present
+      expect(button.className).toContain("min-h-[44px]");
+    });
+  });
+
+  describe("FR-022: Focus management on mount", () => {
+    it("should move focus to the Refresh Page button on mount", () => {
+      render(<AuthErrorState />);
+
+      const button = screen.getByRole("button", { name: /refresh page/i });
+      expect(document.activeElement).toBe(button);
+    });
+  });
+
+  describe("Interaction", () => {
+    it("should call window.location.reload() when Refresh Page is clicked", async () => {
+      const user = userEvent.setup();
+      const reloadSpy = vi.fn();
+
+      Object.defineProperty(window, "location", {
+        value: { reload: reloadSpy },
+        writable: true,
+      });
+
+      render(<AuthErrorState />);
+
+      const button = screen.getByRole("button", { name: /refresh page/i });
+      await user.click(button);
+
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call window.location.reload() when button is activated via keyboard", async () => {
+      const user = userEvent.setup();
+      const reloadSpy = vi.fn();
+
+      Object.defineProperty(window, "location", {
+        value: { reload: reloadSpy },
+        writable: true,
+      });
+
+      render(<AuthErrorState />);
+
+      // Button is auto-focused on mount; press Enter to activate
+      await user.keyboard("{Enter}");
+
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/tests/components/SearchErrorState.test.tsx
+++ b/frontend/src/tests/components/SearchErrorState.test.tsx
@@ -1,9 +1,12 @@
 /**
  * Tests for SearchErrorState Component
  *
- * Tests edge case handling:
- * - T056: Authentication error detection (EC-011-EC-016)
- * - Generic error display with retry
+ * FR-003: Auth errors (401/403) are now handled globally by the QueryCache
+ * interceptor — SearchErrorState only renders generic non-auth errors.
+ *
+ * Tests:
+ * - Generic error display with retry button
+ * - Accessible ARIA attributes
  */
 
 import { render, screen } from "@testing-library/react";
@@ -53,101 +56,21 @@ describe("SearchErrorState", () => {
     });
   });
 
-  describe("T056: Authentication error handling (EC-011-EC-016)", () => {
-    it("should display session expired message for 401 status", () => {
-      const onRetry = vi.fn();
-      render(<SearchErrorState status={401} onRetry={onRetry} />);
-
-      expect(screen.getByText("Session expired")).toBeInTheDocument();
-      expect(screen.getByText("Session expired. Please refresh the page.")).toBeInTheDocument();
-    });
-
-    it("should display session expired message for 403 status", () => {
-      const onRetry = vi.fn();
-      render(<SearchErrorState status={403} onRetry={onRetry} />);
-
-      expect(screen.getByText("Session expired")).toBeInTheDocument();
-      expect(screen.getByText("Session expired. Please refresh the page.")).toBeInTheDocument();
-    });
-
-    it("should extract status from ApiError object", () => {
-      const onRetry = vi.fn();
-      const error = { status: 401, message: "Unauthorized", type: "server" };
-      render(<SearchErrorState error={error} onRetry={onRetry} />);
-
-      expect(screen.getByText("Session expired")).toBeInTheDocument();
-    });
-
-    it("should show Refresh Page button for auth errors", () => {
-      const onRetry = vi.fn();
-      render(<SearchErrorState status={401} onRetry={onRetry} />);
-
-      const refreshButton = screen.getByRole("button", { name: /refresh page/i });
-      expect(refreshButton).toBeInTheDocument();
-    });
-
-    it("should show terminal command help text for auth errors (EC-015)", () => {
-      const onRetry = vi.fn();
-      render(<SearchErrorState status={401} onRetry={onRetry} />);
-
-      expect(screen.getByText(/chronovista auth login/)).toBeInTheDocument();
-      expect(screen.getByText(/Or run/)).toBeInTheDocument();
-      expect(screen.getByText(/in your terminal/)).toBeInTheDocument();
-    });
-
-    it("should call window.location.reload when Refresh Page is clicked", async () => {
-      const user = userEvent.setup();
-      const onRetry = vi.fn();
-      const reloadSpy = vi.fn();
-
-      // Mock window.location.reload
-      Object.defineProperty(window, "location", {
-        value: { reload: reloadSpy },
-        writable: true,
-      });
-
-      render(<SearchErrorState status={401} onRetry={onRetry} />);
-
-      const refreshButton = screen.getByRole("button", { name: /refresh page/i });
-      await user.click(refreshButton);
-
-      expect(reloadSpy).toHaveBeenCalledTimes(1);
-      expect(onRetry).not.toHaveBeenCalled(); // Refresh should be called instead of retry
-    });
-
-    it("should not show auth error UI for non-auth status codes", () => {
-      const onRetry = vi.fn();
-      render(<SearchErrorState status={500} onRetry={onRetry} />);
-
-      expect(screen.queryByText("Session expired")).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /retry search/i })).toBeInTheDocument();
-    });
-
-    it("should prioritize explicit status prop over error object status", () => {
-      const onRetry = vi.fn();
-      const error = { status: 500, message: "Server error", type: "server" };
-      render(<SearchErrorState status={401} error={error} onRetry={onRetry} />);
-
-      // Should show auth error UI because explicit status=401 takes precedence
-      expect(screen.getByText("Session expired")).toBeInTheDocument();
-    });
-  });
-
   describe("Accessibility", () => {
-    it("should have proper ARIA attributes for auth errors", () => {
+    it("should have proper ARIA role on error container", () => {
       const onRetry = vi.fn();
-      render(<SearchErrorState status={401} onRetry={onRetry} />);
+      render(<SearchErrorState onRetry={onRetry} />);
 
       const errorContainer = screen.getByRole("alert");
-      expect(errorContainer).toHaveAttribute("aria-live", "assertive");
+      expect(errorContainer).toBeInTheDocument();
     });
 
-    it("should have accessible button labels", () => {
+    it("should have accessible button label for retry", () => {
       const onRetry = vi.fn();
-      render(<SearchErrorState status={401} onRetry={onRetry} />);
+      render(<SearchErrorState onRetry={onRetry} />);
 
-      const refreshButton = screen.getByRole("button", { name: /refresh page to re-authenticate/i });
-      expect(refreshButton).toBeInTheDocument();
+      const button = screen.getByRole("button", { name: /retry search/i });
+      expect(button).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/tests/components/TagLinkMigration.test.tsx
+++ b/frontend/src/tests/components/TagLinkMigration.test.tsx
@@ -30,10 +30,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ClassificationSection } from "../../components/ClassificationSection";
 import { VideoFilters } from "../../components/VideoFilters";
-import type {
-  CanonicalTagListItem,
-  CanonicalTagDetail,
-} from "../../types/canonical-tags";
+import type { CanonicalTagDetail } from "../../types/canonical-tags";
 
 // ---------------------------------------------------------------------------
 // Mocks for VideoFilters dependencies
@@ -65,34 +62,8 @@ vi.mock("../../hooks/useOnlineStatus", () => ({
 // Helpers for ClassificationSection fetch mock
 // ---------------------------------------------------------------------------
 
-function makeListResponse(items: CanonicalTagListItem[]): string {
-  return JSON.stringify({
-    data: items,
-    pagination: {
-      total: items.length,
-      limit: 1,
-      offset: 0,
-      has_more: false,
-    },
-  });
-}
-
 function makeDetailResponse(detail: CanonicalTagDetail): string {
   return JSON.stringify({ data: detail });
-}
-
-function makeListItem(
-  canonicalForm: string,
-  normalizedForm: string,
-  aliasCount: number,
-  videoCount = 10
-): CanonicalTagListItem {
-  return {
-    canonical_form: canonicalForm,
-    normalized_form: normalizedForm,
-    alias_count: aliasCount,
-    video_count: videoCount,
-  };
 }
 
 function makeDetail(

--- a/frontend/src/tests/components/transcript/TextHighlighter.test.tsx
+++ b/frontend/src/tests/components/transcript/TextHighlighter.test.tsx
@@ -1,0 +1,376 @@
+/**
+ * Unit tests for TextHighlighter component.
+ *
+ * Tests text splitting, mark element rendering, active match styling,
+ * empty query rendering, and multiple matches.
+ *
+ * @module tests/components/transcript/TextHighlighter
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { TextHighlighter } from "../../../components/transcript/TextHighlighter";
+import type { TranscriptSearchMatch } from "../../../hooks/useTranscriptSearch";
+
+/**
+ * Helper to build a TranscriptSearchMatch.
+ */
+function makeMatch(
+  segmentIndex: number,
+  startOffset: number,
+  length: number
+): TranscriptSearchMatch {
+  return { segmentIndex, startOffset, length };
+}
+
+describe("TextHighlighter", () => {
+  describe("no matches renders plain text", () => {
+    it("renders full text without any marks when matches is empty", () => {
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[]}
+          segmentIndex={0}
+          activeMatchIndex={0}
+          allMatches={[]}
+        />
+      );
+
+      expect(container.textContent).toBe("Hello world");
+      expect(container.querySelectorAll("mark")).toHaveLength(0);
+    });
+
+    it("renders plain text when no matches belong to this segment", () => {
+      // A match exists but for a different segment
+      const otherSegmentMatch = makeMatch(5, 0, 4);
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[otherSegmentMatch]}
+          segmentIndex={0}
+          activeMatchIndex={0}
+          allMatches={[otherSegmentMatch]}
+        />
+      );
+
+      expect(container.textContent).toBe("Hello world");
+      expect(container.querySelectorAll("mark")).toHaveLength(0);
+    });
+  });
+
+  describe("text splits correctly at match positions", () => {
+    it("splits text into before, match, and after portions", () => {
+      const match = makeMatch(0, 6, 5); // "world" at position 6 in "Hello world"
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={-1}
+          allMatches={[match]}
+        />
+      );
+
+      expect(container.textContent).toBe("Hello world");
+
+      const marks = container.querySelectorAll("mark");
+      expect(marks).toHaveLength(1);
+      expect(marks[0]?.textContent).toBe("world");
+    });
+
+    it("handles match at the very beginning of text", () => {
+      const match = makeMatch(0, 0, 5); // "Hello" at start
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={-1}
+          allMatches={[match]}
+        />
+      );
+
+      const marks = container.querySelectorAll("mark");
+      expect(marks).toHaveLength(1);
+      expect(marks[0]?.textContent).toBe("Hello");
+      // Should be "Hello" (mark) + " world" (span)
+      expect(container.textContent).toBe("Hello world");
+    });
+
+    it("handles match at the very end of text", () => {
+      const match = makeMatch(0, 6, 5); // "world" at end of "Hello world"
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={-1}
+          allMatches={[match]}
+        />
+      );
+
+      const marks = container.querySelectorAll("mark");
+      expect(marks).toHaveLength(1);
+      expect(marks[0]?.textContent).toBe("world");
+    });
+  });
+
+  describe("mark elements render with correct styling", () => {
+    it("renders non-active match with amber-200 background classes", () => {
+      const match = makeMatch(0, 6, 5);
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={-1} // Not active
+          allMatches={[match]}
+        />
+      );
+
+      const mark = container.querySelector("mark");
+      expect(mark).toBeInTheDocument();
+      // Non-active: amber-200 background, bold, underline
+      expect(mark?.className).toContain("bg-amber-200");
+      expect(mark?.className).toContain("font-bold");
+      expect(mark?.className).toContain("underline");
+    });
+
+    it("non-active match does NOT have ring classes", () => {
+      const match = makeMatch(0, 6, 5);
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={-1}
+          allMatches={[match]}
+        />
+      );
+
+      const mark = container.querySelector("mark");
+      expect(mark?.className).not.toContain("ring-2");
+      expect(mark?.className).not.toContain("bg-amber-400");
+    });
+  });
+
+  describe("active match gets distinct style", () => {
+    it("renders active match with amber-400 background and ring", () => {
+      const match = makeMatch(0, 6, 5);
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={0} // This match IS active
+          allMatches={[match]}
+        />
+      );
+
+      const mark = container.querySelector("mark");
+      expect(mark).toBeInTheDocument();
+      // Active: amber-400 background + ring
+      expect(mark?.className).toContain("bg-amber-400");
+      expect(mark?.className).toContain("ring-2");
+      expect(mark?.className).toContain("font-bold");
+      expect(mark?.className).toContain("underline");
+    });
+
+    it("active match has aria-current='true'", () => {
+      const match = makeMatch(0, 0, 5);
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={0}
+          allMatches={[match]}
+        />
+      );
+
+      const mark = container.querySelector("mark");
+      expect(mark).toHaveAttribute("aria-current", "true");
+    });
+
+    it("non-active match does NOT have aria-current", () => {
+      const match = makeMatch(0, 6, 5);
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={-1}
+          allMatches={[match]}
+        />
+      );
+
+      const mark = container.querySelector("mark");
+      expect(mark).not.toHaveAttribute("aria-current");
+    });
+
+    it("highlights correct match as active when there are multiple", () => {
+      // "test test test" — match at 0, 5, 10
+      const match0 = makeMatch(0, 0, 4);
+      const match1 = makeMatch(0, 5, 4);
+      const match2 = makeMatch(0, 10, 4);
+      const allMatches = [match0, match1, match2];
+
+      const { container } = render(
+        <TextHighlighter
+          text="test test test"
+          matches={allMatches}
+          segmentIndex={0}
+          activeMatchIndex={1} // Second match is active
+          allMatches={allMatches}
+        />
+      );
+
+      const marks = container.querySelectorAll("mark");
+      expect(marks).toHaveLength(3);
+
+      // Second mark (index 1) should be active
+      expect(marks[0]?.className).not.toContain("bg-amber-400");
+      expect(marks[1]?.className).toContain("bg-amber-400");
+      expect(marks[2]?.className).not.toContain("bg-amber-400");
+    });
+  });
+
+  describe("multiple matches in same text", () => {
+    it("renders all matches as mark elements", () => {
+      const match0 = makeMatch(0, 0, 4);  // first "test"
+      const match1 = makeMatch(0, 5, 4);  // second "test"
+      const match2 = makeMatch(0, 10, 4); // third "test"
+      const allMatches = [match0, match1, match2];
+
+      const { container } = render(
+        <TextHighlighter
+          text="test test test"
+          matches={allMatches}
+          segmentIndex={0}
+          activeMatchIndex={0}
+          allMatches={allMatches}
+        />
+      );
+
+      const marks = container.querySelectorAll("mark");
+      expect(marks).toHaveLength(3);
+      marks.forEach((mark) => {
+        expect(mark.textContent).toBe("test");
+      });
+    });
+
+    it("preserves text between matches", () => {
+      const match0 = makeMatch(0, 0, 3);  // "abc"
+      const match1 = makeMatch(0, 8, 3);  // "abc" (second)
+      const allMatches = [match0, match1];
+
+      const { container } = render(
+        <TextHighlighter
+          text="abc defg abc"
+          matches={allMatches}
+          segmentIndex={0}
+          activeMatchIndex={-1}
+          allMatches={allMatches}
+        />
+      );
+
+      // Total text should be preserved
+      expect(container.textContent).toBe("abc defg abc");
+
+      const marks = container.querySelectorAll("mark");
+      expect(marks).toHaveLength(2);
+    });
+  });
+
+  describe("active match across multiple segments", () => {
+    it("does not mark as active a match from this segment when active index belongs to different segment", () => {
+      const matchSeg0 = makeMatch(0, 6, 5);
+      const matchSeg1 = makeMatch(1, 0, 5);
+      const allMatches = [matchSeg0, matchSeg1];
+
+      // Rendering segment 0, active index is 1 (which is in segment 1)
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={allMatches}
+          segmentIndex={0}
+          activeMatchIndex={1}
+          allMatches={allMatches}
+        />
+      );
+
+      const mark = container.querySelector("mark");
+      expect(mark?.className).toContain("bg-amber-200");
+      expect(mark?.className).not.toContain("bg-amber-400");
+    });
+  });
+
+  describe("accessibility — not color alone (NFR-003)", () => {
+    it("active match uses bold AND underline in addition to background color", () => {
+      const match = makeMatch(0, 0, 5);
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={0}
+          allMatches={[match]}
+        />
+      );
+
+      const mark = container.querySelector("mark");
+      // Must have BOTH bold AND underline — not just color
+      expect(mark?.className).toContain("font-bold");
+      expect(mark?.className).toContain("underline");
+    });
+
+    it("non-active match uses bold AND underline in addition to background color", () => {
+      const match = makeMatch(0, 0, 5);
+      const { container } = render(
+        <TextHighlighter
+          text="Hello world"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={-1}
+          allMatches={[match]}
+        />
+      );
+
+      const mark = container.querySelector("mark");
+      expect(mark?.className).toContain("font-bold");
+      expect(mark?.className).toContain("underline");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty text string", () => {
+      const { container } = render(
+        <TextHighlighter
+          text=""
+          matches={[]}
+          segmentIndex={0}
+          activeMatchIndex={0}
+          allMatches={[]}
+        />
+      );
+
+      expect(container.textContent).toBe("");
+      expect(container.querySelectorAll("mark")).toHaveLength(0);
+    });
+
+    it("preserves full text content with marks", () => {
+      const match = makeMatch(0, 7, 7); // "testing" in "Welcome testing here"
+      const { container } = render(
+        <TextHighlighter
+          text="Welcome testing here"
+          matches={[match]}
+          segmentIndex={0}
+          activeMatchIndex={0}
+          allMatches={[match]}
+        />
+      );
+
+      expect(container.textContent).toBe("Welcome testing here");
+    });
+  });
+});

--- a/frontend/src/tests/hooks/useChannelVideos.test.tsx
+++ b/frontend/src/tests/hooks/useChannelVideos.test.tsx
@@ -139,7 +139,8 @@ describe("useChannelVideos", () => {
 
       // Verify API was called with include_unavailable=true
       expect(apiConfig.apiFetch).toHaveBeenCalledWith(
-        `/channels/${mockChannelId}/videos?offset=0&limit=25&include_unavailable=true`
+        `/channels/${mockChannelId}/videos?offset=0&limit=25&include_unavailable=true`,
+        expect.anything()
       );
 
       // Verify both available and unavailable videos are included
@@ -177,7 +178,8 @@ describe("useChannelVideos", () => {
 
       // Verify API was called with include_unavailable=false
       expect(apiConfig.apiFetch).toHaveBeenCalledWith(
-        `/channels/${mockChannelId}/videos?offset=0&limit=25&include_unavailable=false`
+        `/channels/${mockChannelId}/videos?offset=0&limit=25&include_unavailable=false`,
+        expect.anything()
       );
 
       // Verify only available videos are included
@@ -201,7 +203,8 @@ describe("useChannelVideos", () => {
 
       // Verify API was called with custom limit
       expect(apiConfig.apiFetch).toHaveBeenCalledWith(
-        `/channels/${mockChannelId}/videos?offset=0&limit=50&include_unavailable=true`
+        `/channels/${mockChannelId}/videos?offset=0&limit=50&include_unavailable=true`,
+        expect.anything()
       );
     });
   });

--- a/frontend/src/tests/hooks/usePlaylistVideos.test.tsx
+++ b/frontend/src/tests/hooks/usePlaylistVideos.test.tsx
@@ -147,7 +147,8 @@ describe("usePlaylistVideos", () => {
 
       // Verify API was called with include_unavailable=true
       expect(apiConfig.apiFetch).toHaveBeenCalledWith(
-        `/playlists/${mockPlaylistId}/videos?offset=0&limit=25&include_unavailable=true`
+        `/playlists/${mockPlaylistId}/videos?offset=0&limit=25&include_unavailable=true`,
+        expect.anything()
       );
 
       // Verify all videos (including unavailable) are included
@@ -195,7 +196,8 @@ describe("usePlaylistVideos", () => {
 
       // Verify API was called with include_unavailable=false
       expect(apiConfig.apiFetch).toHaveBeenCalledWith(
-        `/playlists/${mockPlaylistId}/videos?offset=0&limit=25&include_unavailable=false`
+        `/playlists/${mockPlaylistId}/videos?offset=0&limit=25&include_unavailable=false`,
+        expect.anything()
       );
 
       // Verify only available videos are included
@@ -219,7 +221,8 @@ describe("usePlaylistVideos", () => {
 
       // Verify API was called with custom limit
       expect(apiConfig.apiFetch).toHaveBeenCalledWith(
-        `/playlists/${mockPlaylistId}/videos?offset=0&limit=50&include_unavailable=true`
+        `/playlists/${mockPlaylistId}/videos?offset=0&limit=50&include_unavailable=true`,
+        expect.anything()
       );
     });
 

--- a/frontend/src/tests/hooks/useSearchDescriptions.test.tsx
+++ b/frontend/src/tests/hooks/useSearchDescriptions.test.tsx
@@ -58,7 +58,7 @@ describe("useSearchDescriptions", () => {
 
     expect(apiFetch).toHaveBeenCalledWith(
       "/search/descriptions?q=test+query&limit=50",
-      expect.objectContaining({ signal: expect.any(AbortSignal) })
+      expect.objectContaining({ externalSignal: expect.any(AbortSignal) })
     );
   });
 
@@ -176,7 +176,7 @@ describe("useSearchDescriptions", () => {
     await waitFor(() =>
       expect(apiFetch).toHaveBeenCalledWith(
         expect.any(String),
-        expect.objectContaining({ signal: expect.any(AbortSignal) })
+        expect.objectContaining({ externalSignal: expect.any(AbortSignal) })
       )
     );
   });

--- a/frontend/src/tests/hooks/useSearchSegments.test.tsx
+++ b/frontend/src/tests/hooks/useSearchSegments.test.tsx
@@ -134,8 +134,8 @@ describe("useSearchSegments", () => {
       const callArgs = vi.mocked(apiFetch).mock.calls[0];
       if (callArgs) {
         const options = callArgs[1];
-        expect(options).toHaveProperty("signal");
-        expect(options?.signal).toBeInstanceOf(AbortSignal);
+        expect(options).toHaveProperty("externalSignal");
+        expect(options?.externalSignal).toBeInstanceOf(AbortSignal);
       }
     });
 

--- a/frontend/src/tests/hooks/useSearchTitles.test.tsx
+++ b/frontend/src/tests/hooks/useSearchTitles.test.tsx
@@ -258,8 +258,8 @@ describe("useSearchTitles", () => {
       const callArgs = vi.mocked(apiFetch).mock.calls[0];
       if (callArgs) {
         const options = callArgs[1];
-        expect(options).toHaveProperty("signal");
-        expect(options?.signal).toBeInstanceOf(AbortSignal);
+        expect(options).toHaveProperty("externalSignal");
+        expect(options?.externalSignal).toBeInstanceOf(AbortSignal);
       }
     });
   });

--- a/frontend/src/tests/hooks/useTranscript.test.tsx
+++ b/frontend/src/tests/hooks/useTranscript.test.tsx
@@ -82,7 +82,7 @@ describe("useTranscript", () => {
       });
 
       await waitFor(() => {
-        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript?language=en");
+        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript?language=en", expect.anything());
       });
     });
 
@@ -96,7 +96,7 @@ describe("useTranscript", () => {
       });
 
       await waitFor(() => {
-        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript?language=zh-Hans");
+        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript?language=zh-Hans", expect.anything());
       });
     });
 
@@ -291,7 +291,7 @@ describe("useTranscript", () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript?language=en");
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript?language=en", expect.anything());
     });
   });
 

--- a/frontend/src/tests/hooks/useTranscriptLanguages.test.tsx
+++ b/frontend/src/tests/hooks/useTranscriptLanguages.test.tsx
@@ -90,7 +90,7 @@ describe("useTranscriptLanguages", () => {
       });
 
       await waitFor(() => {
-        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages?include_unavailable=true");
+        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages?include_unavailable=true", expect.anything());
       });
     });
 
@@ -278,7 +278,7 @@ describe("useTranscriptLanguages", () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages?include_unavailable=true");
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ/transcript/languages?include_unavailable=true", expect.anything());
     });
   });
 

--- a/frontend/src/tests/hooks/useTranscriptSearch.test.ts
+++ b/frontend/src/tests/hooks/useTranscriptSearch.test.ts
@@ -1,0 +1,565 @@
+/**
+ * Unit tests for useTranscriptSearch hook.
+ *
+ * Tests client-side transcript search with debouncing, navigation, and edge cases.
+ * Implements FR-011, FR-013, FR-020 requirements.
+ *
+ * @module tests/hooks/useTranscriptSearch
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTranscriptSearch } from "../../hooks/useTranscriptSearch";
+import type { TranscriptSegment } from "../../types/transcript";
+
+/**
+ * Creates a minimal TranscriptSegment for testing.
+ */
+function makeSegment(id: number, text: string): TranscriptSegment {
+  return {
+    id,
+    text,
+    start_time: id * 5,
+    end_time: id * 5 + 4.5,
+    duration: 4.5,
+    has_correction: false,
+    corrected_at: null,
+    correction_count: 0,
+  };
+}
+
+describe("useTranscriptSearch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const segments: TranscriptSegment[] = [
+    makeSegment(0, "Hello world"),
+    makeSegment(1, "Welcome to the world of testing"),
+    makeSegment(2, "Testing is important"),
+    makeSegment(3, "No match here at all"),
+  ];
+
+  describe("initial state", () => {
+    it("returns empty matches with empty initial query", () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      expect(result.current.matches).toHaveLength(0);
+      expect(result.current.total).toBe(0);
+      expect(result.current.currentIndex).toBe(0);
+      expect(result.current.query).toBe("");
+    });
+
+    it("returns empty matches when query is only whitespace", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("   ");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.matches).toHaveLength(0);
+      expect(result.current.total).toBe(0);
+    });
+  });
+
+  describe("case-insensitive matching", () => {
+    it("matches lowercase query against uppercase text", async () => {
+      const mixedSegments = [makeSegment(0, "HELLO World")];
+      const { result } = renderHook(() => useTranscriptSearch(mixedSegments));
+
+      act(() => {
+        result.current.setQuery("hello");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.total).toBe(1);
+      expect(result.current.matches[0]).toMatchObject({
+        segmentIndex: 0,
+        startOffset: 0,
+        length: 5,
+      });
+    });
+
+    it("matches uppercase query against lowercase text", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("WORLD");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // "world" appears in segment 0 and segment 1
+      expect(result.current.total).toBe(2);
+    });
+
+    it("matches mixed-case query", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("WoRlD");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.total).toBe(2);
+    });
+  });
+
+  describe("match count accuracy", () => {
+    it("counts a single match correctly", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("Hello");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.total).toBe(1);
+      expect(result.current.matches[0]).toMatchObject({
+        segmentIndex: 0,
+        startOffset: 0,
+        length: 5,
+      });
+    });
+
+    it("counts multiple matches across different segments", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // "world" in segment 0 ("Hello world") and segment 1 ("...world of testing")
+      expect(result.current.total).toBe(2);
+    });
+
+    it("counts multiple matches within a single segment", async () => {
+      const repeatingSegments = [
+        makeSegment(0, "test test test"),
+      ];
+      const { result } = renderHook(() => useTranscriptSearch(repeatingSegments));
+
+      act(() => {
+        result.current.setQuery("test");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.total).toBe(3);
+    });
+
+    it("counts correctly when query matches at end of segment", async () => {
+      const edgeSegments = [makeSegment(0, "prefix suffix")];
+      const { result } = renderHook(() => useTranscriptSearch(edgeSegments));
+
+      act(() => {
+        result.current.setQuery("suffix");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.total).toBe(1);
+      expect(result.current.matches[0]).toMatchObject({
+        segmentIndex: 0,
+        startOffset: 7,
+        length: 6,
+      });
+    });
+
+    it("returns zero matches when query is not found", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("xyznotfound");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.total).toBe(0);
+      expect(result.current.matches).toHaveLength(0);
+    });
+  });
+
+  describe("next/prev navigation with wraparound", () => {
+    it("navigates to next match", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Start at index 0
+      expect(result.current.currentIndex).toBe(0);
+
+      act(() => {
+        result.current.next();
+      });
+
+      // Should advance to index 1
+      expect(result.current.currentIndex).toBe(1);
+    });
+
+    it("wraps from last match to first on next()", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Move to last match (index 1 of 2 total)
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.currentIndex).toBe(1);
+
+      // Next from last should wrap to first
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("wraps from first match to last on prev()", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // At first match (index 0); prev should wrap to last (index 1)
+      act(() => {
+        result.current.prev();
+      });
+
+      expect(result.current.currentIndex).toBe(1);
+    });
+
+    it("navigates to previous match", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Move to second match first
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.currentIndex).toBe(1);
+
+      // Go back to first
+      act(() => {
+        result.current.prev();
+      });
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("does nothing on next() when there are no matches", () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      // No query set, no matches
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("does nothing on prev() when there are no matches", () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.prev();
+      });
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("resets to index 0 when query changes", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.currentIndex).toBe(1);
+
+      // Change query
+      act(() => {
+        result.current.setQuery("testing");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+  });
+
+  describe("debounce behavior (FR-020)", () => {
+    it("does not update query immediately on setQuery", () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      // Query should not be applied yet (before debounce fires)
+      expect(result.current.query).toBe("");
+      expect(result.current.total).toBe(0);
+    });
+
+    it("applies query after 300ms debounce", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      expect(result.current.query).toBe("");
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.query).toBe("world");
+      expect(result.current.total).toBe(2);
+    });
+
+    it("debounces rapid typing — only fires once after 300ms of silence", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      // Simulate rapid keystrokes
+      act(() => {
+        result.current.setQuery("w");
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+
+      act(() => {
+        result.current.setQuery("wo");
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+
+      act(() => {
+        result.current.setQuery("wor");
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      // Query still not committed (only 100ms each, total 400ms but last reset timer)
+      expect(result.current.query).toBe("");
+
+      // Advance the final 300ms
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Should have committed "world" — not intermediate values
+      expect(result.current.query).toBe("world");
+      expect(result.current.total).toBe(2);
+    });
+  });
+
+  describe("empty query returns no matches", () => {
+    it("returns no matches for empty string", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.total).toBe(0);
+      expect(result.current.matches).toHaveLength(0);
+    });
+
+    it("returns no matches when segments array is empty", async () => {
+      const { result } = renderHook(() => useTranscriptSearch([]));
+
+      act(() => {
+        result.current.setQuery("hello");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.total).toBe(0);
+    });
+  });
+
+  describe("reset functionality", () => {
+    it("clears query and matches on reset()", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.total).toBe(2);
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.query).toBe("");
+      expect(result.current.total).toBe(0);
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("cancels pending debounce on reset()", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      // Before debounce fires, reset
+      act(() => {
+        result.current.reset();
+      });
+
+      // Even after 300ms, query should remain empty
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.query).toBe("");
+      expect(result.current.total).toBe(0);
+    });
+
+    it("resets navigation index to 0", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.currentIndex).toBe(1);
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+  });
+
+  describe("match position accuracy", () => {
+    it("tracks correct segmentIndex for each match", async () => {
+      const { result } = renderHook(() => useTranscriptSearch(segments));
+
+      act(() => {
+        result.current.setQuery("world");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // First match should be in segment 0 ("Hello world")
+      expect(result.current.matches[0]).toMatchObject({ segmentIndex: 0 });
+      // Second match should be in segment 1 ("Welcome to the world of testing")
+      expect(result.current.matches[1]).toMatchObject({ segmentIndex: 1 });
+    });
+
+    it("tracks correct startOffset for match", async () => {
+      const preciseSegments = [makeSegment(0, "abc def abc")];
+      const { result } = renderHook(() => useTranscriptSearch(preciseSegments));
+
+      act(() => {
+        result.current.setQuery("abc");
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(result.current.matches).toHaveLength(2);
+      expect(result.current.matches[0]).toMatchObject({ startOffset: 0, length: 3 });
+      expect(result.current.matches[1]).toMatchObject({ startOffset: 8, length: 3 });
+    });
+  });
+});

--- a/frontend/src/tests/hooks/useTranscriptSegments.test.tsx
+++ b/frontend/src/tests/hooks/useTranscriptSegments.test.tsx
@@ -108,7 +108,7 @@ describe("useTranscriptSegments", () => {
       expect(result.current.hasNextPage).toBe(true);
       expect(apiConfig.apiFetch).toHaveBeenCalledWith(
         "/videos/dQw4w9WgXcQ/transcript/segments?language=en&offset=0&limit=50",
-        expect.objectContaining({ signal: expect.any(AbortSignal) })
+        expect.objectContaining({ externalSignal: expect.any(AbortSignal) })
       );
     });
 
@@ -167,7 +167,7 @@ describe("useTranscriptSegments", () => {
 
       expect(apiConfig.apiFetch).toHaveBeenCalledWith(
         "/videos/test-2/transcript/segments?language=en&offset=50&limit=25",
-        expect.objectContaining({ signal: expect.any(AbortSignal) })
+        expect.objectContaining({ externalSignal: expect.any(AbortSignal) })
       );
     });
 
@@ -454,7 +454,7 @@ describe("useTranscriptSegments", () => {
         () => {
           expect(apiConfig.apiFetch).toHaveBeenCalledWith(
             "/videos/test-video-5/transcript/segments?language=es&offset=0&limit=50",
-            expect.objectContaining({ signal: expect.any(AbortSignal) })
+            expect.objectContaining({ externalSignal: expect.any(AbortSignal) })
           );
         },
         { timeout: 10000 }
@@ -516,7 +516,7 @@ describe("useTranscriptSegments", () => {
         () => {
           expect(apiConfig.apiFetch).toHaveBeenCalledWith(
             expect.any(String),
-            expect.objectContaining({ signal: expect.any(AbortSignal) })
+            expect.objectContaining({ externalSignal: expect.any(AbortSignal) })
           );
         },
         { timeout: 10000 }

--- a/frontend/src/tests/hooks/useVideoDetail.test.tsx
+++ b/frontend/src/tests/hooks/useVideoDetail.test.tsx
@@ -107,7 +107,7 @@ describe("useVideoDetail", () => {
       });
 
       await waitFor(() => {
-        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ");
+        expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ", expect.anything());
       });
     });
 
@@ -280,7 +280,7 @@ describe("useVideoDetail", () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ");
+      expect(apiConfig.apiFetch).toHaveBeenCalledWith("/videos/dQw4w9WgXcQ", expect.anything());
     });
   });
 

--- a/frontend/src/types/video.ts
+++ b/frontend/src/types/video.ts
@@ -148,8 +148,14 @@ export interface VideoDetailResponse {
 
 /**
  * Error types for categorizing API failures.
+ *
+ * - "auth"    — HTTP 401 Unauthorized or 403 Forbidden (FR-001)
+ * - "network" — fetch TypeError (no response from server)
+ * - "timeout" — AbortError due to request timeout
+ * - "server"  — HTTP 5xx or other non-auth 4xx responses
+ * - "unknown" — unclassified errors
  */
-export type ApiErrorType = "network" | "timeout" | "server" | "unknown";
+export type ApiErrorType = "auth" | "network" | "timeout" | "server" | "unknown";
 
 /**
  * Structured API error with type classification.

--- a/frontend/tests/components/transcript/TranscriptPanel.test.tsx
+++ b/frontend/tests/components/transcript/TranscriptPanel.test.tsx
@@ -325,7 +325,7 @@ describe('TranscriptPanel', () => {
       await user.click(toggleButton);
 
       await waitFor(() => {
-        const announcement = screen.getByRole('status');
+        const announcement = screen.getByTestId('panel-announcement');
         expect(announcement).toHaveTextContent('Transcript panel expanded');
       });
     });

--- a/frontend/tests/hooks/useChannelDetail.test.tsx
+++ b/frontend/tests/hooks/useChannelDetail.test.tsx
@@ -458,7 +458,8 @@ describe('useChannelDetail', () => {
       });
 
       expect(mockApiFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/channels/UC123456789012345678901')
+        expect.stringContaining('/channels/UC123456789012345678901'),
+        expect.anything()
       );
     });
   });

--- a/frontend/tests/hooks/useChannelVideos.test.tsx
+++ b/frontend/tests/hooks/useChannelVideos.test.tsx
@@ -657,7 +657,8 @@ describe('useChannelVideos', () => {
       });
 
       expect(mockApiFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/channels/UC123456789012345678901/videos')
+        expect.stringContaining('/channels/UC123456789012345678901/videos'),
+        expect.anything()
       );
     });
   });
@@ -685,7 +686,8 @@ describe('useChannelVideos', () => {
 
       await waitFor(() => {
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining('limit=10')
+          expect.stringContaining('limit=10'),
+          expect.anything()
         );
       });
     });

--- a/frontend/tests/hooks/useChannels.test.tsx
+++ b/frontend/tests/hooks/useChannels.test.tsx
@@ -520,7 +520,8 @@ describe('useChannels', () => {
 
       await waitFor(() => {
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining('limit=10')
+          expect.stringContaining('limit=10'),
+          expect.anything()
         );
       });
     });

--- a/frontend/tests/hooks/usePlaylists.test.tsx
+++ b/frontend/tests/hooks/usePlaylists.test.tsx
@@ -531,7 +531,8 @@ describe("usePlaylists", () => {
 
       await waitFor(() => {
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining("/playlists?")
+          expect.stringContaining("/playlists?"),
+          expect.anything()
         );
       });
 
@@ -570,7 +571,8 @@ describe("usePlaylists", () => {
 
       await waitFor(() => {
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining("linked=true")
+          expect.stringContaining("linked=true"),
+          expect.anything()
         );
       });
     });
@@ -603,7 +605,8 @@ describe("usePlaylists", () => {
 
       await waitFor(() => {
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining("linked=false")
+          expect.stringContaining("linked=false"),
+          expect.anything()
         );
       });
     });
@@ -627,7 +630,8 @@ describe("usePlaylists", () => {
 
       await waitFor(() => {
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining("/playlists?")
+          expect.stringContaining("/playlists?"),
+          expect.anything()
         );
       });
 
@@ -725,10 +729,12 @@ describe("usePlaylists", () => {
 
       // Verify both calls had the correct parameters
       expect(mockApiFetch).toHaveBeenCalledWith(
-        expect.stringContaining("limit=10")
+        expect.stringContaining("limit=10"),
+        expect.anything()
       );
       expect(mockApiFetch).toHaveBeenCalledWith(
-        expect.stringContaining("limit=25")
+        expect.stringContaining("limit=25"),
+        expect.anything()
       );
     });
   });
@@ -753,7 +759,8 @@ describe("usePlaylists", () => {
 
       await waitFor(() => {
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining("limit=10")
+          expect.stringContaining("limit=10"),
+          expect.anything()
         );
       });
     });
@@ -790,10 +797,12 @@ describe("usePlaylists", () => {
 
       await waitFor(() => {
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining("linked=true")
+          expect.stringContaining("linked=true"),
+          expect.anything()
         );
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining("limit=10")
+          expect.stringContaining("limit=10"),
+          expect.anything()
         );
       });
     });
@@ -879,14 +888,16 @@ describe("usePlaylists", () => {
       });
 
       expect(mockApiFetch).toHaveBeenCalledWith(
-        expect.stringContaining("offset=0")
+        expect.stringContaining("offset=0"),
+        expect.anything()
       );
 
       result.current.fetchNextPage();
 
       await waitFor(() => {
         expect(mockApiFetch).toHaveBeenCalledWith(
-          expect.stringContaining("offset=1")
+          expect.stringContaining("offset=1"),
+          expect.anything()
         );
       });
 

--- a/frontend/tests/hooks/useSearchSegments.test.tsx
+++ b/frontend/tests/hooks/useSearchSegments.test.tsx
@@ -715,7 +715,7 @@ describe("useSearchSegments", () => {
       expect(mockApiFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          signal: expect.any(AbortSignal),
+          externalSignal: expect.any(AbortSignal),
         })
       );
     });


### PR DESCRIPTION
## Summary

- **Global auth error handling (#48)**: `classifyError()` returns `auth` type for 401/403; global `AuthErrorBoundary` intercepts auth errors before page-level handlers; consistent "Session Expired" UI with lock icon, message, refresh button, and `chronovista auth login` help text; removed per-page 401 handling from SearchErrorState
- **Request cancellation (#37)**: TanStack Query's built-in `signal` propagated through `apiFetch` via `AbortSignal.any()`; filter changes cancel in-flight requests; cancelled requests silently discarded (no error flash, no retry); component unmount cancels pending requests
- **Retry with exponential backoff (#38)**: TanStack Query retry config (3 retries, 1s/2s/4s delays); only transient errors retried (network errors, 5xx); 4xx errors never retried; loading state maintained during retries; manual "Retry" button after exhaustion
- **Skip link expansion (#40)**: Existing `SkipLink` component added to all pages with filter panels; visually hidden until keyboard focus; targets main content area
- **Transcript segment search**: Search input in transcript panel with case-insensitive matching, match highlighting (background + bold), prev/next navigation with "N of M" counter, `aria-live` announcements; client-side only against loaded data; eager-fetch all pages when search active
- **Transcript scroll reset**: Language switch and view mode toggle reset scroll to top; deep-link `seg=` parameter honored on initial load
- **Channel search field**: Search input above channel grid with case-insensitive substring filter, clear button, "No channels match" empty state, auto-focus; client-side against loaded data; eager-fetch all pages when search active

### Bug fixes discovered during testing
- Channel search "No channels match" on fast typing — was filtering against first 25 loaded channels only; fixed with eager-fetch pattern
- Transcript scroll reset at ~25 min mark — virtualization threshold was 500, causing mid-scroll switch from standard to virtualized list; lowered to 50 (initial batch size)
- Transcript search "0 of 0" for existing words — search only ran against loaded segments; fixed with eager-fetch pattern
- Scroll-to-match failing for off-screen virtualized segments — `scrollIntoView()` on null DOM refs; moved to `containerRef.scrollTop` calculation with `prevActiveSegmentIndexRef` guard

## Test plan
- [x] 2,491 frontend tests passing (0 failures)
- [x] TypeScript strict mode (0 errors)
- [x] Channel search: type fast → all channels searched, results appear correctly
- [x] Transcript search: matches found across all loaded segments, scroll-to-match works in virtualized list
- [x] Transcript scroll: no reset at 25-minute mark, language switch resets to top
- [x] Auth error: 401/403 shows global "Session Expired" state
- [x] Request cancellation: rapid filter changes don't produce stale results
- [x] Skip links: keyboard Tab reveals skip link on pages with filter panels

Closes #48, closes #37, closes #38, closes #40