### PR TITLE
feat(search,entities): fix special character search, align mention counts, add audit mode (Feature 044)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.45.0] - 2026-03-14
+
+### Added
+- **Feature 044: Data Accuracy & Search Reliability**
+  - `entities scan --audit` flag — reports user-correction mentions with unregistered text forms in a Rich table with registration suggestions
+  - `_escape_like_pattern()` shared helper for ILIKE wildcard escaping in `transcript_segment_repository.py`
+  - NULL byte (`\x00`) rejection in search endpoints with 400 Bad Request response
+  - 79 new tests across unit and integration suites
+
+### Fixed
+- Special character search (GitHub #84): `_`, `%`, `\` in search queries now match literally instead of acting as SQL ILIKE wildcards
+- Phrase matching (GitHub #84): multi-word queries like `[ __ ]` treated as contiguous phrases, not split into independent terms
+- Batch find-replace literal mode: same ILIKE escaping applied via `find_by_text_pattern()`
+- Entity mention count accuracy (GitHub #89): `mention_count` and `video_count` now exclude mentions matching ASR-error aliases, aligning with visible alias occurrence counts
+- `has_mentions` filter now correctly excludes entities with only ASR-error-matched mentions
+
+### Technical
+- No new dependencies, no schema changes, no migrations
+- Files modified: `search.py`, `transcript_segment_repository.py`, `entity_mention_repository.py`, `entity_mention_scan_service.py`, `entity_commands.py`
+- `update_entity_counters()` rewritten with `union_all` JOIN against visible names (canonical + non-ASR-error aliases)
+
 ## [0.44.0] - 2026-03-13
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.45.0] - 2026-03-14
+
+### Added
+- **Feature 044: Data Accuracy & Search Reliability**
+  - New `--audit` flag on `entities scan` command: reports user-correction mentions with unregistered text forms (text not matching any alias or canonical name); Rich table output showing Entity, Mention Text, Segment Count, and suggested CLI command to register the alias; read-only operation, mutually exclusive with `--full`, compatible with `--dry-run` (GitHub #87)
+
+### Fixed
+- **Special Character Search Fix (GitHub #84)**
+  - ILIKE wildcard escaping: `_`, `%`, and `\` in search queries now match literally instead of acting as SQL wildcards
+  - Phrase matching: multi-word queries like `[ __ ]` are treated as contiguous phrases, not split into independent terms
+  - Same escaping fix applied to batch find-replace literal mode (`find_by_text_pattern()`)
+  - NULL byte (`\x00`) rejection in search queries to prevent PostgreSQL silent truncation
+  - Shared `_escape_like_pattern()` helper in `transcript_segment_repository.py`
+- **Entity Mention Count Accuracy (GitHub #89)**
+  - `update_entity_counters()` now filters by visible names only (canonical name + non-ASR-error aliases via `union_all` JOIN)
+  - `mention_count` and `video_count` on `named_entities` exclude mentions matching ASR-error aliases
+  - Entities with only ASR-error-matched mentions correctly show `mention_count=0`
+  - `has_mentions` filter aligned with visible alias data (intentional behavior change)
+  - Consistent counting across all paths: scan, batch apply, batch revert
+
+### Technical
+- Files modified: `search.py`, `transcript_segment_repository.py`, `entity_mention_repository.py`, `entity_mention_scan_service.py`, `entity_commands.py`
+- No new dependencies, no schema changes, no migrations
+- 79 new tests added
+
 ## [0.44.0] - 2026-03-13
 
 ### Added

--- a/docs/user-guide/cli-overview.md
+++ b/docs/user-guide/cli-overview.md
@@ -1568,6 +1568,9 @@ chronovista entities scan --full
 # Scan only entities with zero existing mentions
 chronovista entities scan --new-entities-only
 
+# Audit: report user-correction mentions with unregistered text forms
+chronovista entities scan --audit
+
 # Custom batch size for large libraries
 chronovista entities scan --batch-size 1000
 
@@ -1591,6 +1594,19 @@ chronovista corrections rebuild-text
 # 3. Rescan for entity mentions (corrections create new aliases automatically)
 chronovista entities scan --full
 ```
+
+**Scan Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Preview mentions without writing |
+| `--full` | Delete existing `rule_match` mentions and rescan |
+| `--audit` | Report user-correction mentions with unregistered text forms. Displays a Rich table showing entities with mention texts that don't match any registered alias or canonical name, along with suggested CLI commands to register them. Read-only operation. Mutually exclusive with `--full`. |
+| `--new-entities-only` | Scan only entities with zero existing mentions |
+| `--entity-type` | Filter by entity type (e.g., `person`) |
+| `--video-id` | Filter by video ID |
+| `--batch-size` | Custom batch size for large libraries |
+| `--limit` | Limit number of segments to scan |
 
 **Limitations:**
 

--- a/docs/user-guide/corrections.md
+++ b/docs/user-guide/corrections.md
@@ -51,6 +51,8 @@ chronovista corrections find-replace \
 
 **When to use**: Simple word or phrase replacements where you know the exact text.
 
+**Special characters**: Characters with special meaning in SQL LIKE patterns (`_`, `%`, `\`) are automatically escaped and matched literally in substring mode. For example, searching for `[ __ ]` will match that exact string rather than treating `_` as a single-character wildcard.
+
 **Watch out**: Substring mode matches inside longer words. `--pattern 'amlo'` will also match "k**amlo**ops". Use regex with `\b` word boundaries to avoid this (see below).
 
 ### Regex Mode (`--regex`)

--- a/docs/user-guide/rest-api.md
+++ b/docs/user-guide/rest-api.md
@@ -1650,7 +1650,9 @@ GET /api/v1/search/segments
 ##### Search Behavior
 
 - Case-insensitive substring matching (ILIKE)
-- Multi-word queries use implicit AND (all terms must match)
+- Multi-word queries are treated as contiguous phrase searches (the entire query is matched as a single phrase, not split into independent terms)
+- Special characters (`_`, `%`, `\`) in search queries are escaped and matched literally
+- Queries containing NULL bytes (`\x00`) are rejected with `400 Bad Request`
 - Results ordered by video upload date (desc), then segment time (asc)
 - Context from adjacent segments included automatically
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.44.0"
+version = "0.45.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.44.0"
+__version__ = "0.45.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/routers/search.py
+++ b/src/chronovista/api/routers/search.py
@@ -24,6 +24,7 @@ from chronovista.db.models import Video as VideoDB
 from chronovista.db.models import VideoTranscript as TranscriptDB
 from chronovista.exceptions import BadRequestError
 from chronovista.models.enums import AvailabilityStatus
+from chronovista.repositories.transcript_segment_repository import _escape_like_pattern
 
 
 router = APIRouter(dependencies=[Depends(require_auth)])
@@ -114,8 +115,15 @@ async def search_segments(
             details={"field": "q", "constraint": "non_empty"},
         )
 
-    # Split query into terms for multi-word search (implicit AND)
-    query_terms = query_text.split()
+    # Reject NULL bytes
+    if "\x00" in query_text:
+        raise BadRequestError(
+            message="Search query contains invalid characters",
+            details={"field": "q", "constraint": "no_null_bytes"},
+        )
+
+    # Escape special LIKE characters for literal phrase matching
+    escaped_query = _escape_like_pattern(query_text)
 
     # Build base query with joins (including Channel for eager loading)
     query = (
@@ -135,16 +143,14 @@ async def search_segments(
     if not include_unavailable:
         query = query.where(VideoDB.availability_status == AvailabilityStatus.AVAILABLE)
 
-    # Apply ILIKE filter for each term (implicit AND)
+    # Apply ILIKE filter for the entire query as a single phrase
     # Search both original text and corrected text so corrections are findable
-    for term in query_terms:
-        escaped_term = term.replace("%", r"\%").replace("_", r"\_")
-        query = query.where(
-            or_(
-                SegmentDB.text.ilike(f"%{escaped_term}%"),
-                SegmentDB.corrected_text.ilike(f"%{escaped_term}%"),
-            )
+    query = query.where(
+        or_(
+            SegmentDB.text.ilike(f"%{escaped_query}%"),
+            SegmentDB.corrected_text.ilike(f"%{escaped_query}%"),
         )
+    )
 
     # Apply optional video filter (affects both available_languages and results)
     if video_id:
@@ -162,15 +168,13 @@ async def search_segments(
     if not include_unavailable:
         lang_base_query = lang_base_query.where(VideoDB.availability_status == AvailabilityStatus.AVAILABLE)
 
-    # Apply the same text search filters (both original and corrected text)
-    for term in query_terms:
-        escaped_term = term.replace("%", r"\%").replace("_", r"\_")
-        lang_base_query = lang_base_query.where(
-            or_(
-                SegmentDB.text.ilike(f"%{escaped_term}%"),
-                SegmentDB.corrected_text.ilike(f"%{escaped_term}%"),
-            )
+    # Apply the same text search filter (single phrase, both original and corrected text)
+    lang_base_query = lang_base_query.where(
+        or_(
+            SegmentDB.text.ilike(f"%{escaped_query}%"),
+            SegmentDB.corrected_text.ilike(f"%{escaped_query}%"),
         )
+    )
 
     # Apply optional video filter
     if video_id:
@@ -251,7 +255,7 @@ async def search_segments(
                 end_time=segment.end_time,
                 context_before=context_before,
                 context_after=context_after,
-                match_count=count_query_matches(_display_text(segment), query_terms),
+                match_count=count_query_matches(_display_text(segment), [query_text]),
                 video_upload_date=video.upload_date,
                 availability_status=video.availability_status,
             )
@@ -316,16 +320,22 @@ async def search_titles(
             details={"field": "q", "constraint": "non_empty"},
         )
 
-    query_terms = query_text.split()
+    # Reject NULL bytes
+    if "\x00" in query_text:
+        raise BadRequestError(
+            message="Search query contains invalid characters",
+            details={"field": "q", "constraint": "no_null_bytes"},
+        )
+
+    # Escape special LIKE characters for literal phrase matching
+    escaped_query = _escape_like_pattern(query_text)
 
     # Build conditions for reuse (count + results)
     conditions = []
     # Apply availability filter unless include_unavailable is True
     if not include_unavailable:
         conditions.append(VideoDB.availability_status == AvailabilityStatus.AVAILABLE)
-    for term in query_terms:
-        escaped_term = term.replace("%", r"\%").replace("_", r"\_")
-        conditions.append(VideoDB.title.ilike(f"%{escaped_term}%"))
+    conditions.append(VideoDB.title.ilike(f"%{escaped_query}%"))
 
     # Get total count
     count_query = select(func.count()).select_from(
@@ -464,16 +474,22 @@ async def search_descriptions(
             details={"field": "q", "constraint": "non_empty"},
         )
 
-    query_terms = query_text.split()
+    # Reject NULL bytes
+    if "\x00" in query_text:
+        raise BadRequestError(
+            message="Search query contains invalid characters",
+            details={"field": "q", "constraint": "no_null_bytes"},
+        )
+
+    # Escape special LIKE characters for literal phrase matching
+    escaped_query = _escape_like_pattern(query_text)
 
     # Build conditions for reuse
     conditions: List[ColumnElement[bool]] = [VideoDB.description.isnot(None)]
     # Apply availability filter unless include_unavailable is True
     if not include_unavailable:
         conditions.append(VideoDB.availability_status == AvailabilityStatus.AVAILABLE)
-    for term in query_terms:
-        escaped_term = term.replace("%", r"\%").replace("_", r"\_")
-        conditions.append(VideoDB.description.ilike(f"%{escaped_term}%"))
+    conditions.append(VideoDB.description.ilike(f"%{escaped_query}%"))
 
     # Get total count
     count_query = select(func.count()).select_from(
@@ -506,7 +522,7 @@ async def search_descriptions(
             title=row.title,
             channel_title=row.channel_title,
             upload_date=row.upload_date,
-            snippet=_generate_snippet(row.description, query_terms),
+            snippet=_generate_snippet(row.description, [query_text]),
             availability_status=row.availability_status,
         )
         for row in rows

--- a/src/chronovista/cli/entity_commands.py
+++ b/src/chronovista/cli/entity_commands.py
@@ -853,8 +853,19 @@ def scan_entities(
         int,
         typer.Option("--limit", help="Dry-run preview row limit"),
     ] = 50,
+    audit: Annotated[
+        bool,
+        typer.Option(
+            "--audit",
+            help="Report user-correction mentions with unregistered text forms",
+        ),
+    ] = False,
 ) -> None:
     """Scan transcript segments for named entity mentions."""
+
+    # Validate mutual exclusivity: --audit and --full
+    if audit and full:
+        raise typer.BadParameter("--audit and --full are mutually exclusive")
 
     # Validate entity type if provided
     if entity_type is not None:
@@ -876,6 +887,49 @@ def scan_entities(
     service = EntityMentionScanService(session_factory=session_factory)
 
     async def _run() -> None:
+        if audit:
+            # Audit mode: report unregistered mention texts (read-only)
+            audit_results = await service.audit_unregistered_mentions()
+
+            if not audit_results:
+                console.print(
+                    "[green]No unregistered mention texts found.[/green]"
+                )
+                return
+
+            audit_table = Table(
+                title="Unregistered Mention Texts",
+                show_header=True,
+                header_style="bold blue",
+            )
+            audit_table.add_column("Entity", style="cyan", width=28)
+            audit_table.add_column("Mention Text", style="green", width=28)
+            audit_table.add_column(
+                "Segment Count", style="yellow", justify="right", width=14
+            )
+            audit_table.add_column("Suggestion", style="dim", width=60)
+
+            entity_ids_seen: set[str] = set()
+            for canonical_name, entity_id, mention_text, segment_count in audit_results:
+                entity_ids_seen.add(str(entity_id))
+                suggestion = (
+                    f'chronovista entities add-alias "{canonical_name}" '
+                    f'--alias "{mention_text}"'
+                )
+                audit_table.add_row(
+                    canonical_name,
+                    mention_text,
+                    str(segment_count),
+                    suggestion,
+                )
+
+            console.print(audit_table)
+            console.print(
+                f"\nFound {len(audit_results)} unregistered mention text(s) "
+                f"across {len(entity_ids_seen)} entity(ies)."
+            )
+            return
+
         if dry_run:
             # Dry-run mode: show preview table
             with Progress(

--- a/src/chronovista/repositories/entity_mention_repository.py
+++ b/src/chronovista/repositories/entity_mention_repository.py
@@ -11,12 +11,15 @@ import uuid
 from typing import Any, Optional
 
 from sqlalchemy import (
+    and_,
     delete,
     distinct,
     func,
     select,
+    union_all,
     update,
 )
+
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -29,6 +32,7 @@ from chronovista.db.models import (
     Video as VideoDB,
 )
 from chronovista.models.entity_mention import EntityMentionCreate
+from chronovista.models.enums import EntityAliasType
 from chronovista.repositories.base import BaseSQLAlchemyRepository
 
 
@@ -294,19 +298,45 @@ class EntityMentionRepository(
         if not entity_ids:
             return
 
-        # Compute mention_count and video_count per entity
+        # Build a subquery of "visible names" per entity: canonical names
+        # plus non-ASR-error aliases.  Only mentions matching these names
+        # should be counted, so that ASR-error alias mentions are excluded.
+        canonical_names = select(
+            NamedEntityDB.id.label("entity_id"),
+            func.lower(NamedEntityDB.canonical_name).label("name_lower"),
+        ).where(NamedEntityDB.id.in_(entity_ids))
+
+        non_asr_aliases = select(
+            EntityAliasDB.entity_id,
+            func.lower(EntityAliasDB.alias_name).label("name_lower"),
+        ).where(
+            EntityAliasDB.entity_id.in_(entity_ids),
+            EntityAliasDB.alias_type != EntityAliasType.ASR_ERROR,
+        )
+
+        visible_names = union_all(canonical_names, non_asr_aliases).subquery()
+
+        # Count only mentions whose mention_text matches a visible name
         agg_subq = (
             select(
                 EntityMentionDB.entity_id,
-                func.count().label("mention_count"),
+                func.count(distinct(EntityMentionDB.id)).label("mention_count"),
                 func.count(distinct(EntityMentionDB.video_id)).label("video_count"),
+            )
+            .join(
+                visible_names,
+                and_(
+                    EntityMentionDB.entity_id == visible_names.c.entity_id,
+                    func.lower(EntityMentionDB.mention_text)
+                    == visible_names.c.name_lower,
+                ),
             )
             .where(EntityMentionDB.entity_id.in_(entity_ids))
             .group_by(EntityMentionDB.entity_id)
             .subquery()
         )
 
-        # Update entities that have mentions
+        # Update entities that have visible mentions
         stmt = (
             update(NamedEntityDB)
             .where(NamedEntityDB.id == agg_subq.c.entity_id)
@@ -317,17 +347,15 @@ class EntityMentionRepository(
         )
         await session.execute(stmt)
 
-        # Set counters to 0 for entities in the list that have NO mentions
-        entities_with_mentions = (
-            select(distinct(EntityMentionDB.entity_id))
-            .where(EntityMentionDB.entity_id.in_(entity_ids))
-            .scalar_subquery()
+        # Set counters to 0 for entities with no visible mentions
+        entities_with_visible_mentions = (
+            select(agg_subq.c.entity_id).scalar_subquery()
         )
         zero_stmt = (
             update(NamedEntityDB)
             .where(
                 NamedEntityDB.id.in_(entity_ids),
-                NamedEntityDB.id.notin_(entities_with_mentions),
+                NamedEntityDB.id.notin_(entities_with_visible_mentions),
             )
             .values(mention_count=0, video_count=0)
         )

--- a/src/chronovista/repositories/transcript_segment_repository.py
+++ b/src/chronovista/repositories/transcript_segment_repository.py
@@ -93,6 +93,22 @@ def translate_python_regex_to_posix(pattern: str) -> str:
     return "".join(result)
 
 
+def _escape_like_pattern(text: str) -> str:
+    """Escape SQL LIKE/ILIKE wildcard characters for literal matching.
+
+    Parameters
+    ----------
+    text : str
+        The text to escape.
+
+    Returns
+    -------
+    str
+        The escaped text safe for use in LIKE/ILIKE patterns.
+    """
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 class TranscriptSegmentRepository(
     BaseSQLAlchemyRepository[
         TranscriptSegmentDB,
@@ -571,7 +587,8 @@ class TranscriptSegmentRepository(
             else:
                 text_condition = effective_text.op("~")(sql_pattern)
         else:
-            like_pattern = f"%{pattern}%"
+            escaped = _escape_like_pattern(pattern)
+            like_pattern = f"%{escaped}%"
             if case_insensitive:
                 text_condition = effective_text.ilike(like_pattern)
             else:

--- a/src/chronovista/services/entity_mention_scan_service.py
+++ b/src/chronovista/services/entity_mention_scan_service.py
@@ -17,7 +17,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from sqlalchemy import Select, literal_column, select, text
+from sqlalchemy import Select, func, literal_column, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from chronovista.db.models import EntityAlias as EntityAliasDB
@@ -319,6 +319,71 @@ class EntityMentionScanService:
             )
 
             return result
+
+    async def audit_unregistered_mentions(
+        self,
+    ) -> list[tuple[str, uuid.UUID, str, int]]:
+        """Find user-correction mentions whose text is not registered as an alias.
+
+        Queries all ``entity_mentions`` rows where
+        ``detection_method = 'user_correction'`` for active entities, then
+        LEFT JOINs against ``entity_aliases`` to find mention texts that do
+        **not** match any alias (case-insensitive) and also differ from the
+        entity's canonical name.
+
+        Returns
+        -------
+        list[tuple[str, uuid.UUID, str, int]]
+            List of ``(canonical_name, entity_id, mention_text, segment_count)``
+            tuples, ordered by canonical name ascending then segment count
+            descending.
+        """
+        async with self._session_factory() as session:
+            stmt = (
+                select(
+                    EntityMentionDB.entity_id,
+                    NamedEntityDB.canonical_name,
+                    EntityMentionDB.mention_text,
+                    func.count().label("segment_count"),
+                )
+                .join(
+                    NamedEntityDB,
+                    EntityMentionDB.entity_id == NamedEntityDB.id,
+                )
+                .outerjoin(
+                    EntityAliasDB,
+                    (EntityMentionDB.entity_id == EntityAliasDB.entity_id)
+                    & (
+                        func.lower(EntityMentionDB.mention_text)
+                        == func.lower(EntityAliasDB.alias_name)
+                    ),
+                )
+                .where(
+                    EntityMentionDB.detection_method
+                    == DetectionMethod.USER_CORRECTION.value,
+                    NamedEntityDB.status == "active",
+                    func.lower(EntityMentionDB.mention_text)
+                    != func.lower(NamedEntityDB.canonical_name),
+                    EntityAliasDB.id.is_(None),
+                )
+                .group_by(
+                    EntityMentionDB.entity_id,
+                    NamedEntityDB.canonical_name,
+                    EntityMentionDB.mention_text,
+                )
+                .order_by(
+                    NamedEntityDB.canonical_name.asc(),
+                    text("segment_count DESC"),
+                )
+            )
+
+            result = await session.execute(stmt)
+            rows = result.all()
+
+            return [
+                (row.canonical_name, row.entity_id, row.mention_text, row.segment_count)
+                for row in rows
+            ]
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/tests/integration/services/test_entity_mention_scan_integration.py
+++ b/tests/integration/services/test_entity_mention_scan_integration.py
@@ -10,6 +10,7 @@ the test session so all writes/reads participate in the same transaction that
 the test can inspect.
 
 Feature 038 -- Entity Mention Detection (T016)
+Feature 044 -- Data Accuracy & Search Reliability (T011)
 
 Test coverage:
 1. End-to-end scan: entities + aliases + segments → mention records
@@ -18,6 +19,7 @@ Test coverage:
 4. Word boundary matching: "Aaronson" must NOT match entity "Aaron"
 5. Multiple aliases: all aliases of an entity trigger mentions
 6. Incremental scan: new_entities_only scans only newly added entity
+7. ASR-error alias exclusion: asr_error alias mentions excluded from counters (T011)
 """
 
 from __future__ import annotations
@@ -924,3 +926,338 @@ class TestCorrectedSegmentText:
         # Match via corrected_text, not original text
         assert len(rows) == 1
         assert result.mentions_found == 1
+
+
+# ---------------------------------------------------------------------------
+# T011 (Feature 044 US2): ASR-error alias exclusion from entity counters
+# ---------------------------------------------------------------------------
+
+
+class TestASRErrorAliasCounterExclusion:
+    """Verify that ASR-error aliases are excluded from mention_count / video_count.
+
+    Feature 044 US2 modified ``update_entity_counters()`` so that only
+    mentions whose ``mention_text`` matches the entity's canonical name or a
+    non-ASR-error alias are counted.  Mentions matched via ``asr_error``
+    aliases contribute to the ``entity_mentions`` table but must NOT increment
+    ``mention_count`` or ``video_count`` on ``named_entities``.
+    """
+
+    async def test_asr_error_alias_mention_excluded_from_mention_count(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        An entity whose mentions are all via ASR-error aliases must end up
+        with mention_count=0 after a full scan.
+
+        Setup:
+        - Entity "Elon Musk" with an ASR-error alias "Elan Musk"
+        - Segment text contains "Elan Musk" only (no canonical name)
+
+        Expected:
+        - One EntityMention row is created (detection still fires)
+        - mention_count=0 because "elan musk" is an asr_error alias
+        """
+        vid = video_id(seed="asr_ex_001")
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid)
+        await _seed_transcript(db_session, vid)
+
+        await _seed_segment(
+            db_session,
+            vid,
+            text="Elan Musk announced a new rocket",
+        )
+        entity = await _seed_entity(db_session, "Elon Musk", entity_type="person")
+        # Register the ASR-error alias so the scanner can match it
+        await _seed_alias(db_session, entity.id, "Elan Musk", alias_type="asr_error")
+
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+        await service.scan()
+
+        await db_session.refresh(entity)
+
+        # The scan creates a mention row (scan still detects)
+        mention_rows = (
+            await db_session.execute(
+                select(EntityMentionDB).where(EntityMentionDB.entity_id == entity.id)
+            )
+        ).scalars().all()
+        assert len(mention_rows) >= 1, (
+            "Expected at least one EntityMention row for the ASR-alias match"
+        )
+
+        # But the counter must be 0 because all matches were via asr_error alias
+        assert entity.mention_count == 0, (
+            f"Expected mention_count=0 (ASR-error alias only), got {entity.mention_count}"
+        )
+        assert entity.video_count == 0, (
+            f"Expected video_count=0 (ASR-error alias only), got {entity.video_count}"
+        )
+
+    async def test_canonical_name_mention_included_in_mention_count(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        An entity whose mentions match its canonical name must have
+        mention_count > 0 after a full scan.
+
+        Setup:
+        - Entity "Elon Musk" (canonical name)
+        - Segment text contains "Elon Musk"
+
+        Expected:
+        - mention_count=1 because canonical name is always visible
+        """
+        vid = video_id(seed="asr_ex_002")
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid)
+        await _seed_transcript(db_session, vid)
+
+        await _seed_segment(
+            db_session,
+            vid,
+            text="Elon Musk is the CEO of SpaceX",
+        )
+        entity = await _seed_entity(db_session, "Elon Musk", entity_type="person")
+
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+        await service.scan()
+
+        await db_session.refresh(entity)
+
+        assert entity.mention_count == 1, (
+            f"Expected mention_count=1 (canonical name match), got {entity.mention_count}"
+        )
+        assert entity.video_count == 1, (
+            f"Expected video_count=1, got {entity.video_count}"
+        )
+
+    async def test_non_asr_alias_mention_included_in_mention_count(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        Mentions matching a non-ASR-error alias must be counted.
+
+        Setup:
+        - Entity "Elon Musk" with a name_variant alias "Musk"
+        - Segment text contains "Musk" only
+
+        Expected:
+        - mention_count=1 because name_variant aliases are visible
+        """
+        vid = video_id(seed="asr_ex_003")
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid)
+        await _seed_transcript(db_session, vid)
+
+        await _seed_segment(
+            db_session,
+            vid,
+            text="Musk tweeted about the new model",
+        )
+        entity = await _seed_entity(db_session, "Elon Musk", entity_type="person")
+        await _seed_alias(db_session, entity.id, "Musk", alias_type="name_variant")
+
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+        await service.scan()
+
+        await db_session.refresh(entity)
+
+        assert entity.mention_count == 1, (
+            f"Expected mention_count=1 (name_variant alias), got {entity.mention_count}"
+        )
+        assert entity.video_count == 1, (
+            f"Expected video_count=1, got {entity.video_count}"
+        )
+
+    async def test_mixed_mentions_count_excludes_asr_error_matches(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        When an entity has both canonical-name matches and ASR-error-alias
+        matches, only canonical-name matches must be counted.
+
+        Setup:
+        - Entity "Google" with ASR-error alias "Googel"
+        - Three segments:
+            seg1: "Google announced new products"  (canonical → counted)
+            seg2: "Googel launched a service"      (asr_error → excluded)
+            seg3: "Google is a search engine"      (canonical → counted)
+
+        Expected:
+        - EntityMention rows: 3 (scanner detects all)
+        - mention_count: 2 (only the 2 canonical-name segments counted)
+        - video_count: 1 (all in same video)
+        """
+        vid = video_id(seed="asr_ex_004")
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid)
+        await _seed_transcript(db_session, vid)
+
+        await _seed_segment(
+            db_session,
+            vid,
+            text="Google announced new products",
+            start_time=0.0,
+            sequence_number=0,
+        )
+        await _seed_segment(
+            db_session,
+            vid,
+            text="Googel launched a service",
+            start_time=10.0,
+            sequence_number=1,
+        )
+        await _seed_segment(
+            db_session,
+            vid,
+            text="Google is a search engine",
+            start_time=20.0,
+            sequence_number=2,
+        )
+
+        entity = await _seed_entity(db_session, "Google", entity_type="organization")
+        await _seed_alias(db_session, entity.id, "Googel", alias_type="asr_error")
+
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+        await service.scan()
+
+        await db_session.refresh(entity)
+
+        mention_rows = (
+            await db_session.execute(
+                select(EntityMentionDB).where(EntityMentionDB.entity_id == entity.id)
+            )
+        ).scalars().all()
+
+        # All three matches were detected
+        assert len(mention_rows) == 3, (
+            f"Expected 3 EntityMention rows (canonical + asr_error), got {len(mention_rows)}"
+        )
+
+        # Only the 2 canonical-name matches count
+        assert entity.mention_count == 2, (
+            f"Expected mention_count=2 (excluding asr_error alias), got {entity.mention_count}"
+        )
+        assert entity.video_count == 1, (
+            f"Expected video_count=1 (single video), got {entity.video_count}"
+        )
+
+    async def test_video_count_excludes_videos_with_only_asr_alias_matches(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        video_count must not count videos where the only mentions are
+        ASR-error alias matches.
+
+        Setup:
+        - Entity "Tesla" with ASR-error alias "Tezla"
+        - Video 1: segment with "Tesla" (canonical — counted)
+        - Video 2: segment with "Tezla" (asr_error — excluded)
+
+        Expected:
+        - mention_count=1 (only Video 1's canonical match)
+        - video_count=1 (only Video 1 qualifies)
+        """
+        vid1 = video_id(seed="asr_vc_001")
+        vid2 = video_id(seed="asr_vc_002")
+        await _seed_channel(db_session)
+
+        for vid in [vid1, vid2]:
+            await _seed_video(db_session, vid)
+            await _seed_transcript(db_session, vid)
+
+        await _seed_segment(
+            db_session,
+            vid1,
+            text="Tesla released a new car",
+        )
+        await _seed_segment(
+            db_session,
+            vid2,
+            text="Tezla is an ASR error",
+        )
+
+        entity = await _seed_entity(db_session, "Tesla", entity_type="organization")
+        await _seed_alias(db_session, entity.id, "Tezla", alias_type="asr_error")
+
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+        await service.scan()
+
+        await db_session.refresh(entity)
+
+        assert entity.mention_count == 1, (
+            f"Expected mention_count=1 (Video 1 canonical only), got {entity.mention_count}"
+        )
+        assert entity.video_count == 1, (
+            f"Expected video_count=1 (Video 2 excluded due to asr_error), got {entity.video_count}"
+        )
+
+    async def test_full_rescan_preserves_asr_exclusion_in_counters(
+        self, db_session: AsyncSession
+    ) -> None:
+        """
+        A full rescan (full_rescan=True) must also apply ASR-error alias
+        exclusion when recalculating counters.
+
+        After a first scan followed by a full rescan, an entity with only
+        ASR-error-alias mentions must still end up with mention_count=0.
+        """
+        vid = video_id(seed="asr_ex_005")
+        await _seed_channel(db_session)
+        await _seed_video(db_session, vid)
+        await _seed_transcript(db_session, vid)
+
+        await _seed_segment(
+            db_session,
+            vid,
+            text="Amazzon Prime delivery arrived",
+        )
+        entity = await _seed_entity(db_session, "Amazon", entity_type="organization")
+        await _seed_alias(db_session, entity.id, "Amazzon", alias_type="asr_error")
+
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+
+        # First scan
+        await service.scan()
+        await db_session.refresh(entity)
+        assert entity.mention_count == 0, (
+            f"After first scan: expected mention_count=0 (ASR-error alias only), "
+            f"got {entity.mention_count}"
+        )
+
+        # Manually bump the counter to simulate drift (as if a bug had set it)
+        entity.mention_count = 99
+        entity.video_count = 99
+        await db_session.flush()
+
+        # Full rescan must recalculate and restore the correct 0
+        await service.scan(full_rescan=True)
+        await db_session.refresh(entity)
+        assert entity.mention_count == 0, (
+            f"After full rescan: expected mention_count=0 (ASR-error alias only), "
+            f"got {entity.mention_count}"
+        )
+        assert entity.video_count == 0, (
+            f"After full rescan: expected video_count=0 (ASR-error alias only), "
+            f"got {entity.video_count}"
+        )

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -1,0 +1,356 @@
+"""
+Unit tests for search router — phrase matching and NULL byte rejection (T006).
+
+Tests focus on request/response behavior of the three search endpoints:
+  - GET /api/v1/search/segments
+  - GET /api/v1/search/titles
+  - GET /api/v1/search/descriptions
+
+All database I/O is mocked via dependency override so these tests run
+without a real database connection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.main import app
+
+# CRITICAL: ensures async tests work correctly with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture: mocked async client
+# ---------------------------------------------------------------------------
+
+
+def _make_empty_execute_result() -> MagicMock:
+    """Return a mock session.execute() result that yields no rows."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_result.scalar.return_value = 0
+    mock_result.all.return_value = []
+    return mock_result
+
+
+@pytest.fixture
+async def async_client() -> AsyncGenerator[AsyncClient, None]:
+    """
+    Create async test client with fully mocked database and auth.
+
+    Overrides ``get_db`` and ``require_auth`` FastAPI dependencies so that
+    no real database or OAuth credentials are required.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.execute = AsyncMock(return_value=_make_empty_execute_result())
+
+    async def mock_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    async def mock_require_auth() -> None:
+        return None
+
+    app.dependency_overrides[get_db] = mock_get_db
+    app.dependency_overrides[require_auth] = mock_require_auth
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# T006-A: TestSearchSegmentsNullByteRejection
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSegmentsNullByteRejection:
+    """
+    Verify that all three search endpoints reject NULL bytes with HTTP 400.
+
+    NULL bytes (``\\x00``) are invalid in SQL and PostgreSQL raises an error
+    when they appear in ILIKE patterns.  The routers must reject them before
+    any SQL is executed.
+
+    Note: NULL bytes must be percent-encoded as ``%00`` in the URL because
+    httpx (and the HTTP spec) prohibit raw ``\\x00`` in URL strings.  The
+    ASGI layer decodes ``%00`` back to the NUL character before the router
+    receives the query parameter value.
+    """
+
+    async def test_segments_null_byte_returns_400(
+        self, async_client: AsyncClient
+    ) -> None:
+        """GET /search/segments with NULL byte (percent-encoded) returns 400."""
+        # %00 → decoded as \x00 by the query-string parser
+        response = await async_client.get("/api/v1/search/segments?q=hello%00world")
+        assert response.status_code == 400
+
+    async def test_segments_null_byte_rfc7807_code(
+        self, async_client: AsyncClient
+    ) -> None:
+        """400 response for NULL byte has RFC 7807 ``code=BAD_REQUEST``."""
+        response = await async_client.get("/api/v1/search/segments?q=hello%00world")
+        assert response.status_code == 400
+        body = response.json()
+        assert body.get("code") == "BAD_REQUEST"
+
+    async def test_segments_null_byte_only_returns_400(
+        self, async_client: AsyncClient
+    ) -> None:
+        """A query with a NULL byte also returns 400 (two chars, one is NUL)."""
+        response = await async_client.get("/api/v1/search/segments?q=a%00")
+        assert response.status_code == 400
+
+    async def test_titles_null_byte_returns_400(
+        self, async_client: AsyncClient
+    ) -> None:
+        """GET /search/titles with NULL byte (percent-encoded) returns 400."""
+        response = await async_client.get("/api/v1/search/titles?q=he%00llo")
+        assert response.status_code == 400
+        body = response.json()
+        assert body.get("code") == "BAD_REQUEST"
+
+    async def test_descriptions_null_byte_returns_400(
+        self, async_client: AsyncClient
+    ) -> None:
+        """GET /search/descriptions with NULL byte (percent-encoded) returns 400."""
+        response = await async_client.get("/api/v1/search/descriptions?q=he%00llo")
+        assert response.status_code == 400
+        body = response.json()
+        assert body.get("code") == "BAD_REQUEST"
+
+    async def test_null_byte_mid_string_segments(
+        self, async_client: AsyncClient
+    ) -> None:
+        """NULL byte embedded in a longer query (segments) is rejected."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=some%00query"
+        )
+        assert response.status_code == 400
+
+    async def test_null_byte_mid_string_titles(
+        self, async_client: AsyncClient
+    ) -> None:
+        """NULL byte embedded in a title search query is rejected."""
+        response = await async_client.get(
+            "/api/v1/search/titles?q=some%00query"
+        )
+        assert response.status_code == 400
+
+    async def test_null_byte_mid_string_descriptions(
+        self, async_client: AsyncClient
+    ) -> None:
+        """NULL byte embedded in a description search query is rejected."""
+        response = await async_client.get(
+            "/api/v1/search/descriptions?q=some%00query"
+        )
+        assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# T006-B: TestSearchSegmentsPhraseMatching
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSegmentsPhraseMatching:
+    """
+    Verify that multi-word queries are treated as a contiguous phrase.
+
+    The old implementation split on whitespace and produced per-word ILIKE
+    conditions.  The new implementation passes the entire query — including
+    spaces — as a single ILIKE argument.  We cannot inspect internal SQL
+    without a real DB, but we can verify that the endpoint accepts
+    multi-word and special-character queries without error, and that those
+    queries produce a valid 200 response (not a 400/422/500).
+    """
+
+    async def test_multi_word_query_accepted_segments(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Multi-word query with space returns 200 (not 422 or 500)."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=hello+world"
+        )
+        assert response.status_code == 200
+
+    async def test_multi_word_with_percent_accepted_segments(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Query containing ``%`` is accepted and returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=100%25+complete"
+        )
+        assert response.status_code == 200
+
+    async def test_multi_word_with_underscore_accepted_segments(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Query containing ``_`` is accepted and returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=__init__+method"
+        )
+        assert response.status_code == 200
+
+    async def test_multi_word_with_backslash_accepted_segments(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Query containing backslash is accepted and returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=C%3A%5Cpath+file"
+        )
+        assert response.status_code == 200
+
+    async def test_multi_word_query_response_structure(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Multi-word query returns the standard paginated response structure."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=hello+world"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert "data" in body
+        assert "pagination" in body
+        assert "available_languages" in body
+        assert isinstance(body["data"], list)
+
+    async def test_multi_word_query_accepted_titles(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Title search: multi-word query is accepted without error."""
+        response = await async_client.get(
+            "/api/v1/search/titles?q=python+tutorial"
+        )
+        assert response.status_code == 200
+
+    async def test_multi_word_with_percent_accepted_titles(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Title search: query with ``%`` is accepted and returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/titles?q=100%25+tutorial"
+        )
+        assert response.status_code == 200
+
+    async def test_multi_word_query_accepted_descriptions(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Description search: multi-word query is accepted without error."""
+        response = await async_client.get(
+            "/api/v1/search/descriptions?q=python+tutorial"
+        )
+        assert response.status_code == 200
+
+    async def test_multi_word_with_percent_accepted_descriptions(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Description search: query with ``%`` is accepted and returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/descriptions?q=100%25+tutorial"
+        )
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# T006-C: TestSearchSegmentsSpecialCharWithVideoFilter
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSegmentsSpecialCharWithVideoFilter:
+    """
+    Verify that special character queries work correctly with video_id filters.
+
+    FR-004 requires that special-character queries scoped to a specific video
+    ID return the correct (possibly empty) result set rather than crashing or
+    ignoring the video_id filter.
+    """
+
+    async def test_percent_query_with_video_id_returns_200(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Percent sign in query combined with video_id filter returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=100%25&video_id=dQw4w9WgXcQ"
+        )
+        assert response.status_code == 200
+
+    async def test_underscore_query_with_video_id_returns_200(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Underscore in query combined with video_id filter returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=__init__&video_id=dQw4w9WgXcQ"
+        )
+        assert response.status_code == 200
+
+    async def test_backslash_query_with_video_id_returns_200(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Backslash in query combined with video_id filter returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=C%3A%5Cpath&video_id=dQw4w9WgXcQ"
+        )
+        assert response.status_code == 200
+
+    async def test_multi_word_special_query_with_video_id_response_structure(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Combined filter returns valid paginated response shape."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=100%25+_done&video_id=dQw4w9WgXcQ"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert "data" in body
+        assert "pagination" in body
+        # With a mocked empty DB, data should be an empty list
+        assert isinstance(body["data"], list)
+
+    async def test_video_id_filter_validation_still_applies_with_special_chars(
+        self, async_client: AsyncClient
+    ) -> None:
+        """video_id validation (must be 11 chars) still applies alongside special chars."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=100%25&video_id=short"
+        )
+        assert response.status_code == 422
+
+    async def test_null_byte_with_video_id_returns_400_not_500(
+        self, async_client: AsyncClient
+    ) -> None:
+        """NULL byte (percent-encoded) is rejected even when video_id filter is present."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=hel%00lo&video_id=dQw4w9WgXcQ"
+        )
+        assert response.status_code == 400
+        body = response.json()
+        assert body.get("code") == "BAD_REQUEST"
+
+    async def test_language_filter_with_special_char_query(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Language filter combined with special character query returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=100%25+done&language=en"
+        )
+        assert response.status_code == 200
+
+    async def test_all_filters_combined_with_special_chars(
+        self, async_client: AsyncClient
+    ) -> None:
+        """All filters (video_id + language) combined with special char query returns 200."""
+        response = await async_client.get(
+            "/api/v1/search/segments?q=__init__&video_id=dQw4w9WgXcQ&language=en"
+        )
+        assert response.status_code == 200

--- a/tests/unit/cli/test_entity_commands.py
+++ b/tests/unit/cli/test_entity_commands.py
@@ -1,0 +1,419 @@
+"""
+Unit tests for Entity CLI commands — ``--audit`` flag on ``entities scan``.
+
+Tests the ``--audit`` parameter of the ``scan_entities`` command without
+touching the database. All external dependencies (session factory, service)
+are mocked so that only CLI option-parsing and output-formatting logic is
+exercised.
+
+Covered scenarios (T015 — Feature 044, US3)
+--------------------------------------------
+(a) ``--audit --full`` is mutually exclusive → raises typer.BadParameter.
+(b) ``--audit`` calls ``audit_unregistered_mentions()`` and displays results.
+(c) Output formatting includes Rich table with expected columns.
+(d) ``--audit --dry-run`` executes without error (dry-run is a no-op for the
+    read-only audit path).
+
+Feature 044 — Search Accuracy & Mention Audit (T015)
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from chronovista.cli.entity_commands import entity_app
+
+# CRITICAL: Module-level asyncio marker ensures async tests work with coverage.
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_uuid() -> uuid.UUID:
+    """Return a fresh UUID4 for test data."""
+    return uuid.uuid4()
+
+
+def _audit_result(
+    canonical_name: str = "Noam Chomsky",
+    entity_id: uuid.UUID | None = None,
+    mention_text: str = "chomsky",
+    segment_count: int = 3,
+) -> tuple[str, uuid.UUID, str, int]:
+    """Build a single audit result tuple matching the service return type."""
+    return (canonical_name, entity_id or _make_uuid(), mention_text, segment_count)
+
+
+# ---------------------------------------------------------------------------
+# TestScanAuditFlag (T015)
+# ---------------------------------------------------------------------------
+
+
+class TestScanAuditFlag:
+    """Tests for the ``--audit`` flag on ``entities scan``.
+
+    Parameters
+    ----------
+    runner : CliRunner
+        Typer CliRunner fixture for invoking CLI commands in-process.
+    """
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Typer CLI test runner."""
+        return CliRunner()
+
+    # ------------------------------------------------------------------
+    # (a) --audit --full raises error / shows error message
+    # ------------------------------------------------------------------
+
+    def test_audit_and_full_are_mutually_exclusive(self, runner: CliRunner) -> None:
+        """``--audit --full`` must be rejected before any I/O occurs.
+
+        The ``scan_entities`` command validates mutual exclusivity in the
+        synchronous preamble (before ``asyncio.run``), so this test does not
+        need to mock the database or service layer.
+        """
+        result = runner.invoke(entity_app, ["scan", "--audit", "--full"])
+
+        # typer.BadParameter causes a non-zero exit
+        assert result.exit_code != 0
+
+    def test_audit_and_full_error_message_contains_audit(
+        self, runner: CliRunner
+    ) -> None:
+        """The error message for ``--audit --full`` must mention both flags."""
+        result = runner.invoke(entity_app, ["scan", "--audit", "--full"])
+
+        combined = (result.stdout or "") + (result.stderr or "")
+        # The error must communicate the conflict; at minimum mention "audit"
+        assert "audit" in combined.lower() or result.exit_code != 0
+
+    # ------------------------------------------------------------------
+    # (b) --audit calls audit_unregistered_mentions() and displays results
+    # ------------------------------------------------------------------
+
+    @patch("chronovista.cli.entity_commands.asyncio.run")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_audit_flag_calls_asyncio_run(
+        self,
+        mock_db_manager: MagicMock,
+        mock_asyncio_run: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """Invoking ``entities scan --audit`` must call ``asyncio.run`` once."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        result = runner.invoke(entity_app, ["scan", "--audit"])
+
+        assert result.exit_code == 0
+        mock_asyncio_run.assert_called_once()
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_audit_invokes_audit_unregistered_mentions(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """The audit path must delegate to ``audit_unregistered_mentions()``.
+
+        We patch ``asyncio.run`` at the entity_commands module level so the
+        inner coroutine runs synchronously in the test via a patched call.
+        """
+        entity_id = _make_uuid()
+        audit_rows = [_audit_result(entity_id=entity_id)]
+
+        # Build a mock service instance whose audit method returns our rows
+        mock_service = MagicMock()
+        mock_service.audit_unregistered_mentions = AsyncMock(return_value=audit_rows)
+        mock_service_cls.return_value = mock_service
+
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        # Capture the coroutine passed to asyncio.run and execute it
+        captured_coro: list[object] = []
+
+        def fake_asyncio_run(coro: object) -> None:
+            import asyncio
+
+            captured_coro.append(coro)
+            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+        with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
+            result = runner.invoke(entity_app, ["scan", "--audit"])
+
+        assert result.exit_code == 0
+        mock_service.audit_unregistered_mentions.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # (c) Output formatting includes Rich table with expected columns
+    # ------------------------------------------------------------------
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_audit_table_columns_present_in_output(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """The Rich table rendered for audit results must include the four
+        expected column headers: Entity, Mention Text, Segment Count,
+        Suggestion.
+
+        The CliRunner captures Rich's rendered output, so column titles
+        appear as plain text in ``result.stdout``.
+        """
+        entity_id = _make_uuid()
+        audit_rows = [
+            _audit_result(
+                canonical_name="Noam Chomsky",
+                entity_id=entity_id,
+                mention_text="chomsky",
+                segment_count=5,
+            )
+        ]
+
+        mock_service = MagicMock()
+        mock_service.audit_unregistered_mentions = AsyncMock(return_value=audit_rows)
+        mock_service_cls.return_value = mock_service
+
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        def fake_asyncio_run(coro: object) -> None:
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+        with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
+            result = runner.invoke(entity_app, ["scan", "--audit"])
+
+        assert result.exit_code == 0
+        output = result.stdout
+
+        # The table title and at least three visible column headers must appear.
+        # Note: CliRunner uses a narrow terminal so Rich may abbreviate
+        # "Segment Count" to fit; we assert on the title and unambiguous headers.
+        assert "Unregistered Mention Texts" in output
+        assert "Entity" in output
+        assert "Mention Text" in output
+        assert "Suggestion" in output
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_audit_table_contains_entity_name_and_mention_text(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """The canonical name and mention text must appear in the table rows."""
+        entity_id = _make_uuid()
+        audit_rows = [
+            _audit_result(
+                canonical_name="Ada Lovelace",
+                entity_id=entity_id,
+                mention_text="lovelace",
+                segment_count=2,
+            )
+        ]
+
+        mock_service = MagicMock()
+        mock_service.audit_unregistered_mentions = AsyncMock(return_value=audit_rows)
+        mock_service_cls.return_value = mock_service
+
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        def fake_asyncio_run(coro: object) -> None:
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+        with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
+            result = runner.invoke(entity_app, ["scan", "--audit"])
+
+        assert result.exit_code == 0
+        output = result.stdout
+        assert "Ada Lovelace" in output
+        assert "lovelace" in output
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_audit_table_contains_suggestion_command(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """The Suggestion column must contain the ``add-alias`` CLI command."""
+        entity_id = _make_uuid()
+        audit_rows = [
+            _audit_result(
+                canonical_name="Noam Chomsky",
+                entity_id=entity_id,
+                mention_text="chomsky",
+                segment_count=1,
+            )
+        ]
+
+        mock_service = MagicMock()
+        mock_service.audit_unregistered_mentions = AsyncMock(return_value=audit_rows)
+        mock_service_cls.return_value = mock_service
+
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        def fake_asyncio_run(coro: object) -> None:
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+        with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
+            result = runner.invoke(entity_app, ["scan", "--audit"])
+
+        assert result.exit_code == 0
+        output = result.stdout
+        # The suggestion renders: chronovista entities add-alias "Noam Chomsky" --alias "chomsky"
+        assert "add-alias" in output
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_audit_displays_summary_line(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """After the table, a summary line with counts must appear."""
+        eid1 = _make_uuid()
+        eid2 = _make_uuid()
+        audit_rows = [
+            _audit_result("Entity A", eid1, "text_a", 3),
+            _audit_result("Entity B", eid2, "text_b", 1),
+        ]
+
+        mock_service = MagicMock()
+        mock_service.audit_unregistered_mentions = AsyncMock(return_value=audit_rows)
+        mock_service_cls.return_value = mock_service
+
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        def fake_asyncio_run(coro: object) -> None:
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+        with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
+            result = runner.invoke(entity_app, ["scan", "--audit"])
+
+        assert result.exit_code == 0
+        output = result.stdout
+        # Summary line mentions result count and entity count
+        assert "2" in output  # 2 unregistered mention texts
+        assert "unregistered" in output.lower()
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_audit_no_results_shows_success_message(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """When audit returns no rows, a success message must be displayed
+        instead of the table.
+        """
+        mock_service = MagicMock()
+        mock_service.audit_unregistered_mentions = AsyncMock(return_value=[])
+        mock_service_cls.return_value = mock_service
+
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        def fake_asyncio_run(coro: object) -> None:
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+        with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
+            result = runner.invoke(entity_app, ["scan", "--audit"])
+
+        assert result.exit_code == 0
+        output = result.stdout
+        assert "No unregistered mention texts found" in output
+
+    # ------------------------------------------------------------------
+    # (d) --audit --dry-run executes without error
+    # ------------------------------------------------------------------
+
+    @patch("chronovista.cli.entity_commands.asyncio.run")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_audit_with_dry_run_does_not_raise(
+        self,
+        mock_db_manager: MagicMock,
+        mock_asyncio_run: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """``--audit --dry-run`` must be accepted and exit cleanly.
+
+        The ``--audit`` path is read-only; ``--dry-run`` is a no-op for it.
+        The two flags are not mutually exclusive (only ``--audit --full`` is).
+        """
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        result = runner.invoke(entity_app, ["scan", "--audit", "--dry-run"])
+
+        assert result.exit_code == 0
+        mock_asyncio_run.assert_called_once()
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_audit_with_dry_run_still_calls_audit_method(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """``--audit --dry-run`` must still delegate to
+        ``audit_unregistered_mentions()`` rather than to ``service.scan()``.
+
+        The ``--audit`` branch runs unconditionally when ``audit=True``,
+        even when ``--dry-run`` is also set.
+        """
+        mock_service = MagicMock()
+        mock_service.audit_unregistered_mentions = AsyncMock(return_value=[])
+        mock_service.scan = AsyncMock()
+        mock_service_cls.return_value = mock_service
+
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        def fake_asyncio_run(coro: object) -> None:
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+        with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
+            result = runner.invoke(entity_app, ["scan", "--audit", "--dry-run"])
+
+        assert result.exit_code == 0
+        mock_service.audit_unregistered_mentions.assert_called_once()
+        # ``service.scan()`` must NOT be called during an audit
+        mock_service.scan.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Additional guard: scan --help shows --audit option
+    # ------------------------------------------------------------------
+
+    def test_scan_help_includes_audit_option(self, runner: CliRunner) -> None:
+        """``entities scan --help`` must document the ``--audit`` option."""
+        result = runner.invoke(entity_app, ["scan", "--help"])
+
+        assert result.exit_code == 0
+        assert "--audit" in result.stdout

--- a/tests/unit/repositories/test_entity_mention_repository.py
+++ b/tests/unit/repositories/test_entity_mention_repository.py
@@ -1,11 +1,12 @@
 """
-Tests for EntityMentionRepository (Feature 038 — T012).
+Tests for EntityMentionRepository (Feature 038 — T012; Feature 044 — T009).
 
 Covers all public methods with mocked AsyncSession:
 - bulk_create_with_conflict_skip() — INSERT ... ON CONFLICT DO NOTHING for bulk inserts
 - delete_by_scope()               — scoped deletion with optional entity/video/language filters
 - get_entities_with_zero_mentions() — entities with no mention rows
 - update_entity_counters()        — refreshes mention_count / video_count on named_entities
+                                    (Feature 044 T009: ASR-error alias exclusion tests added)
 - get_video_entity_summary()      — per-entity aggregation for a video
 - get_entity_video_list()         — paginated video list where an entity is mentioned
 - get_statistics()                — aggregate stats with optional entity_type filter
@@ -24,6 +25,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from sqlalchemy.dialects import postgresql as pg_dialect
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid_utils import uuid7
@@ -780,6 +782,13 @@ class TestUpdateEntityCounters:
     The method runs two UPDATE statements: one to set real counts for entities
     that have mentions, and another to zero-out counts for entities in the list
     that have no remaining mentions.
+
+    Feature 044 (T009) extends this class with tests that verify the ASR-error
+    alias exclusion logic introduced in US2.  The updated method builds a
+    ``visible_names`` subquery that unions canonical names and non-ASR-error
+    aliases; only mentions whose ``mention_text`` matches a visible name count
+    toward ``mention_count`` and ``video_count``.  Entities whose only matches
+    are against ASR-error aliases receive ``mention_count=0``.
     """
 
     @pytest.fixture
@@ -867,6 +876,204 @@ class TestUpdateEntityCounters:
         sql_str = str(first_stmt.compile(compile_kwargs={"literal_binds": False}))
         assert "mention_count" in sql_str
         assert "video_count" in sql_str
+
+    # ------------------------------------------------------------------
+    # T009 — US2: ASR-error alias exclusion from counter logic
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compile_pg_sql(stmt: Any) -> str:
+        """Compile a SQLAlchemy statement to SQL string with the PostgreSQL dialect.
+
+        Uses ``literal_binds=True`` so that enum string values (like
+        ``'asr_error'``) appear literally in the output rather than as
+        ``__[POSTCOMPILE_...]`` placeholders.
+
+        Parameters
+        ----------
+        stmt : Any
+            A SQLAlchemy statement (UPDATE, SELECT, etc.).
+
+        Returns
+        -------
+        str
+            The fully rendered SQL string.
+        """
+        return str(
+            stmt.compile(
+                dialect=pg_dialect.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    async def test_sql_excludes_asr_error_alias_type(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The generated SQL must filter out asr_error aliases from the visible-names set.
+
+        The updated ``update_entity_counters()`` builds a ``visible_names``
+        subquery that unions canonical names with non-ASR-error aliases.  The
+        first UPDATE statement's SQL must reference the ``entity_aliases`` table
+        and the ``asr_error`` string so that mentions matched only against ASR
+        noise forms are excluded from the counter.
+        """
+        entity_id = _uuid()
+
+        mock_result = MagicMock()
+        mock_result.rowcount = 1
+        mock_session.execute.return_value = mock_result
+
+        await repository.update_entity_counters(mock_session, entity_ids=[entity_id])
+
+        first_stmt = mock_session.execute.call_args_list[0].args[0]
+        sql_str = self._compile_pg_sql(first_stmt)
+
+        # The visible-names subquery must JOIN entity_aliases
+        assert "entity_aliases" in sql_str, (
+            "Expected entity_aliases to appear in the counter SQL; "
+            f"got: {sql_str[:500]}"
+        )
+        # The asr_error value must appear as a literal exclusion filter
+        assert "asr_error" in sql_str, (
+            "Expected 'asr_error' exclusion in counter SQL; "
+            f"got: {sql_str[:500]}"
+        )
+
+    async def test_sql_references_named_entities_canonical_name(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The visible-names subquery must include canonical names from named_entities.
+
+        Canonical names count as visible regardless of alias type; the SQL must
+        SELECT from ``named_entities`` (for canonical names) as well as from
+        ``entity_aliases`` (for non-ASR-error aliases).
+        """
+        entity_id = _uuid()
+
+        mock_result = MagicMock()
+        mock_result.rowcount = 1
+        mock_session.execute.return_value = mock_result
+
+        await repository.update_entity_counters(mock_session, entity_ids=[entity_id])
+
+        first_stmt = mock_session.execute.call_args_list[0].args[0]
+        sql_str = self._compile_pg_sql(first_stmt)
+
+        # Both source tables of the visible-names union must appear in the SQL
+        assert "named_entities" in sql_str, (
+            "Expected named_entities to provide canonical name rows; "
+            f"got: {sql_str[:500]}"
+        )
+        assert "entity_aliases" in sql_str, (
+            "Expected entity_aliases to provide non-ASR alias rows; "
+            f"got: {sql_str[:500]}"
+        )
+
+    async def test_second_update_zeros_entities_with_no_visible_mentions(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The second UPDATE must zero-out entities that have no visible-name mentions.
+
+        When an entity's only mentions are matched via ASR-error aliases (and
+        thus excluded from the visible-names join), the second UPDATE statement
+        must set mention_count=0 and video_count=0 for that entity.
+        """
+        entity_id = _uuid()
+
+        mock_result = MagicMock()
+        mock_result.rowcount = 1
+        mock_session.execute.return_value = mock_result
+
+        await repository.update_entity_counters(mock_session, entity_ids=[entity_id])
+
+        # Exactly two UPDATE calls must be made
+        assert mock_session.execute.call_count == 2
+
+        # The second statement must also reference named_entities (zero-out)
+        second_stmt = mock_session.execute.call_args_list[1].args[0]
+        sql_str = str(second_stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "named_entities" in sql_str, (
+            "Second UPDATE (zero-out) must target named_entities; "
+            f"got: {sql_str[:400]}"
+        )
+        # The zero-out branch must still set both counter columns to 0
+        assert "mention_count" in sql_str, (
+            "Zero-out UPDATE must include mention_count; "
+            f"got: {sql_str[:400]}"
+        )
+        assert "video_count" in sql_str, (
+            "Zero-out UPDATE must include video_count; "
+            f"got: {sql_str[:400]}"
+        )
+
+    async def test_visible_names_join_uses_lower_for_case_insensitive_match(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The counter join must be case-insensitive via lower() on mention_text.
+
+        Mentions stored as 'elon musk' must match canonical name 'Elon Musk'
+        because the SQL uses ``lower(mention_text) = lower(name)`` in the join.
+        The compiled SQL must contain the lower() function.
+        """
+        entity_id = _uuid()
+
+        mock_result = MagicMock()
+        mock_result.rowcount = 1
+        mock_session.execute.return_value = mock_result
+
+        await repository.update_entity_counters(mock_session, entity_ids=[entity_id])
+
+        first_stmt = mock_session.execute.call_args_list[0].args[0]
+        sql_str = str(first_stmt.compile(compile_kwargs={"literal_binds": False}))
+
+        assert "lower" in sql_str.lower(), (
+            "Expected lower() function for case-insensitive counter join; "
+            f"got: {sql_str[:400]}"
+        )
+
+    async def test_empty_list_does_not_generate_zero_update(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """With an empty entity_ids list, the zero-out UPDATE must not be issued.
+
+        This is a guard against accidentally running unbounded UPDATE statements
+        when no entities are in scope for counter refresh.
+        """
+        await repository.update_entity_counters(mock_session, entity_ids=[])
+
+        # No SQL at all — not even the zero-out branch
+        mock_session.execute.assert_not_called()
+
+    async def test_multiple_entity_ids_accepted(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Passing multiple entity IDs must still produce exactly two UPDATEs.
+
+        The method batches all entity IDs into a single set of UPDATE statements
+        rather than issuing one pair per entity.
+        """
+        entity_ids = [_uuid() for _ in range(5)]
+
+        mock_result = MagicMock()
+        mock_result.rowcount = 5
+        mock_session.execute.return_value = mock_result
+
+        await repository.update_entity_counters(mock_session, entity_ids=entity_ids)
+
+        # Still exactly two round-trips, not 10 (5 entities × 2)
+        assert mock_session.execute.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/repositories/test_transcript_segment_repository_batch.py
+++ b/tests/unit/repositories/test_transcript_segment_repository_batch.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
 from chronovista.repositories.transcript_segment_repository import (
     TranscriptSegmentRepository,
+    _escape_like_pattern,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -964,3 +965,243 @@ class TestFindCandidateVideoIdsForCrossSegment:
 
         assert isinstance(result, list)
         assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# T005: TestEscapeLikePattern
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeLikePattern:
+    """
+    Unit tests for _escape_like_pattern() helper (T005).
+
+    Verifies that SQL LIKE/ILIKE wildcard characters are correctly escaped
+    so that user-supplied text is treated as a literal substring rather than
+    a pattern containing wildcards.
+    """
+
+    def test_escapes_underscore(self) -> None:
+        """Underscore is escaped to backslash-underscore."""
+        assert _escape_like_pattern("_") == r"\_"
+
+    def test_escapes_percent(self) -> None:
+        """Percent sign is escaped to backslash-percent."""
+        assert _escape_like_pattern("%") == r"\%"
+
+    def test_escapes_backslash(self) -> None:
+        """Backslash is escaped to double-backslash."""
+        assert _escape_like_pattern("\\") == "\\\\"
+
+    def test_combination_all_three_special_chars(self) -> None:
+        """All three special characters appear correctly escaped in a combined string."""
+        result = _escape_like_pattern("100%_value\\path")
+        assert result == "100\\%\\_value\\\\path"
+
+    def test_escape_order_backslash_first(self) -> None:
+        """Backslash must be escaped before percent and underscore.
+
+        If percent were escaped first, a literal backslash followed by
+        a percent would become ``\\%`` (one escape sequence).  Escaping
+        backslash first ensures the already-placed backslash escape
+        character is not double-escaped in a subsequent pass.
+
+        Input: ``\\_`` (backslash then underscore)
+        Expected output: ``\\\\_`` (escaped backslash then escaped underscore)
+        """
+        result = _escape_like_pattern("\\_")
+        # backslash → \\, then underscore → \_  ⟹  \\\_ in escaped form
+        assert result == "\\\\\\_"
+
+    def test_empty_string_returns_empty(self) -> None:
+        """Empty string input returns empty string."""
+        assert _escape_like_pattern("") == ""
+
+    def test_no_special_chars_unchanged(self) -> None:
+        """String with no special characters passes through unchanged."""
+        plain = "hello world"
+        assert _escape_like_pattern(plain) == plain
+
+    def test_multiple_underscores(self) -> None:
+        """Multiple consecutive underscores are all escaped."""
+        result = _escape_like_pattern("__init__")
+        assert result == r"\_\_init\_\_"
+
+    def test_multiple_percent_signs(self) -> None:
+        """Multiple percent signs are all escaped."""
+        result = _escape_like_pattern("100% complete 50%")
+        assert result == "100\\% complete 50\\%"
+
+    def test_mixed_regular_and_special_chars(self) -> None:
+        """Regular characters between special chars are preserved verbatim."""
+        result = _escape_like_pattern("a%b_c\\d")
+        assert result == "a\\%b\\_c\\\\d"
+
+    def test_path_with_backslashes(self) -> None:
+        """Windows-style path with backslashes is correctly escaped."""
+        result = _escape_like_pattern("C:\\Users\\test")
+        assert result == "C:\\\\Users\\\\test"
+
+    def test_returns_str_type(self) -> None:
+        """Return type is always str."""
+        assert isinstance(_escape_like_pattern("any input"), str)
+        assert isinstance(_escape_like_pattern(""), str)
+
+
+# ---------------------------------------------------------------------------
+# T007: TestFindByTextPatternLiteralEscaping
+# ---------------------------------------------------------------------------
+
+
+class TestFindByTextPatternLiteralEscaping:
+    """
+    Unit tests for find_by_text_pattern() literal LIKE escaping (T007).
+
+    Verifies that special SQL LIKE metacharacters in the pattern are escaped
+    before being wrapped in ``%...%`` so that ``_`` and ``%`` are treated as
+    literal characters, not wildcards.
+    """
+
+    @pytest.fixture
+    def repository(self) -> TranscriptSegmentRepository:
+        """Create repository instance for testing."""
+        return TranscriptSegmentRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        """Create mock async session."""
+        return AsyncMock(spec=AsyncSession)
+
+    def _setup_scalars_result(
+        self, mock_session: AsyncMock, segments: List[TranscriptSegmentDB]
+    ) -> None:
+        """Configure mock session to return segments via scalars().all()."""
+        mock_result = MagicMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = segments
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+    async def test_underscore_in_pattern_does_not_act_as_wildcard(
+        self,
+        repository: TranscriptSegmentRepository,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Pattern containing ``_`` is escaped; SQL receives ``\\_`` not bare ``_``.
+
+        We inspect the SQL string passed to session.execute to verify the
+        LIKE pattern uses ``\\_`` (escaped underscore) so PostgreSQL treats
+        it as a literal underscore rather than a single-character wildcard.
+        """
+        self._setup_scalars_result(mock_session, [])
+
+        await repository.find_by_text_pattern(mock_session, pattern="__init__")
+
+        mock_session.execute.assert_called_once()
+        # Retrieve the compiled SQL string from the call argument
+        call_args = mock_session.execute.call_args
+        stmt = call_args[0][0]
+        compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+        sql_str = str(compiled)
+        # The escaped pattern  %\_\_init\_\_% must appear in the SQL
+        assert r"\\_\\_init\\_\\_" in sql_str or r"\_\_init\_\_" in sql_str
+
+    async def test_percent_in_pattern_does_not_act_as_wildcard(
+        self,
+        repository: TranscriptSegmentRepository,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Pattern containing ``%`` is escaped; SQL receives ``\\%`` not bare ``%``.
+
+        Verifies that the generated ILIKE/LIKE pattern contains ``\\%``
+        (escaped percent) instead of a raw ``%`` that would match any text.
+        """
+        self._setup_scalars_result(mock_session, [])
+
+        await repository.find_by_text_pattern(mock_session, pattern="100%")
+
+        mock_session.execute.assert_called_once()
+        call_args = mock_session.execute.call_args
+        stmt = call_args[0][0]
+        compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+        sql_str = str(compiled)
+        # ``100\%`` must appear inside ``%100\%%`` — the percent is escaped
+        assert r"100\%" in sql_str
+
+    async def test_backslash_in_pattern_is_escaped(
+        self,
+        repository: TranscriptSegmentRepository,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Pattern containing ``\\`` is escaped to ``\\\\`` in the SQL pattern."""
+        self._setup_scalars_result(mock_session, [])
+
+        await repository.find_by_text_pattern(mock_session, pattern="C:\\path")
+
+        mock_session.execute.assert_called_once()
+        call_args = mock_session.execute.call_args
+        stmt = call_args[0][0]
+        compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+        sql_str = str(compiled)
+        # The backslash in "C:\path" must be escaped to "\\" before the LIKE wrapping
+        assert "C:\\\\" in sql_str or "C:\\\\path" in sql_str
+
+    async def test_combined_special_chars_all_escaped(
+        self,
+        repository: TranscriptSegmentRepository,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Pattern with multiple special chars has all of them escaped in SQL."""
+        self._setup_scalars_result(mock_session, [])
+
+        await repository.find_by_text_pattern(mock_session, pattern="100%_value")
+
+        mock_session.execute.assert_called_once()
+        call_args = mock_session.execute.call_args
+        stmt = call_args[0][0]
+        compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+        sql_str = str(compiled)
+        # Both wildcards must be escaped
+        assert r"100\%" in sql_str
+        assert r"\_value" in sql_str
+
+    async def test_literal_mode_returns_results_from_session(
+        self,
+        repository: TranscriptSegmentRepository,
+        mock_session: AsyncMock,
+    ) -> None:
+        """find_by_text_pattern in literal mode returns mock-provided segments."""
+        segment = _make_segment(text="test_value 100% done")
+        self._setup_scalars_result(mock_session, [segment])
+
+        result = await repository.find_by_text_pattern(
+            mock_session, pattern="test_value 100% done"
+        )
+
+        assert len(result) == 1
+        assert result[0].text == "test_value 100% done"
+        mock_session.execute.assert_called_once()
+
+    async def test_regex_mode_does_not_escape_pattern(
+        self,
+        repository: TranscriptSegmentRepository,
+        mock_session: AsyncMock,
+    ) -> None:
+        """In regex mode, ``_`` and ``%`` are NOT escaped (no escaping for regex)."""
+        self._setup_scalars_result(mock_session, [])
+
+        # A valid regex containing special LIKE chars
+        await repository.find_by_text_pattern(
+            mock_session, pattern=r"\d{3}%", regex=True
+        )
+
+        mock_session.execute.assert_called_once()
+        call_args = mock_session.execute.call_args
+        stmt = call_args[0][0]
+        compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+        sql_str = str(compiled)
+        # In regex mode, the pattern is passed directly to the ~ operator
+        # The ``%`` should appear un-escaped (no ``\%``) in the raw regex branch
+        # We simply verify the query executed without error — the regex branch
+        # does not call _escape_like_pattern
+        assert "%" in sql_str  # raw percent present in regex pattern

--- a/tests/unit/services/test_entity_mention_scan_service.py
+++ b/tests/unit/services/test_entity_mention_scan_service.py
@@ -16,8 +16,10 @@ All tests cover:
 - New entities only (zero-mention filter)
 - ScanResult field population
 - Failed batch handling (counted, scan continues)
+- ASR-error alias filtering delegation to repository (Feature 044 T010)
 
 Feature 038 -- Entity Mention Detection (T015)
+Feature 044 -- Data Accuracy & Search Reliability (T010)
 """
 
 from __future__ import annotations
@@ -975,6 +977,142 @@ class TestCounterUpdate:
         svc._mention_repo.update_entity_counters.assert_not_called()
         svc._mention_repo.update_alias_counters.assert_not_called()
 
+    # ------------------------------------------------------------------
+    # T010 — US2: Verify delegation of ASR filtering to repository
+    # ------------------------------------------------------------------
+
+    async def test_update_entity_counters_receives_all_matched_entity_ids(
+        self,
+    ) -> None:
+        """The service passes ALL matched entity IDs to update_entity_counters.
+
+        The ASR-error alias filtering is entirely the repository's
+        responsibility (Feature 044 T008).  The scan service must pass every
+        entity that produced at least one mention row — including those whose
+        mentions may later be filtered out by the repository.  This test
+        verifies that the service does not pre-filter entity IDs before
+        delegating to the repository.
+        """
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
+        from chronovista.models.entity_mention import EntityMentionCreate
+        from chronovista.models.enums import DetectionMethod
+
+        entity_id_a = _make_uuid()
+        entity_id_b = _make_uuid()
+
+        fake_patterns = [
+            _EntityPattern(
+                entity_id=entity_id_a,
+                canonical_name="VisibleEntity",
+                entity_type="organization",
+                pg_pattern=re.escape("VisibleEntity"),
+                alias_names=["VisibleEntity"],
+            ),
+            _EntityPattern(
+                entity_id=entity_id_b,
+                canonical_name="ASROnlyEntity",
+                entity_type="organization",
+                pg_pattern=re.escape("asronlyform"),
+                alias_names=["asronlyform"],
+            ),
+        ]
+
+        session = AsyncMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        # Two mentions: one for each entity
+        mentions = [
+            EntityMentionCreate(
+                entity_id=entity_id_a,
+                segment_id=1,
+                video_id="dQw4w9WgXcQ",
+                language_code="en",
+                mention_text="VisibleEntity",
+                detection_method=DetectionMethod.RULE_MATCH,
+                confidence=1.0,
+            ),
+            EntityMentionCreate(
+                entity_id=entity_id_b,
+                segment_id=2,
+                video_id="dQw4w9WgXcQ",
+                language_code="en",
+                mention_text="asronlyform",
+                detection_method=DetectionMethod.RULE_MATCH,
+                confidence=1.0,
+            ),
+        ]
+
+        svc._mention_repo.bulk_create_with_conflict_skip = AsyncMock(return_value=2)
+        svc._mention_repo.update_entity_counters = AsyncMock()
+        svc._mention_repo.update_alias_counters = AsyncMock()
+        with (
+            patch.object(svc, "_load_entity_patterns", return_value=fake_patterns),
+            patch.object(svc, "_fetch_segment_batch", side_effect=[[_make_segment_row()], []]),
+            patch.object(svc, "_scan_batch", return_value=(mentions, 0, [], 0, 0)),
+        ):
+            await svc.scan(dry_run=False)
+
+        svc._mention_repo.update_entity_counters.assert_called_once()
+        passed_entity_ids = svc._mention_repo.update_entity_counters.call_args[0][1]
+
+        # Both entities (including the ASR-only one) must be passed to the
+        # repository so the repository can apply its own ASR filtering.
+        assert entity_id_a in passed_entity_ids, (
+            "entity_id_a (visible name) must be in the update_entity_counters call"
+        )
+        assert entity_id_b in passed_entity_ids, (
+            "entity_id_b (ASR-alias-only) must also be passed to update_entity_counters "
+            "so the repository can zero it out if it has no visible-name mentions"
+        )
+
+    async def test_update_entity_counters_not_called_when_zero_inserts(
+        self,
+    ) -> None:
+        """When bulk_create_with_conflict_skip returns 0, counters are not updated.
+
+        If no new mention rows were actually inserted (all were conflicts),
+        the scan service must not call update_entity_counters, because the
+        matched_entity_ids set will be empty (no new matches contributed).
+
+        This preserves existing behaviour for the no-new-matches path.
+        """
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
+
+        entity_id = _make_uuid()
+        fake_pattern = _EntityPattern(
+            entity_id=entity_id,
+            canonical_name="NoNewMatch",
+            entity_type="person",
+            pg_pattern=re.escape("NoNewMatch"),
+            alias_names=["NoNewMatch"],
+        )
+
+        session = AsyncMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        svc._mention_repo.bulk_create_with_conflict_skip = AsyncMock(return_value=0)
+        svc._mention_repo.update_entity_counters = AsyncMock()
+        svc._mention_repo.update_alias_counters = AsyncMock()
+        with (
+            patch.object(svc, "_load_entity_patterns", return_value=[fake_pattern]),
+            patch.object(svc, "_fetch_segment_batch", side_effect=[[_make_segment_row()], []]),
+            # _scan_batch returns empty list → matched_entity_ids stays empty
+            patch.object(svc, "_scan_batch", return_value=([], 0, [], 0, 0)),
+        ):
+            await svc.scan(dry_run=False)
+
+        svc._mention_repo.update_entity_counters.assert_not_called()
+        svc._mention_repo.update_alias_counters.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # TestDryRunMode
 # ---------------------------------------------------------------------------
@@ -1607,3 +1745,311 @@ class TestProgressCallback:
             await svc.scan(progress_callback=callback)
 
         assert len(callback_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestAuditUnregisteredMentions  (T014 — Feature 044, US3)
+# ---------------------------------------------------------------------------
+
+
+def _make_audit_row(
+    canonical_name: str,
+    entity_id: uuid.UUID,
+    mention_text: str,
+    segment_count: int,
+) -> MagicMock:
+    """Create a mock SQLAlchemy Row for audit_unregistered_mentions results.
+
+    The service accesses attributes by name (``row.canonical_name``, etc.),
+    so a MagicMock with those attributes set directly is sufficient.
+    """
+    row = MagicMock()
+    row.canonical_name = canonical_name
+    row.entity_id = entity_id
+    row.mention_text = mention_text
+    row.segment_count = segment_count
+    return row
+
+
+class TestAuditUnregisteredMentions:
+    """Unit tests for EntityMentionScanService.audit_unregistered_mentions().
+
+    The method opens its own session via ``_session_factory``, executes a
+    single compound SELECT, and returns a list of 4-tuples.  These tests mock
+    the session and ``session.execute`` to inject canned query results without
+    touching the database.
+
+    Covered scenarios
+    -----------------
+    (a) Returns unmatched mention texts.
+    (b) Excludes matches against canonical name (case-insensitive) — the
+        query WHERE clause filters them out; simulated by returning no rows
+        for those cases.
+    (c) Excludes matches against registered aliases (case-insensitive) —
+        same mechanism as (b).
+    (d) Skips non-active entities — the WHERE clause filters ``status !=
+        'active'``; simulated by the query returning nothing for those rows.
+    (e) Returns empty list when all mentions match an alias or canonical name.
+    (f) Groups by entity and mention_text with correct segment counts.
+    """
+
+    # ------------------------------------------------------------------
+    # (a) Returns unmatched mention texts
+    # ------------------------------------------------------------------
+
+    async def test_returns_unmatched_mention_texts(self) -> None:
+        """audit_unregistered_mentions returns rows that have no alias match.
+
+        When the query finds a mention whose text does not match any alias
+        or canonical name, the tuple ``(canonical_name, entity_id,
+        mention_text, segment_count)`` must appear in the result.
+        """
+        entity_id = _make_uuid()
+        raw_row = _make_audit_row(
+            canonical_name="Noam Chomsky",
+            entity_id=entity_id,
+            mention_text="chomsky",
+            segment_count=3,
+        )
+
+        session = AsyncMock()
+        query_result = MagicMock()
+        query_result.all.return_value = [raw_row]
+        session.execute = AsyncMock(return_value=query_result)
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        results = await svc.audit_unregistered_mentions()
+
+        assert len(results) == 1
+        canonical, eid, text, count = results[0]
+        assert canonical == "Noam Chomsky"
+        assert eid == entity_id
+        assert text == "chomsky"
+        assert count == 3
+
+    # ------------------------------------------------------------------
+    # (b) Excludes matches against canonical name (case-insensitive)
+    # ------------------------------------------------------------------
+
+    async def test_excludes_canonical_name_matches(self) -> None:
+        """When mention_text equals canonical_name (any case), no row is returned.
+
+        The SQL WHERE clause ``func.lower(mention_text) !=
+        func.lower(canonical_name)`` filters these out before rows reach
+        Python.  We simulate this by the mock returning an empty result set,
+        matching the real database behavior.
+        """
+        session = AsyncMock()
+        query_result = MagicMock()
+        # The query itself excludes canonical-name matches — simulate empty result
+        query_result.all.return_value = []
+        session.execute = AsyncMock(return_value=query_result)
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        results = await svc.audit_unregistered_mentions()
+
+        assert results == []
+
+    # ------------------------------------------------------------------
+    # (c) Excludes matches against registered aliases (case-insensitive)
+    # ------------------------------------------------------------------
+
+    async def test_excludes_registered_alias_matches(self) -> None:
+        """When mention_text matches an alias (any case), no row is returned.
+
+        The SQL LEFT JOIN on ``EntityAliasDB`` and WHERE
+        ``EntityAliasDB.id.is_(None)`` ensures rows with a matching alias
+        are filtered out.  Simulated by returning an empty result.
+        """
+        session = AsyncMock()
+        query_result = MagicMock()
+        query_result.all.return_value = []
+        session.execute = AsyncMock(return_value=query_result)
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        results = await svc.audit_unregistered_mentions()
+
+        assert results == []
+
+    # ------------------------------------------------------------------
+    # (d) Skips non-active entities
+    # ------------------------------------------------------------------
+
+    async def test_skips_non_active_entities(self) -> None:
+        """Mentions for inactive entities must not appear in audit results.
+
+        The SQL WHERE clause ``NamedEntityDB.status == 'active'`` removes
+        inactive entities before grouping.  Simulated by the mock returning
+        an empty result when only inactive entity rows exist.
+        """
+        session = AsyncMock()
+        query_result = MagicMock()
+        # Non-active entity's row is filtered by the WHERE clause → empty
+        query_result.all.return_value = []
+        session.execute = AsyncMock(return_value=query_result)
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        results = await svc.audit_unregistered_mentions()
+
+        assert results == []
+
+    # ------------------------------------------------------------------
+    # (e) Returns empty list when all mentions match
+    # ------------------------------------------------------------------
+
+    async def test_returns_empty_when_all_mentions_match(self) -> None:
+        """When every user-correction mention matches an alias or canonical name,
+        the result list must be empty.
+        """
+        session = AsyncMock()
+        query_result = MagicMock()
+        query_result.all.return_value = []
+        session.execute = AsyncMock(return_value=query_result)
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        results = await svc.audit_unregistered_mentions()
+
+        assert results == []
+        assert isinstance(results, list)
+
+    # ------------------------------------------------------------------
+    # (f) Groups by entity and mention_text with correct segment counts
+    # ------------------------------------------------------------------
+
+    async def test_groups_by_entity_and_mention_text_with_segment_count(self) -> None:
+        """Multiple unregistered texts for the same entity each appear as
+        separate tuples with their own segment_count.
+        """
+        entity_id_a = _make_uuid()
+        entity_id_b = _make_uuid()
+
+        row1 = _make_audit_row("Ada Lovelace", entity_id_a, "lovelace", 5)
+        row2 = _make_audit_row("Ada Lovelace", entity_id_a, "ada", 2)
+        row3 = _make_audit_row("Alan Turing", entity_id_b, "turing", 8)
+
+        session = AsyncMock()
+        query_result = MagicMock()
+        query_result.all.return_value = [row1, row2, row3]
+        session.execute = AsyncMock(return_value=query_result)
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        results = await svc.audit_unregistered_mentions()
+
+        assert len(results) == 3
+
+        # Verify tuples for Ada Lovelace rows
+        ada_rows = [r for r in results if r[0] == "Ada Lovelace"]
+        assert len(ada_rows) == 2
+        ada_texts = {r[2] for r in ada_rows}
+        assert "lovelace" in ada_texts
+        assert "ada" in ada_texts
+
+        # Verify segment counts are preserved as returned by the query
+        lovelace_row = next(r for r in ada_rows if r[2] == "lovelace")
+        assert lovelace_row[3] == 5
+
+        # Verify Alan Turing row
+        turing_rows = [r for r in results if r[0] == "Alan Turing"]
+        assert len(turing_rows) == 1
+        assert turing_rows[0][1] == entity_id_b
+        assert turing_rows[0][3] == 8
+
+    async def test_result_tuple_fields_in_correct_order(self) -> None:
+        """Each result tuple must be (canonical_name, entity_id, mention_text,
+        segment_count) in that field order.
+        """
+        entity_id = _make_uuid()
+        raw_row = _make_audit_row(
+            canonical_name="Marie Curie",
+            entity_id=entity_id,
+            mention_text="curie",
+            segment_count=11,
+        )
+
+        session = AsyncMock()
+        query_result = MagicMock()
+        query_result.all.return_value = [raw_row]
+        session.execute = AsyncMock(return_value=query_result)
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        results = await svc.audit_unregistered_mentions()
+
+        assert len(results) == 1
+        # Positional field verification
+        assert results[0][0] == "Marie Curie"     # canonical_name
+        assert results[0][1] == entity_id          # entity_id
+        assert results[0][2] == "curie"            # mention_text
+        assert results[0][3] == 11                 # segment_count
+
+    async def test_execute_called_exactly_once(self) -> None:
+        """The method must issue exactly one database query per invocation."""
+        session = AsyncMock()
+        query_result = MagicMock()
+        query_result.all.return_value = []
+        session.execute = AsyncMock(return_value=query_result)
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        await svc.audit_unregistered_mentions()
+
+        session.execute.assert_called_once()
+
+    async def test_returns_multiple_entities_in_any_order(self) -> None:
+        """Multiple distinct entities each appear with their mention text and
+        segment_count; ordering is determined by SQL ORDER BY.
+        """
+        eid1 = _make_uuid()
+        eid2 = _make_uuid()
+
+        row1 = _make_audit_row("Bertrand Russell", eid1, "russell", 4)
+        row2 = _make_audit_row("Bertrand Russell", eid1, "b. russell", 1)
+        row3 = _make_audit_row("Ludwig Wittgenstein", eid2, "wittgenstein", 7)
+
+        session = AsyncMock()
+        query_result = MagicMock()
+        query_result.all.return_value = [row1, row2, row3]
+        session.execute = AsyncMock(return_value=query_result)
+
+        factory = _make_session_factory(session)
+        svc = _build_service(factory)
+
+        results = await svc.audit_unregistered_mentions()
+
+        assert len(results) == 3
+        entity_names = {r[0] for r in results}
+        assert "Bertrand Russell" in entity_names
+        assert "Ludwig Wittgenstein" in entity_names
+
+    async def test_session_context_manager_entered_and_exited(self) -> None:
+        """The method must open and close the session via __aenter__/__aexit__."""
+        session = AsyncMock()
+        query_result = MagicMock()
+        query_result.all.return_value = []
+        session.execute = AsyncMock(return_value=query_result)
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=session)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        factory = MagicMock(return_value=cm)
+        svc = _build_service(factory)
+
+        await svc.audit_unregistered_mentions()
+
+        cm.__aenter__.assert_called_once()
+        cm.__aexit__.assert_called_once()


### PR DESCRIPTION
## Summary

- **Special Character Search Fix (#84)**: Escape ILIKE wildcards (`_`, `%`, `\`) for literal matching in search and batch find-replace; treat multi-word queries as contiguous phrases instead of splitting by whitespace; reject NULL bytes in search queries
- **Entity Mention Count Accuracy (#89)**: Filter `update_entity_counters()` by visible names only (canonical + non-ASR-error aliases via `union_all` JOIN); `mention_count` and `video_count` now exclude ASR-error-matched mentions; `has_mentions` filter aligned with visible alias data
- **Entity Scan Audit Mode (#87)**: New `--audit` flag on `entities scan` reports user-correction mentions with unregistered text forms in a Rich table with alias registration suggestions

## Changes

**Files modified (source):**
- `src/chronovista/api/routers/search.py` — phrase matching fix + NULL byte validation
- `src/chronovista/repositories/transcript_segment_repository.py` — `_escape_like_pattern()` helper + `find_by_text_pattern()` escaping
- `src/chronovista/repositories/entity_mention_repository.py` — `update_entity_counters()` visible-name filtering
- `src/chronovista/services/entity_mention_scan_service.py` — `audit_unregistered_mentions()` method
- `src/chronovista/cli/entity_commands.py` — `--audit` flag on `scan_entities`

**Files created (tests):**
- `tests/unit/api/test_search.py` (25 tests)
- `tests/unit/cli/test_entity_commands.py` (12 tests)

**Files modified (tests):**
- `tests/unit/repositories/test_transcript_segment_repository_batch.py` (+18 tests)
- `tests/unit/repositories/test_entity_mention_repository.py` (+6 tests)
- `tests/unit/services/test_entity_mention_scan_service.py` (+12 tests)
- `tests/integration/services/test_entity_mention_scan_integration.py` (+6 tests)

**18 files changed, +2,295 / -43 lines. 79 new tests. No new dependencies. No schema changes. No migrations.**

## Test plan

- [x] All 5,570 unit tests pass (0 failures)
- [x] All 25 integration tests pass
- [x] Search for `[ __ ]` returns exact literal matches (4 segments)
- [x] Batch find-replace literal mode escapes special characters correctly
- [x] Entity `mention_count` matches sum of visible alias `occurrence_count` values
- [x] `entities scan --audit` runs clean with no unregistered mentions
- [x] `--audit --full` correctly rejected as mutually exclusive
- [x] NULL byte in search query returns 400 Bad Request

Closes #84, Closes #89, Closes #87