### PR TITLE
feat(corrections): correction intelligence frontend (Feature 046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.47.0] - 2026-03-18
+
+### Added
+- **Feature 046: Correction Intelligence Frontend**
+  - **Batch History Page (US1)**: New `/corrections/batch/history` route with paginated list of past batch operations showing pattern, replacement, correction count, actor, and timestamp; "Revert" button with confirmation dialog calling `DELETE /api/v1/corrections/batch/{batch_id}`; pagination with offset/limit and `has_more` flag; TanStack Query cache invalidation on successful revert; user-friendly error messages for 404 (batch not found) and 409 (already reverted); empty state when no batches exist; `useBatchHistory` hook with infinite scroll (GitHub #92)
+  - **Cross-Segment Discovery UI (US2)**: `GET /api/v1/corrections/cross-segment/candidates` endpoint wrapping existing `CrossSegmentDiscovery.discover()` service; "Suggested Cross-Segment Candidates" collapsible panel on `/corrections/batch` page with ranked candidate cards showing both segment texts, proposed correction, source pattern, confidence score, and partial-correction badge; clicking a candidate pre-fills the find-replace form and auto-collapses the panel; loading skeleton, error state, empty state; `useCrossSegmentCandidates` hook (GitHub #91)
+  - **Word-Level Diff Analysis Dashboard (US3)**: `GET /api/v1/corrections/diff-analysis` endpoint wrapping existing `DiffAnalysisService`; ASR Error Patterns page at `/corrections/diff-analysis` with sortable table (frequency column), client-side error token filter, server-side entity name filter (debounced 300ms), "Show completed" toggle; entity column linked to entity detail page; "Find & Replace" action navigates to batch corrections page with `\b` word-boundary regex pattern pre-filled and regex mode enabled; completed rows show disabled "Completed" badge; `useDiffAnalysis` hook (GitHub #93)
+  - **Phonetic ASR Variant Suggestions (US4)**: `GET /api/v1/entities/{entity_id}/phonetic-matches` endpoint wrapping existing `PhoneticMatcher` service; "Suspected ASR Variants" lazy-loaded collapsible section on entity detail page; results table showing original text, proposed correction, confidence score, evidence type, video title, and segment link; "Register as Alias" button (calls existing alias creation API) and "Find & Replace" button (navigates to batch corrections with regex pattern pre-filled); confidence threshold slider (default 0.5); `usePhoneticMatches` hook (GitHub #94)
+  - **Sidebar Navigation Restructure**: Collapsible "Transcripts" nav group in sidebar containing Search, Find & Replace, Batch History, ASR Error Patterns, and Language Preferences; `NavGroup` component with expand/collapse animation and `aria-expanded` accessibility; sidebar icons for new routes (`ChartBarIcon`, `ClockIcon`, `TranscriptsIcon`)
+
+### Fixed
+- **Entity Mention Scan False Positives**: `_load_entity_patterns()` now excludes `asr_error` aliases from scan patterns — previously included ASR error alias text (e.g., "Bonazo") in regex patterns, creating 917 false `rule_match` mentions across 24 entities
+- **Entity Video List Count Inconsistency**: `get_entity_video_list()` now applies visible-names filter (canonical name + non-ASR-error aliases) so video count and mention count are consistent in the entity detail page header — previously showed impossible stats like "2 mentions, 3 videos"
+- **Cross-Segment Stopword False Positives**: Added stopword filtering to `CrossSegmentDiscovery` — common English function word splits like "be out" (from "Rick Beato") no longer generate spurious cross-segment candidates
+- **ASR Alias Quality Gates**: `is_valid_asr_alias()` gate in `asr_alias_registry.py` rejects aliases shorter than 4 characters or consisting entirely of common English function words; applied to both full-string and sub-token alias registration; deleted "be out" alias and 51 associated false entity mentions for Rick Beato
+- **DiffAnalysis Filter Alignment**: Fixed vertical misalignment between "Filter by error token" and "Filter by entity name" inputs on ASR Error Patterns page
+
+### Technical
+- 3 new API endpoints: cross-segment candidates, diff analysis, phonetic matches
+- 6 new React pages/components: `BatchHistoryPage`, `DiffAnalysisPage`, `CrossSegmentPanel`, `NavGroup`, phonetic matches section on `EntityDetailPage`
+- 5 new TanStack Query hooks: `useBatchHistory`, `useCrossSegmentCandidates`, `useDiffAnalysis`, `usePhoneticMatches`, `useBatchApply` (enhanced)
+- 8 new backend tests for ASR alias exclusion and entity video list filtering
+- 7 new tests for cross-segment stopword filtering
+- 15 new tests for ASR alias quality gates
+- Frontend version: 0.15.0 → 0.16.0
+- mypy strict compliance (0 errors)
+- TypeScript strict mode (0 errors)
+- No new dependencies, no new database migrations
+
 ## [0.46.0] - 2026-03-15
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.47.0] - 2026-03-18
+
+### Added
+- **Feature 046: Correction Intelligence Frontend**
+  - **Batch History Page (US1)**: New `/corrections/batch/history` route with paginated list of past batch operations showing pattern, replacement, correction count, actor, and timestamp; "Revert" button with confirmation dialog calling `DELETE /api/v1/corrections/batch/{batch_id}`; pagination with offset/limit and `has_more` flag; TanStack Query cache invalidation on successful revert; user-friendly error messages for 404 (batch not found) and 409 (already reverted); empty state when no batches exist; `useBatchHistory` hook with infinite scroll (GitHub #92)
+  - **Cross-Segment Discovery UI (US2)**: `GET /api/v1/corrections/cross-segment/candidates` endpoint wrapping existing `CrossSegmentDiscovery.discover()` service; "Suggested Cross-Segment Candidates" collapsible panel on `/corrections/batch` page with ranked candidate cards showing both segment texts, proposed correction, source pattern, confidence score, and partial-correction badge; clicking a candidate pre-fills the find-replace form and auto-collapses the panel; loading skeleton, error state, empty state; `useCrossSegmentCandidates` hook (GitHub #91)
+  - **Word-Level Diff Analysis Dashboard (US3)**: `GET /api/v1/corrections/diff-analysis` endpoint wrapping existing `DiffAnalysisService`; ASR Error Patterns page at `/corrections/diff-analysis` with sortable table (frequency column), client-side error token filter, server-side entity name filter (debounced 300ms), "Show completed" toggle; entity column linked to entity detail page; "Find & Replace" action navigates to batch corrections page with `\b` word-boundary regex pattern pre-filled and regex mode enabled; completed rows show disabled "Completed" badge; `useDiffAnalysis` hook (GitHub #93)
+  - **Phonetic ASR Variant Suggestions (US4)**: `GET /api/v1/entities/{entity_id}/phonetic-matches` endpoint wrapping existing `PhoneticMatcher` service; "Suspected ASR Variants" lazy-loaded collapsible section on entity detail page; results table showing original text, proposed correction, confidence score, evidence type, video title, and segment link; "Register as Alias" button (calls existing alias creation API) and "Find & Replace" button (navigates to batch corrections with regex pattern pre-filled); confidence threshold slider (default 0.5); `usePhoneticMatches` hook (GitHub #94)
+  - **Sidebar Navigation Restructure**: Collapsible "Transcripts" nav group in sidebar containing Search, Find & Replace, Batch History, ASR Error Patterns, and Language Preferences; `NavGroup` component with expand/collapse animation and `aria-expanded` accessibility; sidebar icons for new routes (`ChartBarIcon`, `ClockIcon`, `TranscriptsIcon`)
+
+### Fixed
+- **Entity Mention Scan False Positives**: `_load_entity_patterns()` now excludes `asr_error` aliases from scan patterns — previously included ASR error alias text (e.g., "Bonazo") in regex patterns, creating 917 false `rule_match` mentions across 24 entities
+- **Entity Video List Count Inconsistency**: `get_entity_video_list()` now applies visible-names filter (canonical name + non-ASR-error aliases) so video count and mention count are consistent in the entity detail page header — previously showed impossible stats like "2 mentions, 3 videos"
+- **Cross-Segment Stopword False Positives**: Added stopword filtering to `CrossSegmentDiscovery` — common English function word splits like "be out" (from "Rick Beato") no longer generate spurious cross-segment candidates
+- **ASR Alias Quality Gates**: `is_valid_asr_alias()` gate in `asr_alias_registry.py` rejects aliases shorter than 4 characters or consisting entirely of common English function words; applied to both full-string and sub-token alias registration; deleted "be out" alias and 51 associated false entity mentions for Rick Beato
+- **DiffAnalysis Filter Alignment**: Fixed vertical misalignment between "Filter by error token" and "Filter by entity name" inputs on ASR Error Patterns page
+
+### Technical
+- 3 new API endpoints: cross-segment candidates, diff analysis, phonetic matches
+- 6 new React pages/components: `BatchHistoryPage`, `DiffAnalysisPage`, `CrossSegmentPanel`, `NavGroup`, phonetic matches section on `EntityDetailPage`
+- 5 new TanStack Query hooks: `useBatchHistory`, `useCrossSegmentCandidates`, `useDiffAnalysis`, `usePhoneticMatches`, `useBatchApply` (enhanced)
+- 8 new backend tests for ASR alias exclusion and entity video list filtering
+- 7 new tests for cross-segment stopword filtering
+- 15 new tests for ASR alias quality gates
+- Frontend version: 0.15.0 → 0.16.0
+- mypy strict compliance (0 errors)
+- TypeScript strict mode (0 errors)
+- No new dependencies, no new database migrations
+
 ## [0.46.0] - 2026-03-15
 
 ### Added

--- a/docs/user-guide/corrections.md
+++ b/docs/user-guide/corrections.md
@@ -440,3 +440,116 @@ To resolve the mismatch, open the entity detail page and add the replacement tex
 #### Entity Linking is Optional
 
 The autocomplete is always optional. You can still type plain replacement text without selecting an entity. Entity linking only applies to the batch corrections page — the inline segment editor does not support it.
+
+---
+
+## Web UI: Batch History
+
+View and manage past batch correction operations at `/corrections/batch/history`.
+
+### Viewing Past Batches
+
+The batch history page shows a paginated list of all batch operations, sorted by most recent first. Each entry displays:
+
+- **Pattern and replacement** used in the batch
+- **Correction count** (number of segments affected)
+- **Actor** who submitted the batch (e.g., `user:batch`)
+- **Timestamp** of when the batch was applied
+
+Pagination controls at the bottom let you navigate through older batches.
+
+### Reverting a Batch
+
+Each batch entry has a **Revert** button that undoes all corrections in that batch atomically. Clicking it reverts every segment to its pre-correction text in a single operation.
+
+| Outcome | Behavior |
+|---------|----------|
+| Success | The batch is fully reverted; a confirmation shows the reverted and skipped counts |
+| Already reverted (409) | An error message indicates the batch has already been fully reverted |
+| Not found (404) | An error message indicates no corrections exist for that batch ID |
+
+---
+
+## Web UI: ASR Error Patterns Dashboard
+
+The diff analysis page at `/corrections/diff-analysis` surfaces recurring ASR misrecognition patterns extracted from your past corrections.
+
+### How It Works
+
+The dashboard aggregates word-level diffs from all previously applied corrections and groups them by error token and canonical (corrected) form. Each row shows:
+
+- **Error token** — the original ASR-produced text (e.g., "Shane Baum")
+- **Canonical form** — the corrected text (e.g., "Sheinbaum")
+- **Frequency** — how many times this specific correction has been applied
+- **Remaining matches** — how many un-corrected instances of the error token still exist in your transcripts
+- **Entity association** — if the canonical form matches a named entity, the entity name is shown
+
+### Sorting and Filtering
+
+- Results are sorted by **remaining matches** descending, so actionable patterns appear first
+- **Client-side filter**: type in the search box to filter rows by error token text (instant, no server request)
+- **Server-side filter**: filter by entity name using the entity filter input (debounced — waits for you to stop typing before querying the server via the `entityName` query parameter)
+- **"Show completed" toggle**: when off, patterns with zero remaining matches are hidden; when on, all patterns are shown (including fully corrected ones)
+
+### Find & Replace Action
+
+Each row has a **Find & Replace** button that navigates to the batch corrections page (`/corrections/batch`) and pre-fills the form with:
+
+- The error token as the search pattern
+- The canonical form as the replacement
+- Regex mode enabled with `\b` word boundaries wrapping the pattern (e.g., `\bShane Baum\b`)
+
+This lets you quickly apply a known correction pattern to all remaining instances.
+
+---
+
+## Web UI: Cross-Segment Candidates Panel
+
+The Find & Replace page (`/corrections/batch`) includes a collapsible **Cross-Segment Candidates** panel that shows AI-suggested corrections for names split across adjacent transcript segments.
+
+### How It Works
+
+Candidates are discovered by analyzing your existing correction history. When the system finds a recurring correction pattern (e.g., "Shane Bound" corrected to "Sheinbaum" at least 3 times), it scans for uncorrected segment pairs where that same error is split across a boundary.
+
+Each candidate shows:
+
+- **Segment pair text** — the text of both adjacent segments
+- **Proposed correction** — the corrected form derived from the pattern
+- **Source pattern** — the original error text that was matched
+- **Confidence score** — how likely the match is correct (0.0 to 1.0)
+- **Partially corrected flag** — whether one of the two segments already has a correction
+
+### Using Candidates
+
+- Click a candidate to **pre-fill the find-replace form** with the source pattern and proposed correction, with cross-segment mode enabled
+- The panel **auto-collapses** when you click Preview to run a search, keeping the focus on your results
+- Expand the panel again at any time to browse other candidates
+
+---
+
+## Phonetic ASR Variant Suggestions
+
+The entity detail page includes a collapsible **Phonetic ASR Variants** section that helps you discover transcript text that may be a phonetic misrecognition of the entity's name.
+
+### How It Works
+
+The system scans transcript segments from videos where the entity is mentioned, extracts N-grams, and scores them against the entity's canonical name and aliases using phonetic similarity algorithms (Soundex, Metaphone). Results are lazy-loaded when you expand the section.
+
+Each suggested variant shows:
+
+- **Original text** — the N-gram from the transcript that looks like a phonetic match
+- **Proposed correction** — the entity name (or alias) it likely represents
+- **Confidence score** — a weighted score between 0.0 and 1.0
+- **Evidence description** — a human-readable explanation of why the match was flagged
+- **Video title** — the video where the variant was found
+
+### Confidence Threshold
+
+A slider lets you adjust the minimum confidence threshold (default 0.5). Lower values show more results with more false positives; higher values show fewer, more confident matches.
+
+### Actions
+
+Each variant has two action buttons:
+
+- **Register as Alias** — adds the original text as a new alias on the entity, so future `entities scan` runs will detect it automatically
+- **Find & Replace** — navigates to the batch corrections page with the original text as the search pattern and the proposed correction as the replacement, with regex mode and `\b` word boundaries enabled

--- a/docs/user-guide/rest-api.md
+++ b/docs/user-guide/rest-api.md
@@ -1414,6 +1414,143 @@ POST /api/v1/corrections/batch/apply
 !!! info "Explicit Inclusion List"
     The apply endpoint accepts an explicit `segment_ids` inclusion list (not an exclusion list). This ensures the user confirms exactly what gets corrected, even if database state changed between preview and apply.
 
+#### List Batch Groups
+
+Retrieve a paginated list of past batch correction operations, sorted by most recent first.
+
+```
+GET /api/v1/corrections/batch/batches
+```
+
+##### Query Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `offset` | integer | Number of rows to skip | 0 |
+| `limit` | integer | Maximum rows to return (1-100) | 20 |
+| `corrected_by_user_id` | string | Filter by user/actor ID | - |
+
+##### Response (200 OK)
+
+```json
+{
+  "data": [
+    {
+      "batch_id": "01936c8a-...",
+      "correction_count": 12,
+      "corrected_by_user_id": "user:batch",
+      "pattern": "amlo",
+      "replacement": "AMLO",
+      "batch_timestamp": "2026-03-15T10:30:00Z"
+    }
+  ],
+  "pagination": {
+    "total": 45,
+    "limit": 20,
+    "offset": 0,
+    "has_more": true
+  }
+}
+```
+
+#### Revert a Batch
+
+Atomically revert all corrections belonging to a specific batch.
+
+```
+DELETE /api/v1/corrections/batch/{batch_id}
+```
+
+##### Response (200 OK)
+
+```json
+{
+  "data": {
+    "reverted_count": 12,
+    "skipped_count": 0
+  }
+}
+```
+
+| Status | Description |
+|--------|-------------|
+| 404 | No corrections exist for the given batch ID |
+| 409 | All corrections in the batch have already been reverted |
+
+#### Get ASR Error Patterns (Diff Analysis)
+
+Retrieve recurring word-level ASR error patterns extracted from past corrections, enriched with entity associations.
+
+```
+GET /api/v1/corrections/batch/diff-analysis
+```
+
+##### Query Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `min_occurrences` | integer | Minimum occurrences for a pattern to appear (1-50) | 2 |
+| `limit` | integer | Maximum patterns to return (1-500) | 100 |
+| `show_completed` | boolean | Include patterns with no remaining un-corrected matches | true |
+| `entity_name` | string | Filter to patterns whose matched entity name contains this string (case-insensitive) | - |
+
+##### Response (200 OK)
+
+```json
+{
+  "data": [
+    {
+      "error_token": "Shane Baum",
+      "canonical_form": "Sheinbaum",
+      "frequency": 14,
+      "remaining_matches": 23,
+      "entity_id": "01936c8a-...",
+      "entity_name": "Claudia Sheinbaum"
+    }
+  ]
+}
+```
+
+Results are sorted by `remaining_matches` descending so actionable patterns appear first. The `entity_id` and `entity_name` fields are `null` when no named entity matches the canonical form.
+
+#### Get Cross-Segment Candidates
+
+Discover adjacent segment pairs where a known ASR error is split across a boundary, based on recurring correction patterns.
+
+```
+GET /api/v1/corrections/batch/cross-segment/candidates
+```
+
+##### Query Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `min_corrections` | integer | Minimum correction occurrences for a pattern to be considered (1-20) | 3 |
+| `entity_name` | string | Only consider patterns related to this entity name | - |
+
+##### Response (200 OK)
+
+```json
+{
+  "data": [
+    {
+      "segment_n_id": 934,
+      "segment_n_text": "...una entrevista, Claudia Shane",
+      "segment_n1_id": 935,
+      "segment_n1_text": "Bound también siendo candidata...",
+      "proposed_correction": "Sheinbaum",
+      "source_pattern": "Shane Bound",
+      "confidence": 0.85,
+      "is_partially_corrected": false,
+      "video_id": "JIMXfrMtHas",
+      "discovery_source": "correction_pattern"
+    }
+  ]
+}
+```
+
+Each candidate includes the text of both segments, the proposed corrected form, the original error pattern, and a confidence score between 0.0 and 1.0.
+
 #### Rebuild Transcript Text
 
 Re-concatenate segment text to rebuild the full `transcript_text` for specified videos.
@@ -1624,6 +1761,46 @@ Valid alias types: `name_variant`, `abbreviation`, `nickname`, `translated_name`
 |--------|-------------|
 | 404 | Entity not found |
 | 409 | Alias already exists |
+
+---
+
+#### Get Phonetic ASR Variants
+
+Find suspected phonetic ASR misrecognitions of an entity's name by scanning transcript segments from videos where the entity is mentioned.
+
+```
+GET /api/v1/entities/{entity_id}/phonetic-matches
+```
+
+##### Query Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `threshold` | float | Minimum confidence score to include a match (0.0-1.0) | 0.5 |
+
+##### Response (200 OK)
+
+```json
+{
+  "data": [
+    {
+      "original_text": "Shane Baum",
+      "proposed_correction": "Sheinbaum",
+      "confidence": 0.78,
+      "evidence_description": "Phonetic similarity via Soundex + Metaphone",
+      "video_id": "JIMXfrMtHas",
+      "segment_id": 934,
+      "video_title": "Interview with President Sheinbaum"
+    }
+  ]
+}
+```
+
+Each match includes the original transcript N-gram, the entity name it likely represents, a confidence score, and the video/segment location. The `video_title` field is enriched from the videos table.
+
+| Status | Description |
+|--------|-------------|
+| 404 | Entity not found |
 
 ---
 
@@ -2318,6 +2495,24 @@ curl -X POST "http://localhost:8000/api/v1/corrections/batch/apply" \
 curl -X POST "http://localhost:8000/api/v1/corrections/batch/rebuild-text" \
   -H "Content-Type: application/json" \
   -d '{"video_ids": ["dQw4w9WgXcQ"]}'
+
+# List batch history
+curl "http://localhost:8000/api/v1/corrections/batch/batches?limit=10"
+
+# Revert an entire batch
+curl -X DELETE "http://localhost:8000/api/v1/corrections/batch/01936c8a-1234-7000-8000-000000000001"
+
+# Get ASR error patterns (diff analysis)
+curl "http://localhost:8000/api/v1/corrections/batch/diff-analysis?show_completed=false"
+
+# Filter error patterns by entity name
+curl "http://localhost:8000/api/v1/corrections/batch/diff-analysis?entity_name=Sheinbaum"
+
+# Get cross-segment correction candidates
+curl "http://localhost:8000/api/v1/corrections/batch/cross-segment/candidates?min_corrections=3"
+
+# Get phonetic ASR variants for an entity
+curl "http://localhost:8000/api/v1/entities/01936c8a-1234-7000-8000-000000000001/phonetic-matches?threshold=0.5"
 ```
 
 #### Recover Video Metadata

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/__tests__/batchCorrections.test.ts
+++ b/frontend/src/api/__tests__/batchCorrections.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for batchCorrections API client functions (Feature 046, T002).
+ *
+ * Coverage:
+ * - fetchDiffAnalysis: URL construction with and without params, response unwrapping
+ * - fetchCrossSegmentCandidates: URL construction with and without params, response unwrapping
+ * - AbortSignal forwarding for cancellation
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { apiFetch } from "../config";
+import {
+  fetchDiffAnalysis,
+  fetchCrossSegmentCandidates,
+} from "../batchCorrections";
+import type { DiffErrorPattern, CrossSegmentCandidate } from "../../types/corrections";
+
+vi.mock("../config", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DIFF_PATTERN: DiffErrorPattern = {
+  error_token: "cliamte",
+  canonical_form: "climate",
+  frequency: 12,
+  remaining_matches: 8,
+  entity_id: null,
+  entity_name: null,
+};
+
+const CROSS_SEGMENT: CrossSegmentCandidate = {
+  segment_n_id: 101,
+  segment_n_text: "the coun",
+  segment_n1_id: 102,
+  segment_n1_text: "try side",
+  proposed_correction: "the countryside",
+  source_pattern: "coun|try side",
+  confidence: 0.87,
+  is_partially_corrected: false,
+  video_id: "abc123",
+  discovery_source: "correction_pattern",
+};
+
+// ---------------------------------------------------------------------------
+// fetchDiffAnalysis
+// ---------------------------------------------------------------------------
+
+describe("fetchDiffAnalysis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls apiFetch with bare URL when no params provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [DIFF_PATTERN] });
+
+    const result = await fetchDiffAnalysis();
+
+    expect(mockedApiFetch).toHaveBeenCalledOnce();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/diff-analysis",
+      {}
+    );
+    expect(result).toEqual([DIFF_PATTERN]);
+  });
+
+  it("appends min_occurrences query param when provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    await fetchDiffAnalysis({ minOccurrences: 3 });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/diff-analysis?min_occurrences=3",
+      {}
+    );
+  });
+
+  it("appends limit query param when provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    await fetchDiffAnalysis({ limit: 25 });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/diff-analysis?limit=25",
+      {}
+    );
+  });
+
+  it("appends show_completed=true when showCompleted is true", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    await fetchDiffAnalysis({ showCompleted: true });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/diff-analysis?show_completed=true",
+      {}
+    );
+  });
+
+  it("appends show_completed=false when showCompleted is false", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    await fetchDiffAnalysis({ showCompleted: false });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/diff-analysis?show_completed=false",
+      {}
+    );
+  });
+
+  it("appends entity_name query param when provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    await fetchDiffAnalysis({ entityName: "Alexandria Ocasio-Cortez" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/diff-analysis?entity_name=Alexandria+Ocasio-Cortez",
+      {}
+    );
+  });
+
+  it("combines all params into a single query string", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [DIFF_PATTERN] });
+
+    const result = await fetchDiffAnalysis({
+      minOccurrences: 2,
+      limit: 10,
+      showCompleted: false,
+      entityName: "climate",
+    });
+
+    const [[url]] = mockedApiFetch.mock.calls as [[string, object]];
+    expect(url).toContain("min_occurrences=2");
+    expect(url).toContain("limit=10");
+    expect(url).toContain("show_completed=false");
+    expect(url).toContain("entity_name=climate");
+    expect(url).toMatch(/^\/corrections\/batch\/diff-analysis\?/);
+    expect(result).toEqual([DIFF_PATTERN]);
+  });
+
+  it("forwards AbortSignal as externalSignal option", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+    const controller = new AbortController();
+
+    await fetchDiffAnalysis(undefined, controller.signal);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/diff-analysis",
+      { externalSignal: controller.signal }
+    );
+  });
+
+  it("unwraps the data array from the response envelope", async () => {
+    const patterns: DiffErrorPattern[] = [DIFF_PATTERN, { ...DIFF_PATTERN, error_token: "whigt" }];
+    mockedApiFetch.mockResolvedValueOnce({ data: patterns });
+
+    const result = await fetchDiffAnalysis();
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.error_token).toBe("cliamte");
+    expect(result[1]?.error_token).toBe("whigt");
+  });
+
+  it("returns empty array when data is empty", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    const result = await fetchDiffAnalysis();
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchCrossSegmentCandidates
+// ---------------------------------------------------------------------------
+
+describe("fetchCrossSegmentCandidates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls apiFetch with bare URL when no params provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [CROSS_SEGMENT] });
+
+    const result = await fetchCrossSegmentCandidates();
+
+    expect(mockedApiFetch).toHaveBeenCalledOnce();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/cross-segment/candidates",
+      {}
+    );
+    expect(result).toEqual([CROSS_SEGMENT]);
+  });
+
+  it("appends min_corrections query param when provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    await fetchCrossSegmentCandidates({ minCorrections: 5 });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/cross-segment/candidates?min_corrections=5",
+      {}
+    );
+  });
+
+  it("appends entity_name query param when provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    await fetchCrossSegmentCandidates({ entityName: "Bernie Sanders" });
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/cross-segment/candidates?entity_name=Bernie+Sanders",
+      {}
+    );
+  });
+
+  it("combines minCorrections and entityName params", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [CROSS_SEGMENT] });
+
+    const result = await fetchCrossSegmentCandidates({
+      minCorrections: 3,
+      entityName: "AOC",
+    });
+
+    const [[url]] = mockedApiFetch.mock.calls as [[string, object]];
+    expect(url).toContain("min_corrections=3");
+    expect(url).toContain("entity_name=AOC");
+    expect(result).toEqual([CROSS_SEGMENT]);
+  });
+
+  it("forwards AbortSignal as externalSignal option", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+    const controller = new AbortController();
+
+    await fetchCrossSegmentCandidates(undefined, controller.signal);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/cross-segment/candidates",
+      { externalSignal: controller.signal }
+    );
+  });
+
+  it("unwraps the data array from the response envelope", async () => {
+    const candidates: CrossSegmentCandidate[] = [
+      CROSS_SEGMENT,
+      { ...CROSS_SEGMENT, segment_n_id: 200, video_id: "xyz999" },
+    ];
+    mockedApiFetch.mockResolvedValueOnce({ data: candidates });
+
+    const result = await fetchCrossSegmentCandidates();
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.segment_n_id).toBe(101);
+    expect(result[1]?.segment_n_id).toBe(200);
+  });
+
+  it("returns empty array when data is empty", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    const result = await fetchCrossSegmentCandidates();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/src/api/__tests__/entityMentions.phonetic.test.ts
+++ b/frontend/src/api/__tests__/entityMentions.phonetic.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for fetchPhoneticMatches in entityMentions API client (Feature 046, T003).
+ *
+ * Coverage:
+ * - URL construction with and without threshold param
+ * - Response envelope unwrapping (returns PhoneticMatch[], not { data: ... })
+ * - AbortSignal forwarding for cancellation
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { apiFetch } from "../config";
+import { fetchPhoneticMatches } from "../entityMentions";
+import type { PhoneticMatch } from "../../types/corrections";
+
+vi.mock("../config", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ENTITY_ID = "3f4a7b2c-1d9e-4f6a-b8c2-9e0d1f2a3b4c";
+
+const PHONETIC_MATCH: PhoneticMatch = {
+  original_text: "Alexandria Ocasio Cortez",
+  proposed_correction: "Alexandria Ocasio-Cortez",
+  confidence: 0.92,
+  evidence_description: "Hyphen missing in hyphenated surname",
+  video_id: "dQw4w9WgXcQ",
+  segment_id: 42,
+  video_title: "Congressional hearing highlights",
+};
+
+// ---------------------------------------------------------------------------
+// fetchPhoneticMatches
+// ---------------------------------------------------------------------------
+
+describe("fetchPhoneticMatches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls apiFetch with correct endpoint when no threshold provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [PHONETIC_MATCH] });
+
+    const result = await fetchPhoneticMatches(ENTITY_ID);
+
+    expect(mockedApiFetch).toHaveBeenCalledOnce();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/entities/${ENTITY_ID}/phonetic-matches`,
+      {}
+    );
+    expect(result).toEqual([PHONETIC_MATCH]);
+  });
+
+  it("appends threshold query param when provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    await fetchPhoneticMatches(ENTITY_ID, 0.8);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/entities/${ENTITY_ID}/phonetic-matches?threshold=0.8`,
+      {}
+    );
+  });
+
+  it("appends threshold=0 correctly (does not skip falsy zero)", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    await fetchPhoneticMatches(ENTITY_ID, 0);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/entities/${ENTITY_ID}/phonetic-matches?threshold=0`,
+      {}
+    );
+  });
+
+  it("forwards AbortSignal as externalSignal option", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+    const controller = new AbortController();
+
+    await fetchPhoneticMatches(ENTITY_ID, undefined, controller.signal);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/entities/${ENTITY_ID}/phonetic-matches`,
+      { externalSignal: controller.signal }
+    );
+  });
+
+  it("forwards both threshold and AbortSignal together", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [PHONETIC_MATCH] });
+    const controller = new AbortController();
+
+    const result = await fetchPhoneticMatches(ENTITY_ID, 0.75, controller.signal);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/entities/${ENTITY_ID}/phonetic-matches?threshold=0.75`,
+      { externalSignal: controller.signal }
+    );
+    expect(result).toEqual([PHONETIC_MATCH]);
+  });
+
+  it("unwraps the data array from the response envelope", async () => {
+    const matches: PhoneticMatch[] = [
+      PHONETIC_MATCH,
+      { ...PHONETIC_MATCH, original_text: "Ilhan Omar", segment_id: 99 },
+    ];
+    mockedApiFetch.mockResolvedValueOnce({ data: matches });
+
+    const result = await fetchPhoneticMatches(ENTITY_ID);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.original_text).toBe("Alexandria Ocasio Cortez");
+    expect(result[1]?.original_text).toBe("Ilhan Omar");
+  });
+
+  it("returns empty array when data is empty", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ data: [] });
+
+    const result = await fetchPhoneticMatches(ENTITY_ID);
+
+    expect(result).toEqual([]);
+  });
+
+  it("handles video_title being null", async () => {
+    const matchWithNullTitle: PhoneticMatch = { ...PHONETIC_MATCH, video_title: null };
+    mockedApiFetch.mockResolvedValueOnce({ data: [matchWithNullTitle] });
+
+    const result = await fetchPhoneticMatches(ENTITY_ID);
+
+    expect(result[0]?.video_title).toBeNull();
+  });
+});

--- a/frontend/src/components/batch/PatternInput.tsx
+++ b/frontend/src/components/batch/PatternInput.tsx
@@ -56,6 +56,30 @@ export interface PatternInputProps {
    * the canonical name.
    */
   entityAliasNames?: string[];
+  /**
+   * Initial value for the pattern input — used to pre-fill the form when
+   * navigating from the DiffAnalysisPage "Find & Replace" action (T014 / US2).
+   * Only applied as the initial useState value; subsequent user edits are
+   * not controlled by the parent.
+   */
+  initialPattern?: string;
+  /**
+   * Initial value for the replacement input — used to pre-fill the form when
+   * navigating from the DiffAnalysisPage "Find & Replace" action (T014 / US2).
+   * Only applied as the initial useState value; subsequent user edits are
+   * not controlled by the parent.
+   */
+  initialReplacement?: string;
+  /**
+   * When true, the cross-segment toggle is switched on by default — used to
+   * propagate crossSegment=true from router state (T014 / US2).
+   */
+  initialCrossSegment?: boolean;
+  /**
+   * When true, the regex toggle is switched on by default — used to
+   * pre-fill word-boundary patterns from the DiffAnalysisPage.
+   */
+  initialIsRegex?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -178,15 +202,19 @@ export function PatternInput({
   onPatternChange,
   onEntityChange,
   entityAliasNames = [],
+  initialPattern = '',
+  initialReplacement = '',
+  initialCrossSegment = false,
+  initialIsRegex = false,
 }: PatternInputProps) {
   // -------------------------------------------------------------------------
   // Form state
   // -------------------------------------------------------------------------
-  const [pattern, setPattern] = useState('');
-  const [replacement, setReplacement] = useState('');
-  const [isRegex, setIsRegex] = useState(false);
+  const [pattern, setPattern] = useState(initialPattern);
+  const [replacement, setReplacement] = useState(initialReplacement);
+  const [isRegex, setIsRegex] = useState(initialIsRegex);
   const [caseInsensitive, setCaseInsensitive] = useState(false);
-  const [crossSegment, setCrossSegment] = useState(false);
+  const [crossSegment, setCrossSegment] = useState(initialCrossSegment);
 
   // Entity link state (T025 / FR-011)
   const [selectedEntity, setSelectedEntity] = useState<EntityOption | null>(null);

--- a/frontend/src/components/corrections/CrossSegmentPanel.tsx
+++ b/frontend/src/components/corrections/CrossSegmentPanel.tsx
@@ -1,0 +1,351 @@
+/**
+ * CrossSegmentPanel — displays suggested cross-segment ASR correction candidates.
+ *
+ * Renders a ranked list of adjacent-segment pairs where an ASR error spans the
+ * segment boundary. Each candidate card is clickable and calls `prefillForm` to
+ * populate the batch find-replace form with the candidate's source pattern,
+ * proposed correction, and cross-segment flag.
+ *
+ * The panel renders immediately with a loading state while the data fetches and
+ * does NOT block the rest of BatchCorrectionsPage.
+ *
+ * Features:
+ * - Loading skeleton with aria-live polite announcement
+ * - Empty state when no candidates exist
+ * - Candidate cards ranked by confidence (highest first)
+ * - Partial-correction badge when is_partially_corrected is true
+ * - Inline "Form updated" notice that auto-dismisses after 3 seconds
+ * - Keyboard accessible: Enter/Space to select a candidate
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { useCrossSegmentCandidates } from "../../hooks/useCrossSegmentCandidates";
+import type { CrossSegmentCandidate } from "../../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface CrossSegmentPanelProps {
+  /**
+   * Called when the user selects a candidate. The form should be pre-filled
+   * with the provided pattern, replacement, and cross-segment values.
+   */
+  prefillForm: (values: {
+    pattern: string;
+    replacement: string;
+    crossSegment: boolean;
+  }) => void;
+  /**
+   * Controlled open/closed state for the collapsible panel.
+   * Defaults to true (open) when not provided.
+   */
+  isOpen?: boolean;
+  /**
+   * Called when the user clicks the toggle header to open or close the panel.
+   */
+  onToggle?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function CrossSegmentSkeleton() {
+  return (
+    <div
+      className="animate-pulse space-y-3"
+      role="status"
+      aria-label="Loading cross-segment candidates"
+    >
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="rounded-lg border border-slate-200 bg-white p-4 space-y-2"
+        >
+          <div className="h-3 w-3/4 rounded bg-slate-200" />
+          <div className="h-3 w-1/2 rounded bg-slate-200" />
+          <div className="h-3 w-2/3 rounded bg-slate-200" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline notice
+// ---------------------------------------------------------------------------
+
+interface PrefillNoticeProps {
+  onDismiss: () => void;
+}
+
+function PrefillNotice({ onDismiss }: PrefillNoticeProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center justify-between rounded bg-blue-50 border border-blue-200 px-3 py-2 text-sm text-blue-700 mb-3"
+    >
+      <span>Form updated with cross-segment pattern</span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss notice"
+        className="ml-3 text-blue-500 hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 rounded"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Candidate card
+// ---------------------------------------------------------------------------
+
+interface CandidateCardProps {
+  candidate: CrossSegmentCandidate;
+  onSelect: (candidate: CrossSegmentCandidate) => void;
+}
+
+function CandidateCard({ candidate, onSelect }: CandidateCardProps) {
+  const confidencePct = Math.round(candidate.confidence * 100);
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSelect(candidate);
+    }
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(candidate)}
+      onKeyDown={handleKeyDown}
+      aria-label={`Apply cross-segment correction: ${candidate.source_pattern} → ${candidate.proposed_correction}, confidence ${confidencePct}%`}
+      className="cursor-pointer rounded-lg border border-slate-200 bg-white p-4 hover:border-blue-300 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 transition-colors space-y-3"
+    >
+      {/* Segment texts */}
+      <div className="space-y-1">
+        <div>
+          <span className="text-xs font-medium text-slate-500 uppercase tracking-wide">
+            Segment 1:
+          </span>
+          <code className="ml-2 font-mono text-sm text-slate-800">
+            {candidate.segment_n_text}
+          </code>
+        </div>
+        <div>
+          <span className="text-xs font-medium text-slate-500 uppercase tracking-wide">
+            Segment 2:
+          </span>
+          <code className="ml-2 font-mono text-sm text-slate-800">
+            {candidate.segment_n1_text}
+          </code>
+        </div>
+      </div>
+
+      {/* Correction details */}
+      <div className="flex flex-wrap items-center gap-3 text-sm">
+        <div>
+          <span className="text-slate-500">Pattern: </span>
+          <code className="font-mono text-slate-800">{candidate.source_pattern}</code>
+        </div>
+        <span className="text-slate-300" aria-hidden="true">→</span>
+        <div>
+          <span className="text-slate-500">Correction: </span>
+          <code className="font-mono text-slate-800">{candidate.proposed_correction}</code>
+        </div>
+      </div>
+
+      {/* Metadata row: confidence + source badge + partial badge */}
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700">
+          {confidencePct}% confidence
+        </span>
+        {candidate.discovery_source === "entity_alias" && (
+          <span
+            className="inline-flex items-center rounded-full bg-violet-100 px-2.5 py-0.5 text-xs font-medium text-violet-700"
+            title="Discovered via entity alias"
+          >
+            Entity
+          </span>
+        )}
+        {candidate.is_partially_corrected && (
+          <span className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-700">
+            Partial
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * CrossSegmentPanel renders a section of suggested cross-segment correction
+ * candidates. Clicking a candidate pre-fills the batch find-replace form via
+ * the `prefillForm` prop and shows a brief inline notice.
+ *
+ * The panel is collapsible: the `isOpen` prop controls its expanded state and
+ * `onToggle` notifies the parent when the user clicks the header toggle button.
+ */
+export function CrossSegmentPanel({ prefillForm, isOpen = true, onToggle }: CrossSegmentPanelProps) {
+  const { data, isLoading, isError } = useCrossSegmentCandidates();
+
+  // Sort candidates by confidence descending (highest confidence first).
+  const candidates: CrossSegmentCandidate[] = data
+    ? [...data].sort((a, b) => b.confidence - a.confidence)
+    : [];
+
+  // -------------------------------------------------------------------------
+  // Inline notice state
+  // -------------------------------------------------------------------------
+
+  const [showNotice, setShowNotice] = useState(false);
+  const noticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the auto-dismiss timer when the component unmounts.
+  useEffect(() => {
+    return () => {
+      if (noticeTimerRef.current !== null) {
+        clearTimeout(noticeTimerRef.current);
+      }
+    };
+  }, []);
+
+  function showPrefillNotice() {
+    // Cancel any existing timer before starting a new one.
+    if (noticeTimerRef.current !== null) {
+      clearTimeout(noticeTimerRef.current);
+    }
+    setShowNotice(true);
+    noticeTimerRef.current = setTimeout(() => {
+      setShowNotice(false);
+      noticeTimerRef.current = null;
+    }, 3000);
+  }
+
+  function handleDismissNotice() {
+    if (noticeTimerRef.current !== null) {
+      clearTimeout(noticeTimerRef.current);
+      noticeTimerRef.current = null;
+    }
+    setShowNotice(false);
+  }
+
+  // -------------------------------------------------------------------------
+  // Candidate selection
+  // -------------------------------------------------------------------------
+
+  function handleSelectCandidate(candidate: CrossSegmentCandidate) {
+    prefillForm({
+      pattern: candidate.source_pattern,
+      replacement: candidate.proposed_correction,
+      crossSegment: true,
+    });
+    showPrefillNotice();
+  }
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <section aria-label="Suggested Cross-Segment Candidates">
+      {/* Toggle header */}
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls="cross-segment-panel"
+        className="flex w-full items-center justify-between text-left focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 rounded"
+      >
+        <h2 className="text-lg font-semibold text-slate-900">
+          Suggested Cross-Segment Candidates
+        </h2>
+        <svg
+          aria-hidden="true"
+          className={`h-5 w-5 text-slate-500 transition-transform duration-300 ${isOpen ? "rotate-180" : "rotate-0"}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* Collapsible content */}
+      <div
+        className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"}`}
+      >
+        <div id="cross-segment-panel" className="overflow-hidden">
+          <div className="space-y-4 pt-3">
+            {/* Subtitle */}
+            <p className="text-sm text-slate-500">
+              Adjacent segment pairs where an ASR error may span the boundary.
+              Click a candidate to pre-fill the form above.
+            </p>
+
+            {/* Inline prefill notice */}
+            {showNotice && <PrefillNotice onDismiss={handleDismissNotice} />}
+
+            {/* aria-live region for loading → loaded announcement */}
+            <div aria-live="polite" aria-atomic="true" className="sr-only">
+              {isLoading
+                ? "Loading cross-segment candidates"
+                : `${candidates.length} cross-segment candidate${candidates.length === 1 ? "" : "s"} loaded`}
+            </div>
+
+            {/* Loading state */}
+            {isLoading && <CrossSegmentSkeleton />}
+
+            {/* Error state */}
+            {isError && !isLoading && (
+              <div
+                role="alert"
+                className="rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-700"
+              >
+                Failed to load cross-segment candidates. Please try refreshing the page.
+              </div>
+            )}
+
+            {/* Empty state */}
+            {!isLoading && !isError && candidates.length === 0 && (
+              <div className="rounded-lg bg-white border border-slate-200 p-8 text-center">
+                <p className="text-slate-600 font-medium">No cross-segment candidates found.</p>
+                <p className="mt-1 text-sm text-slate-400">
+                  Candidates appear once enough corrections have been applied to
+                  identify cross-boundary patterns.
+                </p>
+              </div>
+            )}
+
+            {/* Candidate list */}
+            {!isLoading && !isError && candidates.length > 0 && (
+              <div className="space-y-3">
+                {candidates.map((candidate) => (
+                  <CandidateCard
+                    key={`${candidate.segment_n_id}-${candidate.segment_n1_id}`}
+                    candidate={candidate}
+                    onSelect={handleSelectCandidate}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/corrections/ExclusionPatternsSection.tsx
+++ b/frontend/src/components/corrections/ExclusionPatternsSection.tsx
@@ -1,0 +1,319 @@
+/**
+ * ExclusionPatternsSection — displays and manages exclusion patterns for a
+ * named entity.
+ *
+ * Exclusion patterns are text phrases that should NOT trigger entity mention
+ * detection. For example, entity "Mexico" might have exclusion pattern
+ * "New Mexico" so "New Mexico" doesn't get flagged as a "Mexico" mention.
+ *
+ * Features:
+ * - Lists current exclusion patterns as removable pills
+ * - Inline remove button (X) per pattern with loading state
+ * - "Add pattern" form at the bottom (text input + Add button)
+ * - Empty state when no patterns exist
+ * - 409 duplicate error shown as inline user-friendly message
+ * - Accessible: proper labels, keyboard navigation, aria attributes
+ *
+ * Visual and interaction patterns mirror the Aliases section in EntityDetailPage.
+ */
+
+import { useState, useRef, useEffect } from "react";
+import { useQueryClient, useMutation } from "@tanstack/react-query";
+
+import {
+  addExclusionPattern,
+  removeExclusionPattern,
+} from "../../api/entityMentions";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ExclusionPatternsSectionProps {
+  /** UUID of the named entity. */
+  entityId: string;
+  /** Current exclusion patterns from the entity detail response. */
+  patterns: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Icons (inline SVG — no icon library dependency)
+// ---------------------------------------------------------------------------
+
+function XMarkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 18 18 6M6 6l12 12"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pattern pill (with remove button)
+// ---------------------------------------------------------------------------
+
+interface PatternPillProps {
+  pattern: string;
+  entityId: string;
+  onRemoved: () => void;
+}
+
+function PatternPill({ pattern, entityId, onRemoved }: PatternPillProps) {
+  const [isRemoving, setIsRemoving] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (errorTimerRef.current !== null) {
+        clearTimeout(errorTimerRef.current);
+      }
+    };
+  }, []);
+
+  async function handleRemove() {
+    if (isRemoving) return;
+    setIsRemoving(true);
+    setErrorMsg(null);
+    try {
+      await removeExclusionPattern(entityId, pattern);
+      onRemoved();
+    } catch (err: unknown) {
+      const status = (err as { status?: number } | null)?.status;
+      let message = "Failed to remove pattern. Please try again.";
+      if (status === 404) {
+        message = "Pattern or entity not found. Please refresh the page.";
+      }
+      setErrorMsg(message);
+      // Auto-dismiss error after 4 seconds.
+      errorTimerRef.current = setTimeout(() => {
+        setErrorMsg(null);
+        errorTimerRef.current = null;
+      }, 4000);
+      setIsRemoving(false);
+    }
+  }
+
+  return (
+    <li className="flex flex-col gap-0.5">
+      <div className="inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 bg-orange-50 text-orange-800 border border-orange-200 rounded-full text-sm font-medium max-w-full">
+        <span className="truncate" title={pattern}>
+          {pattern}
+        </span>
+        <button
+          type="button"
+          onClick={() => void handleRemove()}
+          disabled={isRemoving}
+          aria-label={`Remove exclusion pattern "${pattern}"`}
+          className="flex-shrink-0 flex items-center justify-center w-5 h-5 rounded-full text-orange-600 hover:bg-orange-200 hover:text-orange-900 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {isRemoving ? (
+            <span className="sr-only">Removing…</span>
+          ) : (
+            <XMarkIcon className="w-3.5 h-3.5" />
+          )}
+        </button>
+      </div>
+      {errorMsg && (
+        <p className="text-xs text-red-600 pl-1" role="alert">
+          {errorMsg}
+        </p>
+      )}
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add pattern form
+// ---------------------------------------------------------------------------
+
+interface AddPatternFormProps {
+  entityId: string;
+  /** Called after a successful addition so the parent can refetch. */
+  onAdded: () => void;
+}
+
+/**
+ * Compact form for adding a new exclusion pattern to a named entity.
+ * Shows inline green confirmation on success, and inline red error on failure.
+ */
+function AddPatternForm({ entityId, onAdded }: AddPatternFormProps) {
+  const [pattern, setPattern] = useState("");
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const mutation = useMutation({
+    mutationFn: (pat: string) => addExclusionPattern(entityId, pat),
+    onSuccess: (_data, pat) => {
+      setPattern("");
+      setSuccessMsg(`"${pat}" added as exclusion pattern.`);
+      onAdded();
+
+      // Auto-clear success message after 3 seconds.
+      successTimerRef.current = setTimeout(() => {
+        setSuccessMsg(null);
+      }, 3000);
+
+      // Return focus to the input so the user can add another pattern.
+      inputRef.current?.focus();
+    },
+    onError: (err: unknown) => {
+      const status = (err as { status?: number } | null)?.status;
+      if (status === 409) {
+        setErrorMsg("This exclusion pattern already exists for the entity.");
+      } else if (status === 404) {
+        setErrorMsg("Entity not found. Please refresh the page.");
+      } else {
+        setErrorMsg("Failed to add exclusion pattern. Please try again.");
+      }
+    },
+  });
+
+  // Clean up success timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (successTimerRef.current !== null) {
+        clearTimeout(successTimerRef.current);
+      }
+    };
+  }, []);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const trimmed = pattern.trim();
+    if (!trimmed) return;
+
+    setSuccessMsg(null);
+    setErrorMsg(null);
+    mutation.mutate(trimmed);
+  }
+
+  const isPending = mutation.isPending;
+
+  return (
+    <div className="pt-3 mt-3 border-t border-slate-100">
+      <form
+        onSubmit={handleSubmit}
+        className="flex items-center gap-2"
+        aria-label="Add new exclusion pattern"
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={pattern}
+          onChange={(e) => {
+            setPattern(e.target.value);
+            // Clear error when the user starts typing again.
+            if (errorMsg) setErrorMsg(null);
+          }}
+          placeholder="Add exclusion pattern…"
+          className="flex-1 min-w-0 rounded-md border border-slate-300 px-3 py-1.5 text-sm text-gray-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          disabled={isPending}
+          aria-label="Exclusion pattern text"
+          maxLength={500}
+        />
+        <button
+          type="submit"
+          disabled={isPending || !pattern.trim()}
+          className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {isPending ? "Adding…" : "Add"}
+        </button>
+      </form>
+
+      {/* Inline feedback */}
+      {successMsg && (
+        <p className="mt-1.5 text-xs text-green-600" role="status" aria-live="polite">
+          {successMsg}
+        </p>
+      )}
+      {errorMsg && (
+        <p className="mt-1.5 text-xs text-red-600" role="alert">
+          {errorMsg}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * ExclusionPatternsSection renders a card listing the current exclusion
+ * patterns for a named entity with per-pattern removal and an add form.
+ *
+ * Patterns come from the entity detail query (`exclusion_patterns` field), so
+ * adding or removing a pattern calls `queryClient.invalidateQueries` on the
+ * `entity-detail` key to refresh the list from the server.
+ */
+export function ExclusionPatternsSection({
+  entityId,
+  patterns,
+}: ExclusionPatternsSectionProps) {
+  const queryClient = useQueryClient();
+
+  function handleChange() {
+    void queryClient.invalidateQueries({
+      queryKey: ["entity-detail", entityId],
+    });
+  }
+
+  return (
+    <section aria-labelledby="entity-exclusion-patterns-heading" className="mb-6">
+      <h2
+        id="entity-exclusion-patterns-heading"
+        className="text-lg font-semibold text-gray-900 mb-3"
+      >
+        Exclusion Patterns
+      </h2>
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4">
+        {/* Help text */}
+        <p className="text-xs text-gray-500 mb-3">
+          Phrases listed here will not trigger mention detection for this
+          entity. For example, "New Mexico" can be excluded so it doesn't
+          count as a "Mexico" mention.
+        </p>
+
+        {/* Pattern list or empty state */}
+        {patterns.length > 0 ? (
+          <ul
+            className="flex flex-wrap gap-2"
+            aria-label="Current exclusion patterns"
+          >
+            {patterns.map((p) => (
+              <PatternPill
+                key={p}
+                pattern={p}
+                entityId={entityId}
+                onRemoved={handleChange}
+              />
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-gray-400 italic">
+            No exclusion patterns defined.
+          </p>
+        )}
+
+        {/* Add pattern form */}
+        <AddPatternForm entityId={entityId} onAdded={handleChange} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/corrections/PhoneticVariantsSection.tsx
+++ b/frontend/src/components/corrections/PhoneticVariantsSection.tsx
@@ -1,0 +1,477 @@
+/**
+ * PhoneticVariantsSection — collapsible section that shows suspected ASR
+ * phonetic variants of a named entity's name.
+ *
+ * The section is collapsed by default and only fetches data when expanded
+ * (lazy loading). Each row lets the user:
+ * - Register the original_text as an entity alias (name_variant type).
+ * - Navigate to the batch find-replace page pre-filled with the suggestion.
+ *
+ * Confidence threshold slider (aria-valuetext, step 0.05) filters results
+ * client-side without triggering a refetch.
+ *
+ * Features (Feature 046, US4):
+ * - Collapsible disclosure with aria-expanded on the toggle button
+ * - Lazy fetch: query enabled only when expanded
+ * - Confidence range input with ARIA value announcement
+ * - Register as Alias: POST to /entities/{id}/aliases, then invalidate cache
+ * - Find & Replace: navigate to /corrections/batch with pre-filled state
+ * - Loading, empty, and error states
+ */
+
+import { useState, useRef, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { usePhoneticMatches } from "../../hooks/usePhoneticMatches";
+import { createEntityAlias } from "../../api/entityMentions";
+import type { PhoneticMatch } from "../../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface PhoneticVariantsSectionProps {
+  /** UUID of the named entity to fetch phonetic variants for. */
+  entityId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Icons (inline SVG — no icon library dependency)
+// ---------------------------------------------------------------------------
+
+function ChevronDownIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m19.5 8.25-7.5 7.5-7.5-7.5"
+      />
+    </svg>
+  );
+}
+
+function ChevronUpIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m4.5 15.75 7.5-7.5 7.5 7.5"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m4.5 12.75 6 6 9-13.5"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function PhoneticSkeleton() {
+  return (
+    <div
+      className="animate-pulse space-y-3 mt-4"
+      role="status"
+      aria-label="Loading phonetic variants"
+    >
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="rounded-lg border border-slate-200 bg-white p-4 space-y-2"
+        >
+          <div className="h-3 w-1/2 rounded bg-slate-200" />
+          <div className="h-3 w-3/4 rounded bg-slate-200" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row action state
+// ---------------------------------------------------------------------------
+
+type RowActionState =
+  | { kind: "idle" }
+  | { kind: "pending" }
+  | { kind: "registered" }
+  | { kind: "error"; message: string };
+
+// ---------------------------------------------------------------------------
+// Match row
+// ---------------------------------------------------------------------------
+
+interface MatchRowProps {
+  match: PhoneticMatch;
+  entityId: string;
+  onAliasRegistered: () => void;
+}
+
+function MatchRow({ match, entityId, onAliasRegistered }: MatchRowProps) {
+  const navigate = useNavigate();
+  const [actionState, setActionState] = useState<RowActionState>({
+    kind: "idle",
+  });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up error auto-dismiss timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const confidencePct = Math.round(match.confidence * 100);
+
+  async function handleRegisterAlias() {
+    if (actionState.kind === "pending" || actionState.kind === "registered") {
+      return;
+    }
+    setActionState({ kind: "pending" });
+    try {
+      await createEntityAlias(entityId, match.original_text, "name_variant");
+      setActionState({ kind: "registered" });
+      onAliasRegistered();
+    } catch (err: unknown) {
+      const status = (err as { status?: number } | null)?.status;
+      let message = "Failed to register alias. Please try again.";
+      if (status === 409) {
+        message = "This alias already exists.";
+      } else if (status === 404) {
+        message = "Entity not found.";
+      }
+      setActionState({ kind: "error", message });
+      // Auto-dismiss error after 4 seconds.
+      timerRef.current = setTimeout(() => {
+        setActionState({ kind: "idle" });
+        timerRef.current = null;
+      }, 4000);
+    }
+  }
+
+  function handleFindAndReplace() {
+    navigate("/corrections/batch", {
+      state: {
+        pattern: match.original_text,
+        replacement: match.proposed_correction,
+      },
+    });
+  }
+
+  const isRegistered = actionState.kind === "registered";
+  const isPending = actionState.kind === "pending";
+
+  return (
+    <tr className="hover:bg-slate-50 transition-colors">
+      {/* Original text */}
+      <td className="px-4 py-3 text-sm text-gray-900 font-mono">
+        {match.original_text}
+      </td>
+
+      {/* Proposed correction */}
+      <td className="px-4 py-3 text-sm text-gray-900 font-mono">
+        {match.proposed_correction}
+      </td>
+
+      {/* Confidence */}
+      <td className="px-4 py-3 text-sm text-gray-500 tabular-nums whitespace-nowrap">
+        <span
+          className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700"
+          aria-label={`${confidencePct}% confidence`}
+        >
+          {confidencePct}%
+        </span>
+      </td>
+
+      {/* Evidence */}
+      <td className="px-4 py-3 text-sm text-gray-500">
+        {match.evidence_description}
+      </td>
+
+      {/* Video title */}
+      <td className="px-4 py-3 text-sm text-gray-500">
+        {match.video_title ?? (
+          <span className="italic text-gray-400">Unknown video</span>
+        )}
+      </td>
+
+      {/* Actions */}
+      <td className="px-4 py-3 whitespace-nowrap">
+        <div className="flex items-center gap-2">
+          {/* Register as Alias button */}
+          {isRegistered ? (
+            <span
+              className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-green-700 bg-green-50 border border-green-200 rounded-md"
+              aria-label="Alias registered"
+            >
+              <CheckIcon className="w-3.5 h-3.5" />
+              Registered
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={handleRegisterAlias}
+              disabled={isPending}
+              aria-label={`Register "${match.original_text}" as alias`}
+              className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {isPending ? "Registering…" : "Register as Alias"}
+            </button>
+          )}
+
+          {/* Find & Replace button */}
+          <button
+            type="button"
+            onClick={handleFindAndReplace}
+            aria-label={`Find and replace "${match.original_text}" with "${match.proposed_correction}"`}
+            className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-colors"
+          >
+            Find &amp; Replace
+          </button>
+        </div>
+
+        {/* Inline error feedback */}
+        {actionState.kind === "error" && (
+          <p className="mt-1 text-xs text-red-600" role="alert">
+            {actionState.message}
+          </p>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * PhoneticVariantsSection renders a collapsible card showing suspected ASR
+ * phonetic variants of the entity name.
+ *
+ * Data is only fetched when the user expands the section (lazy loading).
+ * A confidence slider lets the user filter results client-side without
+ * triggering additional network requests.
+ */
+export function PhoneticVariantsSection({
+  entityId,
+}: PhoneticVariantsSectionProps) {
+  const queryClient = useQueryClient();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [displayThreshold, setDisplayThreshold] = useState(0.5);
+
+  const { data: matches, isLoading, isError } = usePhoneticMatches({
+    entityId,
+    serverFloor: 0.3,
+    displayThreshold,
+    enabled: isExpanded,
+  });
+
+  const contentId = `phonetic-variants-content-${entityId}`;
+
+  function handleAliasRegistered() {
+    // Invalidate all relevant query caches.
+    void queryClient.invalidateQueries({
+      queryKey: ["entity-detail", entityId],
+    });
+    void queryClient.invalidateQueries({ queryKey: ["entity-mentions"] });
+    void queryClient.invalidateQueries({ queryKey: ["phonetic-matches"] });
+    void queryClient.invalidateQueries({ queryKey: ["diff-analysis"] });
+  }
+
+  const thresholdPct = Math.round(displayThreshold * 100);
+
+  return (
+    <section aria-labelledby="phonetic-variants-heading" className="mb-6">
+      {/* Collapsible header */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+        <button
+          type="button"
+          id="phonetic-variants-heading"
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+          onClick={() => setIsExpanded((prev) => !prev)}
+          className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500 transition-colors"
+        >
+          <div>
+            <h2 className="text-base font-semibold text-gray-900">
+              Suspected ASR Variants
+            </h2>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Phonetic matches that may represent misrecognised versions of this
+              entity name in transcripts.
+            </p>
+          </div>
+          {isExpanded ? (
+            <ChevronUpIcon className="w-5 h-5 text-gray-400 flex-shrink-0 ml-3" />
+          ) : (
+            <ChevronDownIcon className="w-5 h-5 text-gray-400 flex-shrink-0 ml-3" />
+          )}
+        </button>
+
+        {/* Collapsible body */}
+        {isExpanded && (
+          <div id={contentId} className="px-4 pb-4 border-t border-slate-100">
+            {/* Confidence threshold slider */}
+            <div className="flex items-center gap-3 py-3">
+              <label
+                htmlFor="phonetic-confidence-slider"
+                className="text-xs font-medium text-gray-600 whitespace-nowrap"
+              >
+                Min confidence:
+              </label>
+              <input
+                id="phonetic-confidence-slider"
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={displayThreshold}
+                onChange={(e) =>
+                  setDisplayThreshold(parseFloat(e.target.value))
+                }
+                aria-label="Confidence threshold"
+                aria-valuemin={0}
+                aria-valuemax={1}
+                aria-valuenow={displayThreshold}
+                aria-valuetext={`Confidence threshold: ${thresholdPct}%`}
+                className="flex-1 h-2 accent-indigo-600 cursor-pointer"
+              />
+              <span className="text-xs font-medium text-gray-700 tabular-nums w-10 text-right">
+                {thresholdPct}%
+              </span>
+            </div>
+
+            {/* aria-live region for loading → loaded announcement */}
+            <div aria-live="polite" aria-atomic="true" className="sr-only">
+              {isLoading
+                ? "Loading phonetic variants"
+                : `${matches?.length ?? 0} phonetic variant${(matches?.length ?? 0) === 1 ? "" : "s"} loaded`}
+            </div>
+
+            {/* Loading state */}
+            {isLoading && <PhoneticSkeleton />}
+
+            {/* Error state */}
+            {isError && !isLoading && (
+              <div
+                role="alert"
+                className="mt-3 rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-700"
+              >
+                Failed to load phonetic variants. Please try refreshing the
+                page.
+              </div>
+            )}
+
+            {/* Empty state */}
+            {!isLoading && !isError && matches !== undefined && matches.length === 0 && (
+              <div className="mt-3 rounded-lg bg-white border border-slate-200 p-6 text-center">
+                <p className="text-sm text-gray-500">
+                  No suspected ASR variants found above the{" "}
+                  {thresholdPct}% confidence threshold.
+                </p>
+              </div>
+            )}
+
+            {/* Results table */}
+            {!isLoading && !isError && matches !== undefined && matches.length > 0 && (
+              <div className="mt-3 overflow-x-auto rounded-lg border border-slate-200">
+                <table className="min-w-full divide-y divide-slate-200 text-sm">
+                  <thead className="bg-slate-50">
+                    <tr>
+                      <th
+                        scope="col"
+                        className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide"
+                      >
+                        Original Text
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide"
+                      >
+                        Proposed Correction
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide"
+                      >
+                        Confidence
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide"
+                      >
+                        Evidence
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide"
+                      >
+                        Video Title
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide"
+                      >
+                        Actions
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-slate-100">
+                    {matches.map((match, idx) => (
+                      <MatchRow
+                        key={`${match.video_id}-${match.segment_id}-${idx}`}
+                        match={match}
+                        entityId={entityId}
+                        onAliasRegistered={handleAliasRegistered}
+                      />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/corrections/__tests__/CrossSegmentPanel.test.tsx
+++ b/frontend/src/components/corrections/__tests__/CrossSegmentPanel.test.tsx
@@ -1,0 +1,528 @@
+/**
+ * Tests for CrossSegmentPanel component.
+ *
+ * Coverage:
+ * - Renders loading state initially (skeleton)
+ * - Renders candidate cards with data
+ * - Clicking a candidate calls prefillForm with correct values (crossSegment: true)
+ * - Shows inline notice after pre-fill
+ * - Notice auto-dismisses after 3 seconds
+ * - Notice dismiss button hides notice immediately
+ * - Empty state when no candidates
+ * - Confidence displayed as percentage
+ * - Partial-correction badge shown when is_partially_corrected is true
+ * - Candidates ranked by confidence (highest first)
+ * - Keyboard accessible: Enter triggers prefillForm
+ * - Keyboard accessible: Space triggers prefillForm
+ * - Error state renders alert when fetch fails
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { CrossSegmentPanel } from "../CrossSegmentPanel";
+import { useCrossSegmentCandidates } from "../../../hooks/useCrossSegmentCandidates";
+import type { CrossSegmentCandidate } from "../../../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../../hooks/useCrossSegmentCandidates", () => ({
+  useCrossSegmentCandidates: vi.fn(),
+}));
+
+const mockedUseHook = vi.mocked(useCrossSegmentCandidates);
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeCandidate(overrides: Partial<CrossSegmentCandidate> = {}): CrossSegmentCandidate {
+  return {
+    segment_n_id: 1,
+    segment_n_text: "the senator said",
+    segment_n1_id: 2,
+    segment_n1_text: "bernie would win",
+    proposed_correction: "Bernie",
+    source_pattern: "bernie",
+    confidence: 0.85,
+    is_partially_corrected: false,
+    video_id: "video-uuid-001",
+    discovery_source: "correction_pattern",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default hook return stubs
+// ---------------------------------------------------------------------------
+
+function makeIdleHook(): ReturnType<typeof useCrossSegmentCandidates> {
+  return {
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    status: "pending",
+    fetchStatus: "idle",
+    isPending: true,
+    isRefetching: false,
+    isRefetchError: false,
+    isLoadingError: false,
+    isStale: false,
+    isPlaceholderData: false,
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    errorUpdateCount: 0,
+    failureCount: 0,
+    failureReason: null,
+    refetch: vi.fn(),
+    promise: Promise.resolve([]),
+  } as unknown as ReturnType<typeof useCrossSegmentCandidates>;
+}
+
+function makeLoadingHook(): ReturnType<typeof useCrossSegmentCandidates> {
+  return {
+    ...makeIdleHook(),
+    isLoading: true,
+    isPending: true,
+    status: "pending",
+    fetchStatus: "fetching",
+  } as unknown as ReturnType<typeof useCrossSegmentCandidates>;
+}
+
+function makeSuccessHook(
+  data: CrossSegmentCandidate[]
+): ReturnType<typeof useCrossSegmentCandidates> {
+  return {
+    ...makeIdleHook(),
+    data,
+    isLoading: false,
+    isSuccess: true,
+    isPending: false,
+    status: "success",
+    fetchStatus: "idle",
+  } as unknown as ReturnType<typeof useCrossSegmentCandidates>;
+}
+
+function makeErrorHook(): ReturnType<typeof useCrossSegmentCandidates> {
+  return {
+    ...makeIdleHook(),
+    data: undefined,
+    isLoading: false,
+    isError: true,
+    isPending: false,
+    error: new Error("Network error"),
+    status: "error",
+    fetchStatus: "idle",
+  } as unknown as ReturnType<typeof useCrossSegmentCandidates>;
+}
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function renderPanel(prefillForm = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CrossSegmentPanel prefillForm={prefillForm} />
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CrossSegmentPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Section header
+  // -------------------------------------------------------------------------
+
+  it("renders the section heading", () => {
+    mockedUseHook.mockReturnValue(makeSuccessHook([]));
+    renderPanel();
+    expect(
+      screen.getByRole("heading", { name: /suggested cross-segment candidates/i, level: 2 })
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("renders loading skeleton when isLoading is true", () => {
+    mockedUseHook.mockReturnValue(makeLoadingHook());
+    renderPanel();
+    expect(
+      screen.getByRole("status", { name: /loading cross-segment candidates/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not render candidate cards when loading", () => {
+    mockedUseHook.mockReturnValue(makeLoadingHook());
+    renderPanel();
+    expect(screen.queryByRole("button", { name: /apply cross-segment correction/i })).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it("renders empty state when no candidates exist", () => {
+    mockedUseHook.mockReturnValue(makeSuccessHook([]));
+    renderPanel();
+    expect(
+      screen.getByText(/no cross-segment candidates found/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not render candidate cards in empty state", () => {
+    mockedUseHook.mockReturnValue(makeSuccessHook([]));
+    renderPanel();
+    expect(screen.queryByRole("button", { name: /apply cross-segment correction/i })).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it("renders error alert when fetch fails", () => {
+    mockedUseHook.mockReturnValue(makeErrorHook());
+    renderPanel();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/failed to load cross-segment candidates/i)).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Candidate rendering
+  // -------------------------------------------------------------------------
+
+  it("renders candidate cards with segment texts", () => {
+    const candidate = makeCandidate({
+      segment_n_text: "the senator said",
+      segment_n1_text: "bernie would win",
+    });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    expect(screen.getByText("the senator said")).toBeInTheDocument();
+    expect(screen.getByText("bernie would win")).toBeInTheDocument();
+  });
+
+  it("renders source pattern and proposed correction on candidate cards", () => {
+    const candidate = makeCandidate({
+      source_pattern: "bernie",
+      proposed_correction: "Bernie",
+    });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    expect(screen.getAllByText("bernie").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Bernie").length).toBeGreaterThan(0);
+  });
+
+  it("renders confidence as a percentage", () => {
+    const candidate = makeCandidate({ confidence: 0.85 });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    expect(screen.getByText(/85% confidence/i)).toBeInTheDocument();
+  });
+
+  it("rounds confidence to nearest integer percentage", () => {
+    const candidate = makeCandidate({ confidence: 0.876 });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    expect(screen.getByText(/88% confidence/i)).toBeInTheDocument();
+  });
+
+  it("shows partial-correction badge when is_partially_corrected is true", () => {
+    const candidate = makeCandidate({ is_partially_corrected: true });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    expect(screen.getByText("Partial")).toBeInTheDocument();
+  });
+
+  it("does not show partial-correction badge when is_partially_corrected is false", () => {
+    const candidate = makeCandidate({ is_partially_corrected: false });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    expect(screen.queryByText("Partial")).not.toBeInTheDocument();
+  });
+
+  it("shows Entity badge when discovery_source is entity_alias", () => {
+    const candidate = makeCandidate({ discovery_source: "entity_alias" });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    expect(screen.getByText("Entity")).toBeInTheDocument();
+  });
+
+  it("does not show Entity badge when discovery_source is correction_pattern", () => {
+    const candidate = makeCandidate({ discovery_source: "correction_pattern" });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    expect(screen.queryByText("Entity")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Ranking by confidence
+  // -------------------------------------------------------------------------
+
+  it("renders candidates sorted by confidence descending (highest first)", () => {
+    const candidates = [
+      makeCandidate({ segment_n_id: 10, source_pattern: "low", confidence: 0.4 }),
+      makeCandidate({ segment_n_id: 20, source_pattern: "high", confidence: 0.9 }),
+      makeCandidate({ segment_n_id: 30, source_pattern: "mid", confidence: 0.7 }),
+    ];
+    mockedUseHook.mockReturnValue(makeSuccessHook(candidates));
+    renderPanel();
+
+    const cards = screen.getAllByRole("button", { name: /apply cross-segment correction/i });
+    // Confidence is rendered as "confidence XX%" in the aria-label
+    expect(cards[0]).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("confidence 90%")
+    );
+    expect(cards[1]).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("confidence 70%")
+    );
+    expect(cards[2]).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("confidence 40%")
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Pre-fill on click
+  // -------------------------------------------------------------------------
+
+  it("calls prefillForm with correct values when a candidate is clicked", () => {
+    const prefillForm = vi.fn();
+    const candidate = makeCandidate({
+      source_pattern: "bernie",
+      proposed_correction: "Bernie",
+    });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel(prefillForm);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /apply cross-segment correction/i })
+    );
+
+    expect(prefillForm).toHaveBeenCalledTimes(1);
+    expect(prefillForm).toHaveBeenCalledWith({
+      pattern: "bernie",
+      replacement: "Bernie",
+      crossSegment: true,
+    });
+  });
+
+  it("always passes crossSegment: true in prefillForm call", () => {
+    const prefillForm = vi.fn();
+    const candidate = makeCandidate({ is_partially_corrected: true });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel(prefillForm);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /apply cross-segment correction/i })
+    );
+
+    expect(prefillForm).toHaveBeenCalledWith(
+      expect.objectContaining({ crossSegment: true })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Keyboard accessibility
+  // -------------------------------------------------------------------------
+
+  it("calls prefillForm when Enter is pressed on a candidate card", () => {
+    const prefillForm = vi.fn();
+    const candidate = makeCandidate({
+      source_pattern: "bernie",
+      proposed_correction: "Bernie",
+    });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel(prefillForm);
+
+    const card = screen.getByRole("button", { name: /apply cross-segment correction/i });
+    fireEvent.keyDown(card, { key: "Enter" });
+
+    expect(prefillForm).toHaveBeenCalledTimes(1);
+    expect(prefillForm).toHaveBeenCalledWith({
+      pattern: "bernie",
+      replacement: "Bernie",
+      crossSegment: true,
+    });
+  });
+
+  it("calls prefillForm when Space is pressed on a candidate card", () => {
+    const prefillForm = vi.fn();
+    const candidate = makeCandidate({
+      source_pattern: "bernie",
+      proposed_correction: "Bernie",
+    });
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel(prefillForm);
+
+    const card = screen.getByRole("button", { name: /apply cross-segment correction/i });
+    fireEvent.keyDown(card, { key: " " });
+
+    expect(prefillForm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call prefillForm for other key presses", () => {
+    const prefillForm = vi.fn();
+    const candidate = makeCandidate();
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel(prefillForm);
+
+    const card = screen.getByRole("button", { name: /apply cross-segment correction/i });
+    fireEvent.keyDown(card, { key: "Tab" });
+    fireEvent.keyDown(card, { key: "Escape" });
+
+    expect(prefillForm).not.toHaveBeenCalled();
+  });
+
+  it("candidate cards have tabIndex=0 for keyboard focusability", () => {
+    const candidate = makeCandidate();
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    const card = screen.getByRole("button", { name: /apply cross-segment correction/i });
+    expect(card).toHaveAttribute("tabindex", "0");
+  });
+
+  // -------------------------------------------------------------------------
+  // Inline notice
+  // -------------------------------------------------------------------------
+
+  it("shows inline notice after a candidate is clicked", () => {
+    const candidate = makeCandidate();
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /apply cross-segment correction/i })
+    );
+
+    expect(
+      screen.getByText(/form updated with cross-segment pattern/i)
+    ).toBeInTheDocument();
+  });
+
+  it("notice auto-dismisses after 3 seconds", () => {
+    const candidate = makeCandidate();
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /apply cross-segment correction/i })
+    );
+
+    expect(
+      screen.getByText(/form updated with cross-segment pattern/i)
+    ).toBeInTheDocument();
+
+    // Advance fake timers past the 3-second auto-dismiss threshold.
+    act(() => {
+      vi.advanceTimersByTime(3001);
+    });
+
+    expect(
+      screen.queryByText(/form updated with cross-segment pattern/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("notice dismiss button hides notice immediately", () => {
+    const candidate = makeCandidate();
+    mockedUseHook.mockReturnValue(makeSuccessHook([candidate]));
+    renderPanel();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /apply cross-segment correction/i })
+    );
+
+    expect(
+      screen.getByText(/form updated with cross-segment pattern/i)
+    ).toBeInTheDocument();
+
+    // Click the dismiss (×) button — notice should vanish synchronously.
+    fireEvent.click(screen.getByRole("button", { name: /dismiss notice/i }));
+
+    expect(
+      screen.queryByText(/form updated with cross-segment pattern/i)
+    ).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple candidates
+  // -------------------------------------------------------------------------
+
+  it("renders all candidate cards when multiple candidates exist", () => {
+    const candidates = [
+      makeCandidate({ segment_n_id: 1, segment_n1_id: 2, source_pattern: "pattern-a", confidence: 0.9 }),
+      makeCandidate({ segment_n_id: 3, segment_n1_id: 4, source_pattern: "pattern-b", confidence: 0.7 }),
+    ];
+    mockedUseHook.mockReturnValue(makeSuccessHook(candidates));
+    renderPanel();
+
+    const cards = screen.getAllByRole("button", { name: /apply cross-segment correction/i });
+    expect(cards).toHaveLength(2);
+  });
+
+  it("calls prefillForm for the correct candidate when multiple candidates are shown", () => {
+    const prefillForm = vi.fn();
+    const candidates = [
+      makeCandidate({
+        segment_n_id: 1,
+        segment_n1_id: 2,
+        source_pattern: "alpha",
+        proposed_correction: "Alpha",
+        confidence: 0.9,
+      }),
+      makeCandidate({
+        segment_n_id: 3,
+        segment_n1_id: 4,
+        source_pattern: "beta",
+        proposed_correction: "Beta",
+        confidence: 0.7,
+      }),
+    ];
+    mockedUseHook.mockReturnValue(makeSuccessHook(candidates));
+    renderPanel(prefillForm);
+
+    // Click the second card (lower confidence = second in sorted order)
+    const cards = screen.getAllByRole("button", { name: /apply cross-segment correction/i });
+    fireEvent.click(cards[1]!);
+
+    expect(prefillForm).toHaveBeenCalledWith({
+      pattern: "beta",
+      replacement: "Beta",
+      crossSegment: true,
+    });
+  });
+});

--- a/frontend/src/components/corrections/__tests__/ExclusionPatternsSection.test.tsx
+++ b/frontend/src/components/corrections/__tests__/ExclusionPatternsSection.test.tsx
@@ -1,0 +1,638 @@
+/**
+ * Tests for ExclusionPatternsSection component.
+ *
+ * Coverage:
+ * 1. Renders empty state when no patterns are provided
+ * 2. Renders current patterns as pills when patterns are provided
+ * 3. Each pattern pill has an accessible remove button
+ * 4. Remove button calls removeExclusionPattern and invalidates query on success
+ * 5. Remove button shows loading state while in-flight
+ * 6. Remove failure shows inline error on the pill
+ * 7. Add pattern form renders with accessible label
+ * 8. Add button is disabled when input is empty or whitespace-only
+ * 9. Add button becomes enabled after typing in the input
+ * 10. Submit calls addExclusionPattern with the trimmed value
+ * 11. Success message shown after add and input is cleared
+ * 12. Success message has role="status" / aria-live="polite"
+ * 13. Duplicate pattern (409) shows specific error message
+ * 14. 404 error shows entity-not-found message
+ * 15. Generic error shows fallback message
+ * 16. Error message has role="alert"
+ * 17. Error clears when the user types in the input after an error
+ * 18. Add button shows "Adding…" while request is in flight
+ * 19. Input is disabled while request is in flight
+ * 20. Help text is present in the rendered output
+ * 21. Section heading is accessible (h2 with id used by aria-labelledby)
+ * 22. Pattern list has accessible label when patterns exist
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ExclusionPatternsSection } from "../ExclusionPatternsSection";
+import {
+  addExclusionPattern,
+  removeExclusionPattern,
+} from "../../../api/entityMentions";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../../api/entityMentions", () => ({
+  addExclusionPattern: vi.fn(),
+  removeExclusionPattern: vi.fn(),
+}));
+
+const mockedAdd = vi.mocked(addExclusionPattern);
+const mockedRemove = vi.mocked(removeExclusionPattern);
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function renderSection(
+  patterns: string[] = [],
+  entityId = "entity-uuid-001"
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ExclusionPatternsSection entityId={entityId} patterns={patterns} />
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default: both API calls succeed.
+  mockedAdd.mockResolvedValue([]);
+  mockedRemove.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ExclusionPatternsSection", () => {
+  // -------------------------------------------------------------------------
+  // Test 1 — Empty state
+  // -------------------------------------------------------------------------
+
+  describe("Test 1 — Empty state when no patterns", () => {
+    it("renders the 'No exclusion patterns defined' message when patterns is empty", () => {
+      renderSection([]);
+      expect(
+        screen.getByText(/no exclusion patterns defined/i)
+      ).toBeInTheDocument();
+    });
+
+    it("does not render any pill when patterns is empty", () => {
+      renderSection([]);
+      // The list element should not be present when there are no patterns.
+      expect(
+        screen.queryByRole("list", { name: /current exclusion patterns/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2 — Renders pattern list
+  // -------------------------------------------------------------------------
+
+  describe("Test 2 — Renders current patterns as pills", () => {
+    it("renders a pill for each pattern in the patterns prop", () => {
+      renderSection(["New Mexico", "Mexico City"]);
+      expect(screen.getByText("New Mexico")).toBeInTheDocument();
+      expect(screen.getByText("Mexico City")).toBeInTheDocument();
+    });
+
+    it("does not show the empty state when patterns are provided", () => {
+      renderSection(["New Mexico"]);
+      expect(
+        screen.queryByText(/no exclusion patterns defined/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3 — Remove button accessibility
+  // -------------------------------------------------------------------------
+
+  describe("Test 3 — Each pill has an accessible remove button", () => {
+    it("renders a remove button for each pattern with an accessible label", () => {
+      renderSection(["New Mexico", "Mexico City"]);
+
+      expect(
+        screen.getByRole("button", {
+          name: /remove exclusion pattern "New Mexico"/i,
+        })
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("button", {
+          name: /remove exclusion pattern "Mexico City"/i,
+        })
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4 — Remove calls API and cache invalidation
+  // -------------------------------------------------------------------------
+
+  describe("Test 4 — Remove button calls removeExclusionPattern", () => {
+    it("calls removeExclusionPattern with entity id and pattern on click", async () => {
+      const user = userEvent.setup();
+      renderSection(["New Mexico"], "entity-uuid-001");
+
+      const removeBtn = screen.getByRole("button", {
+        name: /remove exclusion pattern "New Mexico"/i,
+      });
+      await user.click(removeBtn);
+
+      await waitFor(() => {
+        expect(mockedRemove).toHaveBeenCalledOnce();
+      });
+
+      expect(mockedRemove).toHaveBeenCalledWith("entity-uuid-001", "New Mexico");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5 — Remove loading state
+  // -------------------------------------------------------------------------
+
+  describe("Test 5 — Remove button shows loading state while in-flight", () => {
+    it("disables the remove button while the remove request is in flight", async () => {
+      let resolveFn!: (value: string[]) => void;
+      mockedRemove.mockReturnValue(
+        new Promise<string[]>((resolve) => {
+          resolveFn = resolve;
+        })
+      );
+
+      const user = userEvent.setup();
+      renderSection(["New Mexico"]);
+
+      const removeBtn = screen.getByRole("button", {
+        name: /remove exclusion pattern "New Mexico"/i,
+      });
+      await user.click(removeBtn);
+
+      expect(removeBtn).toBeDisabled();
+
+      // Settle promise to avoid warnings.
+      resolveFn([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 6 — Remove failure shows inline error
+  // -------------------------------------------------------------------------
+
+  describe("Test 6 — Remove failure shows inline error on the pill", () => {
+    it("shows a generic error message when remove fails", async () => {
+      mockedRemove.mockRejectedValue({ status: 500 });
+
+      const user = userEvent.setup();
+      renderSection(["New Mexico"]);
+
+      const removeBtn = screen.getByRole("button", {
+        name: /remove exclusion pattern "New Mexico"/i,
+      });
+      await user.click(removeBtn);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/failed to remove pattern/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows a 404 error message when entity or pattern not found", async () => {
+      mockedRemove.mockRejectedValue({ status: 404 });
+
+      const user = userEvent.setup();
+      renderSection(["New Mexico"]);
+
+      const removeBtn = screen.getByRole("button", {
+        name: /remove exclusion pattern "New Mexico"/i,
+      });
+      await user.click(removeBtn);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/pattern or entity not found/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("remove error has role='alert'", async () => {
+      mockedRemove.mockRejectedValue({ status: 500 });
+
+      const user = userEvent.setup();
+      renderSection(["New Mexico"]);
+
+      const removeBtn = screen.getByRole("button", {
+        name: /remove exclusion pattern "New Mexico"/i,
+      });
+      await user.click(removeBtn);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 7 — Add form renders accessibly
+  // -------------------------------------------------------------------------
+
+  describe("Test 7 — Add pattern form renders with accessible label", () => {
+    it("renders a form with label 'Add new exclusion pattern'", () => {
+      renderSection([]);
+      expect(
+        screen.getByRole("form", { name: /add new exclusion pattern/i })
+      ).toBeInTheDocument();
+    });
+
+    it("renders the pattern text input", () => {
+      renderSection([]);
+      expect(
+        screen.getByRole("textbox", { name: /exclusion pattern text/i })
+      ).toBeInTheDocument();
+    });
+
+    it("renders the Add button", () => {
+      renderSection([]);
+      expect(
+        screen.getByRole("button", { name: /^add$/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 8 — Add button disabled when empty
+  // -------------------------------------------------------------------------
+
+  describe("Test 8 — Add button disabled when input is empty or whitespace-only", () => {
+    it("Add button is disabled when the input is empty", () => {
+      renderSection([]);
+      expect(screen.getByRole("button", { name: /^add$/i })).toBeDisabled();
+    });
+
+    it("Add button is disabled when the input contains only whitespace", async () => {
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "   ");
+
+      expect(screen.getByRole("button", { name: /^add$/i })).toBeDisabled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 9 — Add button enabled after typing
+  // -------------------------------------------------------------------------
+
+  describe("Test 9 — Add button becomes enabled after typing", () => {
+    it("Add button is enabled after the user types a non-whitespace character", async () => {
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "Monterrey");
+
+      expect(screen.getByRole("button", { name: /^add$/i })).not.toBeDisabled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 10 — Add calls API with trimmed value
+  // -------------------------------------------------------------------------
+
+  describe("Test 10 — Submit calls addExclusionPattern with the trimmed value", () => {
+    it("calls addExclusionPattern with entity id and trimmed pattern", async () => {
+      const user = userEvent.setup();
+      renderSection([], "entity-uuid-001");
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "  Monterrey  ");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(mockedAdd).toHaveBeenCalledOnce();
+      });
+
+      expect(mockedAdd).toHaveBeenCalledWith("entity-uuid-001", "Monterrey");
+    });
+
+    it("submits via Enter key in the input", async () => {
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "Monterrey");
+      await user.keyboard("{Enter}");
+
+      await waitFor(() => {
+        expect(mockedAdd).toHaveBeenCalledOnce();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 11 — Success message shown and input cleared
+  // -------------------------------------------------------------------------
+
+  describe("Test 11 — Success message shown after add and input cleared", () => {
+    it("clears the input after a successful add", async () => {
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "Monterrey");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(input).toHaveValue("");
+      });
+    });
+
+    it("shows a success message after a successful add", async () => {
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "Monterrey");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/"Monterrey" added as exclusion pattern\./i)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 12 — Success message accessibility
+  // -------------------------------------------------------------------------
+
+  describe("Test 12 — Success message has role='status' / aria-live='polite'", () => {
+    it("success message has role='status' and aria-live='polite'", async () => {
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "Monterrey");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("status")).toBeInTheDocument();
+      });
+
+      const statusEl = screen.getByRole("status");
+      expect(statusEl).toHaveAttribute("aria-live", "polite");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 13 — Duplicate pattern (409) error
+  // -------------------------------------------------------------------------
+
+  describe("Test 13 — Duplicate pattern (409) shows specific error message", () => {
+    it("shows 'This exclusion pattern already exists for the entity.' on 409", async () => {
+      mockedAdd.mockRejectedValue({ status: 409 });
+
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "New Mexico");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "This exclusion pattern already exists for the entity."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 14 — 404 error message
+  // -------------------------------------------------------------------------
+
+  describe("Test 14 — 404 error shows entity-not-found message", () => {
+    it("shows 'Entity not found. Please refresh the page.' on 404", async () => {
+      mockedAdd.mockRejectedValue({ status: 404 });
+
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "some-pattern");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Entity not found. Please refresh the page.")
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 15 — Generic error fallback
+  // -------------------------------------------------------------------------
+
+  describe("Test 15 — Generic error shows fallback message", () => {
+    it("shows fallback error for non-409/404 errors", async () => {
+      mockedAdd.mockRejectedValue({ status: 500 });
+
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "some-pattern");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Failed to add exclusion pattern. Please try again."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 16 — Error message accessibility
+  // -------------------------------------------------------------------------
+
+  describe("Test 16 — Error message has role='alert'", () => {
+    it("add error paragraph has role='alert'", async () => {
+      mockedAdd.mockRejectedValue({ status: 409 });
+
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "dup-pattern");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        const alert = screen.getByRole("alert");
+        expect(alert).toBeInTheDocument();
+        expect(alert.tagName).toBe("P");
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 17 — Error clears on typing
+  // -------------------------------------------------------------------------
+
+  describe("Test 17 — Error clears when user types after an error", () => {
+    it("clears the error message when the user types in the input after an add error", async () => {
+      mockedAdd.mockRejectedValue({ status: 409 });
+
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "dup-pattern");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      // Typing again clears the error.
+      await user.type(input, "x");
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 18 — Add button shows "Adding…" while in-flight
+  // -------------------------------------------------------------------------
+
+  describe("Test 18 — Add button shows 'Adding…' while request is in flight", () => {
+    it("shows 'Adding…' on the button while the mutation is pending", async () => {
+      let resolveFn!: (value: string[]) => void;
+      mockedAdd.mockReturnValue(
+        new Promise<string[]>((resolve) => {
+          resolveFn = resolve;
+        })
+      );
+
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "Monterrey");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      expect(screen.getByRole("button", { name: /adding/i })).toBeInTheDocument();
+
+      resolveFn([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 19 — Input disabled while in-flight
+  // -------------------------------------------------------------------------
+
+  describe("Test 19 — Input is disabled while request is in flight", () => {
+    it("disables the pattern input while the add mutation is pending", async () => {
+      let resolveFn!: (value: string[]) => void;
+      mockedAdd.mockReturnValue(
+        new Promise<string[]>((resolve) => {
+          resolveFn = resolve;
+        })
+      );
+
+      const user = userEvent.setup();
+      renderSection([]);
+
+      const input = screen.getByRole("textbox", { name: /exclusion pattern text/i });
+      await user.type(input, "Monterrey");
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      expect(input).toBeDisabled();
+
+      resolveFn([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 20 — Help text is present
+  // -------------------------------------------------------------------------
+
+  describe("Test 20 — Help text is present", () => {
+    it("renders the descriptive help text about exclusion patterns", () => {
+      renderSection([]);
+      expect(
+        screen.getByText(/phrases listed here will not trigger mention detection/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 21 — Section heading is accessible
+  // -------------------------------------------------------------------------
+
+  describe("Test 21 — Section heading is accessible", () => {
+    it("renders an h2 heading 'Exclusion Patterns'", () => {
+      renderSection([]);
+      expect(
+        screen.getByRole("heading", {
+          name: /exclusion patterns/i,
+          level: 2,
+        })
+      ).toBeInTheDocument();
+    });
+
+    it("section has aria-labelledby pointing at the heading id", () => {
+      const { container } = renderSection([]);
+      const section = container.querySelector(
+        "section[aria-labelledby='entity-exclusion-patterns-heading']"
+      );
+      expect(section).not.toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 22 — Pattern list has accessible label
+  // -------------------------------------------------------------------------
+
+  describe("Test 22 — Pattern list has accessible label when patterns exist", () => {
+    it("pattern list has aria-label 'Current exclusion patterns'", () => {
+      renderSection(["New Mexico"]);
+      expect(
+        screen.getByRole("list", { name: /current exclusion patterns/i })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/corrections/__tests__/PhoneticVariantsSection.test.tsx
+++ b/frontend/src/components/corrections/__tests__/PhoneticVariantsSection.test.tsx
@@ -1,0 +1,535 @@
+/**
+ * Tests for PhoneticVariantsSection component.
+ *
+ * Coverage:
+ * - Renders collapsed by default, does not fetch data when collapsed
+ * - Expands on button click, shows loading then data
+ * - Confidence slider filters results (client-side via hook)
+ * - Register as Alias button calls API and transitions to success state
+ * - Find & Replace button navigates with correct route state
+ * - Empty state shown when no matches pass threshold
+ * - Error state rendered when fetch fails
+ * - aria-expanded toggles correctly
+ * - Table columns present when data loads
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { PhoneticVariantsSection } from "../PhoneticVariantsSection";
+import { usePhoneticMatches } from "../../../hooks/usePhoneticMatches";
+import { createEntityAlias } from "../../../api/entityMentions";
+import type { PhoneticMatch } from "../../../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../../hooks/usePhoneticMatches", () => ({
+  usePhoneticMatches: vi.fn(),
+}));
+
+vi.mock("../../../api/entityMentions", () => ({
+  createEntityAlias: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockedUsePhoneticMatches = vi.mocked(usePhoneticMatches);
+const mockedCreateEntityAlias = vi.mocked(createEntityAlias);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makePhoneticMatch(overrides: Partial<PhoneticMatch> = {}): PhoneticMatch {
+  return {
+    original_text: "noam chomski",
+    proposed_correction: "Noam Chomsky",
+    confidence: 0.8,
+    evidence_description: "Phonetic similarity via double metaphone",
+    video_id: "video-uuid-001",
+    segment_id: 42,
+    video_title: "Chomsky on Language",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hook stub helpers
+// ---------------------------------------------------------------------------
+
+type HookResult = ReturnType<typeof usePhoneticMatches>;
+
+function makeIdleHook(): HookResult {
+  return {
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    effectiveServerFloor: 0.3,
+  };
+}
+
+function makeLoadingHook(): HookResult {
+  return {
+    ...makeIdleHook(),
+    isLoading: true,
+  };
+}
+
+function makeSuccessHook(data: PhoneticMatch[]): HookResult {
+  return {
+    ...makeIdleHook(),
+    data,
+    isSuccess: true,
+  };
+}
+
+function makeErrorHook(): HookResult {
+  return {
+    ...makeIdleHook(),
+    isError: true,
+    error: new Error("Network error"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function renderSection(entityId = "entity-uuid-001") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <PhoneticVariantsSection entityId={entityId} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function getDisclosureButton() {
+  return screen.getByRole("button", { name: /suspected asr variants/i });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PhoneticVariantsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: idle (collapsed — hook receives enabled=false)
+    mockedUsePhoneticMatches.mockReturnValue(makeIdleHook());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Collapsed by default
+  // -------------------------------------------------------------------------
+
+  it("renders the section header collapsed by default", () => {
+    renderSection();
+    const btn = getDisclosureButton();
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("does not render the table when collapsed", () => {
+    renderSection();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("does not pass enabled=true to the hook when collapsed", () => {
+    renderSection();
+    expect(mockedUsePhoneticMatches).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Expanding the section
+  // -------------------------------------------------------------------------
+
+  it("expands on button click and sets aria-expanded to true", () => {
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+    expect(getDisclosureButton()).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("shows loading skeleton while fetching after expand", () => {
+    mockedUsePhoneticMatches.mockReturnValue(makeLoadingHook());
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+    expect(
+      screen.getByRole("status", { name: /loading phonetic variants/i })
+    ).toBeInTheDocument();
+  });
+
+  it("passes enabled=true to the hook after expansion", () => {
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+    expect(mockedUsePhoneticMatches).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true })
+    );
+  });
+
+  it("collapses again on second click", () => {
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+    expect(getDisclosureButton()).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(getDisclosureButton());
+    expect(getDisclosureButton()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  // -------------------------------------------------------------------------
+  // Table columns
+  // -------------------------------------------------------------------------
+
+  it("renders all table column headers when data is present", () => {
+    mockedUsePhoneticMatches.mockReturnValue(
+      makeSuccessHook([makePhoneticMatch()])
+    );
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(screen.getByText("Original Text")).toBeInTheDocument();
+    expect(screen.getByText("Proposed Correction")).toBeInTheDocument();
+    expect(screen.getByText("Confidence")).toBeInTheDocument();
+    expect(screen.getByText("Evidence")).toBeInTheDocument();
+    expect(screen.getByText("Video Title")).toBeInTheDocument();
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+  });
+
+  it("renders match data in table rows", () => {
+    const match = makePhoneticMatch({
+      original_text: "chomski",
+      proposed_correction: "Chomsky",
+      video_title: "Test Video",
+      evidence_description: "Double metaphone",
+    });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(screen.getByText("chomski")).toBeInTheDocument();
+    expect(screen.getByText("Chomsky")).toBeInTheDocument();
+    expect(screen.getByText("Test Video")).toBeInTheDocument();
+    expect(screen.getByText("Double metaphone")).toBeInTheDocument();
+  });
+
+  it("renders confidence as a percentage badge", () => {
+    const match = makePhoneticMatch({ confidence: 0.75 });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(screen.getByLabelText("75% confidence")).toBeInTheDocument();
+  });
+
+  it("shows 'Unknown video' when video_title is null", () => {
+    const match = makePhoneticMatch({ video_title: null });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(screen.getByText("Unknown video")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Confidence slider
+  // -------------------------------------------------------------------------
+
+  it("renders the confidence threshold slider when expanded", () => {
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    const slider = screen.getByRole("slider", { name: /confidence threshold/i });
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute("min", "0");
+    expect(slider).toHaveAttribute("max", "1");
+    expect(slider).toHaveAttribute("step", "0.05");
+  });
+
+  it("slider has correct aria-valuetext", () => {
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    const slider = screen.getByRole("slider", { name: /confidence threshold/i });
+    // Default displayThreshold is 0.5 → 50%
+    expect(slider).toHaveAttribute(
+      "aria-valuetext",
+      "Confidence threshold: 50%"
+    );
+  });
+
+  it("updates displayed threshold percentage when slider changes", () => {
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    const slider = screen.getByRole("slider", { name: /confidence threshold/i });
+    fireEvent.change(slider, { target: { value: "0.7" } });
+
+    // The label/display should now show 70%
+    expect(screen.getByText("70%")).toBeInTheDocument();
+  });
+
+  it("passes displayThreshold to the hook when slider changes", () => {
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    const slider = screen.getByRole("slider", { name: /confidence threshold/i });
+    fireEvent.change(slider, { target: { value: "0.8" } });
+
+    expect(mockedUsePhoneticMatches).toHaveBeenCalledWith(
+      expect.objectContaining({ displayThreshold: 0.8 })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Register as Alias
+  // -------------------------------------------------------------------------
+
+  it("renders 'Register as Alias' button for each match", () => {
+    const match = makePhoneticMatch({ original_text: "chomski" });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(
+      screen.getByRole("button", { name: /register "chomski" as alias/i })
+    ).toBeInTheDocument();
+  });
+
+  it("calls createEntityAlias with correct args when Register as Alias is clicked", async () => {
+    mockedCreateEntityAlias.mockResolvedValueOnce({
+      alias_name: "chomski",
+      alias_type: "name_variant",
+      occurrence_count: 1,
+    });
+    const match = makePhoneticMatch({
+      original_text: "chomski",
+      proposed_correction: "Chomsky",
+    });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    const registerBtn = screen.getByRole("button", {
+      name: /register "chomski" as alias/i,
+    });
+    fireEvent.click(registerBtn);
+
+    await waitFor(() => {
+      expect(mockedCreateEntityAlias).toHaveBeenCalledWith(
+        "entity-uuid-001",
+        "chomski",
+        "name_variant"
+      );
+    });
+  });
+
+  it("shows 'Registered' checkmark state after successful alias creation", async () => {
+    mockedCreateEntityAlias.mockResolvedValueOnce({
+      alias_name: "chomski",
+      alias_type: "name_variant",
+      occurrence_count: 1,
+    });
+    const match = makePhoneticMatch({ original_text: "chomski" });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /register "chomski" as alias/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Alias registered")).toBeInTheDocument();
+    });
+    // The register button should no longer be present
+    expect(
+      screen.queryByRole("button", { name: /register "chomski" as alias/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows error message when alias creation fails", async () => {
+    mockedCreateEntityAlias.mockRejectedValueOnce(
+      Object.assign(new Error("Server error"), { status: 500 })
+    );
+    const match = makePhoneticMatch({ original_text: "chomski" });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    // Use real timers for this test — we only need to verify the error appears,
+    // not that it auto-dismisses after the 4-second timeout.
+    vi.useRealTimers();
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /register "chomski" as alias/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(
+        screen.getByText(/failed to register alias/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows 409 conflict message when alias already exists", async () => {
+    mockedCreateEntityAlias.mockRejectedValueOnce(
+      Object.assign(new Error("Conflict"), { status: 409 })
+    );
+    const match = makePhoneticMatch({ original_text: "chomski" });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    // Use real timers for this test — we only need to verify the conflict
+    // message appears, not the auto-dismiss behaviour.
+    vi.useRealTimers();
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /register "chomski" as alias/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/this alias already exists/i)).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Find & Replace navigation
+  // -------------------------------------------------------------------------
+
+  it("renders 'Find & Replace' button for each match", () => {
+    const match = makePhoneticMatch({
+      original_text: "chomski",
+      proposed_correction: "Chomsky",
+    });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(
+      screen.getByRole("button", {
+        name: /find and replace "chomski" with "Chomsky"/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("navigates to /corrections/batch with state when Find & Replace is clicked", () => {
+    const match = makePhoneticMatch({
+      original_text: "chomski",
+      proposed_correction: "Chomsky",
+    });
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /find and replace "chomski" with "Chomsky"/i,
+      })
+    );
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith("/corrections/batch", {
+      state: {
+        pattern: "chomski",
+        replacement: "Chomsky",
+      },
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it("shows empty state message when no matches are found", () => {
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(
+      screen.getByText(/no suspected asr variants found/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the table in empty state", () => {
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([]));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it("shows error alert when fetch fails", () => {
+    mockedUsePhoneticMatches.mockReturnValue(makeErrorHook());
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(
+      screen.getByText(/failed to load phonetic variants/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the table in error state", () => {
+    mockedUsePhoneticMatches.mockReturnValue(makeErrorHook());
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple matches
+  // -------------------------------------------------------------------------
+
+  it("renders all match rows when multiple matches are returned", () => {
+    const matches = [
+      makePhoneticMatch({
+        original_text: "match-a",
+        segment_id: 1,
+        video_id: "v1",
+      }),
+      makePhoneticMatch({
+        original_text: "match-b",
+        segment_id: 2,
+        video_id: "v2",
+      }),
+    ];
+    mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook(matches));
+    renderSection();
+    fireEvent.click(getDisclosureButton());
+
+    expect(screen.getByText("match-a")).toBeInTheDocument();
+    expect(screen.getByText("match-b")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/icons/ChartBarIcon.tsx
+++ b/frontend/src/components/icons/ChartBarIcon.tsx
@@ -1,0 +1,25 @@
+/**
+ * ChartBarIcon component - a bar chart icon representing analysis/patterns.
+ *
+ * Used as the icon for the ASR Error Patterns navigation entry.
+ */
+
+/**
+ * ChartBarIcon displays a bar chart icon.
+ *
+ * @param props - Standard SVG props for customization
+ */
+export const ChartBarIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    aria-hidden="true"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+  </svg>
+);

--- a/frontend/src/components/icons/ClockIcon.tsx
+++ b/frontend/src/components/icons/ClockIcon.tsx
@@ -1,0 +1,25 @@
+/**
+ * ClockIcon component - a clock icon representing history or time.
+ *
+ * Used as the icon for the Batch History navigation entry.
+ */
+
+/**
+ * ClockIcon displays a clock face icon.
+ *
+ * @param props - Standard SVG props for customization
+ */
+export const ClockIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    aria-hidden="true"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+  </svg>
+);

--- a/frontend/src/components/icons/TranscriptsIcon.tsx
+++ b/frontend/src/components/icons/TranscriptsIcon.tsx
@@ -1,0 +1,25 @@
+/**
+ * TranscriptsIcon component - a document-text icon representing transcripts.
+ *
+ * Used as the group icon for the Transcripts sidebar navigation group.
+ */
+
+/**
+ * TranscriptsIcon displays a document with lines icon for the Transcripts nav group.
+ *
+ * @param props - Standard SVG props for customization
+ */
+export const TranscriptsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    aria-hidden="true"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+  </svg>
+);

--- a/frontend/src/components/icons/index.ts
+++ b/frontend/src/components/icons/index.ts
@@ -3,8 +3,11 @@
  */
 
 export { BatchCorrectionsIcon } from "./BatchCorrectionsIcon";
+export { ChartBarIcon } from "./ChartBarIcon";
 export { ChannelIcon } from "./ChannelIcon";
+export { ClockIcon } from "./ClockIcon";
 export { EntityIcon } from "./EntityIcon";
 export { PlaylistIcon } from "./PlaylistIcon";
 export { SearchIcon } from "./SearchIcon";
+export { TranscriptsIcon } from "./TranscriptsIcon";
 export { VideoIcon } from "./VideoIcon";

--- a/frontend/src/components/layout/NavGroup.tsx
+++ b/frontend/src/components/layout/NavGroup.tsx
@@ -1,0 +1,190 @@
+/**
+ * NavGroup component - collapsible sidebar navigation group.
+ *
+ * Implements the Transcripts sidebar group from Feature 046 (US0).
+ *
+ * Accessibility:
+ * - AR-001: button with aria-expanded for expand/collapse state
+ * - AR-005: Keyboard navigable (Enter/Space toggles group)
+ * - FR-014: Compact mode hides label at <1024px, shows icon + tooltip
+ * - FR-015: title={tooltip} provides browser-native tooltips in icon-only mode
+ */
+
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import type { NavRoute } from "../../router/routes";
+import { NavItem } from "./NavItem";
+
+/**
+ * Props for the NavGroup component.
+ */
+interface NavGroupProps {
+  /** Display label for the group header */
+  label: string;
+  /** Tooltip text for accessibility (shown in compact/icon-only mode) */
+  tooltip: string;
+  /** Icon component for the group header */
+  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  /** Child routes rendered inside this group when expanded */
+  routes: NavRoute[];
+  /** Whether the group starts expanded before localStorage is checked */
+  defaultExpanded?: boolean;
+  /** localStorage key for persisting expand/collapse state */
+  storageKey: string;
+}
+
+/**
+ * Build className for the group header button based on whether any child is active.
+ *
+ * Visual Design mirrors NavItem:
+ * - Active child: bg-slate-800 text-white border-l-[3px] border-blue-500
+ * - Default: text-slate-400 hover:bg-slate-800/50 hover:text-slate-200
+ */
+function buildGroupHeaderClassName(hasActiveChild: boolean): string {
+  const baseClasses = [
+    "w-full flex items-center gap-2",
+    "py-3 px-4 lg:px-4",
+    "justify-center lg:justify-start",
+    "text-sm",
+    "min-h-[44px] min-w-[44px]",
+    "focus:ring-2 focus:ring-blue-500 focus:outline-none",
+    "transition-colors duration-150",
+  ];
+
+  const stateClasses = hasActiveChild
+    ? [
+        "bg-slate-800/50 text-white",
+        "border-l-[3px] border-blue-500/60",
+      ]
+    : [
+        "text-slate-400",
+        "hover:bg-slate-800/50 hover:text-slate-200",
+        "border-l-[3px] border-transparent",
+      ];
+
+  return [...baseClasses, ...stateClasses].join(" ");
+}
+
+/**
+ * NavGroup renders a collapsible group of navigation links.
+ *
+ * Behaviour:
+ * - Expand/collapse toggled by clicking the group header button
+ * - State persisted to localStorage via storageKey
+ * - Auto-expands when any child route matches the current pathname
+ * - In compact (<1024px) mode: shows icon only; click navigates to first child
+ * - In full (>=1024px) mode: shows icon + label + chevron; click toggles
+ *
+ * @param props - NavGroup properties
+ */
+export function NavGroup({
+  label,
+  tooltip,
+  icon: Icon,
+  routes,
+  defaultExpanded = true,
+  storageKey,
+}: NavGroupProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // Determine whether any child route is active
+  const hasActiveChild = routes.some(
+    (child) =>
+      location.pathname === child.path ||
+      location.pathname.startsWith(child.path + "/")
+  );
+
+  // Initialize from localStorage, falling back to defaultExpanded
+  const [isExpanded, setIsExpanded] = useState<boolean>(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored !== null) {
+      return stored === "true";
+    }
+    return defaultExpanded;
+  });
+
+  // Auto-expand when a child route becomes active
+  useEffect(() => {
+    if (hasActiveChild) {
+      setIsExpanded(true);
+    }
+  }, [hasActiveChild]);
+
+  // Persist expand/collapse state to localStorage
+  useEffect(() => {
+    localStorage.setItem(storageKey, String(isExpanded));
+  }, [isExpanded, storageKey]);
+
+  /**
+   * Handle header button click.
+   *
+   * In compact mode (<1024px), the label is hidden; clicking should navigate
+   * to the first child rather than toggling the group (which would be invisible).
+   * We detect compact mode by checking window.innerWidth against the lg breakpoint (1024px).
+   */
+  function handleHeaderClick() {
+    const isCompact = window.innerWidth < 1024;
+    if (isCompact) {
+      const firstChild = routes[0];
+      if (firstChild) {
+        navigate(firstChild.path);
+      }
+    } else {
+      setIsExpanded((prev) => !prev);
+    }
+  }
+
+  return (
+    <li>
+      {/* Group header button */}
+      <button
+        type="button"
+        onClick={handleHeaderClick}
+        title={tooltip}
+        aria-expanded={isExpanded}
+        className={buildGroupHeaderClassName(hasActiveChild)}
+      >
+        {/* Group icon */}
+        <Icon className="h-6 w-6 flex-shrink-0" />
+
+        {/* Group label — hidden in compact mode, visible at lg: */}
+        <span className="hidden lg:inline flex-1 text-left">{label}</span>
+
+        {/* Chevron indicator — hidden in compact mode */}
+        <svg
+          className={[
+            "hidden lg:block h-4 w-4 flex-shrink-0 transition-transform duration-200",
+            isExpanded ? "rotate-90" : "",
+          ].join(" ")}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          aria-hidden="true"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+
+      {/* Child routes — only rendered when expanded */}
+      {isExpanded && (
+        <ul role="list" className="flex flex-col lg:pl-4">
+          {routes.map((child) => (
+            <li key={child.path}>
+              <NavItem
+                to={child.path}
+                icon={child.icon}
+                label={child.label}
+                tooltip={child.tooltip}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/components/layout/NavItem.tsx
+++ b/frontend/src/components/layout/NavItem.tsx
@@ -93,7 +93,7 @@ function buildClassName(isActive: boolean): string {
  */
 export function NavItem({ to, icon: Icon, label, tooltip }: NavItemProps) {
   return (
-    <NavLink to={to} title={tooltip} className={({ isActive }) => buildClassName(isActive)}>
+    <NavLink to={to} end title={tooltip} className={({ isActive }) => buildClassName(isActive)}>
       {/* VD-009: Icon 24x24px with aria-hidden (already set in icon components) */}
       <Icon className="h-6 w-6 flex-shrink-0" />
       {/* FR-014: Label hidden below 1024px, visible at lg: breakpoint */}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -7,9 +7,12 @@
  * Implements User Story 5: Responsive Sidebar Layout
  * - FR-014: Responsive sidebar with full labels at >=1024px, icons-only below
  * - VD-006: Width 64px (icons-only) or 240px (full labels)
+ *
+ * Feature 046 (US0): Supports collapsible NavGroup entries alongside flat NavItem entries.
  */
 
 import { navRoutes } from "../../router/routes";
+import { NavGroup } from "./NavGroup";
 import { NavItem } from "./NavItem";
 
 /**
@@ -26,7 +29,7 @@ import { NavItem } from "./NavItem";
  * Accessibility:
  * - AR-001: <nav aria-label="Main navigation">
  * - AR-003: Icons have aria-hidden="true" (handled in icon components)
- * - AR-005: Keyboard navigable (Tab/Shift+Tab) via NavLink
+ * - AR-005: Keyboard navigable (Tab/Shift+Tab) via NavLink / button
  *
  * Layout:
  * - Fixed height: min-h-screen
@@ -56,16 +59,32 @@ export function Sidebar() {
     >
       {/* Navigation items */}
       <ul className="flex flex-col" role="list">
-        {navRoutes.map((route) => (
-          <li key={route.path}>
-            <NavItem
-              to={route.path}
-              icon={route.icon}
-              label={route.label}
-              tooltip={route.tooltip}
-            />
-          </li>
-        ))}
+        {navRoutes.map((entry) => {
+          if (entry.kind === "group") {
+            return (
+              <NavGroup
+                key={entry.label}
+                label={entry.label}
+                tooltip={entry.tooltip}
+                icon={entry.icon}
+                routes={entry.children}
+                defaultExpanded={entry.defaultExpanded}
+                storageKey={entry.storageKey}
+              />
+            );
+          }
+
+          return (
+            <li key={entry.path}>
+              <NavItem
+                to={entry.path}
+                icon={entry.icon}
+                label={entry.label}
+                tooltip={entry.tooltip}
+              />
+            </li>
+          );
+        })}
       </ul>
     </nav>
   );

--- a/frontend/src/components/layout/__tests__/NavGroup.test.tsx
+++ b/frontend/src/components/layout/__tests__/NavGroup.test.tsx
@@ -1,0 +1,352 @@
+/**
+ * Tests for NavGroup component — Feature 046 (US0) sidebar restructuring.
+ *
+ * Coverage:
+ * - Renders expanded by default when defaultExpanded=true
+ * - Renders collapsed by default when defaultExpanded=false
+ * - Toggle collapse on button click
+ * - Toggle expand on button click when collapsed
+ * - localStorage persistence: reads initial state from storage
+ * - localStorage persistence: writes state changes to storage
+ * - Auto-expand when a child route is active (mock useLocation)
+ * - Compact mode: click navigates to first child (mock useNavigate)
+ * - aria-expanded attribute updates correctly
+ * - Child routes render as NavItem links when expanded
+ * - Child routes are hidden when collapsed
+ * - Group header has accessible title (tooltip)
+ * - Chevron is present in expanded state
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { NavGroup } from "../NavGroup";
+import type { NavRoute } from "../../../router/routes";
+
+// ---------------------------------------------------------------------------
+// Mock useNavigate so we can assert navigation calls
+// ---------------------------------------------------------------------------
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_ICON: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg data-testid="group-icon" {...props} />
+);
+
+const CHILD_ICON: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg data-testid="child-icon" {...props} />
+);
+
+const mockRoutes: NavRoute[] = [
+  {
+    kind: "route",
+    path: "/search",
+    label: "Search",
+    tooltip: "Search transcripts",
+    icon: CHILD_ICON,
+  },
+  {
+    kind: "route",
+    path: "/corrections/batch",
+    label: "Find & Replace",
+    tooltip: "Batch corrections",
+    icon: CHILD_ICON,
+  },
+];
+
+const STORAGE_KEY = "test.navgroup.expanded";
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+interface RenderOptions {
+  currentPath?: string;
+  defaultExpanded?: boolean;
+  storageKey?: string;
+}
+
+function renderNavGroup({
+  currentPath = "/",
+  defaultExpanded = true,
+  storageKey = STORAGE_KEY,
+}: RenderOptions = {}) {
+  return render(
+    <MemoryRouter initialEntries={[currentPath]}>
+      <ul>
+        <NavGroup
+          label="Transcripts"
+          tooltip="Transcripts navigation group"
+          icon={MOCK_ICON}
+          routes={mockRoutes}
+          defaultExpanded={defaultExpanded}
+          storageKey={storageKey}
+        />
+      </ul>
+    </MemoryRouter>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// localStorage mock helpers
+// ---------------------------------------------------------------------------
+
+function setLocalStorage(key: string, value: string) {
+  localStorage.setItem(key, value);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  localStorage.clear();
+  mockNavigate.mockClear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("NavGroup — default expansion", () => {
+  it("renders expanded by default when defaultExpanded=true", () => {
+    renderNavGroup({ defaultExpanded: true });
+    // Children are visible when expanded
+    expect(screen.getByRole("link", { name: /search/i })).toBeInTheDocument();
+  });
+
+  it("renders collapsed by default when defaultExpanded=false", () => {
+    renderNavGroup({ defaultExpanded: false });
+    // Children are hidden when collapsed
+    expect(
+      screen.queryByRole("link", { name: /search/i })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("NavGroup — toggle behaviour", () => {
+  it("collapses when the header button is clicked while expanded", () => {
+    renderNavGroup({ defaultExpanded: true });
+
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    fireEvent.click(button);
+
+    expect(
+      screen.queryByRole("link", { name: /search/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("expands when the header button is clicked while collapsed", () => {
+    renderNavGroup({ defaultExpanded: false });
+
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    fireEvent.click(button);
+
+    expect(screen.getByRole("link", { name: /search/i })).toBeInTheDocument();
+  });
+});
+
+describe("NavGroup — aria-expanded", () => {
+  it("aria-expanded is 'true' when expanded", () => {
+    renderNavGroup({ defaultExpanded: true });
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("aria-expanded is 'false' when collapsed", () => {
+    renderNavGroup({ defaultExpanded: false });
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("aria-expanded updates to 'false' after collapsing", () => {
+    renderNavGroup({ defaultExpanded: true });
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("aria-expanded updates to 'true' after expanding", () => {
+    renderNavGroup({ defaultExpanded: false });
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+});
+
+describe("NavGroup — localStorage persistence", () => {
+  it("reads initial collapsed state from localStorage", () => {
+    setLocalStorage(STORAGE_KEY, "false");
+    renderNavGroup({ defaultExpanded: true }); // defaultExpanded is overridden by storage
+
+    expect(
+      screen.queryByRole("link", { name: /search/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("reads initial expanded state from localStorage", () => {
+    setLocalStorage(STORAGE_KEY, "true");
+    renderNavGroup({ defaultExpanded: false }); // defaultExpanded is overridden by storage
+
+    expect(screen.getByRole("link", { name: /search/i })).toBeInTheDocument();
+  });
+
+  it("writes collapsed state to localStorage after toggle", () => {
+    renderNavGroup({ defaultExpanded: true });
+
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    fireEvent.click(button);
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("false");
+  });
+
+  it("writes expanded state to localStorage after toggle", () => {
+    renderNavGroup({ defaultExpanded: false });
+
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    fireEvent.click(button);
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+});
+
+describe("NavGroup — auto-expand when child route is active", () => {
+  it("auto-expands when current path matches a child route", () => {
+    // Start collapsed, navigate to a child route — should auto-expand
+    renderNavGroup({
+      currentPath: "/search",
+      defaultExpanded: false,
+    });
+
+    // The group should auto-expand because /search is an active child
+    expect(screen.getByRole("link", { name: /search/i })).toBeInTheDocument();
+  });
+
+  it("stays collapsed when no child route is active and defaultExpanded is false", () => {
+    renderNavGroup({
+      currentPath: "/videos",
+      defaultExpanded: false,
+    });
+
+    expect(
+      screen.queryByRole("link", { name: /search/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("auto-expands for nested child path (sub-route prefix match)", () => {
+    // /corrections/batch is a child; /corrections/batch/123 should still match
+    renderNavGroup({
+      currentPath: "/corrections/batch/123",
+      defaultExpanded: false,
+    });
+
+    expect(screen.getByRole("link", { name: /find & replace/i })).toBeInTheDocument();
+  });
+});
+
+describe("NavGroup — child routes render as NavItem links", () => {
+  it("renders all child routes as links when expanded", () => {
+    renderNavGroup({ defaultExpanded: true });
+
+    expect(screen.getByRole("link", { name: /search/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /find & replace/i })
+    ).toBeInTheDocument();
+  });
+
+  it("each child link has the correct href", () => {
+    renderNavGroup({ defaultExpanded: true });
+
+    const searchLink = screen.getByRole("link", { name: /search/i });
+    expect(searchLink).toHaveAttribute("href", "/search");
+
+    const batchLink = screen.getByRole("link", { name: /find & replace/i });
+    expect(batchLink).toHaveAttribute("href", "/corrections/batch");
+  });
+
+  it("child routes are not rendered when collapsed", () => {
+    renderNavGroup({ defaultExpanded: false });
+
+    expect(
+      screen.queryByRole("link", { name: /search/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /find & replace/i })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("NavGroup — group header", () => {
+  it("renders the group label text", () => {
+    renderNavGroup({ defaultExpanded: true });
+    // The label text is rendered in the button
+    expect(
+      screen.getByRole("button", { name: /transcripts/i })
+    ).toBeInTheDocument();
+  });
+
+  it("header button has title attribute set to tooltip", () => {
+    renderNavGroup({ defaultExpanded: true });
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    expect(button).toHaveAttribute("title", "Transcripts navigation group");
+  });
+
+  it("renders the group icon", () => {
+    renderNavGroup({ defaultExpanded: true });
+    expect(screen.getByTestId("group-icon")).toBeInTheDocument();
+  });
+});
+
+describe("NavGroup — compact mode (< 1024px)", () => {
+  beforeEach(() => {
+    // Simulate compact viewport
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 768,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+  });
+
+  it("clicking the header navigates to the first child route in compact mode", () => {
+    renderNavGroup({ defaultExpanded: true });
+
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    fireEvent.click(button);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/search");
+  });
+
+  it("does not toggle expand/collapse state in compact mode", () => {
+    renderNavGroup({ defaultExpanded: true });
+
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    fireEvent.click(button);
+
+    // State should not have changed from expanded — links still visible
+    expect(screen.getByRole("link", { name: /search/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Tests for Sidebar component — Feature 046 (US0) sidebar restructuring.
+ *
+ * Coverage:
+ * - Renders the nav landmark with accessible label
+ * - Renders exactly 5 top-level entries (4 li items + 1 NavGroup li)
+ * - Flat nav items (Videos, Channels, Playlists, Entities) render as links
+ * - Transcripts group renders with NavGroup (disclosure button)
+ * - Transcripts group is expanded by default and shows child links
+ * - Sidebar has correct background and responsive width classes
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { Sidebar } from "../Sidebar";
+
+// ---------------------------------------------------------------------------
+// Mock useNavigate (NavGroup uses it internally)
+// ---------------------------------------------------------------------------
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+function renderSidebar(currentPath = "/videos") {
+  return render(
+    <MemoryRouter initialEntries={[currentPath]}>
+      <Sidebar />
+    </MemoryRouter>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Sidebar — landmark", () => {
+  it("renders a <nav> with aria-label='Main navigation'", () => {
+    renderSidebar();
+    expect(
+      screen.getByRole("navigation", { name: "Main navigation" })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Sidebar — flat nav items", () => {
+  it("renders the Videos link", () => {
+    renderSidebar();
+    expect(screen.getByRole("link", { name: /videos/i })).toBeInTheDocument();
+  });
+
+  it("Videos link points to /videos", () => {
+    renderSidebar();
+    const link = screen.getByRole("link", { name: /videos/i });
+    expect(link).toHaveAttribute("href", "/videos");
+  });
+
+  it("renders the Channels link", () => {
+    renderSidebar();
+    expect(screen.getByRole("link", { name: /channels/i })).toBeInTheDocument();
+  });
+
+  it("renders the Playlists link", () => {
+    renderSidebar();
+    expect(screen.getByRole("link", { name: /playlists/i })).toBeInTheDocument();
+  });
+
+  it("renders the Entities link", () => {
+    renderSidebar();
+    expect(screen.getByRole("link", { name: /entities/i })).toBeInTheDocument();
+  });
+});
+
+describe("Sidebar — Transcripts group", () => {
+  it("renders the Transcripts disclosure button", () => {
+    renderSidebar();
+    expect(
+      screen.getByRole("button", { name: /transcripts/i })
+    ).toBeInTheDocument();
+  });
+
+  it("Transcripts group is expanded by default", () => {
+    renderSidebar();
+    const button = screen.getByRole("button", { name: /transcripts/i });
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("renders Search as a top-level link (not nested under Transcripts)", () => {
+    renderSidebar();
+    expect(screen.getByRole("link", { name: /search/i })).toBeInTheDocument();
+  });
+
+  it("renders Find & Replace child link when Transcripts group is expanded", () => {
+    renderSidebar();
+    expect(
+      screen.getByRole("link", { name: /find & replace/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders Batch History child link when Transcripts group is expanded", () => {
+    renderSidebar();
+    expect(
+      screen.getByRole("link", { name: /batch history/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders ASR Error Patterns child link when Transcripts group is expanded", () => {
+    renderSidebar();
+    expect(
+      screen.getByRole("link", { name: /asr error patterns/i })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Sidebar — total top-level nav item count", () => {
+  it("top-level list contains 6 entries (Videos, Transcripts group, Channels, Playlists, Entities, Search)", () => {
+    renderSidebar();
+    // The outer <ul role="list"> has exactly 6 <li> children (5 flat routes + 1 group)
+    const nav = screen.getByRole("navigation", { name: "Main navigation" });
+    // The direct child ul has role="list" — query it within the nav
+    const outerList = nav.querySelector("ul[role='list']");
+    expect(outerList).not.toBeNull();
+    const directLiChildren = outerList
+      ? Array.from(outerList.children).filter((el) => el.tagName === "LI")
+      : [];
+    expect(directLiChildren).toHaveLength(6);
+  });
+});

--- a/frontend/src/hooks/__tests__/useBatchApply.test.ts
+++ b/frontend/src/hooks/__tests__/useBatchApply.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for useBatchApply mutation hook.
+ *
+ * Coverage:
+ * - Calls POST /corrections/batch/apply with the correct request body
+ * - Returns the unwrapped BatchApplyResult from the API envelope
+ * - Invalidates all 6 query keys on success per the Feature 046 cache
+ *   invalidation matrix
+ * - Does NOT invalidate caches when the mutation fails
+ * - Does not retry 4xx (client) errors
+ * - Exposes the error when the mutation fails
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+import { apiFetch, isApiError } from "../../api/config";
+import { useBatchApply } from "../useBatchApply";
+import type { BatchApplyRequest, BatchApplyResult } from "../../types/batchCorrections";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  isApiError: vi.fn((err: unknown) => {
+    return (
+      typeof err === "object" &&
+      err !== null &&
+      "status" in err
+    );
+  }),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedIsApiError = vi.mocked(isApiError);
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeRequest(overrides: Partial<BatchApplyRequest> = {}): BatchApplyRequest {
+  return {
+    pattern: "teh",
+    replacement: "the",
+    segment_ids: [42, 99, 137],
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<BatchApplyResult> = {}): BatchApplyResult {
+  return {
+    total_applied: 3,
+    total_skipped: 0,
+    total_failed: 0,
+    failed_segment_ids: [],
+    affected_video_ids: ["video-abc"],
+    rebuild_triggered: true,
+    ...overrides,
+  };
+}
+
+function makeApiEnvelope(result: BatchApplyResult): { data: BatchApplyResult } {
+  return { data: result };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useBatchApply tests
+// ---------------------------------------------------------------------------
+
+describe("useBatchApply", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+    // Default: isApiError returns false unless overridden
+    mockedIsApiError.mockReturnValue(false);
+  });
+
+  it("calls POST /corrections/batch/apply with the request body", async () => {
+    const result = makeResult();
+    mockedApiFetch.mockResolvedValueOnce(makeApiEnvelope(result));
+
+    const request = makeRequest();
+    const { result: hook } = renderHook(() => useBatchApply(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      hook.current.mutate(request);
+    });
+
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true));
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/apply",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(request),
+      })
+    );
+  });
+
+  it("returns the unwrapped BatchApplyResult on success", async () => {
+    const result = makeResult({ total_applied: 5, total_skipped: 2 });
+    mockedApiFetch.mockResolvedValueOnce(makeApiEnvelope(result));
+
+    const { result: hook } = renderHook(() => useBatchApply(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      hook.current.mutate(makeRequest());
+    });
+
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true));
+
+    expect(hook.current.data?.total_applied).toBe(5);
+    expect(hook.current.data?.total_skipped).toBe(2);
+    expect(hook.current.data?.affected_video_ids).toEqual(["video-abc"]);
+  });
+
+  it("invalidates all 6 query keys on success", async () => {
+    mockedApiFetch.mockResolvedValueOnce(makeApiEnvelope(makeResult()));
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result: hook } = renderHook(() => useBatchApply(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      hook.current.mutate(makeRequest());
+    });
+
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true));
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey[0]
+    );
+
+    expect(invalidatedKeys).toContain("transcriptSegments");
+    expect(invalidatedKeys).toContain("transcript");
+    expect(invalidatedKeys).toContain("batch-list");
+    expect(invalidatedKeys).toContain("corrections");
+    expect(invalidatedKeys).toContain("diff-analysis");
+    expect(invalidatedKeys).toContain("cross-segment-candidates");
+    expect(invalidateSpy).toHaveBeenCalledTimes(6);
+
+    invalidateSpy.mockRestore();
+  });
+
+  it("does NOT invalidate caches when the mutation fails", async () => {
+    // Use a 4xx-shaped error so the hook's retry guard returns false immediately
+    // (no retries), preventing the 1-second waitFor timeout.
+    const clientError = Object.assign(new Error("Bad request"), { status: 400 });
+    mockedIsApiError.mockReturnValue(true);
+    mockedApiFetch.mockRejectedValueOnce(clientError);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result: hook } = renderHook(() => useBatchApply(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      hook.current.mutate(makeRequest());
+    });
+
+    await waitFor(() => expect(hook.current.isError).toBe(true));
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+
+    invalidateSpy.mockRestore();
+  });
+
+  it("exposes the error object when the mutation fails", async () => {
+    // Use a 4xx-shaped error so the hook's retry guard returns false immediately.
+    const clientError = Object.assign(new Error("Network failure"), { status: 400 });
+    mockedIsApiError.mockReturnValue(true);
+    mockedApiFetch.mockRejectedValueOnce(clientError);
+
+    const { result: hook } = renderHook(() => useBatchApply(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      hook.current.mutate(makeRequest());
+    });
+
+    await waitFor(() => expect(hook.current.isError).toBe(true));
+
+    expect(hook.current.error).toBeTruthy();
+    expect(hook.current.error?.message).toBe("Network failure");
+  });
+
+  it("does not retry 4xx client errors", async () => {
+    const clientError = Object.assign(new Error("Validation error"), { status: 422 });
+    // isApiError returns true for this error (has status property)
+    mockedIsApiError.mockImplementation((err: unknown) => {
+      return (
+        typeof err === "object" &&
+        err !== null &&
+        "status" in err
+      );
+    });
+    mockedApiFetch.mockRejectedValue(clientError);
+
+    const { result: hook } = renderHook(() => useBatchApply(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      hook.current.mutate(makeRequest());
+    });
+
+    await waitFor(() => expect(hook.current.isError).toBe(true));
+
+    // Only one attempt — no retries for 4xx
+    expect(mockedApiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes optional fields (correction_type, correction_note, entity_id) in the request", async () => {
+    mockedApiFetch.mockResolvedValueOnce(makeApiEnvelope(makeResult()));
+
+    const request = makeRequest({
+      correction_type: "proper_noun",
+      correction_note: "Fixing entity name capitalisation",
+      entity_id: "entity-uuid-001",
+      is_regex: false,
+      case_insensitive: true,
+    });
+
+    const { result: hook } = renderHook(() => useBatchApply(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      hook.current.mutate(request);
+    });
+
+    await waitFor(() => expect(hook.current.isSuccess).toBe(true));
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/apply",
+      expect.objectContaining({
+        body: JSON.stringify(request),
+      })
+    );
+  });
+});

--- a/frontend/src/hooks/__tests__/useBatchHistory.test.ts
+++ b/frontend/src/hooks/__tests__/useBatchHistory.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for useBatchHistory and useRevertBatch hooks.
+ *
+ * Coverage:
+ * - useBatchHistory: fetches first page, getNextPageParam returns undefined
+ *   when has_more=false, returns next offset when has_more=true
+ * - useRevertBatch: calls DELETE with correct URL, invalidates all 6 query
+ *   keys on success
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+import { apiFetch } from "../../api/config";
+import { useBatchHistory, useRevertBatch } from "../useBatchHistory";
+import type { BatchSummary } from "../../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  isApiError: vi.fn((err: unknown) => {
+    return (
+      typeof err === "object" &&
+      err !== null &&
+      "type" in err &&
+      "message" in err
+    );
+  }),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeBatchSummary(overrides: Partial<BatchSummary> = {}): BatchSummary {
+  return {
+    batch_id: "batch-uuid-001",
+    correction_count: 5,
+    corrected_by_user_id: "user:batch",
+    pattern: "colour",
+    replacement: "color",
+    batch_timestamp: "2025-01-15T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeBatchListResponse(
+  data: BatchSummary[],
+  pagination: {
+    has_more: boolean;
+    total: number;
+    offset: number;
+    limit: number;
+  }
+) {
+  return { data, pagination };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useBatchHistory tests
+// ---------------------------------------------------------------------------
+
+describe("useBatchHistory", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+  });
+
+  it("fetches the first page and returns batch data", async () => {
+    const batch = makeBatchSummary();
+    const response = makeBatchListResponse([batch], {
+      has_more: false,
+      total: 1,
+      offset: 0,
+      limit: 20,
+    });
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useBatchHistory(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const batches = result.current.data?.pages.flatMap((p) => p.data) ?? [];
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.batch_id).toBe("batch-uuid-001");
+    expect(batches[0]?.pattern).toBe("colour");
+  });
+
+  it("calls apiFetch with correct URL including offset and limit", async () => {
+    const response = makeBatchListResponse([], {
+      has_more: false,
+      total: 0,
+      offset: 0,
+      limit: 20,
+    });
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useBatchHistory(20), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/batches?offset=0&limit=20",
+      expect.objectContaining({ externalSignal: expect.anything() })
+    );
+  });
+
+  it("returns undefined from getNextPageParam when has_more is false", async () => {
+    const response = makeBatchListResponse([makeBatchSummary()], {
+      has_more: false,
+      total: 1,
+      offset: 0,
+      limit: 20,
+    });
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useBatchHistory(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("returns next offset from getNextPageParam when has_more is true", async () => {
+    const batches = Array.from({ length: 20 }, (_, i) =>
+      makeBatchSummary({ batch_id: `batch-${i}`, pattern: `pattern-${i}` })
+    );
+    const response = makeBatchListResponse(batches, {
+      has_more: true,
+      total: 35,
+      offset: 0,
+      limit: 20,
+    });
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useBatchHistory(20), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it("fetches the second page with offset=20 when fetchNextPage is called", async () => {
+    // First page: 20 items, has_more=true
+    const firstPageBatches = Array.from({ length: 20 }, (_, i) =>
+      makeBatchSummary({ batch_id: `batch-p1-${i}` })
+    );
+    const firstResponse = makeBatchListResponse(firstPageBatches, {
+      has_more: true,
+      total: 25,
+      offset: 0,
+      limit: 20,
+    });
+
+    // Second page: 5 items, has_more=false
+    const secondPageBatches = Array.from({ length: 5 }, (_, i) =>
+      makeBatchSummary({ batch_id: `batch-p2-${i}` })
+    );
+    const secondResponse = makeBatchListResponse(secondPageBatches, {
+      has_more: false,
+      total: 25,
+      offset: 20,
+      limit: 20,
+    });
+
+    mockedApiFetch
+      .mockResolvedValueOnce(firstResponse)
+      .mockResolvedValueOnce(secondResponse);
+
+    const { result } = renderHook(() => useBatchHistory(20), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.pages).toHaveLength(1);
+
+    // Fetch next page
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.data?.pages).toHaveLength(2));
+
+    // Second apiFetch call should use offset=20
+    expect(mockedApiFetch).toHaveBeenNthCalledWith(
+      2,
+      "/corrections/batch/batches?offset=20&limit=20",
+      expect.objectContaining({ externalSignal: expect.anything() })
+    );
+
+    // Both pages' data should be available
+    const allBatches = result.current.data?.pages.flatMap((p) => p.data) ?? [];
+    expect(allBatches).toHaveLength(25);
+    expect(result.current.hasNextPage).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useRevertBatch tests
+// ---------------------------------------------------------------------------
+
+describe("useRevertBatch", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+  });
+
+  it("calls DELETE with the correct batch ID URL", async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      data: { reverted_count: 5, skipped_count: 0 },
+    });
+
+    const { result } = renderHook(() => useRevertBatch(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate("batch-uuid-abc");
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/corrections/batch/batch-uuid-abc",
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+
+  it("returns the reverted_count and skipped_count from the API response", async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      data: { reverted_count: 12, skipped_count: 3 },
+    });
+
+    const { result } = renderHook(() => useRevertBatch(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate("batch-uuid-xyz");
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.reverted_count).toBe(12);
+    expect(result.current.data?.skipped_count).toBe(3);
+  });
+
+  it("invalidates all 6 query keys on success", async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      data: { reverted_count: 1, skipped_count: 0 },
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useRevertBatch(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate("batch-uuid-123");
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey[0]
+    );
+
+    expect(invalidatedKeys).toContain("batch-list");
+    expect(invalidatedKeys).toContain("corrections");
+    expect(invalidatedKeys).toContain("transcriptSegments");
+    expect(invalidatedKeys).toContain("transcript");
+    expect(invalidatedKeys).toContain("diff-analysis");
+    expect(invalidatedKeys).toContain("cross-segment-candidates");
+    expect(invalidateSpy).toHaveBeenCalledTimes(6);
+
+    invalidateSpy.mockRestore();
+  });
+
+  it("does NOT invalidate caches when the mutation fails", async () => {
+    mockedApiFetch.mockRejectedValueOnce(new Error("Not found"));
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useRevertBatch(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate("batch-uuid-bad");
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+
+    invalidateSpy.mockRestore();
+  });
+
+  it("exposes the error when the mutation fails", async () => {
+    const error = new Error("Server error");
+    mockedApiFetch.mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => useRevertBatch(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate("batch-uuid-fail");
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeTruthy();
+  });
+});

--- a/frontend/src/hooks/__tests__/useCrossSegmentCandidates.test.ts
+++ b/frontend/src/hooks/__tests__/useCrossSegmentCandidates.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for useCrossSegmentCandidates hook.
+ *
+ * Coverage:
+ * - Fetches candidates without params (bare query key)
+ * - Fetches candidates with params included in the query key
+ * - Returns data array on success
+ * - Passes AbortSignal through to fetchCrossSegmentCandidates
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+import { fetchCrossSegmentCandidates } from "../../api/batchCorrections";
+import { useCrossSegmentCandidates } from "../useCrossSegmentCandidates";
+import type { CrossSegmentCandidate } from "../../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../api/batchCorrections", () => ({
+  fetchCrossSegmentCandidates: vi.fn(),
+}));
+
+const mockedFetch = vi.mocked(fetchCrossSegmentCandidates);
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeCrossSegmentCandidate(
+  overrides: Partial<CrossSegmentCandidate> = {}
+): CrossSegmentCandidate {
+  return {
+    segment_n_id: 1,
+    segment_n_text: "the quick brown",
+    segment_n1_id: 2,
+    segment_n1_text: "fox jumps over",
+    proposed_correction: "The Quick Brown",
+    source_pattern: "the quick brown",
+    confidence: 0.85,
+    is_partially_corrected: false,
+    video_id: "video-uuid-001",
+    discovery_source: "correction_pattern",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useCrossSegmentCandidates", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+  });
+
+  it("fetches candidates without params and returns data on success", async () => {
+    const candidate = makeCrossSegmentCandidate();
+    mockedFetch.mockResolvedValueOnce([candidate]);
+
+    const { result } = renderHook(() => useCrossSegmentCandidates(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0]?.segment_n_id).toBe(1);
+    expect(result.current.data?.[0]?.proposed_correction).toBe(
+      "The Quick Brown"
+    );
+  });
+
+  it("uses query key that includes params when params are provided", async () => {
+    mockedFetch.mockResolvedValueOnce([]);
+
+    const params = { minCorrections: 3, entityName: "TestEntity" };
+    const { result } = renderHook(() => useCrossSegmentCandidates(params), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The query should have been called (params are part of the cache key)
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledWith(params, expect.any(AbortSignal));
+  });
+
+  it("uses separate cache entries for different params", async () => {
+    mockedFetch
+      .mockResolvedValueOnce([makeCrossSegmentCandidate({ segment_n_id: 10 })])
+      .mockResolvedValueOnce([makeCrossSegmentCandidate({ segment_n_id: 20 })]);
+
+    const { result: result1 } = renderHook(
+      () => useCrossSegmentCandidates({ minCorrections: 1 }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result1.current.isSuccess).toBe(true));
+    expect(result1.current.data?.[0]?.segment_n_id).toBe(10);
+
+    const { result: result2 } = renderHook(
+      () => useCrossSegmentCandidates({ minCorrections: 5 }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result2.current.isSuccess).toBe(true));
+    expect(result2.current.data?.[0]?.segment_n_id).toBe(20);
+  });
+
+  it("returns an empty array when no candidates exist", async () => {
+    mockedFetch.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useCrossSegmentCandidates(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("returns multiple candidates with correct fields", async () => {
+    const candidates = [
+      makeCrossSegmentCandidate({
+        segment_n_id: 1,
+        confidence: 0.9,
+        is_partially_corrected: false,
+      }),
+      makeCrossSegmentCandidate({
+        segment_n_id: 2,
+        confidence: 0.7,
+        is_partially_corrected: true,
+      }),
+    ];
+    mockedFetch.mockResolvedValueOnce(candidates);
+
+    const { result } = renderHook(() => useCrossSegmentCandidates(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data?.[1]?.is_partially_corrected).toBe(true);
+  });
+
+  it("exposes isLoading=true while the fetch is in progress", () => {
+    // Never resolves during this test
+    mockedFetch.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useCrossSegmentCandidates(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("exposes isError=true and data=undefined when fetch rejects", async () => {
+    mockedFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useCrossSegmentCandidates(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("passes AbortSignal to fetchCrossSegmentCandidates", async () => {
+    mockedFetch.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useCrossSegmentCandidates(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const callArgs = mockedFetch.mock.calls[0];
+    expect(callArgs?.[1]).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/frontend/src/hooks/__tests__/useDiffAnalysis.test.ts
+++ b/frontend/src/hooks/__tests__/useDiffAnalysis.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for useDiffAnalysis hook.
+ *
+ * Coverage:
+ * - Fetches data with no params (default case)
+ * - Fetches data with entityName param (server-side filter)
+ * - Query key includes params object (cache segmentation — different params → separate fetches)
+ * - Returns data on success
+ * - Exposes error on fetch failure
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+import { fetchDiffAnalysis } from "../../api/batchCorrections";
+import { useDiffAnalysis } from "../useDiffAnalysis";
+import type { DiffErrorPattern } from "../../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../api/batchCorrections", () => ({
+  fetchDiffAnalysis: vi.fn(),
+}));
+
+const mockedFetchDiffAnalysis = vi.mocked(fetchDiffAnalysis);
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeDiffErrorPattern(
+  overrides: Partial<DiffErrorPattern> = {}
+): DiffErrorPattern {
+  return {
+    error_token: "barak",
+    canonical_form: "Barack",
+    frequency: 12,
+    remaining_matches: 8,
+    entity_id: null,
+    entity_name: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDiffAnalysis", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+  });
+
+  it("fetches diff analysis data with no params and returns the array", async () => {
+    const pattern = makeDiffErrorPattern();
+    mockedFetchDiffAnalysis.mockResolvedValueOnce([pattern]);
+
+    const { result } = renderHook(() => useDiffAnalysis(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0]?.error_token).toBe("barak");
+    expect(result.current.data?.[0]?.canonical_form).toBe("Barack");
+    expect(result.current.data?.[0]?.frequency).toBe(12);
+  });
+
+  it("passes params to fetchDiffAnalysis when provided", async () => {
+    mockedFetchDiffAnalysis.mockResolvedValueOnce([]);
+
+    const params = { entityName: "Obama", minOccurrences: 5, limit: 50 };
+
+    const { result } = renderHook(() => useDiffAnalysis(params), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedFetchDiffAnalysis).toHaveBeenCalledWith(
+      params,
+      expect.anything() // AbortSignal
+    );
+  });
+
+  it("issues separate fetches for different params objects (cache segmentation)", async () => {
+    mockedFetchDiffAnalysis.mockResolvedValue([]);
+
+    const paramsA = { entityName: "Obama" };
+    const paramsB = { entityName: "Clinton" };
+
+    // Each hook uses its own QueryClient wrapper to avoid cross-test cache hits.
+    const qcA = createQueryClient();
+    const qcB = createQueryClient();
+
+    const { result: resultA } = renderHook(() => useDiffAnalysis(paramsA), {
+      wrapper: createWrapper(qcA),
+    });
+
+    await waitFor(() => expect(resultA.current.isSuccess).toBe(true));
+
+    const { result: resultB } = renderHook(() => useDiffAnalysis(paramsB), {
+      wrapper: createWrapper(qcB),
+    });
+
+    await waitFor(() => expect(resultB.current.isSuccess).toBe(true));
+
+    // fetchDiffAnalysis should have been called twice — once per unique params.
+    expect(mockedFetchDiffAnalysis).toHaveBeenCalledTimes(2);
+    expect(mockedFetchDiffAnalysis).toHaveBeenCalledWith(paramsA, expect.anything());
+    expect(mockedFetchDiffAnalysis).toHaveBeenCalledWith(paramsB, expect.anything());
+  });
+
+  it("calls fetchDiffAnalysis with undefined when no params are passed", async () => {
+    mockedFetchDiffAnalysis.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useDiffAnalysis(undefined), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedFetchDiffAnalysis).toHaveBeenCalledTimes(1);
+    expect(mockedFetchDiffAnalysis).toHaveBeenCalledWith(
+      undefined,
+      expect.anything()
+    );
+  });
+
+  it("returns an empty array when the API returns no patterns", async () => {
+    mockedFetchDiffAnalysis.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useDiffAnalysis(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("returns multiple patterns when the API returns multiple results", async () => {
+    const patterns = [
+      makeDiffErrorPattern({ error_token: "barak", canonical_form: "Barack" }),
+      makeDiffErrorPattern({
+        error_token: "hussain",
+        canonical_form: "Hussein",
+        frequency: 7,
+      }),
+    ];
+    mockedFetchDiffAnalysis.mockResolvedValueOnce(patterns);
+
+    const { result } = renderHook(() => useDiffAnalysis(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(2);
+  });
+
+  it("exposes isError and error when fetchDiffAnalysis rejects", async () => {
+    const err = new Error("Network failure");
+    mockedFetchDiffAnalysis.mockRejectedValueOnce(err);
+
+    const { result } = renderHook(() => useDiffAnalysis(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns a pattern with entity_id and entity_name when entity is linked", async () => {
+    const pattern = makeDiffErrorPattern({
+      error_token: "obamma",
+      canonical_form: "Obama",
+      entity_id: "entity-uuid-123",
+      entity_name: "Barack Obama",
+    });
+    mockedFetchDiffAnalysis.mockResolvedValueOnce([pattern]);
+
+    const { result } = renderHook(() => useDiffAnalysis(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0]?.entity_id).toBe("entity-uuid-123");
+    expect(result.current.data?.[0]?.entity_name).toBe("Barack Obama");
+  });
+});

--- a/frontend/src/hooks/__tests__/usePhoneticMatches.test.ts
+++ b/frontend/src/hooks/__tests__/usePhoneticMatches.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Tests for usePhoneticMatches hook.
+ *
+ * Coverage:
+ * - Returns filtered data based on displayThreshold (client-side)
+ * - Query key only includes serverFloor, not displayThreshold
+ * - Query is disabled when enabled=false
+ * - Re-fetches when serverFloor changes
+ * - Server floor bumps up when displayThreshold < serverFloor
+ * - Returns undefined when query has not fired (enabled=false)
+ * - Error state propagates from fetchPhoneticMatches
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+import { fetchPhoneticMatches } from "../../api/entityMentions";
+import { usePhoneticMatches } from "../usePhoneticMatches";
+import type { PhoneticMatch } from "../../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../api/entityMentions", () => ({
+  fetchPhoneticMatches: vi.fn(),
+}));
+
+const mockedFetch = vi.mocked(fetchPhoneticMatches);
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makePhoneticMatch(
+  overrides: Partial<PhoneticMatch> = {}
+): PhoneticMatch {
+  return {
+    original_text: "noam chomski",
+    proposed_correction: "Noam Chomsky",
+    confidence: 0.8,
+    evidence_description: "Phonetic similarity via double metaphone",
+    video_id: "video-uuid-001",
+    segment_id: 42,
+    video_title: "Chomsky on Language",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("usePhoneticMatches", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Basic fetch behaviour
+  // -------------------------------------------------------------------------
+
+  it("fetches phonetic matches for an entity and returns data on success", async () => {
+    const match = makePhoneticMatch({ confidence: 0.8 });
+    mockedFetch.mockResolvedValueOnce([match]);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0.3,
+          displayThreshold: 0.5,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0]?.original_text).toBe("noam chomski");
+  });
+
+  it("calls fetchPhoneticMatches with entityId and serverFloor", async () => {
+    mockedFetch.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0.4,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "entity-uuid-001",
+      0.4,
+      expect.any(AbortSignal)
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Client-side displayThreshold filtering
+  // -------------------------------------------------------------------------
+
+  it("filters out matches below displayThreshold on the client side", async () => {
+    const matches = [
+      makePhoneticMatch({ confidence: 0.9, original_text: "high-confidence" }),
+      makePhoneticMatch({ confidence: 0.55, original_text: "mid-confidence" }),
+      makePhoneticMatch({ confidence: 0.3, original_text: "low-confidence" }),
+    ];
+    mockedFetch.mockResolvedValueOnce(matches);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0.3,
+          displayThreshold: 0.6,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Only the 0.9-confidence match should pass the 0.6 display threshold
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0]?.original_text).toBe("high-confidence");
+  });
+
+  it("keeps all matches when displayThreshold is 0", async () => {
+    const matches = [
+      makePhoneticMatch({ confidence: 0.9 }),
+      makePhoneticMatch({ confidence: 0.3 }),
+    ];
+    mockedFetch.mockResolvedValueOnce(matches);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0,
+          displayThreshold: 0,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(2);
+  });
+
+  it("includes matches exactly at the displayThreshold boundary", async () => {
+    const match = makePhoneticMatch({ confidence: 0.5 });
+    mockedFetch.mockResolvedValueOnce([match]);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0.3,
+          displayThreshold: 0.5,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Query key — serverFloor included, displayThreshold excluded
+  // -------------------------------------------------------------------------
+
+  it("does not issue a new fetch when only displayThreshold changes", async () => {
+    const matches = [makePhoneticMatch({ confidence: 0.8 })];
+    mockedFetch.mockResolvedValue(matches);
+
+    const { result, rerender } = renderHook(
+      ({ threshold }: { threshold: number }) =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0.3,
+          displayThreshold: threshold,
+        }),
+      {
+        wrapper: createWrapper(queryClient),
+        initialProps: { threshold: 0.5 },
+      }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+    // Change only displayThreshold — no new fetch should occur
+    rerender({ threshold: 0.7 });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Still only one fetch
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues a new fetch when serverFloor changes", async () => {
+    // Use separate QueryClients to avoid cache hits from the same query client.
+    // displayThreshold must be >= serverFloor in both hooks to avoid the
+    // bump logic triggering additional fetches that would confuse the assertion.
+    const qcA = createQueryClient();
+    const qcB = createQueryClient();
+
+    mockedFetch.mockResolvedValue([]);
+
+    // First hook: serverFloor=0.3, displayThreshold=0.3 (no bump needed)
+    const { result: resultA } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0.3,
+          displayThreshold: 0.3,
+        }),
+      { wrapper: createWrapper(qcA) }
+    );
+
+    await waitFor(() => expect(resultA.current.isSuccess).toBe(true));
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "entity-uuid-001",
+      0.3,
+      expect.any(AbortSignal)
+    );
+
+    // Second hook: serverFloor=0.6, displayThreshold=0.6 (no bump needed)
+    const { result: resultB } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0.6,
+          displayThreshold: 0.6,
+        }),
+      { wrapper: createWrapper(qcB) }
+    );
+
+    await waitFor(() => expect(resultB.current.isSuccess).toBe(true));
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    expect(mockedFetch).toHaveBeenLastCalledWith(
+      "entity-uuid-001",
+      0.6,
+      expect.any(AbortSignal)
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Lazy loading: enabled=false
+  // -------------------------------------------------------------------------
+
+  it("does not fetch when enabled is false", () => {
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          enabled: false,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    expect(mockedFetch).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("starts fetching when enabled flips from false to true", async () => {
+    mockedFetch.mockResolvedValueOnce([makePhoneticMatch()]);
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          enabled,
+        }),
+      {
+        wrapper: createWrapper(queryClient),
+        initialProps: { enabled: false },
+      }
+    );
+
+    expect(mockedFetch).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Server floor bumping when displayThreshold < serverFloor
+  // -------------------------------------------------------------------------
+
+  it("bumps effectiveServerFloor up when displayThreshold falls below serverFloor", async () => {
+    mockedFetch.mockResolvedValue([]);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0.5,
+          displayThreshold: 0.2, // below serverFloor
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // effectiveServerFloor should be bumped to displayThreshold (0.2)
+    expect(result.current.effectiveServerFloor).toBe(0.2);
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "entity-uuid-001",
+      0.2,
+      expect.any(AbortSignal)
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it("exposes isError=true and error when fetch rejects", async () => {
+    mockedFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty results
+  // -------------------------------------------------------------------------
+
+  it("returns an empty array when API returns no matches", async () => {
+    mockedFetch.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          displayThreshold: 0.5,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("exposes isLoading=true while fetch is in progress", () => {
+    mockedFetch.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Default parameter values
+  // -------------------------------------------------------------------------
+
+  it("uses default serverFloor of 0.3 when not provided", async () => {
+    mockedFetch.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "entity-uuid-001",
+      0.3,
+      expect.any(AbortSignal)
+    );
+  });
+
+  it("filters with default displayThreshold of 0.5 when not provided", async () => {
+    const matches = [
+      makePhoneticMatch({ confidence: 0.8, original_text: "above-threshold" }),
+      makePhoneticMatch({ confidence: 0.3, original_text: "below-threshold" }),
+    ];
+    mockedFetch.mockResolvedValueOnce(matches);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+          serverFloor: 0.3,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Default displayThreshold is 0.5, so 0.3 confidence should be filtered
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0]?.original_text).toBe("above-threshold");
+  });
+
+  // -------------------------------------------------------------------------
+  // AbortSignal forwarding
+  // -------------------------------------------------------------------------
+
+  it("passes AbortSignal to fetchPhoneticMatches", async () => {
+    mockedFetch.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(
+      () =>
+        usePhoneticMatches({
+          entityId: "entity-uuid-001",
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const callArgs = mockedFetch.mock.calls[0];
+    expect(callArgs?.[2]).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/frontend/src/hooks/useBatchApply.ts
+++ b/frontend/src/hooks/useBatchApply.ts
@@ -7,7 +7,9 @@
  * fires via `mutate` / `mutateAsync`.
  *
  * On success, all transcript segment and transcript detail caches are
- * invalidated so subsequent renders reflect the corrected text.
+ * invalidated so subsequent renders reflect the corrected text. The batch
+ * history list, correction state, diff analysis, and cross-segment candidate
+ * caches are also invalidated per the Feature 046 cache invalidation matrix.
  *
  * @module hooks/useBatchApply
  */
@@ -66,6 +68,10 @@ async function postBatchApply(
  *   cached by useTranscriptSegments (segmentsQueryKey factory)
  * - `["transcript"]` prefix — covers all transcript detail views cached by
  *   useTranscript
+ * - `["batch-list"]` prefix — batch history list so the new batch appears
+ * - `["corrections"]` prefix — segment correction state
+ * - `["diff-analysis"]` prefix — ASR error pattern analysis
+ * - `["cross-segment-candidates"]` prefix — cross-segment correction suggestions
  *
  * @returns UseMutationResult for the batch apply
  *
@@ -104,6 +110,16 @@ export function useBatchApply(): UseMutationResult<
       return failureCount < 3;
     },
 
+    /**
+     * Invalidates all caches affected by a batch apply per the Feature 046
+     * cache invalidation matrix:
+     * - `["transcriptSegments"]` — virtual-scroll segment pages
+     * - `["transcript"]` — transcript detail views
+     * - `["batch-list"]` — batch history list
+     * - `["corrections"]` — segment correction state
+     * - `["diff-analysis"]` — ASR error pattern analysis
+     * - `["cross-segment-candidates"]` — cross-segment correction suggestions
+     */
     onSuccess: () => {
       // Invalidate all cached transcript segment pages so the corrected text
       // is refetched on next render. Prefix matching covers every
@@ -112,6 +128,20 @@ export function useBatchApply(): UseMutationResult<
 
       // Invalidate transcript detail queries (useTranscript) for the same reason.
       void queryClient.invalidateQueries({ queryKey: ["transcript"] });
+
+      // Invalidate the batch history list so the new batch record appears.
+      void queryClient.invalidateQueries({ queryKey: ["batch-list"] });
+
+      // Invalidate segment correction state (correction count, has_correction flags).
+      void queryClient.invalidateQueries({ queryKey: ["corrections"] });
+
+      // Invalidate ASR error pattern analysis — pattern frequencies change
+      // after corrections are applied.
+      void queryClient.invalidateQueries({ queryKey: ["diff-analysis"] });
+
+      // Invalidate cross-segment correction suggestions — applied corrections
+      // may resolve or surface new cross-segment candidates.
+      void queryClient.invalidateQueries({ queryKey: ["cross-segment-candidates"] });
     },
   });
 }

--- a/frontend/src/hooks/useBatchHistory.ts
+++ b/frontend/src/hooks/useBatchHistory.ts
@@ -1,0 +1,147 @@
+/**
+ * TanStack Query hooks for batch correction history.
+ *
+ * Exports:
+ * - useBatchHistory(limit?) — paginated list of past batch operations (Load More)
+ * - useRevertBatch() — mutation to revert all corrections in a batch
+ *
+ * @module hooks/useBatchHistory
+ */
+
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import { apiFetch } from "../api/config";
+import type { BatchSummary } from "../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+/** Pagination envelope returned by the batch list endpoint. */
+interface BatchListPagination {
+  has_more: boolean;
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+/** Full API response envelope for GET /corrections/batch/batches. */
+interface BatchListResponse {
+  data: BatchSummary[];
+  pagination: BatchListPagination;
+}
+
+/** API response envelope for DELETE /corrections/batch/{batchId}. */
+interface BatchRevertApiResponse {
+  data: {
+    reverted_count: number;
+    skipped_count: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// useBatchHistory — infinite query for batch list
+// ---------------------------------------------------------------------------
+
+/**
+ * Hook that fetches the paginated list of past batch correction operations.
+ *
+ * Uses `useInfiniteQuery` with manual "Load More" triggering. Call
+ * `fetchNextPage()` when the user clicks the Load More button and check
+ * `hasNextPage` to decide whether to show it.
+ *
+ * Data is flattened across pages via `data.pages.flatMap(p => p.data)`.
+ *
+ * @param limit - Number of items per page (default: 20)
+ * @returns TanStack InfiniteQuery result for batch operations
+ *
+ * @example
+ * ```tsx
+ * const { data, hasNextPage, fetchNextPage, isLoading } = useBatchHistory();
+ * const batches = data?.pages.flatMap(p => p.data) ?? [];
+ * ```
+ */
+export function useBatchHistory(limit = 20) {
+  return useInfiniteQuery({
+    queryKey: ["batch-list"],
+    queryFn: async ({ pageParam, signal }) => {
+      const response = await apiFetch<BatchListResponse>(
+        `/corrections/batch/batches?offset=${pageParam}&limit=${limit}`,
+        { externalSignal: signal }
+      );
+      return response;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.pagination.has_more) return undefined;
+      return lastPage.pagination.offset + lastPage.pagination.limit;
+    },
+    staleTime: 60 * 1000, // 1 minute — batch list changes only after apply/revert
+    gcTime: 5 * 60 * 1000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useRevertBatch — mutation to revert all corrections in a batch
+// ---------------------------------------------------------------------------
+
+/** The result returned by a successful batch revert. */
+export interface BatchRevertResult {
+  reverted_count: number;
+  skipped_count: number;
+}
+
+/**
+ * Mutation hook for reverting all corrections in a batch operation.
+ *
+ * Calls DELETE /api/v1/corrections/batch/{batchId}. On success, invalidates
+ * all caches that may reference batch-corrected data so the UI stays consistent:
+ *
+ * - `["batch-list"]` — removes the reverted batch from the history list
+ * - `["corrections"]` — segment correction state
+ * - `["transcriptSegments"]` — transcript segment text
+ * - `["transcript"]` — transcript detail view
+ * - `["diff-analysis"]` — ASR error pattern analysis
+ * - `["cross-segment-candidates"]` — cross-segment correction suggestions
+ *
+ * Retries are disabled for 4xx responses (including 404 / 409 which indicate
+ * the batch is not found or has already been reverted). Network/server errors
+ * follow the default TanStack Query retry behaviour of 3 attempts.
+ *
+ * @returns UseMutationResult for the batch revert
+ *
+ * @example
+ * ```tsx
+ * const revert = useRevertBatch();
+ * revert.mutate("batch-uuid-123");
+ * ```
+ */
+export function useRevertBatch() {
+  const queryClient = useQueryClient();
+
+  return useMutation<BatchRevertResult, Error, string>({
+    mutationFn: async (batchId: string): Promise<BatchRevertResult> => {
+      const envelope = await apiFetch<BatchRevertApiResponse>(
+        `/corrections/batch/${batchId}`,
+        { method: "DELETE" }
+      );
+      return envelope.data;
+    },
+
+    onSuccess: () => {
+      // Invalidate all caches that may contain batch-corrected data.
+      // Void the promises — we do not await cache invalidations so the UI
+      // doesn't block on background refetches.
+      void queryClient.invalidateQueries({ queryKey: ["batch-list"] });
+      void queryClient.invalidateQueries({ queryKey: ["corrections"] });
+      void queryClient.invalidateQueries({ queryKey: ["transcriptSegments"] });
+      void queryClient.invalidateQueries({ queryKey: ["transcript"] });
+      void queryClient.invalidateQueries({ queryKey: ["diff-analysis"] });
+      void queryClient.invalidateQueries({ queryKey: ["cross-segment-candidates"] });
+    },
+  });
+}

--- a/frontend/src/hooks/useCrossSegmentCandidates.ts
+++ b/frontend/src/hooks/useCrossSegmentCandidates.ts
@@ -1,0 +1,38 @@
+/**
+ * TanStack Query hook for fetching cross-segment ASR error candidates.
+ *
+ * Cross-segment candidates are adjacent segment pairs where an ASR error
+ * spans the boundary between segments. Each candidate includes both segment
+ * texts, a proposed correction, a source pattern, and a confidence score.
+ *
+ * @module hooks/useCrossSegmentCandidates
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  fetchCrossSegmentCandidates,
+  type FetchCrossSegmentParams,
+} from "../api/batchCorrections";
+
+/**
+ * Hook that fetches cross-segment ASR error candidates.
+ *
+ * The query result is used by CrossSegmentPanel to display ranked candidates
+ * that the user can click to pre-fill the batch find-replace form.
+ *
+ * @param params - Optional filter parameters (minCorrections, entityName)
+ * @returns TanStack Query result for cross-segment candidates
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, isError } = useCrossSegmentCandidates();
+ * const candidates = data ?? [];
+ * ```
+ */
+export function useCrossSegmentCandidates(params?: FetchCrossSegmentParams) {
+  return useQuery({
+    queryKey: ["cross-segment-candidates", params],
+    queryFn: ({ signal }) => fetchCrossSegmentCandidates(params, signal),
+  });
+}

--- a/frontend/src/hooks/useDiffAnalysis.ts
+++ b/frontend/src/hooks/useDiffAnalysis.ts
@@ -1,0 +1,40 @@
+/**
+ * TanStack Query hook for the diff analysis (ASR error patterns) endpoint.
+ *
+ * Wraps GET /api/v1/corrections/batch/diff-analysis and exposes the result
+ * as a standard useQuery so components can react to loading / error / data
+ * states without duplicating fetch logic.
+ *
+ * @module hooks/useDiffAnalysis
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  fetchDiffAnalysis,
+  type FetchDiffAnalysisParams,
+} from "../api/batchCorrections";
+
+/**
+ * Fetches recurring ASR error patterns identified by word-level diff analysis.
+ *
+ * The query key includes the full params object so that changes to any filter
+ * (e.g. entityName) automatically trigger a refetch. Callers should debounce
+ * user-typed entity name input before passing it here to avoid redundant
+ * network requests.
+ *
+ * @param params - Optional filter parameters forwarded to the API
+ * @returns TanStack Query result containing an array of DiffErrorPattern items
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, isError } = useDiffAnalysis({ entityName: "Obama" });
+ * const patterns = data ?? [];
+ * ```
+ */
+export function useDiffAnalysis(params?: FetchDiffAnalysisParams) {
+  return useQuery({
+    queryKey: ["diff-analysis", params],
+    queryFn: ({ signal }) => fetchDiffAnalysis(params, signal),
+  });
+}

--- a/frontend/src/hooks/usePhoneticMatches.ts
+++ b/frontend/src/hooks/usePhoneticMatches.ts
@@ -1,0 +1,145 @@
+/**
+ * TanStack Query hook for fetching suspected phonetic ASR variants of an entity name.
+ *
+ * Implements lazy loading (query disabled by default) and client-side filtering
+ * by `displayThreshold` without triggering a refetch. When `displayThreshold`
+ * falls below `serverFloor`, the server floor is bumped to match so the backend
+ * never returns matches below what the client will show.
+ *
+ * @module hooks/usePhoneticMatches
+ */
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchPhoneticMatches } from "../api/entityMentions";
+import type { PhoneticMatch } from "../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UsePhoneticMatchesParams {
+  /** UUID of the named entity to fetch phonetic matches for */
+  entityId: string;
+  /**
+   * Minimum confidence the backend should return (0.0–1.0).
+   * Changing this value triggers a new network request.
+   * @default 0.3
+   */
+  serverFloor?: number;
+  /**
+   * Minimum confidence shown to the user after client-side filtering.
+   * Changing this value does NOT trigger a refetch.
+   * If set below `serverFloor`, serverFloor is bumped up to match.
+   * @default 0.5
+   */
+  displayThreshold?: number;
+  /**
+   * When false the query will not execute (for lazy loading — only fetch
+   * when the collapsible section is expanded).
+   * @default true
+   */
+  enabled?: boolean;
+}
+
+export interface UsePhoneticMatchesResult {
+  /** Filtered results where confidence >= displayThreshold */
+  data: PhoneticMatch[] | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  error: Error | null;
+  /** The effective serverFloor used for the current query */
+  effectiveServerFloor: number;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Hook that fetches suspected phonetic ASR variants for a named entity.
+ *
+ * Key behaviours:
+ * - Query key includes `entityId` and `serverFloor` only — changing
+ *   `displayThreshold` alone does not cause a refetch.
+ * - Results are filtered client-side to `confidence >= displayThreshold`.
+ * - When `displayThreshold` < `serverFloor`, the effective server floor is
+ *   automatically bumped so the backend respects the display threshold.
+ * - Query is disabled when `enabled` is false (lazy loading support).
+ *
+ * @param params - Configuration for the query
+ * @returns TanStack Query result with client-filtered data
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading } = usePhoneticMatches({
+ *   entityId: "entity-uuid-001",
+ *   enabled: isExpanded,
+ * });
+ * const matches = data ?? [];
+ * ```
+ */
+export function usePhoneticMatches({
+  entityId,
+  serverFloor: serverFloorProp = 0.3,
+  displayThreshold = 0.5,
+  enabled = true,
+}: UsePhoneticMatchesParams): UsePhoneticMatchesResult {
+  // When the user sets displayThreshold below serverFloor, bump up the
+  // effective server floor so the backend does not return matches that would
+  // be hidden anyway. This is tracked in state so a re-render fires and the
+  // query key updates to trigger a fresh fetch.
+  const [serverFloorOverride, setServerFloorOverride] = useState<number | null>(
+    null
+  );
+
+  const effectiveServerFloor = useMemo(() => {
+    const base = serverFloorOverride ?? serverFloorProp;
+    // If displayThreshold has dropped below the current floor, update the
+    // override so the next render picks it up (side-effect via useState is
+    // handled after the memo runs).
+    return base;
+  }, [serverFloorProp, serverFloorOverride]);
+
+  // Synchronise override when displayThreshold falls below the current floor.
+  // We compare against the previously-computed effectiveServerFloor.
+  if (displayThreshold < effectiveServerFloor) {
+    setServerFloorOverride(displayThreshold);
+  } else if (
+    serverFloorOverride !== null &&
+    displayThreshold >= serverFloorProp
+  ) {
+    // Reset override once displayThreshold is back above the original prop.
+    setServerFloorOverride(null);
+  }
+
+  const queryResult = useQuery({
+    queryKey: ["phonetic-matches", entityId, effectiveServerFloor],
+    queryFn: ({ signal }) =>
+      fetchPhoneticMatches(entityId, effectiveServerFloor, signal),
+    enabled: enabled && Boolean(entityId),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  // Apply client-side threshold filter.
+  const filteredData = useMemo(() => {
+    if (!queryResult.data) return queryResult.data;
+    return queryResult.data.filter(
+      (match) => match.confidence >= displayThreshold
+    );
+  }, [queryResult.data, displayThreshold]);
+
+  return {
+    data: filteredData,
+    isLoading: queryResult.isLoading,
+    isFetching: queryResult.isFetching,
+    isError: queryResult.isError,
+    isSuccess: queryResult.isSuccess,
+    error: queryResult.error,
+    effectiveServerFloor,
+  };
+}

--- a/frontend/src/pages/BatchCorrectionsPage.tsx
+++ b/frontend/src/pages/BatchCorrectionsPage.tsx
@@ -30,11 +30,13 @@
  */
 
 import { useEffect, useReducer, useCallback, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 
 import { ApplyControls } from "../components/batch/ApplyControls";
 import { MatchList } from "../components/batch/MatchList";
 import { PatternInput } from "../components/batch/PatternInput";
 import { ResultSummary } from "../components/batch/ResultSummary";
+import { CrossSegmentPanel } from "../components/corrections/CrossSegmentPanel";
 import { useBatchApply } from "../hooks/useBatchApply";
 import { useBatchPreview } from "../hooks/useBatchPreview";
 import { useBatchRebuild } from "../hooks/useBatchRebuild";
@@ -281,6 +283,66 @@ function IdleInstructions() {
  */
 export function BatchCorrectionsPage() {
   // -------------------------------------------------------------------------
+  // Router location state — cross-page pre-fill (T014 / US2)
+  // -------------------------------------------------------------------------
+
+  /**
+   * When navigating from DiffAnalysisPage via the "Find & Replace" action,
+   * the router state carries `pattern`, `replacement`, and optionally
+   * `crossSegment`. We consume them once on mount (via useState initializers
+   * on PatternInput), then clear the history state so back-navigation does
+   * not re-apply the pre-fill.
+   */
+  const location = useLocation();
+  const locationState = location.state as
+    | { pattern?: string; replacement?: string; crossSegment?: boolean; isRegex?: boolean }
+    | null
+    | undefined;
+
+  // Capture the initial values synchronously from location state so they can
+  // be used as useState initial values inside PatternInput. Using refs means
+  // the values are stable across renders and do not cause PatternInput to
+  // re-mount if the parent re-renders.
+  const prefillPattern = locationState?.pattern ?? "";
+  const prefillReplacement = locationState?.replacement ?? "";
+  const prefillCrossSegment = locationState?.crossSegment ?? false;
+  const prefillIsRegex = locationState?.isRegex ?? false;
+
+  // Clear history state after consuming it so back-navigation does not
+  // re-apply the pre-fill (T014 spec requirement).
+  useEffect(() => {
+    if (locationState?.pattern || locationState?.replacement) {
+      window.history.replaceState({}, document.title);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // -------------------------------------------------------------------------
+  // Cross-segment panel open/closed state
+  // -------------------------------------------------------------------------
+
+  /** Whether the CrossSegmentPanel is expanded. Starts open; collapses on preview. */
+  const [crossSegmentOpen, setCrossSegmentOpen] = useState(true);
+
+  // -------------------------------------------------------------------------
+  // Cross-segment panel pre-fill state (T017–T019 / US3)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Tracks the active initial values for PatternInput. When a cross-segment
+   * candidate is selected from CrossSegmentPanel, we increment `patternInputKey`
+   * to remount PatternInput with the new initial values, which is the only
+   * reliable way to drive an uncontrolled form field to a new value.
+   *
+   * The key starts at 0 (equivalent to the router-state-driven initial render).
+   * Each call to handlePrefill bumps it so PatternInput mounts fresh.
+   */
+  const [patternInputKey, setPatternInputKey] = useState(0);
+  const [panelPrefillPattern, setPanelPrefillPattern] = useState(prefillPattern);
+  const [panelPrefillReplacement, setPanelPrefillReplacement] = useState(prefillReplacement);
+  const [panelPrefillCrossSegment, setPanelPrefillCrossSegment] = useState(prefillCrossSegment);
+  const [panelPrefillIsRegex, setPanelPrefillIsRegex] = useState(prefillIsRegex);
+
+  // -------------------------------------------------------------------------
   // State machine
   // -------------------------------------------------------------------------
   const [state, dispatch] = useReducer(batchReducer, { phase: "idle" });
@@ -494,6 +556,8 @@ export function BatchCorrectionsPage() {
   /** Called by PatternInput when user clicks "Preview matches". */
   const handlePreview = useCallback(
     (request: BatchPreviewRequest) => {
+      // Auto-collapse the cross-segment panel so the match results are visible.
+      setCrossSegmentOpen(false);
       previewMutation.mutate(request, {
         onSuccess: (data) => {
           dispatch({
@@ -511,14 +575,15 @@ export function BatchCorrectionsPage() {
   /**
    * Called by PatternInput whenever pattern or replacement text changes.
    * Resets to idle so stale preview results are cleared (FR-029).
-   * Also clears the correction note and entity link since this constitutes
-   * a new session.
+   * Entity selection is intentionally preserved — the user may be correcting
+   * another misspelling variant of the same entity (second-round workflow).
+   * Entity is cleared via FR-011 (replacement emptied) or handlePrefill
+   * (cross-segment candidate selected).
    */
   const handlePatternChange = useCallback(() => {
     dispatch({ type: "RESET" });
     previewMutation.reset();
     setCorrectionNote('');
-    setSelectedEntity(null);
   }, [previewMutation]);
 
   /** Toggle a single segment's selection state. */
@@ -609,6 +674,28 @@ export function BatchCorrectionsPage() {
     rebuildMutation.mutate({ video_ids: state.result.affected_video_ids });
   }, [state, rebuildMutation]);
 
+  /**
+   * Called by CrossSegmentPanel when the user clicks a candidate card (T019).
+   * Pre-fills PatternInput by remounting it with new initial values, then
+   * resets the state machine to idle so any stale preview results are cleared.
+   */
+  const handlePrefill = useCallback(
+    (values: { pattern: string; replacement: string; crossSegment: boolean }) => {
+      setPanelPrefillPattern(values.pattern);
+      setPanelPrefillReplacement(values.replacement);
+      setPanelPrefillCrossSegment(values.crossSegment);
+      setPanelPrefillIsRegex(false);
+      // Remount PatternInput so the new initial values take effect.
+      setPatternInputKey((k) => k + 1);
+      // Clear any stale preview state.
+      dispatch({ type: "RESET" });
+      previewMutation.reset();
+      setCorrectionNote("");
+      setSelectedEntity(null);
+    },
+    [previewMutation]
+  );
+
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -629,13 +716,27 @@ export function BatchCorrectionsPage() {
       <div className="space-y-6">
         {/* Pattern configuration card — always visible */}
         <PatternInput
+          key={patternInputKey}
           onPreview={handlePreview}
           isLoading={isPreviewLoading}
           isLocked={isLocked}
           onPatternChange={handlePatternChange}
           onEntityChange={handleEntityChange}
           entityAliasNames={selectedEntityAliasNames}
+          initialPattern={panelPrefillPattern}
+          initialReplacement={panelPrefillReplacement}
+          initialCrossSegment={panelPrefillCrossSegment}
+          initialIsRegex={panelPrefillIsRegex}
         />
+
+        {/* Cross-segment candidates panel (T019) */}
+        <div className="border-t border-slate-200 pt-6">
+          <CrossSegmentPanel
+            prefillForm={handlePrefill}
+            isOpen={crossSegmentOpen}
+            onToggle={() => setCrossSegmentOpen((prev) => !prev)}
+          />
+        </div>
 
         {/* Preview results section */}
         {showMatchList ? (

--- a/frontend/src/pages/BatchHistoryPage.tsx
+++ b/frontend/src/pages/BatchHistoryPage.tsx
@@ -1,0 +1,503 @@
+/**
+ * BatchHistoryPage — displays the history of batch correction operations with
+ * per-batch revert capability.
+ *
+ * Route: /corrections/batch/history
+ *
+ * Features (Feature 046, T009):
+ * - Table of past BatchSummary items sorted most-recent-first (API default)
+ * - Columns: Pattern, Replacement, Count, Actor, Timestamp, Actions
+ * - "Load More" pagination (useBatchHistory infinite query)
+ * - Confirmation dialog before reverting a batch (FR-027 focus trap)
+ * - 404 / 409 error states in the confirmation dialog
+ * - Empty state when no batches exist
+ * - Loading skeleton on initial fetch
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { useBatchHistory, useRevertBatch } from "../hooks/useBatchHistory";
+import { isApiError } from "../api/config";
+import type { BatchSummary } from "../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Format an ISO 8601 datetime string into a readable local date/time. */
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/** Derive a human-readable error message from a revert failure. */
+function getRevertErrorMessage(error: Error): string {
+  if (isApiError(error)) {
+    if (error.status === 404) return "Batch not found.";
+    if (error.status === 409) return "This batch has already been reverted.";
+  }
+  return "Failed to revert batch. Please try again.";
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function BatchHistorySkeleton() {
+  return (
+    <div className="animate-pulse" aria-label="Loading batch history" role="status">
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="bg-slate-100 px-6 py-3 flex gap-6">
+          {[120, 120, 60, 100, 140].map((w, i) => (
+            <div key={i} className={`h-4 w-${w} rounded bg-slate-300`} style={{ width: w }} />
+          ))}
+        </div>
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="border-t border-slate-100 px-6 py-4 flex gap-6 items-center">
+            <div className="h-4 rounded bg-slate-200" style={{ width: 140 }} />
+            <div className="h-4 rounded bg-slate-200" style={{ width: 100 }} />
+            <div className="h-4 rounded bg-slate-200" style={{ width: 40 }} />
+            <div className="h-4 rounded bg-slate-200" style={{ width: 80 }} />
+            <div className="h-4 rounded bg-slate-200" style={{ width: 150 }} />
+            <div className="h-8 rounded bg-slate-200" style={{ width: 70 }} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Revert confirmation dialog (FR-027 focus trap)
+// ---------------------------------------------------------------------------
+
+interface RevertDialogProps {
+  /** The batch to revert */
+  batch: BatchSummary;
+  /** Whether the revert mutation is in progress */
+  isPending: boolean;
+  /** Error from a failed revert attempt */
+  error: Error | null;
+  /** Called when the user confirms the revert */
+  onConfirm: () => void;
+  /** Called when the user cancels or the dialog is closed */
+  onCancel: () => void;
+}
+
+/**
+ * Modal confirmation dialog for reverting a batch operation.
+ *
+ * Implements FR-027 focus management:
+ * - Focus moves into the dialog when it mounts
+ * - Tab cycles within the dialog only (Cancel → Confirm → Cancel → …)
+ * - Escape dismisses the dialog
+ * - Focus is returned to the trigger element by the parent via the triggerRef
+ */
+function RevertDialog({
+  batch,
+  isPending,
+  error,
+  onConfirm,
+  onCancel,
+}: RevertDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Move focus to the Cancel button when the dialog opens.
+  useEffect(() => {
+    cancelBtnRef.current?.focus();
+  }, []);
+
+  // Close on Escape key.
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onCancel();
+        return;
+      }
+      // Focus trap: Tab / Shift+Tab cycles within the dialog.
+      if (e.key === "Tab" && dialogRef.current) {
+        const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (!first || !last) return;
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onCancel]);
+
+  const errorMessage = error ? getRevertErrorMessage(error) : null;
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="presentation"
+      onClick={(e) => {
+        // Dismiss if clicking the backdrop itself (not the dialog).
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="revert-dialog-title"
+        aria-describedby="revert-dialog-desc"
+        className="w-full max-w-md rounded-xl bg-white shadow-xl border border-slate-200 p-6"
+      >
+        <h2
+          id="revert-dialog-title"
+          className="text-lg font-semibold text-slate-900 mb-2"
+        >
+          Revert batch correction?
+        </h2>
+
+        <p id="revert-dialog-desc" className="text-sm text-slate-600 mb-4">
+          This will undo all{" "}
+          <strong>{batch.correction_count}</strong> correction
+          {batch.correction_count === 1 ? "" : "s"} in this batch:
+        </p>
+
+        {/* Batch details */}
+        <div className="rounded-lg bg-slate-50 border border-slate-200 px-4 py-3 mb-4 space-y-1 text-sm">
+          <div>
+            <span className="text-slate-500">Pattern: </span>
+            <code className="font-mono text-slate-800">{batch.pattern}</code>
+          </div>
+          <div>
+            <span className="text-slate-500">Replacement: </span>
+            <code className="font-mono text-slate-800">{batch.replacement}</code>
+          </div>
+          <div>
+            <span className="text-slate-500">Applied: </span>
+            <span className="text-slate-800">{formatTimestamp(batch.batch_timestamp)}</span>
+          </div>
+        </div>
+
+        {/* Error feedback */}
+        {errorMessage && (
+          <p className="mb-4 text-sm text-red-600" role="alert">
+            {errorMessage}
+          </p>
+        )}
+
+        {/* Action buttons */}
+        <div className="flex gap-3 justify-end">
+          <button
+            ref={cancelBtnRef}
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="px-4 py-2 text-sm font-medium text-slate-700 bg-white border border-slate-300 rounded-lg hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isPending}
+            className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isPending ? "Reverting…" : "Confirm Revert"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table row
+// ---------------------------------------------------------------------------
+
+interface BatchRowProps {
+  batch: BatchSummary;
+  onRevert: (batch: BatchSummary, triggerEl: HTMLElement) => void;
+}
+
+function BatchRow({ batch, onRevert }: BatchRowProps) {
+  const revertBtnRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <tr className="hover:bg-slate-50 transition-colors">
+      <td className="px-4 py-3 text-sm">
+        <code className="font-mono text-slate-800 break-all">{batch.pattern}</code>
+      </td>
+      <td className="px-4 py-3 text-sm">
+        <code className="font-mono text-slate-800 break-all">{batch.replacement}</code>
+      </td>
+      <td className="px-4 py-3 text-sm text-slate-700 tabular-nums">
+        {batch.correction_count.toLocaleString()}
+      </td>
+      <td className="px-4 py-3 text-sm text-slate-600 max-w-[120px] truncate">
+        {batch.corrected_by_user_id || <span className="text-slate-400 italic">unknown</span>}
+      </td>
+      <td className="px-4 py-3 text-sm text-slate-500 whitespace-nowrap">
+        <time dateTime={batch.batch_timestamp}>
+          {formatTimestamp(batch.batch_timestamp)}
+        </time>
+      </td>
+      <td className="px-4 py-3 text-right">
+        <button
+          ref={revertBtnRef}
+          type="button"
+          onClick={() => {
+            if (revertBtnRef.current) {
+              onRevert(batch, revertBtnRef.current);
+            }
+          }}
+          className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-red-700 bg-red-50 border border-red-200 rounded-md hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+          aria-label={`Revert batch: ${batch.pattern} → ${batch.replacement}`}
+        >
+          Revert
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page component
+// ---------------------------------------------------------------------------
+
+/**
+ * BatchHistoryPage — table of past batch correction operations.
+ *
+ * Route: /corrections/batch/history
+ */
+export function BatchHistoryPage() {
+  // -------------------------------------------------------------------------
+  // Data fetching
+  // -------------------------------------------------------------------------
+  const {
+    data,
+    isLoading,
+    isError,
+    error: queryError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useBatchHistory();
+
+  const revertMutation = useRevertBatch();
+
+  // -------------------------------------------------------------------------
+  // Dialog state
+  // -------------------------------------------------------------------------
+
+  /** The batch currently pending revert confirmation, or null when dialog closed. */
+  const [confirmingBatch, setConfirmingBatch] = useState<BatchSummary | null>(null);
+
+  /** Ref to the Revert button that triggered the dialog (for focus return on close). */
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  // -------------------------------------------------------------------------
+  // Page title
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    document.title = "Batch History - ChronoVista";
+    return () => {
+      document.title = "ChronoVista";
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Derived values
+  // -------------------------------------------------------------------------
+  const batches = data?.pages.flatMap((p) => p.data) ?? [];
+  const isEmpty = !isLoading && batches.length === 0;
+
+  // -------------------------------------------------------------------------
+  // Handlers
+  // -------------------------------------------------------------------------
+
+  function handleOpenDialog(batch: BatchSummary, triggerEl: HTMLElement) {
+    triggerRef.current = triggerEl;
+    revertMutation.reset(); // clear any previous error
+    setConfirmingBatch(batch);
+  }
+
+  function handleCloseDialog() {
+    setConfirmingBatch(null);
+    // Return focus to the Revert button that opened the dialog (FR-027).
+    triggerRef.current?.focus();
+    triggerRef.current = null;
+  }
+
+  function handleConfirmRevert() {
+    if (!confirmingBatch) return;
+    revertMutation.mutate(confirmingBatch.batch_id, {
+      onSuccess: () => {
+        setConfirmingBatch(null);
+        // Return focus to the Revert button that opened the dialog so it is
+        // not silently lost after a successful revert (FR-027).
+        triggerRef.current?.focus();
+        triggerRef.current = null;
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+  return (
+    <main className="container mx-auto px-4 py-8">
+      {/* Page header */}
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold text-gray-900">Batch History</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Past batch find-and-replace operations. Revert any batch to undo all
+          its corrections.
+        </p>
+      </div>
+
+      {/* Loading state */}
+      {isLoading && <BatchHistorySkeleton />}
+
+      {/* Query error state */}
+      {isError && !isLoading && (
+        <div
+          className="rounded-xl bg-red-50 border border-red-200 p-6 text-sm text-red-700"
+          role="alert"
+        >
+          Failed to load batch history.{" "}
+          {isApiError(queryError)
+            ? queryError.message
+            : "Please try refreshing the page."}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {isEmpty && !isError && (
+        <div className="rounded-xl bg-white border border-slate-200 p-12 text-center shadow-sm">
+          <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center">
+            <svg
+              aria-hidden="true"
+              className="w-6 h-6 text-slate-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+            </svg>
+          </div>
+          <p className="text-slate-600 font-medium">No batch operations found.</p>
+          <p className="mt-1 text-sm text-slate-400">
+            Apply a find-replace batch to see history here.
+          </p>
+        </div>
+      )}
+
+      {/* Batch table */}
+      {batches.length > 0 && (
+        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200">
+              <thead className="bg-slate-100">
+                <tr>
+                  <th
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider"
+                  >
+                    Pattern
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider"
+                  >
+                    Replacement
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider"
+                  >
+                    Count
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider"
+                  >
+                    Actor
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider"
+                  >
+                    Timestamp
+                  </th>
+                  <th scope="col" className="relative px-4 py-3">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 bg-white">
+                {batches.map((batch) => (
+                  <BatchRow
+                    key={batch.batch_id}
+                    batch={batch}
+                    onRevert={handleOpenDialog}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Load More footer */}
+          {(hasNextPage || isFetchingNextPage) && (
+            <div className="border-t border-slate-200 px-4 py-3 flex justify-center">
+              <button
+                type="button"
+                onClick={() => void fetchNextPage()}
+                disabled={isFetchingNextPage}
+                className="px-4 py-2 text-sm font-medium text-slate-700 bg-white border border-slate-300 rounded-lg hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                aria-label="Load more batch operations"
+              >
+                {isFetchingNextPage ? "Loading…" : "Load More"}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Confirmation dialog */}
+      {confirmingBatch && (
+        <RevertDialog
+          batch={confirmingBatch}
+          isPending={revertMutation.isPending}
+          error={revertMutation.error}
+          onConfirm={handleConfirmRevert}
+          onCancel={handleCloseDialog}
+        />
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/DiffAnalysisPage.tsx
+++ b/frontend/src/pages/DiffAnalysisPage.tsx
@@ -1,0 +1,524 @@
+/**
+ * DiffAnalysisPage — ASR Error Patterns dashboard.
+ *
+ * Route: /corrections/diff-analysis
+ *
+ * Features (Feature 046, T013):
+ * - Sortable table of DiffErrorPattern items (frequency sort only — FR-008)
+ * - Client-side error token text filter (instant, no API call)
+ * - Server-side entity name filter (debounced 300ms, sent as entityName param)
+ * - "Show completed" toggle (server-side, default false) to include/exclude
+ *   patterns where remaining_matches === 0
+ * - Hidden live region announces sort direction changes (FR-028)
+ * - Entity column: linked to /entities/{id} when entity_id is present
+ * - "Find & Replace" action pre-fills BatchCorrectionsPage via router state (US2)
+ * - Completed rows show a disabled "Completed" badge instead of "Find & Replace"
+ * - Empty / loading / error states
+ */
+
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { useDiffAnalysis } from "../hooks/useDiffAnalysis";
+import type { DiffErrorPattern } from "../types/corrections";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SortDirection = "asc" | "desc";
+
+// ---------------------------------------------------------------------------
+// Custom hook: debounce a value by `delay` ms
+// ---------------------------------------------------------------------------
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function DiffAnalysisSkeleton() {
+  return (
+    <div
+      className="animate-pulse"
+      aria-label="Loading ASR error patterns"
+      role="status"
+    >
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="bg-slate-100 px-6 py-3 flex gap-6">
+          {[100, 120, 80, 100, 90].map((w, i) => (
+            <div
+              key={i}
+              className="h-4 rounded bg-slate-300"
+              style={{ width: w }}
+            />
+          ))}
+        </div>
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div
+            key={i}
+            className="border-t border-slate-100 px-6 py-4 flex gap-6 items-center"
+          >
+            <div className="h-4 rounded bg-slate-200" style={{ width: 120 }} />
+            <div className="h-4 rounded bg-slate-200" style={{ width: 140 }} />
+            <div className="h-4 rounded bg-slate-200" style={{ width: 50 }} />
+            <div className="h-4 rounded bg-slate-200" style={{ width: 110 }} />
+            <div className="h-8 rounded bg-slate-200" style={{ width: 110 }} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sort icon (ascending / descending / neutral)
+// ---------------------------------------------------------------------------
+
+function SortIcon({ direction }: { direction: SortDirection | null }) {
+  if (direction === "asc") {
+    return (
+      <svg
+        aria-hidden="true"
+        className="inline-block w-3.5 h-3.5 ml-1 flex-shrink-0"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M5 15l7-7 7 7" />
+      </svg>
+    );
+  }
+  if (direction === "desc") {
+    return (
+      <svg
+        aria-hidden="true"
+        className="inline-block w-3.5 h-3.5 ml-1 flex-shrink-0"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M19 9l-7 7-7-7" />
+      </svg>
+    );
+  }
+  // Neutral — no active sort
+  return (
+    <svg
+      aria-hidden="true"
+      className="inline-block w-3.5 h-3.5 ml-1 flex-shrink-0 opacity-40"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M8 9l4-4 4 4M8 15l4 4 4-4" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table row
+// ---------------------------------------------------------------------------
+
+interface PatternRowProps {
+  pattern: DiffErrorPattern;
+  onFindAndReplace: (pattern: DiffErrorPattern) => void;
+}
+
+function PatternRow({ pattern, onFindAndReplace }: PatternRowProps) {
+  const completed = pattern.remaining_matches === 0;
+
+  return (
+    <tr className={`hover:bg-slate-50 transition-colors${completed ? " opacity-60" : ""}`}>
+      <td className="px-4 py-3 text-sm">
+        <code className={`font-mono break-all${completed ? " text-slate-400" : " text-rose-700"}`}>
+          {pattern.error_token}
+        </code>
+      </td>
+      <td className="px-4 py-3 text-sm">
+        <code className={`font-mono break-all${completed ? " text-slate-400" : " text-emerald-700"}`}>
+          {pattern.canonical_form}
+        </code>
+      </td>
+      <td className={`px-4 py-3 text-sm tabular-nums${completed ? " text-slate-400" : " text-slate-700"}`}>
+        {pattern.frequency.toLocaleString()}
+      </td>
+      <td className="px-4 py-3 text-sm text-slate-600">
+        {pattern.entity_id !== null && pattern.entity_name !== null ? (
+          <Link
+            to={`/entities/${pattern.entity_id}`}
+            className="text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 rounded"
+          >
+            {pattern.entity_name}
+          </Link>
+        ) : null}
+      </td>
+      <td className="px-4 py-3 text-right">
+        {completed ? (
+          <span
+            className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-slate-400 bg-slate-100 border border-slate-200 rounded-md cursor-default select-none"
+            title="All instances corrected"
+            aria-label={`Completed: ${pattern.error_token} → ${pattern.canonical_form}`}
+          >
+            Completed
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onFindAndReplace(pattern)}
+            className="inline-flex items-center px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+            aria-label={`Find and replace: ${pattern.error_token} → ${pattern.canonical_form}`}
+          >
+            Find &amp; Replace
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page component
+// ---------------------------------------------------------------------------
+
+/**
+ * DiffAnalysisPage — sortable table of recurring ASR error patterns.
+ *
+ * Route: /corrections/diff-analysis
+ */
+export function DiffAnalysisPage() {
+  const navigate = useNavigate();
+
+  // -------------------------------------------------------------------------
+  // Filter state
+  // -------------------------------------------------------------------------
+
+  /** Client-side text filter applied to error_token. Instant, no API call. */
+  const [errorTokenSearch, setErrorTokenSearch] = useState("");
+
+  /** Server-side entity name filter. Debounced before being sent to API. */
+  const [entityNameInput, setEntityNameInput] = useState("");
+  const debouncedEntityName = useDebounce(entityNameInput, 300);
+
+  /**
+   * Server-side toggle: when false (default), the API excludes patterns where
+   * remaining_matches === 0. When true, completed patterns are included so the
+   * user can see the full history.
+   */
+  const [showCompleted, setShowCompleted] = useState(false);
+
+  // -------------------------------------------------------------------------
+  // Sort state (frequency-only, FR-008)
+  // -------------------------------------------------------------------------
+
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
+  // -------------------------------------------------------------------------
+  // Live region ref for sort announcements (FR-028)
+  // -------------------------------------------------------------------------
+
+  const liveRegionRef = useRef<HTMLDivElement>(null);
+
+  const announceSortChange = useCallback((direction: SortDirection) => {
+    if (liveRegionRef.current) {
+      liveRegionRef.current.textContent = `Sorted by frequency, ${direction === "desc" ? "descending" : "ascending"}`;
+    }
+  }, []);
+
+  const handleToggleSort = useCallback(() => {
+    setSortDirection((prev) => {
+      const next: SortDirection = prev === "desc" ? "asc" : "desc";
+      announceSortChange(next);
+      return next;
+    });
+  }, [announceSortChange]);
+
+  // -------------------------------------------------------------------------
+  // Data fetching
+  // -------------------------------------------------------------------------
+
+  const { data, isLoading, isError, error: queryError } = useDiffAnalysis({
+    ...(debouncedEntityName ? { entityName: debouncedEntityName } : {}),
+    showCompleted,
+  });
+
+  // -------------------------------------------------------------------------
+  // Page title
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    document.title = "ASR Error Patterns - ChronoVista";
+    return () => {
+      document.title = "ChronoVista";
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Derived: filtered + sorted patterns
+  // -------------------------------------------------------------------------
+
+  const filteredAndSortedPatterns = useMemo<DiffErrorPattern[]>(() => {
+    const raw = data ?? [];
+
+    // Client-side error token filter
+    const filtered =
+      errorTokenSearch.trim() === ""
+        ? raw
+        : raw.filter((p) =>
+            p.error_token
+              .toLowerCase()
+              .includes(errorTokenSearch.trim().toLowerCase())
+          );
+
+    // Sort by frequency
+    return [...filtered].sort((a, b) =>
+      sortDirection === "desc"
+        ? b.frequency - a.frequency
+        : a.frequency - b.frequency
+    );
+  }, [data, errorTokenSearch, sortDirection]);
+
+  const isEmpty =
+    !isLoading && !isError && filteredAndSortedPatterns.length === 0;
+
+  // -------------------------------------------------------------------------
+  // Handlers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Navigate to BatchCorrectionsPage with pre-filled pattern and replacement.
+   * Uses router state so the target page can consume and then clear it
+   * (T014 / US2 cross-page pre-fill).
+   */
+  const handleFindAndReplace = useCallback(
+    (pattern: DiffErrorPattern) => {
+      // Wrap in \b word boundaries and enable regex mode so short tokens
+      // like "Pari" don't match inside longer words like "Paris".
+      const escaped = pattern.error_token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      navigate("/corrections/batch", {
+        state: {
+          pattern: `\\b${escaped}\\b`,
+          replacement: pattern.canonical_form,
+          isRegex: true,
+        },
+      });
+    },
+    [navigate]
+  );
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      {/* Hidden live region for sort announcements (FR-028) */}
+      <div
+        ref={liveRegionRef}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      />
+
+      {/* Page header */}
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold text-gray-900">ASR Error Patterns</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Recurring ASR misrecognition patterns identified by word-level diff
+          analysis. Use "Find &amp; Replace" to batch-correct any pattern across
+          all transcripts.
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start">
+        {/* Error token search (client-side, instant) */}
+        <div className="flex-1 space-y-1">
+          <label
+            htmlFor="error-token-filter"
+            className="block text-sm font-medium text-slate-700"
+          >
+            Filter by error token
+          </label>
+          <input
+            id="error-token-filter"
+            type="search"
+            value={errorTokenSearch}
+            onChange={(e) => setErrorTokenSearch(e.target.value)}
+            placeholder="e.g. barak, hussain…"
+            className="w-full px-3 py-2 rounded-md border border-slate-300 bg-white text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+            aria-label="Filter patterns by error token"
+          />
+        </div>
+
+        {/* Entity name filter (server-side, debounced) */}
+        <div className="flex-1 space-y-1">
+          <label
+            htmlFor="entity-name-filter"
+            className="block text-sm font-medium text-slate-700"
+          >
+            Filter by entity name
+          </label>
+          <input
+            id="entity-name-filter"
+            type="search"
+            value={entityNameInput}
+            onChange={(e) => setEntityNameInput(e.target.value)}
+            placeholder="e.g. Barack Obama…"
+            className="w-full px-3 py-2 rounded-md border border-slate-300 bg-white text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+            aria-label="Filter patterns by entity name"
+            aria-describedby="entity-filter-hint"
+          />
+          <p id="entity-filter-hint" className="text-xs text-slate-400">
+            Filters by associated named entity (server-side, ~300 ms delay)
+          </p>
+        </div>
+
+        {/* Show completed toggle (server-side) */}
+        <div className="flex items-center sm:mt-6 sm:pt-1">
+          <label
+            htmlFor="show-completed-toggle"
+            className="flex items-center gap-2 text-sm font-medium text-slate-700 cursor-pointer select-none"
+          >
+            <input
+              id="show-completed-toggle"
+              type="checkbox"
+              checked={showCompleted}
+              onChange={(e) => setShowCompleted(e.target.checked)}
+              className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 cursor-pointer"
+            />
+            Show completed
+          </label>
+        </div>
+      </div>
+
+      {/* Loading state */}
+      {isLoading && <DiffAnalysisSkeleton />}
+
+      {/* Query error state */}
+      {isError && !isLoading && (
+        <div
+          className="rounded-xl bg-red-50 border border-red-200 p-6 text-sm text-red-700"
+          role="alert"
+        >
+          Failed to load ASR error patterns.{" "}
+          {queryError instanceof Error
+            ? queryError.message
+            : "Please try refreshing the page."}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <div className="rounded-xl bg-white border border-slate-200 p-12 text-center shadow-sm">
+          <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center">
+            <svg
+              aria-hidden="true"
+              className="w-6 h-6 text-slate-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25Z" />
+            </svg>
+          </div>
+          <p className="text-slate-600 font-medium">
+            {errorTokenSearch.trim() !== "" || entityNameInput.trim() !== ""
+              ? "No patterns match the current filters."
+              : "No ASR error patterns found."}
+          </p>
+          <p className="mt-1 text-sm text-slate-400">
+            {errorTokenSearch.trim() !== "" || entityNameInput.trim() !== ""
+              ? "Try clearing the filters to see all patterns."
+              : "Apply batch corrections to generate diff analysis data."}
+          </p>
+        </div>
+      )}
+
+      {/* Patterns table */}
+      {filteredAndSortedPatterns.length > 0 && (
+        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200">
+              <thead className="bg-slate-100">
+                <tr>
+                  <th
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider"
+                  >
+                    Error Token
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider"
+                  >
+                    Canonical Form
+                  </th>
+                  {/* Sortable frequency column (FR-008) */}
+                  <th
+                    scope="col"
+                    aria-sort={
+                      sortDirection === "asc" ? "ascending" : "descending"
+                    }
+                    className="px-4 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider"
+                  >
+                    <button
+                      type="button"
+                      onClick={handleToggleSort}
+                      className="inline-flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 rounded"
+                      aria-label={`Sort by frequency, currently ${sortDirection === "desc" ? "descending" : "ascending"}. Click to sort ${sortDirection === "desc" ? "ascending" : "descending"}.`}
+                    >
+                      Frequency
+                      <SortIcon direction={sortDirection} />
+                    </button>
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-4 py-3 text-left text-xs font-semibold text-slate-600 uppercase tracking-wider"
+                  >
+                    Entity
+                  </th>
+                  <th scope="col" className="relative px-4 py-3">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 bg-white">
+                {filteredAndSortedPatterns.map((pattern) => (
+                  <PatternRow
+                    key={`${pattern.error_token}:${pattern.canonical_form}`}
+                    pattern={pattern}
+                    onFindAndReplace={handleFindAndReplace}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -22,6 +22,8 @@ import { apiFetch } from "../api/config";
 import type { EntityDetail, EntityAliasSummary } from "../api/entityMentions";
 import { createEntityAlias } from "../api/entityMentions";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { PhoneticVariantsSection } from "../components/corrections/PhoneticVariantsSection";
+import { ExclusionPatternsSection } from "../components/corrections/ExclusionPatternsSection";
 
 /** Default page title to restore on unmount */
 const DEFAULT_PAGE_TITLE = "Chronovista";
@@ -577,6 +579,17 @@ export function EntityDetailPage() {
           )}
         </div>
       </section>
+
+      {/* Exclusion Patterns section */}
+      {entityId && (
+        <ExclusionPatternsSection
+          entityId={entityId}
+          patterns={entity.exclusion_patterns ?? []}
+        />
+      )}
+
+      {/* Suspected ASR Variants section */}
+      {entityId && <PhoneticVariantsSection entityId={entityId} />}
 
       {/* Video list section */}
       <section aria-labelledby="entity-videos-heading">

--- a/frontend/src/pages/__tests__/BatchCorrectionsPage.crosssegment.test.tsx
+++ b/frontend/src/pages/__tests__/BatchCorrectionsPage.crosssegment.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * Tests for BatchCorrectionsPage — Cross-Segment Panel integration (T019).
+ *
+ * Coverage:
+ * - CrossSegmentPanel renders on the page
+ * - prefillForm handler updates PatternInput with new pattern and replacement
+ * - prefillForm handler enables the cross-segment toggle
+ * - Calling prefillForm resets a stale preview (dispatches RESET)
+ * - Existing PatternInput form functionality still works after prefill
+ *
+ * Strategy:
+ * - CrossSegmentPanel is mocked so we can inject test candidates and
+ *   trigger prefillForm without testing the panel internals twice.
+ * - All batch hooks are mocked with stable idle stubs.
+ * - We render the real PatternInput (uncontrolled) and inspect DOM after
+ *   the prefillForm callback fires.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { BatchCorrectionsPage } from "../BatchCorrectionsPage";
+
+// ---------------------------------------------------------------------------
+// Mock CrossSegmentPanel — capture the prefillForm callback for testing
+// ---------------------------------------------------------------------------
+
+vi.mock("../../components/corrections/CrossSegmentPanel", () => ({
+  CrossSegmentPanel: vi.fn(({ prefillForm }: { prefillForm: (values: { pattern: string; replacement: string; crossSegment: boolean }) => void }) => {
+    return (
+      <div data-testid="cross-segment-panel">
+        <button
+          type="button"
+          onClick={() =>
+            prefillForm({
+              pattern: "bernie",
+              replacement: "Bernie",
+              crossSegment: true,
+            })
+          }
+        >
+          Use candidate
+        </button>
+      </div>
+    );
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock batch hooks with idle stubs
+// ---------------------------------------------------------------------------
+
+const mockPreviewReset = vi.fn();
+const mockPreviewMutate = vi.fn();
+
+vi.mock("../../hooks/useBatchPreview", () => ({
+  useBatchPreview: vi.fn(() => ({
+    mutate: mockPreviewMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: mockPreviewReset,
+  })),
+}));
+
+vi.mock("../../hooks/useBatchApply", () => ({
+  useBatchApply: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock("../../hooks/useBatchRebuild", () => ({
+  useBatchRebuild: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  })),
+}));
+
+vi.mock("../../hooks/useEntityDetail", () => ({
+  useEntityDetail: vi.fn(() => ({
+    entity: null,
+    aliasNames: [],
+    isLoading: false,
+    isError: false,
+  })),
+}));
+
+vi.mock("../../hooks/useEntities", () => ({
+  useEntities: vi.fn(() => ({
+    entities: [],
+    total: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  })),
+}));
+
+// EntityAutocomplete uses apiFetch — mock config module
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  isApiError: vi.fn(() => false),
+}));
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function renderPage(initialPath = "/corrections/batch") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <BatchCorrectionsPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BatchCorrectionsPage — CrossSegmentPanel integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Panel presence
+  // -------------------------------------------------------------------------
+
+  it("renders CrossSegmentPanel on the page", () => {
+    renderPage();
+    expect(screen.getByTestId("cross-segment-panel")).toBeInTheDocument();
+  });
+
+  it("renders the page heading alongside the panel", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /batch find & replace/i, level: 1 })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("cross-segment-panel")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // prefillForm updates PatternInput
+  // -------------------------------------------------------------------------
+
+  it("fills the pattern input when prefillForm is called with a candidate", async () => {
+    renderPage();
+
+    // The pattern input should initially be empty
+    const patternInput = screen.getByPlaceholderText(/enter text or regex pattern/i);
+    expect(patternInput).toHaveValue("");
+
+    // Trigger prefill via the mock CrossSegmentPanel's button
+    fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+    // PatternInput should remount with the new initial value
+    await waitFor(() => {
+      const updatedInput = screen.getByPlaceholderText(/enter text or regex pattern/i);
+      expect(updatedInput).toHaveValue("bernie");
+    });
+  });
+
+  it("fills the replacement input when prefillForm is called with a candidate", async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+    await waitFor(() => {
+      const replacementInput = screen.getByPlaceholderText(/replacement text/i);
+      expect(replacementInput).toHaveValue("Bernie");
+    });
+  });
+
+  it("enables the cross-segment toggle when prefillForm passes crossSegment: true", async () => {
+    renderPage();
+
+    // Initially cross-segment toggle should be off
+    const crossSegmentToggle = screen.getByRole("switch", {
+      name: /match across segment boundaries/i,
+    });
+    expect(crossSegmentToggle).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+    await waitFor(() => {
+      const updatedToggle = screen.getByRole("switch", {
+        name: /match across segment boundaries/i,
+      });
+      expect(updatedToggle).toHaveAttribute("aria-checked", "true");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stale preview reset
+  // -------------------------------------------------------------------------
+
+  it("resets preview mutation state when prefillForm is called", async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+    await waitFor(() => {
+      expect(mockPreviewReset).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Existing functionality unchanged
+  // -------------------------------------------------------------------------
+
+  it("still renders the PatternInput section with Preview Matches button", () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("button", { name: /preview matches/i })
+    ).toBeInTheDocument();
+  });
+
+  it("Preview Matches button is disabled when pattern is empty", () => {
+    renderPage();
+
+    const previewBtn = screen.getByRole("button", { name: /preview matches/i });
+    expect(previewBtn).toBeDisabled();
+  });
+
+  it("Preview Matches button enables after pattern is typed", () => {
+    renderPage();
+
+    const patternInput = screen.getByPlaceholderText(/enter text or regex pattern/i);
+    fireEvent.change(patternInput, { target: { value: "somepattern" } });
+
+    const previewBtn = screen.getByRole("button", { name: /preview matches/i });
+    expect(previewBtn).not.toBeDisabled();
+  });
+
+  it("clicking Preview Matches calls the preview mutation", () => {
+    renderPage();
+
+    const patternInput = screen.getByPlaceholderText(/enter text or regex pattern/i);
+    fireEvent.change(patternInput, { target: { value: "somepattern" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /preview matches/i }));
+
+    expect(mockPreviewMutate).toHaveBeenCalledTimes(1);
+    expect(mockPreviewMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ pattern: "somepattern" }),
+      expect.any(Object)
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // prefillForm then normal usage flow
+  // -------------------------------------------------------------------------
+
+  it("allows previewing after prefill by clicking Preview Matches", async () => {
+    renderPage();
+
+    // Trigger prefill
+    fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+    await waitFor(() => {
+      const patternInput = screen.getByPlaceholderText(/enter text or regex pattern/i);
+      expect(patternInput).toHaveValue("bernie");
+    });
+
+    // Preview should now be clickable (pattern is non-empty)
+    const previewBtn = screen.getByRole("button", { name: /preview matches/i });
+    expect(previewBtn).not.toBeDisabled();
+
+    fireEvent.click(previewBtn);
+
+    expect(mockPreviewMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pattern: "bernie",
+        replacement: "Bernie",
+        cross_segment: true,
+      }),
+      expect.any(Object)
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------------
+
+  it("renders a <main> landmark", () => {
+    renderPage();
+    expect(screen.getByRole("main")).toBeInTheDocument();
+  });
+
+  it("CrossSegmentPanel has a section with accessible label", () => {
+    // The real CrossSegmentPanel uses aria-label="Suggested Cross-Segment Candidates"
+    // but since we mock it as a plain div, here we just verify it's present.
+    renderPage();
+    expect(screen.getByTestId("cross-segment-panel")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/BatchCorrectionsPage.entity.test.tsx
+++ b/frontend/src/pages/__tests__/BatchCorrectionsPage.entity.test.tsx
@@ -1,0 +1,548 @@
+/**
+ * Tests for BatchCorrectionsPage — Entity Selection Persistence (T026 / FR-011).
+ *
+ * Coverage:
+ * - Entity persists when the user changes the find pattern (second-round workflow)
+ * - Entity clears when the replacement field is emptied (FR-011 auto-clear)
+ * - Entity clears when a cross-segment candidate pre-fills the form (handlePrefill)
+ *
+ * Strategy:
+ * - EntityAutocomplete is rendered real but its search hook (useEntitySearch) is
+ *   mocked to return a single fake entity, making the dropdown appear without a
+ *   live API call. We simulate selecting the entity by typing into the replacement
+ *   field (which drives EntityAutocomplete.searchText) and then clicking the list
+ *   option that appears.
+ * - CrossSegmentPanel is mocked (same as the crosssegment test) so we can trigger
+ *   handlePrefill via a button click.
+ * - All batch mutation hooks are mocked with stable idle stubs.
+ * - DOM assertions focus on the entity pill (role="status") rendered inside
+ *   EntityAutocomplete and the "Linked entity:" summary in ApplyControls.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { BatchCorrectionsPage } from "../BatchCorrectionsPage";
+
+// ---------------------------------------------------------------------------
+// Mock CrossSegmentPanel — reuse exact pattern from crosssegment test
+// ---------------------------------------------------------------------------
+
+vi.mock("../../components/corrections/CrossSegmentPanel", () => ({
+  CrossSegmentPanel: vi.fn(
+    ({
+      prefillForm,
+    }: {
+      prefillForm: (values: {
+        pattern: string;
+        replacement: string;
+        crossSegment: boolean;
+      }) => void;
+    }) => {
+      return (
+        <div data-testid="cross-segment-panel">
+          <button
+            type="button"
+            onClick={() =>
+              prefillForm({
+                pattern: "bernie",
+                replacement: "Bernie",
+                crossSegment: true,
+              })
+            }
+          >
+            Use candidate
+          </button>
+        </div>
+      );
+    }
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock batch mutation hooks with idle stubs
+// ---------------------------------------------------------------------------
+
+const mockPreviewReset = vi.fn();
+const mockPreviewMutate = vi.fn();
+
+vi.mock("../../hooks/useBatchPreview", () => ({
+  useBatchPreview: vi.fn(() => ({
+    mutate: mockPreviewMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: mockPreviewReset,
+  })),
+}));
+
+vi.mock("../../hooks/useBatchApply", () => ({
+  useBatchApply: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock("../../hooks/useBatchRebuild", () => ({
+  useBatchRebuild: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  })),
+}));
+
+vi.mock("../../hooks/useEntityDetail", () => ({
+  useEntityDetail: vi.fn(() => ({
+    entity: null,
+    aliasNames: [],
+    isLoading: false,
+    isError: false,
+  })),
+}));
+
+vi.mock("../../hooks/useEntities", () => ({
+  useEntities: vi.fn(() => ({
+    entities: [],
+    total: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  })),
+}));
+
+// EntityAutocomplete uses apiFetch — mock config module
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  isApiError: vi.fn(() => false),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock useEntitySearch so the dropdown appears without live API calls.
+//
+// We expose a mutable ref so individual tests can toggle whether results are
+// returned. Default: returns one "Andrés Manuel López Obrador" entity.
+// ---------------------------------------------------------------------------
+
+const mockEntitySearchResult = {
+  entities: [
+    {
+      entity_id: "entity-uuid-001",
+      canonical_name: "Andrés Manuel López Obrador",
+      entity_type: "person",
+    },
+  ],
+  isLoading: false,
+  isFetched: true,
+  isError: false,
+  isBelowMinChars: false,
+};
+
+vi.mock("../../hooks/useEntitySearch", () => ({
+  useEntitySearch: vi.fn(() => mockEntitySearchResult),
+}));
+
+// ---------------------------------------------------------------------------
+// Render helper — identical to the crosssegment test
+// ---------------------------------------------------------------------------
+
+function renderPage(initialPath = "/corrections/batch") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <BatchCorrectionsPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: select an entity via the EntityAutocomplete dropdown.
+//
+// The EntityAutocomplete.searchText is driven by the replacement field value.
+// We type a replacement value (≥2 chars) so useEntitySearch fires and the
+// dropdown option appears, then click the option to select the entity.
+// ---------------------------------------------------------------------------
+
+async function selectEntityViaAutocomplete(replacementValue: string) {
+  // Type into the replacement field — this drives EntityAutocomplete.searchText
+  const replacementInput = screen.getByPlaceholderText(/replacement text/i);
+  fireEvent.change(replacementInput, { target: { value: replacementValue } });
+
+  // The dropdown option should appear (useEntitySearch is mocked to return results)
+  const option = await screen.findByRole("option", {
+    name: /Andrés Manuel López Obrador/i,
+  });
+  fireEvent.click(option);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BatchCorrectionsPage — Entity Selection Persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 1: Entity persists when the pattern changes
+  //
+  // Spec: handlePatternChange does NOT call setSelectedEntity(null).
+  // The entity pill in EntityAutocomplete (role="status") should remain
+  // visible after the user types a new pattern (second-round workflow).
+  // -------------------------------------------------------------------------
+
+  describe("Scenario 1: entity persists when find pattern changes", () => {
+    it("entity pill is visible inside PatternInput after selecting an entity", async () => {
+      renderPage();
+
+      // Select the entity by typing in the replacement field and clicking the option
+      await selectEntityViaAutocomplete("AMLO");
+
+      // The entity pill (role="status") should now be visible inside PatternInput
+      const entityPill = await screen.findByRole("status");
+      expect(entityPill).toBeInTheDocument();
+      expect(entityPill).toHaveTextContent("Andrés Manuel López Obrador");
+    });
+
+    it("entity pill remains visible after the user changes the find pattern", async () => {
+      renderPage();
+
+      // Select an entity
+      await selectEntityViaAutocomplete("AMLO");
+
+      // Verify entity pill is present
+      const entityPill = await screen.findByRole("status");
+      expect(entityPill).toHaveTextContent("Andrés Manuel López Obrador");
+
+      // Now change the find pattern — this triggers handlePatternChange
+      const patternInput = screen.getByPlaceholderText(
+        /enter text or regex pattern/i
+      );
+      fireEvent.change(patternInput, { target: { value: "amlo" } });
+
+      // The entity pill must still be present (entity was NOT cleared by pattern change)
+      await waitFor(() => {
+        const pill = screen.queryByRole("status");
+        expect(pill).toBeInTheDocument();
+        expect(pill).toHaveTextContent("Andrés Manuel López Obrador");
+      });
+    });
+
+    it("changing the pattern multiple times does not clear the entity", async () => {
+      renderPage();
+
+      await selectEntityViaAutocomplete("AMLO");
+
+      const patternInput = screen.getByPlaceholderText(
+        /enter text or regex pattern/i
+      );
+
+      // Change pattern twice — simulates second-round workflow
+      fireEvent.change(patternInput, { target: { value: "amlo" } });
+      fireEvent.change(patternInput, { target: { value: "amlo variant" } });
+
+      await waitFor(() => {
+        const pill = screen.queryByRole("status");
+        expect(pill).toBeInTheDocument();
+        expect(pill).toHaveTextContent("Andrés Manuel López Obrador");
+      });
+    });
+
+    it("the 'Remove entity link' dismiss button is still present after pattern change", async () => {
+      renderPage();
+
+      await selectEntityViaAutocomplete("AMLO");
+
+      const patternInput = screen.getByPlaceholderText(
+        /enter text or regex pattern/i
+      );
+      fireEvent.change(patternInput, { target: { value: "new pattern" } });
+
+      // Dismiss button must still be accessible
+      await waitFor(() => {
+        const dismissBtn = screen.queryByRole("button", {
+          name: /remove entity link/i,
+        });
+        expect(dismissBtn).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 2: Entity clears when the replacement field is emptied (FR-011)
+  //
+  // PatternInput.handleReplacementChange calls onEntityChange(null) when the
+  // replacement value is empty or whitespace-only (lines 279-282).
+  // -------------------------------------------------------------------------
+
+  describe("Scenario 2: entity clears when replacement field is emptied (FR-011)", () => {
+    it("entity pill disappears when the replacement field is cleared", async () => {
+      renderPage();
+
+      // Select an entity
+      await selectEntityViaAutocomplete("AMLO");
+
+      // Verify entity pill is present
+      const entityPill = await screen.findByRole("status");
+      expect(entityPill).toHaveTextContent("Andrés Manuel López Obrador");
+
+      // Clear the replacement field
+      const replacementInput = screen.getByPlaceholderText(/replacement text/i);
+      fireEvent.change(replacementInput, { target: { value: "" } });
+
+      // FR-011: entity pill must be gone
+      await waitFor(() => {
+        // The "status" role pill inside EntityAutocomplete must not be in DOM
+        const pill = screen.queryByRole("status");
+        expect(pill).not.toBeInTheDocument();
+      });
+    });
+
+    it("entity pill disappears when replacement is set to whitespace only", async () => {
+      renderPage();
+
+      await selectEntityViaAutocomplete("AMLO");
+
+      const entityPill = await screen.findByRole("status");
+      expect(entityPill).toHaveTextContent("Andrés Manuel López Obrador");
+
+      const replacementInput = screen.getByPlaceholderText(/replacement text/i);
+      // Only whitespace — handleReplacementChange calls !value.trim() → true
+      fireEvent.change(replacementInput, { target: { value: "   " } });
+
+      await waitFor(() => {
+        const pill = screen.queryByRole("status");
+        expect(pill).not.toBeInTheDocument();
+      });
+    });
+
+    it("'Remove entity link' button disappears when replacement is cleared", async () => {
+      renderPage();
+
+      await selectEntityViaAutocomplete("AMLO");
+
+      // Confirm dismiss button is visible
+      const dismissBtn = await screen.findByRole("button", {
+        name: /remove entity link/i,
+      });
+      expect(dismissBtn).toBeInTheDocument();
+
+      // Clear the replacement
+      const replacementInput = screen.getByPlaceholderText(/replacement text/i);
+      fireEvent.change(replacementInput, { target: { value: "" } });
+
+      // Dismiss button must be gone (pill rendered it, and pill is now gone)
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /remove entity link/i })
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("entity can be re-selected after clearing the replacement and typing again", async () => {
+      renderPage();
+
+      // First selection
+      await selectEntityViaAutocomplete("AMLO");
+      await screen.findByRole("status");
+
+      // Clear replacement (FR-011 auto-clear)
+      const replacementInput = screen.getByPlaceholderText(/replacement text/i);
+      fireEvent.change(replacementInput, { target: { value: "" } });
+
+      await waitFor(() => {
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      });
+
+      // Re-select the entity
+      await selectEntityViaAutocomplete("AMLO");
+
+      // Entity pill should be back
+      const pill = await screen.findByRole("status");
+      expect(pill).toHaveTextContent("Andrés Manuel López Obrador");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 3: Entity clears when a cross-segment candidate pre-fills the form
+  //
+  // handlePrefill (BatchCorrectionsPage.tsx ~line 681) calls
+  // setSelectedEntity(null) — clearing the page-level entity state.
+  // PatternInput remounts (key increment), which resets PatternInput's own
+  // selectedEntity state too. The entity pill must be gone.
+  // -------------------------------------------------------------------------
+
+  describe("Scenario 3: entity clears when cross-segment candidate is selected (handlePrefill)", () => {
+    it("entity pill disappears after prefillForm is called from CrossSegmentPanel", async () => {
+      renderPage();
+
+      // Select an entity
+      await selectEntityViaAutocomplete("AMLO");
+
+      const entityPill = await screen.findByRole("status");
+      expect(entityPill).toHaveTextContent("Andrés Manuel López Obrador");
+
+      // Trigger prefill from the mock CrossSegmentPanel — this calls handlePrefill
+      // which calls setSelectedEntity(null)
+      fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+      // After prefill the entity must be cleared
+      await waitFor(() => {
+        const pill = screen.queryByRole("status");
+        expect(pill).not.toBeInTheDocument();
+      });
+    });
+
+    it("prefillForm fills the pattern field while clearing the entity", async () => {
+      renderPage();
+
+      await selectEntityViaAutocomplete("AMLO");
+      await screen.findByRole("status");
+
+      fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+      // Pattern must be prefilled with the candidate value
+      await waitFor(() => {
+        const patternInput = screen.getByPlaceholderText(
+          /enter text or regex pattern/i
+        );
+        expect(patternInput).toHaveValue("bernie");
+      });
+
+      // Entity must be cleared
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("prefillForm fills the replacement field while clearing the entity", async () => {
+      renderPage();
+
+      await selectEntityViaAutocomplete("AMLO");
+      await screen.findByRole("status");
+
+      fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+      // Replacement must be prefilled with the candidate value
+      await waitFor(() => {
+        const replacementInput = screen.getByPlaceholderText(/replacement text/i);
+        expect(replacementInput).toHaveValue("Bernie");
+      });
+
+      // Entity must be cleared
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("dismiss button is gone after entity is cleared via prefillForm", async () => {
+      renderPage();
+
+      await selectEntityViaAutocomplete("AMLO");
+
+      // Confirm dismiss button exists
+      const dismissBtn = await screen.findByRole("button", {
+        name: /remove entity link/i,
+      });
+      expect(dismissBtn).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /remove entity link/i })
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("preview reset is called when prefillForm clears the entity", async () => {
+      renderPage();
+
+      await selectEntityViaAutocomplete("AMLO");
+      await screen.findByRole("status");
+
+      // Record how many times reset has been called before prefill
+      const callsBefore = mockPreviewReset.mock.calls.length;
+
+      fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+      // handlePrefill calls previewMutation.reset() — verify at least one more call
+      // occurred after the button click (previous calls may come from replacement
+      // field changes triggering handlePatternChange in PatternInput).
+      await waitFor(() => {
+        expect(mockPreviewReset.mock.calls.length).toBeGreaterThan(callsBefore);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Contrast: pattern change does NOT call preview reset for entity
+  //
+  // This test is complementary — it ensures handlePatternChange preserves the
+  // entity while confirming the state machine does reset (RESET dispatched).
+  // The "Preview Matches" button returning to disabled proves the machine reset.
+  // -------------------------------------------------------------------------
+
+  describe("Contrast: handlePatternChange vs handlePrefill behavior", () => {
+    it("Preview Matches button is re-disabled (state RESET) after pattern change, but entity stays", async () => {
+      renderPage();
+
+      // Select an entity
+      await selectEntityViaAutocomplete("AMLO");
+      await screen.findByRole("status");
+
+      // Type a pattern to enable the preview button
+      const patternInput = screen.getByPlaceholderText(
+        /enter text or regex pattern/i
+      );
+      fireEvent.change(patternInput, { target: { value: "amlo" } });
+
+      const previewBtn = screen.getByRole("button", { name: /preview matches/i });
+      expect(previewBtn).not.toBeDisabled();
+
+      // Change the pattern — triggers handlePatternChange → dispatches RESET
+      fireEvent.change(patternInput, { target: { value: "amlo variant" } });
+
+      // Entity still present
+      await waitFor(() => {
+        const pill = screen.queryByRole("status");
+        expect(pill).toBeInTheDocument();
+        expect(pill).toHaveTextContent("Andrés Manuel López Obrador");
+      });
+    });
+
+    it("prefillForm clears entity but handlePatternChange does not", async () => {
+      renderPage();
+
+      // Set up entity
+      await selectEntityViaAutocomplete("AMLO");
+      await screen.findByRole("status");
+
+      // Pattern change — entity persists
+      const patternInput = screen.getByPlaceholderText(
+        /enter text or regex pattern/i
+      );
+      fireEvent.change(patternInput, { target: { value: "amlo" } });
+
+      await waitFor(() => {
+        expect(screen.queryByRole("status")).toBeInTheDocument();
+      });
+
+      // prefillForm — entity clears
+      fireEvent.click(screen.getByRole("button", { name: /use candidate/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/BatchHistoryPage.test.tsx
+++ b/frontend/src/pages/__tests__/BatchHistoryPage.test.tsx
@@ -1,0 +1,760 @@
+/**
+ * Tests for BatchHistoryPage — Feature 046 (T009).
+ *
+ * Coverage:
+ * - Renders loading state initially (skeleton)
+ * - Renders table with batch data
+ * - Renders empty state when no batches exist
+ * - Revert button opens confirmation dialog
+ * - Confirm revert calls mutation with correct batch ID
+ * - Cancel closes dialog without reverting
+ * - Error states (404, 409) display correctly in dialog
+ * - Load More button appears when has_more=true
+ * - Focus management: dialog gets focus on open; trigger gets focus on close
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { BatchHistoryPage } from "../BatchHistoryPage";
+
+// ---------------------------------------------------------------------------
+// Mock hooks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../hooks/useBatchHistory", () => ({
+  useBatchHistory: vi.fn(),
+  useRevertBatch: vi.fn(),
+}));
+
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  isApiError: vi.fn((err: unknown): boolean => {
+    return (
+      typeof err === "object" &&
+      err !== null &&
+      "type" in err &&
+      "message" in err
+    );
+  }),
+}));
+
+import { useBatchHistory, useRevertBatch } from "../../hooks/useBatchHistory";
+import type { BatchSummary } from "../../types/corrections";
+
+const mockedUseBatchHistory = vi.mocked(useBatchHistory);
+const mockedUseRevertBatch = vi.mocked(useRevertBatch);
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+function makeBatchSummary(overrides: Partial<BatchSummary> = {}): BatchSummary {
+  return {
+    batch_id: "batch-uuid-001",
+    correction_count: 5,
+    corrected_by_user_id: "user:batch",
+    pattern: "colour",
+    replacement: "color",
+    batch_timestamp: "2025-01-15T10:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default mock returns
+// ---------------------------------------------------------------------------
+
+const defaultMutateResult = {
+  mutate: vi.fn(),
+  mutateAsync: vi.fn(),
+  isPending: false,
+  isPaused: false,
+  isSuccess: false,
+  isError: false,
+  isIdle: true,
+  data: undefined,
+  error: null,
+  reset: vi.fn(),
+  context: undefined,
+  failureCount: 0,
+  failureReason: null,
+  status: "idle" as const,
+  variables: undefined,
+  submittedAt: 0,
+};
+
+function makeDefaultBatchHistory(overrides: Partial<ReturnType<typeof useBatchHistory>> = {}) {
+  return {
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    fetchPreviousPage: vi.fn(),
+    hasPreviousPage: false,
+    isFetchingPreviousPage: false,
+    isFetchNextPageError: false,
+    isFetchPreviousPageError: false,
+    isRefetching: false,
+    isRefetchError: false,
+    isLoadingError: false,
+    isPending: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isStale: false,
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    errorUpdateCount: 0,
+    failureCount: 0,
+    failureReason: null,
+    refetch: vi.fn(),
+    status: "pending" as const,
+    fetchStatus: "idle" as const,
+    ...overrides,
+  } as ReturnType<typeof useBatchHistory>;
+}
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <BatchHistoryPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BatchHistoryPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseRevertBatch.mockReturnValue(defaultMutateResult as ReturnType<typeof useRevertBatch>);
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("renders a loading skeleton during initial fetch", () => {
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({ isLoading: true, isPending: true })
+    );
+
+    renderPage();
+
+    // The skeleton has an aria-label for screen readers
+    expect(
+      screen.getByRole("status", { name: /loading batch history/i })
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Table with data
+  // -------------------------------------------------------------------------
+
+  it("renders the page heading", () => {
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [{ data: [], pagination: { has_more: false, total: 0, offset: 0, limit: 20 } }],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: /batch history/i, level: 1 })
+    ).toBeInTheDocument();
+  });
+
+  it("renders a table with batch data when batches exist", () => {
+    const batch = makeBatchSummary({
+      pattern: "teh",
+      replacement: "the",
+      correction_count: 10,
+      corrected_by_user_id: "user:cli",
+    });
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    // Table headers
+    expect(screen.getByRole("columnheader", { name: /pattern/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /replacement/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /count/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /actor/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /timestamp/i })).toBeInTheDocument();
+
+    // Row data
+    expect(screen.getByText("teh")).toBeInTheDocument();
+    expect(screen.getByText("the")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("user:cli")).toBeInTheDocument();
+  });
+
+  it("renders multiple rows when multiple batches exist", () => {
+    const batches = [
+      makeBatchSummary({ batch_id: "b1", pattern: "colour", replacement: "color" }),
+      makeBatchSummary({ batch_id: "b2", pattern: "favourite", replacement: "favorite" }),
+      makeBatchSummary({ batch_id: "b3", pattern: "neighbour", replacement: "neighbor" }),
+    ];
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: batches,
+              pagination: { has_more: false, total: 3, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    expect(screen.getByText("colour")).toBeInTheDocument();
+    expect(screen.getByText("favourite")).toBeInTheDocument();
+    expect(screen.getByText("neighbour")).toBeInTheDocument();
+
+    // Three Revert buttons — one per row
+    const revertButtons = screen.getAllByRole("button", { name: /revert batch/i });
+    expect(revertButtons).toHaveLength(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it("renders empty state when no batches exist", () => {
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [],
+              pagination: { has_more: false, total: 0, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByText(/no batch operations found/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/apply a find-replace batch to see history here/i)
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Revert dialog
+  // -------------------------------------------------------------------------
+
+  it("opens confirmation dialog when Revert button is clicked", async () => {
+    const batch = makeBatchSummary({ pattern: "colour", replacement: "color" });
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    const revertBtn = screen.getByRole("button", { name: /revert batch/i });
+    fireEvent.click(revertBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    // Dialog shows batch details
+    expect(
+      screen.getByText(/revert batch correction/i)
+    ).toBeInTheDocument();
+    // Pattern and replacement appear inside dialog
+    expect(screen.getAllByText("colour")).not.toHaveLength(0);
+    expect(screen.getAllByText("color")).not.toHaveLength(0);
+  });
+
+  it("calls mutate with the correct batch ID when Confirm Revert is clicked", async () => {
+    const mutateFn = vi.fn();
+    mockedUseRevertBatch.mockReturnValue({
+      ...defaultMutateResult,
+      mutate: mutateFn,
+    } as ReturnType<typeof useRevertBatch>);
+
+    const batch = makeBatchSummary({ batch_id: "batch-target-99" });
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /revert batch/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm revert/i }));
+
+    expect(mutateFn).toHaveBeenCalledWith(
+      "batch-target-99",
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it("closes dialog without calling mutate when Cancel is clicked", async () => {
+    const mutateFn = vi.fn();
+    mockedUseRevertBatch.mockReturnValue({
+      ...defaultMutateResult,
+      mutate: mutateFn,
+    } as ReturnType<typeof useRevertBatch>);
+
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /revert batch/i }));
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    expect(mutateFn).not.toHaveBeenCalled();
+  });
+
+  it("closes dialog when Escape key is pressed", async () => {
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /revert batch/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    // Press Escape
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error states in dialog
+  // -------------------------------------------------------------------------
+
+  it("shows 404 error message in dialog when batch is not found", async () => {
+    const notFoundError = Object.assign(new Error("Not found"), {
+      type: "server",
+      message: "Something went wrong on the server.",
+      status: 404,
+    });
+
+    mockedUseRevertBatch.mockReturnValue({
+      ...defaultMutateResult,
+      isError: true,
+      error: notFoundError,
+      variables: "batch-uuid-001",
+    } as unknown as ReturnType<typeof useRevertBatch>);
+
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /revert batch/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    // The error is shown in the dialog
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/batch not found/i);
+  });
+
+  it("shows 409 error message in dialog when batch is already reverted", async () => {
+    const conflictError = Object.assign(new Error("Conflict"), {
+      type: "server",
+      message: "Something went wrong on the server.",
+      status: 409,
+    });
+
+    mockedUseRevertBatch.mockReturnValue({
+      ...defaultMutateResult,
+      isError: true,
+      error: conflictError,
+      variables: "batch-uuid-001",
+    } as unknown as ReturnType<typeof useRevertBatch>);
+
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /revert batch/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /this batch has already been reverted/i
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Load More
+  // -------------------------------------------------------------------------
+
+  it("shows Load More button when has_more is true", () => {
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        hasNextPage: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: true, total: 50, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByRole("button", { name: /load more batch operations/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not show Load More button when has_more is false", () => {
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        hasNextPage: false,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    expect(
+      screen.queryByRole("button", { name: /load more batch operations/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls fetchNextPage when Load More is clicked", async () => {
+    const fetchNextPageFn = vi.fn();
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        hasNextPage: true,
+        fetchNextPage: fetchNextPageFn,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: true, total: 50, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /load more batch operations/i })
+    );
+
+    expect(fetchNextPageFn).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Focus management (FR-027)
+  // -------------------------------------------------------------------------
+
+  it("moves focus into the dialog when it opens", async () => {
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    const revertBtn = screen.getByRole("button", { name: /revert batch/i });
+    await act(async () => {
+      fireEvent.click(revertBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    // After the dialog mounts, focus should be inside it.
+    // The Cancel button receives focus first per the implementation.
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  it("returns focus to the Revert button when dialog is cancelled", async () => {
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    const revertBtn = screen.getByRole("button", { name: /revert batch/i });
+    revertBtn.focus();
+
+    await act(async () => {
+      fireEvent.click(revertBtn);
+    });
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    );
+
+    // Focus should have returned to the revert button
+    expect(document.activeElement).toBe(revertBtn);
+  });
+
+  // -------------------------------------------------------------------------
+  // Query error state
+  // -------------------------------------------------------------------------
+
+  it("renders an error message when the query fails", () => {
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isError: true,
+        error: new Error("Network error"),
+      })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByRole("alert")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/failed to load batch history/i)
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------------
+
+  it("renders a <main> landmark", () => {
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [],
+              pagination: { has_more: false, total: 0, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    expect(screen.getByRole("main")).toBeInTheDocument();
+  });
+
+  it("dialog has aria-modal and aria-labelledby attributes", async () => {
+    const batch = makeBatchSummary();
+    mockedUseBatchHistory.mockReturnValue(
+      makeDefaultBatchHistory({
+        isSuccess: true,
+        data: {
+          pages: [
+            {
+              data: [batch],
+              pagination: { has_more: false, total: 1, offset: 0, limit: 20 },
+            },
+          ],
+          pageParams: [0],
+        },
+      })
+    );
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /revert batch/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby");
+  });
+});

--- a/frontend/src/pages/__tests__/DiffAnalysisPage.test.tsx
+++ b/frontend/src/pages/__tests__/DiffAnalysisPage.test.tsx
@@ -1,0 +1,783 @@
+/**
+ * Tests for DiffAnalysisPage — Feature 046 (T013).
+ *
+ * Coverage:
+ * - Renders loading state (skeleton)
+ * - Renders table with pattern data
+ * - Page has correct heading
+ * - Sort by frequency toggles direction (asc ↔ desc)
+ * - aria-sort attribute on frequency <th> updates correctly
+ * - Sort announcement appears in hidden live region (FR-028)
+ * - Error token filter works client-side (instant)
+ * - Entity name rendered as link when entity_id is present
+ * - Entity column is empty when entity_id is null
+ * - "Find & Replace" button calls navigate with correct state (US2)
+ * - Empty state — no data
+ * - Empty state — filters produce no results
+ * - Query error state
+ * - <main> landmark present
+ * - "Show completed" toggle renders with correct label
+ * - Default state: toggle is unchecked, hook called with showCompleted: false
+ * - When toggled on: hook called with showCompleted: true
+ * - Completed rows (remaining_matches=0) show "Completed" badge, not "Find & Replace"
+ * - Completed rows have muted/grayed styling (opacity-60)
+ * - Non-completed rows still show "Find & Replace" button
+ * - Entity link remains functional on completed rows
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { DiffAnalysisPage } from "../DiffAnalysisPage";
+
+// ---------------------------------------------------------------------------
+// Mock hooks and navigation
+// ---------------------------------------------------------------------------
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("../../hooks/useDiffAnalysis", () => ({
+  useDiffAnalysis: vi.fn(),
+}));
+
+import { useDiffAnalysis } from "../../hooks/useDiffAnalysis";
+import type { DiffErrorPattern } from "../../types/corrections";
+
+const mockedUseDiffAnalysis = vi.mocked(useDiffAnalysis);
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makePattern(overrides: Partial<DiffErrorPattern> = {}): DiffErrorPattern {
+  return {
+    error_token: "barak",
+    canonical_form: "Barack",
+    frequency: 12,
+    remaining_matches: 8,
+    entity_id: null,
+    entity_name: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default mock returns
+// ---------------------------------------------------------------------------
+
+function makeDefaultQueryResult(
+  overrides: Partial<ReturnType<typeof useDiffAnalysis>> = {}
+) {
+  return {
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    refetch: vi.fn(),
+    status: "pending" as const,
+    fetchStatus: "idle" as const,
+    isPending: false,
+    isPaused: false,
+    isRefetching: false,
+    isRefetchError: false,
+    isLoadingError: false,
+    isPlaceholderData: false,
+    isStale: false,
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    errorUpdateCount: 0,
+    failureCount: 0,
+    failureReason: null,
+    ...overrides,
+  } as ReturnType<typeof useDiffAnalysis>;
+}
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DiffAnalysisPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DiffAnalysisPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Heading and landmark
+  // -------------------------------------------------------------------------
+
+  it("renders the ASR Error Patterns heading", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [] })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: "ASR Error Patterns", level: 1 })
+    ).toBeInTheDocument();
+  });
+
+  it("renders a <main> landmark", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [] })
+    );
+
+    renderPage();
+
+    expect(screen.getByRole("main")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("renders a loading skeleton during initial fetch", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isLoading: true, isPending: true })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByRole("status", { name: /loading asr error patterns/i })
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Table with data
+  // -------------------------------------------------------------------------
+
+  it("renders table with error token and canonical form data", () => {
+    const pattern = makePattern({
+      error_token: "obamma",
+      canonical_form: "Obama",
+      frequency: 25,
+    });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [pattern] })
+    );
+
+    renderPage();
+
+    expect(screen.getByText("obamma")).toBeInTheDocument();
+    expect(screen.getByText("Obama")).toBeInTheDocument();
+    expect(screen.getByText("25")).toBeInTheDocument();
+  });
+
+  it("renders table column headers", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [makePattern()] })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByRole("columnheader", { name: /error token/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /canonical form/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /entity/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders multiple rows when multiple patterns exist", () => {
+    const patterns = [
+      makePattern({ error_token: "barak", canonical_form: "Barack", frequency: 20 }),
+      makePattern({ error_token: "hussain", canonical_form: "Hussein", frequency: 10 }),
+      makePattern({ error_token: "obamma", canonical_form: "Obama", frequency: 5 }),
+    ];
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: patterns })
+    );
+
+    renderPage();
+
+    expect(screen.getByText("barak")).toBeInTheDocument();
+    expect(screen.getByText("hussain")).toBeInTheDocument();
+    expect(screen.getByText("obamma")).toBeInTheDocument();
+
+    const buttons = screen.getAllByRole("button", { name: /find and replace/i });
+    expect(buttons).toHaveLength(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // Sort by frequency (FR-008)
+  // -------------------------------------------------------------------------
+
+  it("renders frequency column as a sortable button with aria-sort", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [makePattern()] })
+    );
+
+    renderPage();
+
+    const freqHeader = screen.getByRole("columnheader", {
+      name: /frequency/i,
+    });
+    // Initially sorted descending
+    expect(freqHeader).toHaveAttribute("aria-sort", "descending");
+
+    // The button is inside the th
+    const sortBtn = within(freqHeader).getByRole("button");
+    expect(sortBtn).toBeInTheDocument();
+  });
+
+  it("toggles sort direction from descending to ascending on click", () => {
+    const patterns = [
+      makePattern({ error_token: "high", frequency: 100 }),
+      makePattern({ error_token: "low", canonical_form: "Low", frequency: 1 }),
+    ];
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: patterns })
+    );
+
+    renderPage();
+
+    const freqHeader = screen.getByRole("columnheader", { name: /frequency/i });
+    expect(freqHeader).toHaveAttribute("aria-sort", "descending");
+
+    const sortBtn = within(freqHeader).getByRole("button");
+    fireEvent.click(sortBtn);
+
+    expect(freqHeader).toHaveAttribute("aria-sort", "ascending");
+  });
+
+  it("toggles sort direction from ascending back to descending on second click", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [makePattern()] })
+    );
+
+    renderPage();
+
+    const freqHeader = screen.getByRole("columnheader", { name: /frequency/i });
+    const sortBtn = within(freqHeader).getByRole("button");
+
+    // desc → asc
+    fireEvent.click(sortBtn);
+    expect(freqHeader).toHaveAttribute("aria-sort", "ascending");
+
+    // asc → desc
+    fireEvent.click(sortBtn);
+    expect(freqHeader).toHaveAttribute("aria-sort", "descending");
+  });
+
+  it("sorts rows by frequency descending by default", () => {
+    const patterns = [
+      makePattern({ error_token: "low", canonical_form: "Low", frequency: 3 }),
+      makePattern({ error_token: "high", canonical_form: "High", frequency: 50 }),
+      makePattern({ error_token: "mid", canonical_form: "Mid", frequency: 20 }),
+    ];
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: patterns })
+    );
+
+    renderPage();
+
+    const rows = screen.getAllByRole("row");
+    // rows[0] is the header row; rows[1] should be the highest frequency
+    const firstDataRow = rows[1];
+    expect(firstDataRow).toHaveTextContent("high");
+  });
+
+  it("sorts rows by frequency ascending after clicking sort button", () => {
+    const patterns = [
+      makePattern({ error_token: "low", canonical_form: "Low", frequency: 3 }),
+      makePattern({ error_token: "high", canonical_form: "High", frequency: 50 }),
+    ];
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: patterns })
+    );
+
+    renderPage();
+
+    const freqHeader = screen.getByRole("columnheader", { name: /frequency/i });
+    const sortBtn = within(freqHeader).getByRole("button");
+    fireEvent.click(sortBtn);
+
+    const rows = screen.getAllByRole("row");
+    // After ascending sort, first data row should be lowest frequency
+    const firstDataRow = rows[1];
+    expect(firstDataRow).toHaveTextContent("low");
+  });
+
+  // -------------------------------------------------------------------------
+  // Live region sort announcements (FR-028)
+  // -------------------------------------------------------------------------
+
+  it("announces sort direction change in a live region after clicking sort button", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [makePattern()] })
+    );
+
+    renderPage();
+
+    const freqHeader = screen.getByRole("columnheader", { name: /frequency/i });
+    const sortBtn = within(freqHeader).getByRole("button");
+    fireEvent.click(sortBtn);
+
+    // The sr-only live region should announce the new sort direction
+    const liveRegion = document.querySelector('[role="status"][aria-live="polite"]');
+    expect(liveRegion).toBeInTheDocument();
+    expect(liveRegion?.textContent).toMatch(/sorted by frequency.*ascending/i);
+  });
+
+  it("announces descending when toggled back from ascending", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [makePattern()] })
+    );
+
+    renderPage();
+
+    const freqHeader = screen.getByRole("columnheader", { name: /frequency/i });
+    const sortBtn = within(freqHeader).getByRole("button");
+
+    // desc → asc
+    fireEvent.click(sortBtn);
+    // asc → desc
+    fireEvent.click(sortBtn);
+
+    const liveRegion = document.querySelector('[role="status"][aria-live="polite"]');
+    expect(liveRegion?.textContent).toMatch(/sorted by frequency.*descending/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Error token client-side filter
+  // -------------------------------------------------------------------------
+
+  it("filters rows by error token when user types in the filter input", () => {
+    const patterns = [
+      makePattern({ error_token: "barak", canonical_form: "Barack", frequency: 10 }),
+      makePattern({ error_token: "hussain", canonical_form: "Hussein", frequency: 5 }),
+    ];
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: patterns })
+    );
+
+    renderPage();
+
+    // Both rows visible initially
+    expect(screen.getByText("barak")).toBeInTheDocument();
+    expect(screen.getByText("hussain")).toBeInTheDocument();
+
+    // Filter to only "barak"
+    const filterInput = screen.getByRole("searchbox", {
+      name: /filter patterns by error token/i,
+    });
+    fireEvent.change(filterInput, { target: { value: "barak" } });
+
+    expect(screen.getByText("barak")).toBeInTheDocument();
+    expect(screen.queryByText("hussain")).not.toBeInTheDocument();
+  });
+
+  it("filter is case-insensitive for error token", () => {
+    const patterns = [
+      makePattern({ error_token: "Barak", canonical_form: "Barack", frequency: 10 }),
+    ];
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: patterns })
+    );
+
+    renderPage();
+
+    const filterInput = screen.getByRole("searchbox", {
+      name: /filter patterns by error token/i,
+    });
+    fireEvent.change(filterInput, { target: { value: "barak" } });
+
+    expect(screen.getByText("Barak")).toBeInTheDocument();
+  });
+
+  it("shows empty state with filter message when error token filter matches nothing", () => {
+    const pattern = makePattern({ error_token: "barak" });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [pattern] })
+    );
+
+    renderPage();
+
+    const filterInput = screen.getByRole("searchbox", {
+      name: /filter patterns by error token/i,
+    });
+    fireEvent.change(filterInput, { target: { value: "zzznomatch" } });
+
+    expect(
+      screen.getByText(/no patterns match the current filters/i)
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Entity column
+  // -------------------------------------------------------------------------
+
+  it("renders entity name as a link to /entities/{id} when entity_id is present", () => {
+    const pattern = makePattern({
+      entity_id: "entity-uuid-abc",
+      entity_name: "Barack Obama",
+    });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [pattern] })
+    );
+
+    renderPage();
+
+    const entityLink = screen.getByRole("link", { name: "Barack Obama" });
+    expect(entityLink).toBeInTheDocument();
+    expect(entityLink).toHaveAttribute("href", "/entities/entity-uuid-abc");
+  });
+
+  it("renders empty entity cell when entity_id is null", () => {
+    const pattern = makePattern({ entity_id: null, entity_name: null });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [pattern] })
+    );
+
+    renderPage();
+
+    // There should be no link in the entity column
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+
+    // The entity column header still exists
+    expect(
+      screen.getByRole("columnheader", { name: /entity/i })
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Find & Replace action (US2)
+  // -------------------------------------------------------------------------
+
+  it("calls navigate with correct state when Find & Replace is clicked", () => {
+    const pattern = makePattern({
+      error_token: "barak",
+      canonical_form: "Barack",
+    });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [pattern] })
+    );
+
+    renderPage();
+
+    const findReplaceBtn = screen.getByRole("button", {
+      name: /find and replace.*barak.*Barack/i,
+    });
+    fireEvent.click(findReplaceBtn);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/corrections/batch", {
+      state: {
+        pattern: "\\bbarak\\b",
+        replacement: "Barack",
+        isRegex: true,
+      },
+    });
+  });
+
+  it("calls navigate with the correct pattern for each row independently", () => {
+    const patterns = [
+      makePattern({ error_token: "alpha", canonical_form: "Alpha", frequency: 5 }),
+      makePattern({ error_token: "beta", canonical_form: "Beta", frequency: 3 }),
+    ];
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: patterns })
+    );
+
+    renderPage();
+
+    const betaBtn = screen.getByRole("button", {
+      name: /find and replace.*beta.*Beta/i,
+    });
+    fireEvent.click(betaBtn);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/corrections/batch", {
+      state: {
+        pattern: "\\bbeta\\b",
+        replacement: "Beta",
+        isRegex: true,
+      },
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it("renders empty state when no patterns exist and no filters active", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [] })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByText(/no asr error patterns found/i)
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Query error state
+  // -------------------------------------------------------------------------
+
+  it("renders an error message when the query fails", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({
+        isError: true,
+        error: new Error("Network error"),
+      })
+    );
+
+    renderPage();
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(
+      screen.getByText(/failed to load asr error patterns/i)
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Show completed toggle
+  // -------------------------------------------------------------------------
+
+  it('renders a "Show completed" checkbox toggle', () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [] })
+    );
+
+    renderPage();
+
+    const toggle = screen.getByRole("checkbox", { name: /show completed/i });
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it("toggle is unchecked by default", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [] })
+    );
+
+    renderPage();
+
+    const toggle = screen.getByRole("checkbox", { name: /show completed/i });
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("calls useDiffAnalysis with showCompleted: false by default", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [] })
+    );
+
+    renderPage();
+
+    expect(mockedUseDiffAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({ showCompleted: false })
+    );
+  });
+
+  it("calls useDiffAnalysis with showCompleted: true when toggle is checked", async () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [] })
+    );
+
+    renderPage();
+
+    const toggle = screen.getByRole("checkbox", { name: /show completed/i });
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(mockedUseDiffAnalysis).toHaveBeenCalledWith(
+        expect.objectContaining({ showCompleted: true })
+      );
+    });
+  });
+
+  it("toggle becomes checked after clicking", () => {
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [] })
+    );
+
+    renderPage();
+
+    const toggle = screen.getByRole("checkbox", { name: /show completed/i });
+    expect(toggle).not.toBeChecked();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toBeChecked();
+  });
+
+  // -------------------------------------------------------------------------
+  // Completed row behavior (remaining_matches === 0)
+  // -------------------------------------------------------------------------
+
+  it('shows "Completed" badge instead of "Find & Replace" button for completed patterns', () => {
+    const completedPattern = makePattern({
+      error_token: "barak",
+      canonical_form: "Barack",
+      remaining_matches: 0,
+    });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [completedPattern] })
+    );
+
+    renderPage();
+
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /find and replace/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("completed badge has title attribute set to 'All instances corrected'", () => {
+    const completedPattern = makePattern({ remaining_matches: 0 });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [completedPattern] })
+    );
+
+    renderPage();
+
+    const badge = screen.getByText("Completed");
+    expect(badge).toHaveAttribute("title", "All instances corrected");
+  });
+
+  it("completed row has muted styling (opacity-60 class)", () => {
+    const completedPattern = makePattern({ remaining_matches: 0 });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [completedPattern] })
+    );
+
+    renderPage();
+
+    const rows = screen.getAllByRole("row");
+    // rows[0] is header; rows[1] is the data row
+    const dataRow = rows[1];
+    expect(dataRow).toBeDefined();
+    expect(dataRow!.className).toMatch(/opacity-60/);
+  });
+
+  it("non-completed row does not have muted styling", () => {
+    const activePattern = makePattern({ remaining_matches: 5 });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [activePattern] })
+    );
+
+    renderPage();
+
+    const rows = screen.getAllByRole("row");
+    const dataRow = rows[1];
+    expect(dataRow).toBeDefined();
+    expect(dataRow!.className).not.toMatch(/opacity-60/);
+  });
+
+  it('non-completed rows still show "Find & Replace" button', () => {
+    const activePattern = makePattern({
+      error_token: "barak",
+      canonical_form: "Barack",
+      remaining_matches: 3,
+    });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [activePattern] })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByRole("button", { name: /find and replace.*barak.*Barack/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Completed")).not.toBeInTheDocument();
+  });
+
+  it("mixed rows: completed show badge, active show Find & Replace", () => {
+    const patterns = [
+      makePattern({
+        error_token: "active",
+        canonical_form: "Active",
+        remaining_matches: 4,
+      }),
+      makePattern({
+        error_token: "done",
+        canonical_form: "Done",
+        remaining_matches: 0,
+      }),
+    ];
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: patterns })
+    );
+
+    renderPage();
+
+    expect(
+      screen.getByRole("button", { name: /find and replace.*active.*Active/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+  });
+
+  it("entity link on completed row remains functional", () => {
+    const completedWithEntity = makePattern({
+      remaining_matches: 0,
+      entity_id: "entity-uuid-xyz",
+      entity_name: "Barack Obama",
+    });
+
+    mockedUseDiffAnalysis.mockReturnValue(
+      makeDefaultQueryResult({ isSuccess: true, data: [completedWithEntity] })
+    );
+
+    renderPage();
+
+    const entityLink = screen.getByRole("link", { name: "Barack Obama" });
+    expect(entityLink).toBeInTheDocument();
+    expect(entityLink).toHaveAttribute("href", "/entities/entity-uuid-xyz");
+  });
+});

--- a/frontend/src/pages/__tests__/EntityDetailPage.AddAliasForm.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.AddAliasForm.test.tsx
@@ -45,6 +45,17 @@ vi.mock("../../hooks/useEntityMentions", () => ({
   })),
 }));
 
+// Mock PhoneticVariantsSection to avoid it calling useQuery independently,
+// which would conflict with the global useQuery mock below.
+vi.mock("../../components/corrections/PhoneticVariantsSection", () => ({
+  PhoneticVariantsSection: () => null,
+}));
+
+// Mock ExclusionPatternsSection to keep tests focused on AddAliasForm.
+vi.mock("../../components/corrections/ExclusionPatternsSection", () => ({
+  ExclusionPatternsSection: () => null,
+}));
+
 // Mock TanStack Query useQuery so we can control the entity detail fetch.
 vi.mock("@tanstack/react-query", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-query")>();
@@ -81,6 +92,7 @@ const mockEntity = {
   mention_count: 42,
   video_count: 3,
   aliases: [],
+  exclusion_patterns: [] as string[],
 };
 
 /** Default empty hook state for useEntityVideos. */

--- a/frontend/src/pages/__tests__/EntityDetailPage.phonetic.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.phonetic.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Tests verifying that PhoneticVariantsSection is rendered within EntityDetailPage.
+ *
+ * Coverage (Feature 046, T024):
+ * - PhoneticVariantsSection is rendered between Aliases and Videos sections
+ * - The "Suspected ASR Variants" disclosure button is visible
+ * - Section is absent when entityId is not defined (null entity state)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { EntityDetailPage } from "../EntityDetailPage";
+
+// ---------------------------------------------------------------------------
+// Mock dependencies
+// ---------------------------------------------------------------------------
+
+vi.mock("../../hooks/useEntityMentions", () => ({
+  useEntityVideos: vi.fn(),
+  useVideoEntities: vi.fn(() => ({
+    entities: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+  };
+});
+
+// Mock PhoneticVariantsSection to keep tests simple and focused on integration.
+vi.mock("../../components/corrections/PhoneticVariantsSection", () => ({
+  PhoneticVariantsSection: ({ entityId }: { entityId: string }) => (
+    <section aria-label="Suspected ASR Variants mock">
+      <button type="button" aria-expanded="false">
+        Suspected ASR Variants
+      </button>
+      <span data-testid="phonetic-entity-id">{entityId}</span>
+    </section>
+  ),
+}));
+
+import { useQuery } from "@tanstack/react-query";
+import { useEntityVideos } from "../../hooks/useEntityMentions";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const mockEntity = {
+  entity_id: "entity-uuid-001",
+  canonical_name: "Noam Chomsky",
+  entity_type: "person",
+  description: "American linguist and political commentator.",
+  status: "active",
+  mention_count: 42,
+  video_count: 3,
+  aliases: [] as { alias_name: string; alias_type: string; occurrence_count: number }[],
+};
+
+const defaultUseEntityVideos = {
+  videos: [],
+  total: null,
+  pagination: null,
+  isLoading: false,
+  isError: false,
+  error: null,
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  fetchNextPage: vi.fn(),
+  loadMoreRef: { current: null },
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function renderPage(entityId = "entity-uuid-001") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/entities/${entityId}`]}>
+        <Routes>
+          <Route path="/entities/:entityId" element={<EntityDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(useQuery).mockReturnValue({
+    data: mockEntity,
+    isLoading: false,
+    isError: false,
+    error: null,
+    status: "success",
+    isFetching: false,
+    isPending: false,
+    isSuccess: true,
+    isRefetching: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isStale: false,
+    dataUpdatedAt: Date.now(),
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    fetchStatus: "idle" as const,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isInitialLoading: false,
+    isEnabled: true,
+    refetch: vi.fn(),
+    promise: Promise.resolve(mockEntity),
+  } as ReturnType<typeof useQuery>);
+
+  vi.mocked(useEntityVideos).mockReturnValue(defaultUseEntityVideos);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EntityDetailPage — PhoneticVariantsSection integration", () => {
+  it("renders the PhoneticVariantsSection disclosure button when entity is loaded", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /suspected asr variants/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the PhoneticVariantsSection between Aliases and Videos sections", () => {
+    renderPage();
+
+    // Get key landmarks by their headings.
+    const aliasesHeading = screen.getByRole("heading", { name: /aliases/i });
+    const phoneticButton = screen.getByRole("button", {
+      name: /suspected asr variants/i,
+    });
+    const videosHeading = screen.getByRole("heading", { name: /videos/i });
+
+    // Verify DOM ordering: aliases < phonetic < videos
+    const position = (el: Element) =>
+      Array.from(document.body.querySelectorAll("*")).indexOf(el);
+
+    expect(position(aliasesHeading)).toBeLessThan(position(phoneticButton));
+    expect(position(phoneticButton)).toBeLessThan(position(videosHeading));
+  });
+
+  it("passes the entityId to PhoneticVariantsSection", () => {
+    renderPage("entity-uuid-001");
+    expect(screen.getByTestId("phonetic-entity-id")).toHaveTextContent(
+      "entity-uuid-001"
+    );
+  });
+
+  it("does not render PhoneticVariantsSection in the 404 state", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      ...({} as ReturnType<typeof useQuery>),
+      data: null,
+      isLoading: false,
+      isError: false,
+      error: null,
+      status: "success",
+      isPending: false,
+      isSuccess: true,
+      isFetching: false,
+      fetchStatus: "idle" as const,
+    } as ReturnType<typeof useQuery>);
+
+    renderPage();
+
+    expect(
+      screen.queryByRole("button", { name: /suspected asr variants/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render PhoneticVariantsSection in the loading skeleton state", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      ...({} as ReturnType<typeof useQuery>),
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      status: "pending",
+      isPending: true,
+      isSuccess: false,
+      isFetching: true,
+      fetchStatus: "fetching" as const,
+    } as ReturnType<typeof useQuery>);
+
+    renderPage();
+
+    expect(
+      screen.queryByRole("button", { name: /suspected asr variants/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/EntityDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.test.tsx
@@ -30,6 +30,17 @@ vi.mock("../../hooks/useEntityMentions", () => ({
   useVideoEntities: vi.fn(() => ({ entities: [], isLoading: false, isError: false, error: null })),
 }));
 
+// Mock PhoneticVariantsSection to avoid it calling useQuery independently,
+// which would conflict with the global useQuery mock below.
+vi.mock("../../components/corrections/PhoneticVariantsSection", () => ({
+  PhoneticVariantsSection: () => null,
+}));
+
+// Mock ExclusionPatternsSection to keep tests focused on EntityDetailPage.
+vi.mock("../../components/corrections/ExclusionPatternsSection", () => ({
+  ExclusionPatternsSection: () => null,
+}));
+
 // We need to mock the TanStack Query useQuery to control entity detail fetch
 vi.mock("@tanstack/react-query", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-query")>();
@@ -56,6 +67,7 @@ const mockEntity = {
   mention_count: 42,
   video_count: 3,
   aliases: [] as { alias_name: string; alias_type: string; occurrence_count: number }[],
+  exclusion_patterns: [] as string[],
 };
 
 function createMockVideo(overrides: Partial<EntityVideoResult> = {}): EntityVideoResult {

--- a/frontend/src/router/__tests__/routes.test.ts
+++ b/frontend/src/router/__tests__/routes.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for navRoutes structure — Feature 046 (US0) sidebar restructuring.
+ *
+ * Verifies:
+ * - All expected top-level entries are present
+ * - The Transcripts group has the correct children
+ * - Flat nav items remain as NavRoute (kind: "route")
+ * - The Transcripts group is a NavGroupRoute (kind: "group")
+ * - Each child of Transcripts group carries correct paths and labels
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  navRoutes,
+  type NavRoute,
+  type NavGroupRoute,
+  type NavEntry,
+} from "../routes";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findRoute(entries: NavEntry[], path: string): NavRoute | undefined {
+  for (const entry of entries) {
+    if (entry.kind === "route" && entry.path === path) return entry;
+    if (entry.kind === "group") {
+      const match = entry.children.find((c) => c.path === path);
+      if (match) return match;
+    }
+  }
+  return undefined;
+}
+
+function findGroup(entries: NavEntry[], label: string): NavGroupRoute | undefined {
+  return entries.find(
+    (e): e is NavGroupRoute => e.kind === "group" && e.label === label
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("navRoutes — top-level structure", () => {
+  it("has exactly 6 top-level entries", () => {
+    expect(navRoutes).toHaveLength(6);
+  });
+
+  it("first entry is Videos flat route", () => {
+    const entry = navRoutes[0];
+    expect(entry?.kind).toBe("route");
+    if (entry?.kind === "route") {
+      expect(entry.path).toBe("/videos");
+      expect(entry.label).toBe("Videos");
+    }
+  });
+
+  it("second entry is the Transcripts group", () => {
+    const entry = navRoutes[1];
+    expect(entry?.kind).toBe("group");
+    if (entry?.kind === "group") {
+      expect(entry.label).toBe("Transcripts");
+    }
+  });
+
+  it("third entry is Channels flat route", () => {
+    const entry = navRoutes[2];
+    expect(entry?.kind).toBe("route");
+    if (entry?.kind === "route") {
+      expect(entry.path).toBe("/channels");
+    }
+  });
+
+  it("fourth entry is Playlists flat route", () => {
+    const entry = navRoutes[3];
+    expect(entry?.kind).toBe("route");
+    if (entry?.kind === "route") {
+      expect(entry.path).toBe("/playlists");
+    }
+  });
+
+  it("fifth entry is Entities flat route", () => {
+    const entry = navRoutes[4];
+    expect(entry?.kind).toBe("route");
+    if (entry?.kind === "route") {
+      expect(entry.path).toBe("/entities");
+    }
+  });
+
+  it("sixth entry is Search flat route", () => {
+    const entry = navRoutes[5];
+    expect(entry?.kind).toBe("route");
+    if (entry?.kind === "route") {
+      expect(entry.path).toBe("/search");
+      expect(entry.label).toBe("Search");
+    }
+  });
+});
+
+describe("navRoutes — flat NavRoute entries", () => {
+  it("/videos route has correct label and tooltip", () => {
+    const route = findRoute(navRoutes, "/videos");
+    expect(route).toBeDefined();
+    expect(route?.label).toBe("Videos");
+    expect(route?.tooltip).toBeTruthy();
+    expect(route?.icon).toBeDefined();
+  });
+
+  it("/channels route has correct label and tooltip", () => {
+    const route = findRoute(navRoutes, "/channels");
+    expect(route).toBeDefined();
+    expect(route?.label).toBe("Channels");
+    expect(route?.icon).toBeDefined();
+  });
+
+  it("/playlists route has correct label and tooltip", () => {
+    const route = findRoute(navRoutes, "/playlists");
+    expect(route).toBeDefined();
+    expect(route?.label).toBe("Playlists");
+    expect(route?.icon).toBeDefined();
+  });
+
+  it("/entities route has correct label and tooltip", () => {
+    const route = findRoute(navRoutes, "/entities");
+    expect(route).toBeDefined();
+    expect(route?.label).toBe("Entities");
+    expect(route?.icon).toBeDefined();
+  });
+
+  it("/search route is a top-level flat route (not nested under Transcripts)", () => {
+    const topLevel = navRoutes.find(
+      (e) => e.kind === "route" && e.path === "/search"
+    );
+    expect(topLevel).toBeDefined();
+    expect(topLevel?.label).toBe("Search");
+    expect(topLevel?.icon).toBeDefined();
+  });
+});
+
+describe("navRoutes — Transcripts group", () => {
+  it("Transcripts group exists", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    expect(group).toBeDefined();
+  });
+
+  it("Transcripts group has kind='group'", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    expect(group?.kind).toBe("group");
+  });
+
+  it("Transcripts group has an icon", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    expect(group?.icon).toBeDefined();
+  });
+
+  it("Transcripts group has a tooltip", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    expect(group?.tooltip).toBeTruthy();
+  });
+
+  it("Transcripts group has a storageKey", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    expect(group?.storageKey).toBeTruthy();
+  });
+
+  it("Transcripts group defaultExpanded is true", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    expect(group?.defaultExpanded).toBe(true);
+  });
+
+  it("Transcripts group has exactly 3 children", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    expect(group?.children).toHaveLength(3);
+  });
+
+  it("Transcripts group children all have kind='route'", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    group?.children.forEach((child) => {
+      expect(child.kind).toBe("route");
+    });
+  });
+
+  it("Transcripts group contains Find & Replace child at /corrections/batch", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    const child = group?.children.find((c) => c.path === "/corrections/batch");
+    expect(child).toBeDefined();
+    expect(child?.label).toBe("Find & Replace");
+    expect(child?.icon).toBeDefined();
+  });
+
+  it("Transcripts group contains Batch History child at /corrections/batch/history", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    const child = group?.children.find(
+      (c) => c.path === "/corrections/batch/history"
+    );
+    expect(child).toBeDefined();
+    expect(child?.label).toBe("Batch History");
+    expect(child?.icon).toBeDefined();
+  });
+
+  it("Transcripts group contains ASR Error Patterns child at /corrections/diff-analysis", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    const child = group?.children.find(
+      (c) => c.path === "/corrections/diff-analysis"
+    );
+    expect(child).toBeDefined();
+    expect(child?.label).toBe("ASR Error Patterns");
+    expect(child?.icon).toBeDefined();
+  });
+
+  it("Transcripts group child order is Find & Replace, Batch History, ASR Error Patterns", () => {
+    const group = findGroup(navRoutes, "Transcripts");
+    const labels = group?.children.map((c) => c.label);
+    expect(labels).toEqual([
+      "Find & Replace",
+      "Batch History",
+      "ASR Error Patterns",
+    ]);
+  });
+});

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -12,8 +12,10 @@ import {
 
 import { AppShell } from "../components/layout";
 import { BatchCorrectionsPage } from "../pages/BatchCorrectionsPage";
+import { BatchHistoryPage } from "../pages/BatchHistoryPage";
 import { ChannelDetailPage } from "../pages/ChannelDetailPage";
 import { ChannelsPage } from "../pages/ChannelsPage";
+import { DiffAnalysisPage } from "../pages/DiffAnalysisPage";
 import { EntitiesPage } from "../pages/EntitiesPage";
 import { EntityDetailPage } from "../pages/EntityDetailPage";
 import { HomePage } from "../pages/HomePage";
@@ -104,6 +106,14 @@ export const router = createBrowserRouter([
       {
         path: "corrections/batch",
         element: <BatchCorrectionsPage />,
+      },
+      {
+        path: "corrections/batch/history",
+        element: <BatchHistoryPage />,
+      },
+      {
+        path: "corrections/diff-analysis",
+        element: <DiffAnalysisPage />,
       },
       {
         path: "*",

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -6,10 +6,13 @@ import type React from "react";
 
 import {
   BatchCorrectionsIcon,
+  ChartBarIcon,
   ChannelIcon,
+  ClockIcon,
   EntityIcon,
   PlaylistIcon,
   SearchIcon,
+  TranscriptsIcon,
   VideoIcon,
 } from "../components/icons";
 
@@ -17,6 +20,8 @@ import {
  * NavRoute defines a navigable route in the application.
  */
 export interface NavRoute {
+  /** Discriminant tag for the discriminated union */
+  kind: "route";
   /** URL path for this route */
   path: string;
   /** Display label for navigation */
@@ -28,43 +33,98 @@ export interface NavRoute {
 }
 
 /**
- * Main navigation routes for the application.
+ * NavGroupRoute defines a collapsible group of child routes in the sidebar.
  */
-export const navRoutes: NavRoute[] = [
+export interface NavGroupRoute {
+  /** Discriminant tag for the discriminated union */
+  kind: "group";
+  /** Display label for the group header */
+  label: string;
+  /** Tooltip text shown in compact (icon-only) mode */
+  tooltip: string;
+  /** Icon component for the group header */
+  icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  /** Child navigation routes within this group */
+  children: NavRoute[];
+  /** Whether the group starts expanded (before localStorage overrides) */
+  defaultExpanded: boolean;
+  /** localStorage key for persisting expand/collapse state */
+  storageKey: string;
+}
+
+/**
+ * Union type for top-level navigation entries.
+ */
+export type NavEntry = NavRoute | NavGroupRoute;
+
+/**
+ * Main navigation entries for the application sidebar.
+ */
+export const navRoutes: NavEntry[] = [
   {
+    kind: "route",
     path: "/videos",
     label: "Videos",
     tooltip: "Browse your video library",
     icon: VideoIcon,
   },
   {
-    path: "/search",
-    label: "Search",
-    tooltip: "Search across all content",
-    icon: SearchIcon,
+    kind: "group",
+    label: "Transcripts",
+    tooltip: "Transcripts",
+    icon: TranscriptsIcon,
+    defaultExpanded: true,
+    storageKey: "chronovista.sidebar.transcriptsExpanded",
+    children: [
+      {
+        kind: "route",
+        path: "/corrections/batch",
+        label: "Find & Replace",
+        tooltip: "Batch find and replace across all transcripts",
+        icon: BatchCorrectionsIcon,
+      },
+      {
+        kind: "route",
+        path: "/corrections/batch/history",
+        label: "Batch History",
+        tooltip: "View batch correction history",
+        icon: ClockIcon,
+      },
+      {
+        kind: "route",
+        path: "/corrections/diff-analysis",
+        label: "ASR Error Patterns",
+        tooltip: "Analyse ASR error patterns across transcripts",
+        icon: ChartBarIcon,
+      },
+    ],
   },
   {
+    kind: "route",
     path: "/channels",
     label: "Channels",
     tooltip: "Manage your channel subscriptions",
     icon: ChannelIcon,
   },
   {
+    kind: "route",
     path: "/playlists",
     label: "Playlists",
     tooltip: "Browse your playlists",
     icon: PlaylistIcon,
   },
   {
+    kind: "route",
     path: "/entities",
     label: "Entities",
     tooltip: "Browse named entities",
     icon: EntityIcon,
   },
   {
-    path: "/corrections/batch",
-    label: "Find & Replace",
-    tooltip: "Batch find and replace across all transcripts",
-    icon: BatchCorrectionsIcon,
+    kind: "route",
+    path: "/search",
+    label: "Search",
+    tooltip: "Search across all content",
+    icon: SearchIcon,
   },
 ];

--- a/frontend/src/types/__tests__/corrections.feature046.test.ts
+++ b/frontend/src/types/__tests__/corrections.feature046.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Type-level tests for Feature 046 interfaces in corrections.ts (T001).
+ *
+ * These tests verify that:
+ * - Each new interface can be instantiated with all required fields
+ * - Optional fields (null unions) accept both values
+ * - The interfaces are exported correctly from types/index.ts
+ *
+ * No mocking required — pure TypeScript structural verification at runtime.
+ */
+
+import { describe, it, expect } from "vitest";
+import type {
+  BatchSummary,
+  DiffErrorPattern,
+  CrossSegmentCandidate,
+  PhoneticMatch,
+} from "../corrections";
+
+// Also verify the barrel re-exports compile correctly
+import type {
+  BatchSummary as BatchSummaryFromIndex,
+  DiffErrorPattern as DiffErrorPatternFromIndex,
+  CrossSegmentCandidate as CrossSegmentCandidateFromIndex,
+  PhoneticMatch as PhoneticMatchFromIndex,
+} from "../index";
+
+describe("Feature 046 type interfaces (T001)", () => {
+  describe("BatchSummary", () => {
+    it("can be constructed with all required fields", () => {
+      const summary: BatchSummary = {
+        batch_id: "batch-uuid-001",
+        correction_count: 47,
+        corrected_by_user_id: "user:batch",
+        pattern: "cliamte",
+        replacement: "climate",
+        batch_timestamp: "2026-03-15T10:00:00Z",
+      };
+
+      expect(summary.batch_id).toBe("batch-uuid-001");
+      expect(summary.correction_count).toBe(47);
+      expect(summary.corrected_by_user_id).toBe("user:batch");
+      expect(summary.pattern).toBe("cliamte");
+      expect(summary.replacement).toBe("climate");
+      expect(summary.batch_timestamp).toBe("2026-03-15T10:00:00Z");
+    });
+  });
+
+  describe("DiffErrorPattern", () => {
+    it("can be constructed with entity_id and entity_name as null", () => {
+      const pattern: DiffErrorPattern = {
+        error_token: "whigt",
+        canonical_form: "white",
+        frequency: 5,
+        remaining_matches: 3,
+        entity_id: null,
+        entity_name: null,
+      };
+
+      expect(pattern.error_token).toBe("whigt");
+      expect(pattern.entity_id).toBeNull();
+      expect(pattern.entity_name).toBeNull();
+    });
+
+    it("can be constructed with entity_id and entity_name as strings", () => {
+      const pattern: DiffErrorPattern = {
+        error_token: "berny",
+        canonical_form: "Bernie",
+        frequency: 10,
+        remaining_matches: 7,
+        entity_id: "3f4a7b2c-1d9e-4f6a-b8c2-9e0d1f2a3b4c",
+        entity_name: "Bernie Sanders",
+      };
+
+      expect(pattern.entity_id).toBe("3f4a7b2c-1d9e-4f6a-b8c2-9e0d1f2a3b4c");
+      expect(pattern.entity_name).toBe("Bernie Sanders");
+    });
+  });
+
+  describe("CrossSegmentCandidate", () => {
+    it("can be constructed with all required fields", () => {
+      const candidate: CrossSegmentCandidate = {
+        segment_n_id: 101,
+        segment_n_text: "the coun",
+        segment_n1_id: 102,
+        segment_n1_text: "try side",
+        proposed_correction: "the countryside",
+        source_pattern: "coun|try side",
+        confidence: 0.87,
+        is_partially_corrected: false,
+        video_id: "abc123",
+        discovery_source: "correction_pattern",
+      };
+
+      expect(candidate.segment_n_id).toBe(101);
+      expect(candidate.segment_n1_id).toBe(102);
+      expect(candidate.confidence).toBe(0.87);
+      expect(candidate.is_partially_corrected).toBe(false);
+      expect(candidate.video_id).toBe("abc123");
+    });
+
+    it("accepts is_partially_corrected as true", () => {
+      const candidate: CrossSegmentCandidate = {
+        segment_n_id: 200,
+        segment_n_text: "half fixed",
+        segment_n1_id: 201,
+        segment_n1_text: "text here",
+        proposed_correction: "half-fixed text here",
+        source_pattern: "half fixed",
+        confidence: 0.6,
+        is_partially_corrected: true,
+        video_id: "xyz789",
+        discovery_source: "correction_pattern",
+      };
+
+      expect(candidate.is_partially_corrected).toBe(true);
+    });
+  });
+
+  describe("PhoneticMatch", () => {
+    it("can be constructed with video_title as null", () => {
+      const match: PhoneticMatch = {
+        original_text: "Alexandria Ocasio Cortez",
+        proposed_correction: "Alexandria Ocasio-Cortez",
+        confidence: 0.92,
+        evidence_description: "Hyphen missing in hyphenated surname",
+        video_id: "dQw4w9WgXcQ",
+        segment_id: 42,
+        video_title: null,
+      };
+
+      expect(match.video_title).toBeNull();
+      expect(match.segment_id).toBe(42);
+    });
+
+    it("can be constructed with video_title as a string", () => {
+      const match: PhoneticMatch = {
+        original_text: "Ilhan",
+        proposed_correction: "Ilhan Omar",
+        confidence: 0.78,
+        evidence_description: "Truncated name — surname likely cut by ASR pause",
+        video_id: "vid456",
+        segment_id: 99,
+        video_title: "Congressional hearing highlights",
+      };
+
+      expect(match.video_title).toBe("Congressional hearing highlights");
+    });
+  });
+
+  describe("Barrel re-exports from types/index.ts", () => {
+    it("BatchSummary is accessible from the index barrel", () => {
+      const summary: BatchSummaryFromIndex = {
+        batch_id: "b",
+        correction_count: 1,
+        corrected_by_user_id: "u",
+        pattern: "p",
+        replacement: "r",
+        batch_timestamp: "2026-01-01T00:00:00Z",
+      };
+      expect(summary.batch_id).toBe("b");
+    });
+
+    it("DiffErrorPattern is accessible from the index barrel", () => {
+      const pattern: DiffErrorPatternFromIndex = {
+        error_token: "tok",
+        canonical_form: "token",
+        frequency: 1,
+        remaining_matches: 1,
+        entity_id: null,
+        entity_name: null,
+      };
+      expect(pattern.canonical_form).toBe("token");
+    });
+
+    it("CrossSegmentCandidate is accessible from the index barrel", () => {
+      const candidate: CrossSegmentCandidateFromIndex = {
+        segment_n_id: 1,
+        segment_n_text: "a",
+        segment_n1_id: 2,
+        segment_n1_text: "b",
+        proposed_correction: "ab",
+        source_pattern: "a b",
+        confidence: 0.5,
+        is_partially_corrected: false,
+        video_id: "v",
+        discovery_source: "correction_pattern",
+      };
+      expect(candidate.video_id).toBe("v");
+    });
+
+    it("PhoneticMatch is accessible from the index barrel", () => {
+      const match: PhoneticMatchFromIndex = {
+        original_text: "x",
+        proposed_correction: "y",
+        confidence: 0.9,
+        evidence_description: "desc",
+        video_id: "v",
+        segment_id: 1,
+        video_title: null,
+      };
+      expect(match.proposed_correction).toBe("y");
+    });
+  });
+});

--- a/frontend/src/types/corrections.ts
+++ b/frontend/src/types/corrections.ts
@@ -98,3 +98,50 @@ export interface SegmentEditFormState {
   correctionNote: string;
   validationError: string | null;
 }
+
+// --- Feature 046: Correction Intelligence Frontend ---
+
+/** Past batch correction operation for the Batch History panel. */
+export interface BatchSummary {
+  batch_id: string;
+  correction_count: number;
+  corrected_by_user_id: string;
+  pattern: string;
+  replacement: string;
+  batch_timestamp: string; // ISO 8601
+}
+
+/** Recurring ASR error identified by word-level diff analysis. */
+export interface DiffErrorPattern {
+  error_token: string;
+  canonical_form: string;
+  frequency: number;
+  remaining_matches: number;
+  entity_id: string | null;
+  entity_name: string | null;
+}
+
+/** Adjacent segment pair with ASR error spanning the boundary. */
+export interface CrossSegmentCandidate {
+  segment_n_id: number;
+  segment_n_text: string;
+  segment_n1_id: number;
+  segment_n1_text: string;
+  proposed_correction: string;
+  source_pattern: string;
+  confidence: number;
+  is_partially_corrected: boolean;
+  video_id: string;
+  discovery_source: "entity_alias" | "correction_pattern";
+}
+
+/** Suspected phonetic ASR variant of an entity name. */
+export interface PhoneticMatch {
+  original_text: string;
+  proposed_correction: string;
+  confidence: number;
+  evidence_description: string;
+  video_id: string;
+  segment_id: number;
+  video_title: string | null;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -75,3 +75,10 @@ export type {
 } from "./filters";
 
 export { FILTER_COLORS, FILTER_LIMITS, TIMEOUT_CONFIG } from "./filters";
+
+export type {
+  BatchSummary,
+  CrossSegmentCandidate,
+  DiffErrorPattern,
+  PhoneticMatch,
+} from "./corrections";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.46.0"
+version = "0.47.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.46.0"
+__version__ = "0.47.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/routers/batch_corrections.py
+++ b/src/chronovista/api/routers/batch_corrections.py
@@ -13,6 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from uuid_utils import uuid7
 
 from chronovista.api.deps import get_db, require_auth
+from sqlalchemy import case, func, select
+
 from chronovista.api.schemas.batch_corrections import (
     BatchApplyRequest,
     BatchApplyResult,
@@ -22,6 +24,8 @@ from chronovista.api.schemas.batch_corrections import (
     BatchRebuildRequest,
     BatchRebuildResult,
     BatchRevertResponse,
+    CrossSegmentCandidateResponse,
+    DiffErrorPatternResponse,
 )
 from chronovista.api.schemas.responses import ApiResponse, PaginationMeta
 from chronovista.exceptions import APIValidationError, ConflictError, NotFoundError
@@ -36,8 +40,16 @@ from chronovista.repositories.transcript_segment_repository import (
 from chronovista.repositories.video_transcript_repository import (
     VideoTranscriptRepository,
 )
+from chronovista.db.models import EntityAlias as EntityAliasDB
+from chronovista.db.models import NamedEntity as NamedEntityDB
+from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
 from chronovista.models.batch_correction_models import BatchCorrectionResult
-from chronovista.services.batch_correction_service import BatchCorrectionService
+from chronovista.services.batch_correction_service import (
+    BatchCorrectionService,
+    word_level_diff,
+)
+from chronovista.services.cross_segment_discovery import CrossSegmentDiscovery
+from chronovista.utils.text import strip_boundary_punctuation
 from chronovista.services.transcript_correction_service import (
     TranscriptCorrectionService,
 )
@@ -413,3 +425,230 @@ async def revert_batch(
         skipped_count=0,
     )
     return ApiResponse[BatchRevertResponse](data=response_data)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+async def _find_entity_by_name(
+    session: AsyncSession,
+    name: str,
+) -> tuple[uuid.UUID | None, str | None]:
+    """Look up a named entity by canonical name or alias.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session.
+    name : str
+        The text to match against canonical_name or alias_name.
+
+    Returns
+    -------
+    tuple[uuid.UUID | None, str | None]
+        ``(entity_id, entity_name)`` if found, otherwise ``(None, None)``.
+    """
+    # Try canonical name first
+    stmt = (
+        select(NamedEntityDB.id, NamedEntityDB.canonical_name)
+        .where(NamedEntityDB.canonical_name.ilike(name))
+        .limit(1)
+    )
+    row = (await session.execute(stmt)).first()
+    if row is not None:
+        return row.id, row.canonical_name
+
+    # Try alias name
+    alias_stmt = (
+        select(EntityAliasDB.entity_id, EntityAliasDB.alias_name)
+        .where(EntityAliasDB.alias_name.ilike(name))
+        .limit(1)
+    )
+    alias_row = (await session.execute(alias_stmt)).first()
+    if alias_row is not None:
+        # Fetch the entity's canonical name
+        entity_stmt = (
+            select(NamedEntityDB.canonical_name)
+            .where(NamedEntityDB.id == alias_row.entity_id)
+        )
+        entity_name_val = (await session.execute(entity_stmt)).scalar_one_or_none()
+        return alias_row.entity_id, entity_name_val
+
+    return None, None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /diff-analysis
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.get(
+    "/diff-analysis",
+    response_model=ApiResponse[list[DiffErrorPatternResponse]],
+    status_code=200,
+    summary="Get word-level diff error patterns with entity associations",
+)
+async def get_diff_analysis(
+    min_occurrences: int = Query(default=2, ge=1, le=50),
+    limit: int = Query(default=100, ge=1, le=500),
+    show_completed: bool = Query(default=True),
+    entity_name: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+) -> ApiResponse[list[DiffErrorPatternResponse]]:
+    """Get recurring correction patterns enriched with entity associations.
+
+    Wraps ``BatchCorrectionService.get_patterns()`` and enriches each
+    pattern with an entity lookup based on the corrected text.
+
+    Parameters
+    ----------
+    min_occurrences : int
+        Minimum number of occurrences for a pattern to be included (1-50).
+    limit : int
+        Maximum number of patterns to return (1-500).
+    show_completed : bool
+        Whether to include patterns with no remaining un-corrected matches.
+    entity_name : str | None
+        If provided, filter results to patterns whose matched entity name
+        contains this string (case-insensitive).
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    ApiResponse[list[DiffErrorPatternResponse]]
+        List of error patterns with optional entity associations.
+    """
+    # Always fetch all patterns (including completed) so we can extract
+    # word-level tokens and recompute remaining_matches at the token level.
+    patterns = await _batch_service.get_patterns(
+        session,
+        min_occurrences=min_occurrences,
+        limit=limit,
+        show_completed=True,
+    )
+
+    # Aggregate word-level token pairs across all patterns.
+    # Key: (error_token, canonical_form) -> frequency
+    aggregated: dict[tuple[str, str], int] = {}
+
+    for p in patterns:
+        diff_result = word_level_diff(p.original_text, p.corrected_text)
+
+        if not diff_result.changed_pairs:
+            continue
+
+        for error_frag, canon_frag in diff_result.changed_pairs:
+            error_token = strip_boundary_punctuation(error_frag)
+            canonical_form = strip_boundary_punctuation(canon_frag)
+
+            # Skip empty tokens after stripping
+            if not error_token and not canonical_form:
+                continue
+
+            key = (error_token, canonical_form)
+            aggregated[key] = aggregated.get(key, 0) + p.occurrences
+
+    # Recompute remaining_matches at the token level: count segments whose
+    # effective text (corrected_text if corrected, else text) still contains
+    # the error token.  This replaces the repository's full-segment-level
+    # remaining_matches which doesn't work after word-level extraction.
+    effective_text = case(
+        (TranscriptSegmentDB.has_correction, TranscriptSegmentDB.corrected_text),
+        else_=TranscriptSegmentDB.text,
+    )
+
+    # Build response items with entity enrichment.
+    results: list[DiffErrorPatternResponse] = []
+    for (error_token, canonical_form), freq in aggregated.items():
+        # Token-level remaining_matches query
+        remaining_stmt = (
+            select(func.count())
+            .select_from(TranscriptSegmentDB)
+            .where(effective_text.contains(error_token))
+        )
+        remaining_result = await session.execute(remaining_stmt)
+        remaining = remaining_result.scalar_one()
+
+        # Apply show_completed filter at the token level
+        if not show_completed and remaining == 0:
+            continue
+
+        lookup_text = canonical_form if canonical_form else error_token
+        entity_id, matched_entity_name = await _find_entity_by_name(
+            session, lookup_text
+        )
+
+        # If entity_name filter is set, skip non-matching entries
+        if entity_name is not None:
+            if matched_entity_name is None:
+                continue
+            if entity_name.lower() not in matched_entity_name.lower():
+                continue
+
+        results.append(
+            DiffErrorPatternResponse(
+                error_token=error_token,
+                canonical_form=canonical_form,
+                frequency=freq,
+                remaining_matches=remaining,
+                entity_id=entity_id,
+                entity_name=matched_entity_name,
+            )
+        )
+
+    # Sort by remaining_matches DESC so actionable patterns come first
+    results.sort(key=lambda r: r.remaining_matches, reverse=True)
+
+    return ApiResponse[list[DiffErrorPatternResponse]](data=results)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /cross-segment/candidates
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.get(
+    "/cross-segment/candidates",
+    response_model=ApiResponse[list[CrossSegmentCandidateResponse]],
+    status_code=200,
+    summary="Discover cross-segment ASR error candidates",
+)
+async def get_cross_segment_candidates(
+    min_corrections: int = Query(default=3, ge=1, le=20),
+    entity_name: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+) -> ApiResponse[list[CrossSegmentCandidateResponse]]:
+    """Discover adjacent segment pairs where a known error is split across a boundary.
+
+    Uses ``CrossSegmentDiscovery`` to analyse recurring correction patterns
+    and find segment pairs matching prefix/suffix combinations.
+
+    Parameters
+    ----------
+    min_corrections : int
+        Minimum correction occurrences for a pattern to be considered (1-20).
+    entity_name : str | None
+        If provided, only consider patterns related to this entity name.
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    ApiResponse[list[CrossSegmentCandidateResponse]]
+        List of cross-segment ASR error candidates.
+    """
+    discovery = CrossSegmentDiscovery(batch_service=_batch_service)
+    candidates = await discovery.discover(
+        session,
+        min_corrections=min_corrections,
+        entity_name=entity_name,
+    )
+
+    results = [
+        CrossSegmentCandidateResponse(**c.model_dump()) for c in candidates
+    ]
+
+    return ApiResponse[list[CrossSegmentCandidateResponse]](data=results)

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -21,11 +21,13 @@ from chronovista.api.schemas.entity_mentions import (
     EntityAliasSummary,
     EntityVideoResponse,
     EntityVideoResult,
+    ExclusionPatternRequest,
     MentionPreview,
+    PhoneticMatchResponse,
     VideoEntitiesResponse,
     VideoEntitySummary,
 )
-from chronovista.api.schemas.responses import PaginationMeta
+from chronovista.api.schemas.responses import ApiResponse, PaginationMeta
 from chronovista.db.models import EntityAlias as EntityAliasDB
 from chronovista.db.models import NamedEntity as NamedEntityDB
 from chronovista.db.models import Video as VideoDB
@@ -34,6 +36,7 @@ from chronovista.models.entity_alias import EntityAliasCreate
 from chronovista.models.enums import EntityAliasType
 from chronovista.repositories.entity_alias_repository import EntityAliasRepository
 from chronovista.repositories.entity_mention_repository import EntityMentionRepository
+from chronovista.services.phonetic_matcher import PhoneticMatcher
 from chronovista.services.tag_normalization import TagNormalizationService
 
 router = APIRouter(dependencies=[Depends(require_auth)])
@@ -336,6 +339,7 @@ async def get_entity_detail(
             "mention_count": entity.mention_count or 0,
             "video_count": entity.video_count or 0,
             "aliases": [a.model_dump() for a in genuine_aliases],
+            "exclusion_patterns": list(entity.exclusion_patterns or []),
         }
     }
 
@@ -523,4 +527,239 @@ async def create_entity_alias(
             alias_type=db_alias.alias_type,
             occurrence_count=db_alias.occurrence_count,
         ).model_dump()
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /entities/{entity_id}/phonetic-matches
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.get(
+    "/entities/{entity_id}/phonetic-matches",
+    response_model=ApiResponse[list[PhoneticMatchResponse]],
+    status_code=200,
+    summary="Find phonetic ASR variants for an entity",
+)
+async def get_phonetic_matches(
+    entity_id: uuid.UUID,
+    threshold: float = Query(default=0.5, ge=0.0, le=1.0),
+    session: AsyncSession = Depends(get_db),
+) -> ApiResponse[list[PhoneticMatchResponse]]:
+    """Find suspected phonetic ASR variants for a named entity.
+
+    Uses ``PhoneticMatcher`` to scan transcript segments from videos
+    associated with the entity and scores N-grams against the entity
+    name and aliases.
+
+    Parameters
+    ----------
+    entity_id : uuid.UUID
+        Named entity UUID.
+    threshold : float
+        Minimum confidence score to include a match (0.0-1.0, default 0.5).
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    ApiResponse[list[PhoneticMatchResponse]]
+        List of phonetic matches with video title enrichment.
+
+    Raises
+    ------
+    NotFoundError
+        If the entity does not exist in the database (404).
+    """
+    # Verify entity exists
+    entity = await session.get(NamedEntityDB, entity_id)
+    if entity is None:
+        raise NotFoundError(resource_type="Entity", identifier=str(entity_id))
+
+    # Run phonetic matcher
+    matcher = PhoneticMatcher(entity_mention_repo=EntityMentionRepository())
+    matches = await matcher.match_entity(
+        entity_id=entity_id,
+        session=session,
+        threshold=threshold,
+    )
+
+    # Video title enrichment
+    video_ids = list({m.video_id for m in matches})
+    if video_ids:
+        stmt = select(VideoDB.video_id, VideoDB.title).where(
+            VideoDB.video_id.in_(video_ids)
+        )
+        rows = (await session.execute(stmt)).all()
+        title_map = {r.video_id: r.title for r in rows}
+    else:
+        title_map = {}
+
+    results = [
+        PhoneticMatchResponse(
+            original_text=m.original_text,
+            proposed_correction=m.proposed_correction,
+            confidence=m.confidence,
+            evidence_description=m.evidence_description,
+            video_id=m.video_id,
+            segment_id=m.segment_id,
+            video_title=title_map.get(m.video_id),
+        )
+        for m in matches
+    ]
+
+    return ApiResponse[list[PhoneticMatchResponse]](data=results)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# POST /entities/{entity_id}/exclusion-patterns
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+    "/entities/{entity_id}/exclusion-patterns",
+    status_code=201,
+    summary="Add an exclusion pattern to a named entity",
+)
+async def add_exclusion_pattern(
+    entity_id: str = Path(..., description="Named entity UUID"),
+    body: ExclusionPatternRequest = Body(...),
+    session: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Add an exclusion pattern to a named entity.
+
+    Exclusion patterns are strings that, when found in a transcript segment,
+    cause the entity mention scanner to skip that segment for this entity.
+
+    Parameters
+    ----------
+    entity_id : str
+        Named entity UUID (string representation).
+    body : ExclusionPatternRequest
+        Request body with the pattern string.
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    dict
+        Updated exclusion_patterns list wrapped in a ``data`` envelope.
+
+    Raises
+    ------
+    NotFoundError
+        If the entity does not exist (404).
+    ConflictError
+        If the pattern already exists on this entity (409).
+    """
+    # Parse entity_id
+    try:
+        parsed_entity_id = uuid.UUID(entity_id)
+    except ValueError:
+        raise NotFoundError(resource_type="Entity", identifier=entity_id)
+
+    # Look up entity
+    entity = await session.get(NamedEntityDB, parsed_entity_id)
+    if entity is None:
+        raise NotFoundError(resource_type="Entity", identifier=entity_id)
+
+    trimmed = body.pattern.strip()
+    if not trimmed:
+        raise ConflictError(
+            message="Pattern is empty after trimming whitespace",
+            details={"pattern": body.pattern},
+        )
+
+    current_patterns: list[str] = list(entity.exclusion_patterns or [])
+
+    # Check for duplicate
+    if trimmed in current_patterns:
+        raise ConflictError(
+            message=f"Exclusion pattern '{trimmed}' already exists for this entity",
+            details={
+                "entity_id": entity_id,
+                "pattern": trimmed,
+            },
+        )
+
+    current_patterns.append(trimmed)
+    entity.exclusion_patterns = current_patterns
+    session.add(entity)
+    await session.commit()
+    await session.refresh(entity)
+
+    return {
+        "data": {
+            "exclusion_patterns": list(entity.exclusion_patterns or []),
+        }
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DELETE /entities/{entity_id}/exclusion-patterns
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.delete(
+    "/entities/{entity_id}/exclusion-patterns",
+    status_code=200,
+    summary="Remove an exclusion pattern from a named entity",
+)
+async def remove_exclusion_pattern(
+    entity_id: str = Path(..., description="Named entity UUID"),
+    body: ExclusionPatternRequest = Body(...),
+    session: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Remove an exclusion pattern from a named entity.
+
+    Parameters
+    ----------
+    entity_id : str
+        Named entity UUID (string representation).
+    body : ExclusionPatternRequest
+        Request body with the pattern string to remove.
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    dict
+        Updated exclusion_patterns list wrapped in a ``data`` envelope.
+
+    Raises
+    ------
+    NotFoundError
+        If the entity does not exist (404), or if the pattern is not
+        found in the entity's exclusion_patterns list (404).
+    """
+    # Parse entity_id
+    try:
+        parsed_entity_id = uuid.UUID(entity_id)
+    except ValueError:
+        raise NotFoundError(resource_type="Entity", identifier=entity_id)
+
+    # Look up entity
+    entity = await session.get(NamedEntityDB, parsed_entity_id)
+    if entity is None:
+        raise NotFoundError(resource_type="Entity", identifier=entity_id)
+
+    trimmed = body.pattern.strip()
+    current_patterns: list[str] = list(entity.exclusion_patterns or [])
+
+    if trimmed not in current_patterns:
+        raise NotFoundError(
+            resource_type="ExclusionPattern",
+            identifier=trimmed,
+        )
+
+    current_patterns.remove(trimmed)
+    entity.exclusion_patterns = current_patterns
+    session.add(entity)
+    await session.commit()
+    await session.refresh(entity)
+
+    return {
+        "data": {
+            "exclusion_patterns": list(entity.exclusion_patterns or []),
+        }
     }

--- a/src/chronovista/api/schemas/batch_corrections.py
+++ b/src/chronovista/api/schemas/batch_corrections.py
@@ -408,3 +408,71 @@ class BatchRevertResponse(BaseModel):
 
     reverted_count: int
     skipped_count: int
+
+
+class DiffErrorPatternResponse(BaseModel):
+    """A recurring ASR error pattern with optional entity association.
+
+    Attributes
+    ----------
+    error_token : str
+        The original (incorrect) text pattern.
+    canonical_form : str
+        The corrected text that replaced the original.
+    frequency : int
+        Number of times this correction has been applied.
+    remaining_matches : int
+        Number of un-corrected instances remaining.
+    entity_id : uuid.UUID | None
+        Associated named entity UUID, if any.
+    entity_name : str | None
+        Associated named entity canonical name, if any.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    error_token: str
+    canonical_form: str
+    frequency: int
+    remaining_matches: int
+    entity_id: uuid.UUID | None = None
+    entity_name: str | None = None
+
+
+class CrossSegmentCandidateResponse(BaseModel):
+    """A cross-segment ASR error candidate.
+
+    Attributes
+    ----------
+    segment_n_id : int
+        Primary key of the first segment.
+    segment_n_text : str
+        Effective text of the first segment.
+    segment_n1_id : int
+        Primary key of the second segment.
+    segment_n1_text : str
+        Effective text of the second segment.
+    proposed_correction : str
+        The corrected form derived from the source pattern.
+    source_pattern : str
+        The original ASR error text from the correction pattern.
+    confidence : float
+        Confidence score in [0.0, 1.0].
+    is_partially_corrected : bool
+        Whether one of the two segments has already been corrected.
+    video_id : str
+        YouTube video ID where the candidate was found.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    segment_n_id: int
+    segment_n_text: str
+    segment_n1_id: int
+    segment_n1_text: str
+    proposed_correction: str
+    source_pattern: str
+    confidence: float
+    is_partially_corrected: bool
+    video_id: str
+    discovery_source: str = "correction_pattern"

--- a/src/chronovista/api/schemas/entity_mentions.py
+++ b/src/chronovista/api/schemas/entity_mentions.py
@@ -176,6 +176,38 @@ _ALLOWED_ALIAS_TYPES = Literal[
 ]
 
 
+class PhoneticMatchResponse(BaseModel):
+    """A suspected phonetic ASR variant of an entity name.
+
+    Attributes
+    ----------
+    original_text : str
+        The N-gram text from the transcript segment.
+    proposed_correction : str
+        The entity name (or alias) that the N-gram likely represents.
+    confidence : float
+        Weighted confidence score in [0.0, 1.0].
+    evidence_description : str
+        Human-readable description of the evidence supporting this match.
+    video_id : str
+        YouTube video ID where the match was found.
+    segment_id : int
+        Transcript segment primary key.
+    video_title : str | None
+        Title of the video (enriched from the videos table).
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    original_text: str
+    proposed_correction: str
+    confidence: float
+    evidence_description: str
+    video_id: str
+    segment_id: int
+    video_title: str | None = None
+
+
 class CreateEntityAliasRequest(BaseModel):
     """Request body for creating a new alias on a named entity.
 
@@ -199,4 +231,24 @@ class CreateEntityAliasRequest(BaseModel):
             "Alias type (name_variant, abbreviation, nickname, "
             "translated_name, former_name)"
         ),
+    )
+
+
+class ExclusionPatternRequest(BaseModel):
+    """Request body for adding or removing an exclusion pattern.
+
+    Attributes
+    ----------
+    pattern : str
+        The exclusion pattern string. Must be non-empty and at most
+        500 characters.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    pattern: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Exclusion pattern to add or remove",
     )

--- a/src/chronovista/repositories/entity_mention_repository.py
+++ b/src/chronovista/repositories/entity_mention_repository.py
@@ -540,16 +540,47 @@ class EntityMentionRepository(
         tuple[list[dict[str, Any]], int]
             Tuple of (results list, total count of distinct videos).
         """
-        # Base filter
-        base_filter = EntityMentionDB.entity_id == entity_id
-        filters = [base_filter]
+        # Build "visible names" subquery: canonical name + non-ASR-error
+        # aliases.  This keeps video/mention counts consistent with the
+        # counters stored on named_entities (which also exclude ASR-error
+        # alias mentions).
+        canonical_names = select(
+            func.lower(NamedEntityDB.canonical_name).label("name_lower"),
+        ).where(NamedEntityDB.id == entity_id)
+
+        non_asr_aliases = select(
+            func.lower(EntityAliasDB.alias_name).label("name_lower"),
+        ).where(
+            EntityAliasDB.entity_id == entity_id,
+            EntityAliasDB.alias_type != EntityAliasType.ASR_ERROR,
+        )
+
+        visible_names = union_all(canonical_names, non_asr_aliases).subquery()
+
+        # Base filter: entity match + visible-name match
+        base_filters = [
+            EntityMentionDB.entity_id == entity_id,
+            func.lower(EntityMentionDB.mention_text) == visible_names.c.name_lower,
+        ]
         if language_code is not None:
-            filters.append(EntityMentionDB.language_code == language_code)
+            base_filters.append(EntityMentionDB.language_code == language_code)
 
         # Total count of distinct videos
         count_stmt = (
             select(func.count(distinct(EntityMentionDB.video_id)))
-            .where(*filters)
+            .join(
+                visible_names,
+                func.lower(EntityMentionDB.mention_text)
+                == visible_names.c.name_lower,
+            )
+            .where(
+                EntityMentionDB.entity_id == entity_id,
+                *(
+                    [EntityMentionDB.language_code == language_code]
+                    if language_code is not None
+                    else []
+                ),
+            )
         )
         total_result = await session.execute(count_stmt)
         total_count = total_result.scalar() or 0
@@ -567,9 +598,21 @@ class EntityMentionRepository(
                 ),
                 func.count().label("mention_count"),
             )
+            .join(
+                visible_names,
+                func.lower(EntityMentionDB.mention_text)
+                == visible_names.c.name_lower,
+            )
             .join(VideoDB, EntityMentionDB.video_id == VideoDB.video_id)
             .outerjoin(Channel, VideoDB.channel_id == Channel.channel_id)
-            .where(*filters)
+            .where(
+                EntityMentionDB.entity_id == entity_id,
+                *(
+                    [EntityMentionDB.language_code == language_code]
+                    if language_code is not None
+                    else []
+                ),
+            )
             .group_by(
                 EntityMentionDB.video_id,
                 VideoDB.title,
@@ -586,7 +629,7 @@ class EntityMentionRepository(
 
         results: list[dict[str, Any]] = []
         for row in video_rows:
-            # Fetch up to 5 mention previews for this video
+            # Fetch up to 5 mention previews for this video (visible names only)
             preview_stmt = (
                 select(
                     EntityMentionDB.segment_id,
@@ -596,6 +639,11 @@ class EntityMentionRepository(
                 .join(
                     TranscriptSegmentDB,
                     EntityMentionDB.segment_id == TranscriptSegmentDB.id,
+                )
+                .join(
+                    visible_names,
+                    func.lower(EntityMentionDB.mention_text)
+                    == visible_names.c.name_lower,
                 )
                 .where(
                     EntityMentionDB.entity_id == entity_id,

--- a/src/chronovista/services/asr_alias_registry.py
+++ b/src/chronovista/services/asr_alias_registry.py
@@ -24,6 +24,64 @@ from chronovista.services.tag_normalization import TagNormalizationService
 
 logger = logging.getLogger(__name__)
 
+# Common English function words.  When every token in a candidate alias
+# belongs to this set the alias is almost certainly a false positive
+# (e.g. "be out" from "Rick Beato").
+_HIGH_FREQUENCY_WORDS: frozenset[str] = frozenset({
+    "a", "an", "the", "and", "or", "but", "not", "no", "so",
+    "is", "am", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did",
+    "will", "would", "shall", "should", "may", "might", "can", "could",
+    "i", "me", "my", "we", "us", "our", "you", "your",
+    "he", "him", "his", "she", "her", "it", "its", "they", "them", "their",
+    "this", "that", "these", "those",
+    "in", "on", "at", "to", "of", "for", "by", "with", "from",
+    "up", "out", "off", "over", "into", "onto", "upon",
+    "if", "then", "than", "as", "while", "when", "where", "how", "what",
+    "who", "whom", "which", "why",
+    "all", "each", "every", "both", "few", "more", "most", "some", "any",
+    "much", "many", "such", "own", "other",
+    "just", "also", "very", "too", "quite", "about", "still",
+    "here", "there", "now", "well", "back",
+    "get", "got", "go", "going", "gone", "come", "came",
+    "make", "made", "take", "took", "put", "let", "say", "said",
+    "know", "think", "see", "look", "want", "give", "use",
+})
+
+# Minimum character length for an alias to be worth registering.
+_MIN_ALIAS_LENGTH = 4
+
+
+def is_valid_asr_alias(alias_text: str) -> bool:
+    """Check whether an alias candidate is worth registering.
+
+    Rejects aliases that are too short or consist entirely of common
+    English function words — these produce overwhelming false-positive
+    entity mentions when scanned across a large transcript corpus.
+
+    Parameters
+    ----------
+    alias_text : str
+        The candidate alias text (the ASR error form).
+
+    Returns
+    -------
+    bool
+        ``True`` if the alias passes quality gates, ``False`` otherwise.
+    """
+    stripped = alias_text.strip()
+    if len(stripped) < _MIN_ALIAS_LENGTH:
+        return False
+
+    tokens = stripped.lower().split()
+    if not tokens:
+        return False
+
+    if all(t in _HIGH_FREQUENCY_WORDS for t in tokens):
+        return False
+
+    return True
+
 
 async def resolve_entity_id_from_text(
     session: AsyncSession,
@@ -99,6 +157,16 @@ async def register_asr_alias(
         Prefix for log messages to distinguish callers.
     """
     try:
+        # Quality gate: reject aliases that are too short or consist
+        # entirely of common English function words.
+        if not is_valid_asr_alias(original_text):
+            logger.debug(
+                "%s: rejected alias '%s' (failed quality gate)",
+                log_prefix,
+                original_text,
+            )
+            return
+
         match = await resolve_entity_id_from_text(session, corrected_text)
         if match is None:
             return
@@ -160,12 +228,14 @@ async def register_asr_alias(
 
             diff = word_level_diff(original_text, corrected_text)
             for error_token, canonical_token in diff.changed_pairs:
-                # Skip empty tokens (insertions/deletions) and duplicates of
-                # the full-string alias we just registered.
+                # Skip empty tokens (insertions/deletions), duplicates of
+                # the full-string alias, and sub-tokens that fail the
+                # quality gate.
                 if (
                     not error_token
                     or not canonical_token
                     or error_token.strip() == original_text.strip()
+                    or not is_valid_asr_alias(error_token)
                 ):
                     continue
 

--- a/src/chronovista/services/cross_segment_discovery.py
+++ b/src/chronovista/services/cross_segment_discovery.py
@@ -2,10 +2,15 @@
 Cross-segment candidate discovery service.
 
 Identifies transcript segments where ASR errors span the boundary between
-consecutive segments. Uses recurring correction patterns to find adjacent
-segment pairs where a known error form is split across segment N (suffix)
-and segment N+1 (prefix), then scores candidates using phonetic similarity
-and pattern confidence.
+consecutive segments. Two discovery strategies are combined:
+
+1. **Correction-pattern based** (original): Uses recurring correction patterns
+   from ``BatchCorrectionService`` to find adjacent segment pairs where a
+   known error form is split across the segment boundary.
+
+2. **Entity-alias based** (new): Uses multi-word ASR error aliases from
+   ``entity_aliases`` to find segment boundary splits. This leverages
+   curated entity knowledge and does not require prior corrections.
 
 Feature 045 — Correction Intelligence Pipeline (US5, T033)
 """
@@ -14,17 +19,21 @@ from __future__ import annotations
 
 import logging
 import re
+from types import SimpleNamespace
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import and_, select
+from sqlalchemy import and_, case, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from chronovista.db.models import EntityAlias as EntityAliasDB
+from chronovista.db.models import NamedEntity as NamedEntityDB
 from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
 from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
 from chronovista.models.batch_correction_models import CorrectionPattern
 from chronovista.services.batch_correction_service import BatchCorrectionService
 from chronovista.services.phonetic_matcher import PhoneticMatcher
+from chronovista.utils.text import strip_boundary_punctuation
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +84,10 @@ class CrossSegmentCandidate(BaseModel):
         description="True if one of the two segments already has a correction",
     )
     video_id: str = Field(..., description="YouTube video ID")
+    discovery_source: str = Field(
+        default="correction_pattern",
+        description="How this candidate was discovered: 'entity_alias' or 'correction_pattern'",
+    )
 
     model_config = ConfigDict(frozen=True)
 
@@ -84,6 +97,47 @@ class CrossSegmentCandidate(BaseModel):
 # ---------------------------------------------------------------------------
 
 _WORD_BOUNDARY_RE = re.compile(r"\s+")
+
+# Common English function words.  When BOTH halves of a 2-word alias
+# split consist entirely of stopwords the split is too noisy for
+# cross-segment discovery (e.g. "be out" from "Rick Beato").
+_STOPWORDS: frozenset[str] = frozenset({
+    "a", "an", "the", "and", "or", "but", "not", "no", "so",
+    "is", "am", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did",
+    "will", "would", "shall", "should", "may", "might", "can", "could",
+    "i", "me", "my", "we", "us", "our", "you", "your",
+    "he", "him", "his", "she", "her", "it", "its", "they", "them", "their",
+    "this", "that", "these", "those",
+    "in", "on", "at", "to", "of", "for", "by", "with", "from",
+    "up", "out", "off", "over", "into", "onto", "upon",
+    "if", "then", "than", "as", "while", "when", "where", "how", "what",
+    "who", "whom", "which", "why",
+    "all", "each", "every", "both", "few", "more", "most", "some", "any",
+    "much", "many", "such", "own", "other",
+    "just", "also", "very", "too", "quite", "about", "still",
+    "here", "there", "now", "well", "back",
+    "get", "got", "go", "going", "gone", "come", "came",
+    "make", "made", "take", "took", "put", "let", "say", "said",
+    "know", "think", "see", "look", "want", "give", "use",
+})
+
+
+def _is_stopword_split(prefix: str, suffix: str) -> bool:
+    """Return True if both sides of the split are common stopwords.
+
+    A split is considered "stopword-only" when every word in both the
+    prefix and suffix appears in ``_STOPWORDS``.  Such splits produce
+    overwhelming false-positive matches in cross-segment discovery.
+    """
+    prefix_words = prefix.lower().split()
+    suffix_words = suffix.lower().split()
+    return (
+        bool(prefix_words)
+        and bool(suffix_words)
+        and all(w in _STOPWORDS for w in prefix_words)
+        and all(w in _STOPWORDS for w in suffix_words)
+    )
 
 
 def _effective_text(segment: Any) -> str:
@@ -133,6 +187,35 @@ def _generate_splits(text: str) -> list[tuple[str, str, bool]]:
     return splits
 
 
+def _generate_word_splits(text: str) -> list[tuple[str, str]]:
+    """Generate word-boundary split points for a multi-word text.
+
+    For text with N words, returns N-1 splits. Only word-boundary splits
+    are generated (no character-level splits) since entity aliases are
+    clean multi-word strings.
+
+    Parameters
+    ----------
+    text : str
+        The text to split (e.g. an entity alias name).
+
+    Returns
+    -------
+    list[tuple[str, str]]
+        Each tuple contains (prefix, suffix).
+    """
+    words = _WORD_BOUNDARY_RE.split(text)
+    if len(words) < 2:
+        return []
+    splits: list[tuple[str, str]] = []
+    for i in range(1, len(words)):
+        prefix = " ".join(words[:i])
+        suffix = " ".join(words[i:])
+        if prefix.strip() and suffix.strip():
+            splits.append((prefix, suffix))
+    return splits
+
+
 # ---------------------------------------------------------------------------
 # Service
 # ---------------------------------------------------------------------------
@@ -162,27 +245,485 @@ class CrossSegmentDiscovery:
     ) -> list[CrossSegmentCandidate]:
         """Discover cross-segment ASR error candidates.
 
-        Analyses recurring correction patterns, generates split-point
-        hypotheses for each error form, then searches for adjacent segment
-        pairs matching prefix/suffix combinations.
+        Combines two discovery strategies:
+        1. Entity-alias based — uses curated ASR error aliases from
+           ``entity_aliases`` (no prior corrections required).
+        2. Correction-pattern based — uses recurring correction patterns
+           from ``BatchCorrectionService``.
+
+        Entity-based candidates are prioritised when both strategies find
+        the same segment pair.
 
         Parameters
         ----------
         session : AsyncSession
             Database session.
         min_corrections : int, optional
-            Minimum correction occurrences for a pattern to be considered
+            Minimum correction occurrences for pattern-based discovery
             (default 3).
         entity_name : str | None, optional
-            If provided, only consider patterns whose original or corrected
-            text contains this entity name (case-insensitive substring match).
+            If provided, only consider patterns/aliases matching this
+            entity name (case-insensitive substring match).
 
         Returns
         -------
         list[CrossSegmentCandidate]
             Candidates sorted by confidence descending.
         """
-        # 1. Get recurring patterns
+        # 1. Entity-based discovery
+        entity_candidates = await self.discover_from_entities(
+            session, entity_name=entity_name
+        )
+
+        # 2. Pattern-based discovery
+        pattern_candidates = await self._discover_from_patterns(
+            session,
+            min_corrections=min_corrections,
+            entity_name=entity_name,
+        )
+
+        # 3. Merge and deduplicate (entity candidates take priority)
+        merged = self._merge_candidates(entity_candidates, pattern_candidates)
+
+        # 4. Sort by confidence descending
+        merged.sort(key=lambda c: c.confidence, reverse=True)
+
+        logger.info(
+            "Cross-segment discovery complete: %d candidates "
+            "(%d entity-based, %d pattern-based)",
+            len(merged),
+            len(entity_candidates),
+            len(pattern_candidates),
+        )
+        return merged
+
+    # ------------------------------------------------------------------
+    # Entity-alias based discovery
+    # ------------------------------------------------------------------
+
+    async def discover_from_entities(
+        self,
+        session: AsyncSession,
+        entity_name: str | None = None,
+    ) -> list[CrossSegmentCandidate]:
+        """Discover cross-segment candidates using entity ASR aliases.
+
+        Loads multi-word ASR error aliases, generates word-boundary splits,
+        and searches for adjacent segment pairs matching any split in a
+        single batched SQL query (avoiding per-split round-trips).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        entity_name : str | None
+            Optional filter by entity canonical name.
+
+        Returns
+        -------
+        list[CrossSegmentCandidate]
+            Candidates with ``discovery_source='entity_alias'``.
+        """
+        aliases = await self._load_multiword_asr_aliases(session, entity_name)
+        if not aliases:
+            logger.debug("No multi-word ASR aliases found for entity discovery")
+            return []
+
+        # Prioritize aliases: 2-word aliases first (more precise), then
+        # shorter names.  Limit to 30 to keep query cost reasonable on
+        # large segment tables (~1M rows → sequential ILIKE scan).
+        aliases.sort(
+            key=lambda a: (len(a[0].split()), len(a[0]))
+        )
+        max_aliases = 30
+        if len(aliases) > max_aliases:
+            logger.info(
+                "Limiting entity aliases from %d to %d for performance",
+                len(aliases),
+                max_aliases,
+            )
+            aliases = aliases[:max_aliases]
+
+        # Collect all (prefix, suffix) splits with their alias metadata,
+        # filtering out splits where both halves are common stopwords.
+        split_entries: list[tuple[str, str, str, str, str]] = []
+        skipped_stopword = 0
+        for alias_name, canonical_name, entity_type in aliases:
+            for prefix, suffix in _generate_word_splits(alias_name):
+                if _is_stopword_split(prefix, suffix):
+                    skipped_stopword += 1
+                    continue
+                split_entries.append(
+                    (prefix, suffix, alias_name, canonical_name, entity_type)
+                )
+        if skipped_stopword:
+            logger.info(
+                "Skipped %d stopword-only splits from entity aliases",
+                skipped_stopword,
+            )
+
+        if not split_entries:
+            logger.debug("No word-boundary splits generated from aliases")
+            return []
+
+        corrected_segment_ids = await self._get_corrected_segment_ids(session)
+
+        # Single batched query for ALL alias splits
+        pairs = await self._find_adjacent_pairs_batched(
+            session,
+            [(p, s) for p, s, _, _, _ in split_entries],
+        )
+
+        candidates: list[CrossSegmentCandidate] = []
+        for seg_n, seg_n1 in pairs:
+            n_corrected = seg_n.id in corrected_segment_ids
+            n1_corrected = seg_n1.id in corrected_segment_ids
+            if n_corrected and n1_corrected:
+                continue
+            is_partial = n_corrected or n1_corrected
+
+            seg_n_text = _effective_text(seg_n)
+            seg_n1_text = _effective_text(seg_n1)
+
+            # Match this pair to the best-scoring alias
+            best_alias: tuple[str, str] | None = None
+            best_score = -1.0
+            for prefix, suffix, a_name, c_name, e_type in split_entries:
+                if seg_n_text.lower().rstrip().endswith(
+                    prefix.lower().rstrip()
+                ) and seg_n1_text.lower().lstrip().startswith(
+                    suffix.lower().lstrip()
+                ):
+                    score = self._score_entity_candidate(
+                        prefix=prefix,
+                        suffix=suffix,
+                        seg_n_text=seg_n_text,
+                        seg_n1_text=seg_n1_text,
+                        is_partially_corrected=is_partial,
+                        entity_type=e_type,
+                        alias_word_count=len(
+                            _WORD_BOUNDARY_RE.split(a_name)
+                        ),
+                    )
+                    if score > best_score:
+                        best_score = score
+                        best_alias = (a_name, c_name)
+
+            if best_alias:
+                alias_name, canonical_name = best_alias
+                candidates.append(
+                    CrossSegmentCandidate(
+                        segment_n_id=seg_n.id,
+                        segment_n_text=seg_n_text,
+                        segment_n1_id=seg_n1.id,
+                        segment_n1_text=seg_n1_text,
+                        proposed_correction=canonical_name,
+                        source_pattern=alias_name,
+                        confidence=round(best_score, 4),
+                        is_partially_corrected=is_partial,
+                        video_id=seg_n.video_id,
+                        discovery_source="entity_alias",
+                    )
+                )
+
+        logger.info(
+            "Entity-alias discovery: %d candidates from %d aliases "
+            "(%d splits, %d pairs found)",
+            len(candidates),
+            len(aliases),
+            len(split_entries),
+            len(pairs),
+        )
+        return candidates
+
+    async def _load_multiword_asr_aliases(
+        self,
+        session: AsyncSession,
+        entity_name: str | None = None,
+    ) -> list[tuple[str, str, str]]:
+        """Load multi-word ASR error aliases with their entity canonical names.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        entity_name : str | None
+            Optional case-insensitive filter on canonical_name.
+
+        Returns
+        -------
+        list[tuple[str, str, str]]
+            Each tuple is (alias_name, canonical_name, entity_type).
+        """
+        stmt = (
+            select(
+                EntityAliasDB.alias_name,
+                NamedEntityDB.canonical_name,
+                NamedEntityDB.entity_type,
+            )
+            .join(NamedEntityDB, EntityAliasDB.entity_id == NamedEntityDB.id)
+            .where(
+                EntityAliasDB.alias_type == "asr_error",
+                EntityAliasDB.alias_name.contains(" "),
+            )
+        )
+        if entity_name is not None:
+            stmt = stmt.where(
+                func.lower(NamedEntityDB.canonical_name).contains(
+                    entity_name.lower()
+                )
+            )
+
+        result = await session.execute(stmt)
+        return [(row[0], row[1], row[2]) for row in result.all()]
+
+    async def _find_adjacent_pairs_batched(
+        self,
+        session: AsyncSession,
+        prefix_suffix_pairs: list[tuple[str, str]],
+        limit: int = 500,
+    ) -> list[tuple[Any, Any]]:
+        """Find adjacent segment pairs matching any of the given splits.
+
+        Batches all ``(prefix, suffix)`` pairs into a single SQL query
+        with OR conditions, avoiding one round-trip per split.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        prefix_suffix_pairs : list[tuple[str, str]]
+            Each tuple is ``(prefix, suffix)`` where segment N should
+            end with *prefix* and segment N+1 should start with *suffix*.
+        limit : int
+            Maximum number of rows to return (default 500).
+
+        Returns
+        -------
+        list[tuple[Any, Any]]
+            List of ``(seg_n, seg_n1)`` lightweight namespace objects
+            with ``id``, ``text``, ``corrected_text``, ``has_correction``,
+            and ``video_id`` attributes.
+        """
+        if not prefix_suffix_pairs:
+            return []
+
+        seg_n = TranscriptSegmentDB.__table__.alias("seg_n")
+        seg_n1 = TranscriptSegmentDB.__table__.alias("seg_n1")
+
+        eff_text_n = case(
+            (seg_n.c.has_correction, seg_n.c.corrected_text),
+            else_=seg_n.c.text,
+        )
+        eff_text_n1 = case(
+            (seg_n1.c.has_correction, seg_n1.c.corrected_text),
+            else_=seg_n1.c.text,
+        )
+
+        or_conditions = [
+            and_(
+                eff_text_n.ilike(f"%{prefix}"),
+                eff_text_n1.ilike(f"{suffix}%"),
+            )
+            for prefix, suffix in prefix_suffix_pairs
+        ]
+
+        stmt = (
+            select(
+                seg_n.c.id.label("n_id"),
+                seg_n.c.text.label("n_text"),
+                seg_n.c.corrected_text.label("n_corrected_text"),
+                seg_n.c.has_correction.label("n_has_correction"),
+                seg_n.c.video_id.label("n_video_id"),
+                seg_n1.c.id.label("n1_id"),
+                seg_n1.c.text.label("n1_text"),
+                seg_n1.c.corrected_text.label("n1_corrected_text"),
+                seg_n1.c.has_correction.label("n1_has_correction"),
+            )
+            .where(
+                and_(
+                    seg_n.c.video_id == seg_n1.c.video_id,
+                    seg_n.c.language_code == seg_n1.c.language_code,
+                    seg_n1.c.sequence_number == seg_n.c.sequence_number + 1,
+                    or_(*or_conditions),
+                )
+            )
+            .limit(limit)
+        )
+
+        result = await session.execute(stmt)
+        rows = result.fetchall()
+
+        seen: set[tuple[int, int]] = set()
+        pairs: list[tuple[Any, Any]] = []
+        for row in rows:
+            key = (row.n_id, row.n1_id)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            seg_n_obj = SimpleNamespace(
+                id=row.n_id,
+                text=row.n_text,
+                corrected_text=row.n_corrected_text,
+                has_correction=row.n_has_correction,
+                video_id=row.n_video_id,
+            )
+            seg_n1_obj = SimpleNamespace(
+                id=row.n1_id,
+                text=row.n1_text,
+                corrected_text=row.n1_corrected_text,
+                has_correction=row.n1_has_correction,
+            )
+            pairs.append((seg_n_obj, seg_n1_obj))
+
+        logger.debug(
+            "Batched adjacent-pair query: %d OR conditions → %d unique pairs",
+            len(prefix_suffix_pairs),
+            len(pairs),
+        )
+        return pairs
+
+    def _score_entity_candidate(
+        self,
+        *,
+        prefix: str,
+        suffix: str,
+        seg_n_text: str,
+        seg_n1_text: str,
+        is_partially_corrected: bool,
+        entity_type: str,
+        alias_word_count: int,
+    ) -> float:
+        """Score an entity-based cross-segment candidate.
+
+        Entity candidates use a higher base score than pattern-based
+        candidates because they are derived from curated ASR aliases
+        with known canonical corrections.
+
+        Scoring factors (0.0-1.0):
+        - Entity source base: 0.50
+        - Boundary precision: 0.0-0.20
+        - Partial correction evidence: 0.10
+        - Person entity type boost: 0.10
+        - 2-word alias boost: 0.10
+
+        Parameters
+        ----------
+        prefix : str
+            The prefix portion of the alias split.
+        suffix : str
+            The suffix portion of the alias split.
+        seg_n_text : str
+            Effective text of segment N.
+        seg_n1_text : str
+            Effective text of segment N+1.
+        is_partially_corrected : bool
+            Whether one segment already has a correction.
+        entity_type : str
+            The entity type (e.g. 'person', 'organization').
+        alias_word_count : int
+            Number of words in the alias.
+
+        Returns
+        -------
+        float
+            Confidence score in [0.0, 1.0].
+        """
+        score = 0.50  # Entity source base
+
+        # Boundary precision
+        ends_exact = seg_n_text.rstrip().endswith(prefix.rstrip())
+        starts_exact = seg_n1_text.lstrip().startswith(suffix.lstrip())
+        if ends_exact and starts_exact:
+            score += 0.20
+        elif ends_exact or starts_exact:
+            score += 0.10
+
+        # Partial correction evidence
+        if is_partially_corrected:
+            score += 0.10
+
+        # Person entity type boost (ASR most commonly mangles names)
+        if entity_type == "person":
+            score += 0.10
+
+        # 2-word aliases are more precise than 3+ word aliases
+        if alias_word_count == 2:
+            score += 0.10
+
+        return min(score, 1.0)
+
+    @staticmethod
+    def _merge_candidates(
+        entity_candidates: list[CrossSegmentCandidate],
+        pattern_candidates: list[CrossSegmentCandidate],
+    ) -> list[CrossSegmentCandidate]:
+        """Merge entity-based and pattern-based candidates, deduplicating by segment pair.
+
+        Entity-based candidates take priority when both approaches find
+        the same ``(segment_n_id, segment_n1_id)`` pair.
+
+        Parameters
+        ----------
+        entity_candidates : list[CrossSegmentCandidate]
+            Candidates from entity-alias discovery.
+        pattern_candidates : list[CrossSegmentCandidate]
+            Candidates from correction-pattern discovery.
+
+        Returns
+        -------
+        list[CrossSegmentCandidate]
+            Merged, deduplicated candidates.
+        """
+        seen: set[tuple[int, int]] = set()
+        merged: list[CrossSegmentCandidate] = []
+
+        for c in entity_candidates:
+            key = (c.segment_n_id, c.segment_n1_id)
+            if key not in seen:
+                seen.add(key)
+                merged.append(c)
+
+        for c in pattern_candidates:
+            key = (c.segment_n_id, c.segment_n1_id)
+            if key not in seen:
+                seen.add(key)
+                merged.append(c)
+
+        return merged
+
+    # ------------------------------------------------------------------
+    # Correction-pattern based discovery (original approach)
+    # ------------------------------------------------------------------
+
+    async def _discover_from_patterns(
+        self,
+        session: AsyncSession,
+        min_corrections: int = 3,
+        entity_name: str | None = None,
+    ) -> list[CrossSegmentCandidate]:
+        """Discover cross-segment candidates from recurring correction patterns.
+
+        Collects word-boundary splits across all qualifying patterns and
+        runs a single batched SQL query (same optimisation as entity
+        discovery).  Character-level splits are skipped — they generate
+        hundreds of noisy, low-confidence queries.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        min_corrections : int
+            Minimum correction occurrences for a pattern to be considered.
+        entity_name : str | None
+            Optional entity name filter.
+
+        Returns
+        -------
+        list[CrossSegmentCandidate]
+            Candidates with ``discovery_source='correction_pattern'``.
+        """
         patterns = await self._batch_service.get_patterns(
             session,
             min_occurrences=min_corrections,
@@ -191,10 +732,12 @@ class CrossSegmentDiscovery:
         )
 
         if not patterns:
-            logger.info("No recurring patterns found (min_corrections=%d)", min_corrections)
+            logger.info(
+                "No recurring patterns found (min_corrections=%d)",
+                min_corrections,
+            )
             return []
 
-        # 2. Optionally filter by entity name
         if entity_name is not None:
             entity_lower = entity_name.lower()
             patterns = [
@@ -209,102 +752,92 @@ class CrossSegmentDiscovery:
                 )
                 return []
 
-        logger.info(
-            "Processing %d patterns for cross-segment discovery", len(patterns)
-        )
-
-        # 3. Collect corrected segment IDs to filter out fully corrected pairs
-        corrected_segment_ids = await self._get_corrected_segment_ids(session)
-
-        candidates: list[CrossSegmentCandidate] = []
-
+        # Collect word-boundary splits across all patterns
+        # (prefix, suffix, pattern) — skip character-level splits
+        split_entries: list[tuple[str, str, CorrectionPattern]] = []
         for pattern in patterns:
-            pattern_candidates = await self._process_pattern(
-                session, pattern, corrected_segment_ids
+            for prefix, suffix, is_word_boundary in _generate_splits(
+                pattern.original_text
+            ):
+                if not is_word_boundary:
+                    continue
+                if not prefix.strip() or not suffix.strip():
+                    continue
+                if _is_stopword_split(prefix, suffix):
+                    continue
+                split_entries.append((prefix, suffix, pattern))
+
+        if not split_entries:
+            logger.info(
+                "No word-boundary splits from %d patterns", len(patterns)
             )
-            candidates.extend(pattern_candidates)
-
-        # Sort by confidence descending
-        candidates.sort(key=lambda c: c.confidence, reverse=True)
-
-        logger.info(
-            "Cross-segment discovery complete: %d candidates found",
-            len(candidates),
-        )
-        return candidates
-
-    async def _process_pattern(
-        self,
-        session: AsyncSession,
-        pattern: CorrectionPattern,
-        corrected_segment_ids: set[int],
-    ) -> list[CrossSegmentCandidate]:
-        """Process a single correction pattern for cross-segment splits.
-
-        Parameters
-        ----------
-        session : AsyncSession
-            Database session.
-        pattern : CorrectionPattern
-            The correction pattern to process.
-        corrected_segment_ids : set[int]
-            Set of segment IDs that already have corrections applied.
-
-        Returns
-        -------
-        list[CrossSegmentCandidate]
-            Candidates found for this pattern.
-        """
-        original = pattern.original_text
-        splits = _generate_splits(original)
-
-        if not splits:
             return []
 
+        logger.info(
+            "Pattern discovery: %d word-boundary splits from %d patterns",
+            len(split_entries),
+            len(patterns),
+        )
+
+        corrected_segment_ids = await self._get_corrected_segment_ids(session)
+
+        # Single batched query for ALL pattern splits
+        pairs = await self._find_adjacent_pairs_batched(
+            session,
+            [(p, s) for p, s, _ in split_entries],
+        )
+
         candidates: list[CrossSegmentCandidate] = []
-
-        for prefix, suffix, is_word_boundary in splits:
-            if not prefix.strip() or not suffix.strip():
+        for seg_n, seg_n1 in pairs:
+            n_corrected = seg_n.id in corrected_segment_ids
+            n1_corrected = seg_n1.id in corrected_segment_ids
+            if n_corrected and n1_corrected:
                 continue
+            is_partial = n_corrected or n1_corrected
 
-            # Search for segment pairs where segment N ends with prefix
-            # and segment N+1 starts with suffix
-            pairs = await self._find_adjacent_pairs(
-                session, prefix, suffix
-            )
+            seg_n_text = _effective_text(seg_n)
+            seg_n1_text = _effective_text(seg_n1)
 
-            for seg_n, seg_n1 in pairs:
-                # Determine correction status
-                n_corrected = seg_n.id in corrected_segment_ids
-                n1_corrected = seg_n1.id in corrected_segment_ids
-                both_corrected = n_corrected and n1_corrected
+            # Find best-scoring pattern match for this pair
+            best_pattern: CorrectionPattern | None = None
+            best_score = -1.0
+            best_prefix = ""
+            best_suffix = ""
+            for prefix, suffix, pat in split_entries:
+                if seg_n_text.lower().rstrip().endswith(
+                    prefix.lower().rstrip()
+                ) and seg_n1_text.lower().lstrip().startswith(
+                    suffix.lower().lstrip()
+                ):
+                    score = self._score_candidate(
+                        prefix=prefix,
+                        suffix=suffix,
+                        seg_n_text=seg_n_text,
+                        seg_n1_text=seg_n1_text,
+                        is_word_boundary=True,
+                        pattern_occurrences=pat.occurrences,
+                        is_partially_corrected=is_partial,
+                    )
+                    if score > best_score:
+                        best_score = score
+                        best_pattern = pat
+                        best_prefix = prefix
+                        best_suffix = suffix
 
-                # Skip fully corrected pairs
-                if both_corrected:
-                    continue
-
-                is_partial = n_corrected or n1_corrected
-
-                # Score the candidate
-                confidence = self._score_candidate(
-                    prefix=prefix,
-                    suffix=suffix,
-                    seg_n_text=_effective_text(seg_n),
-                    seg_n1_text=_effective_text(seg_n1),
-                    is_word_boundary=is_word_boundary,
-                    pattern_occurrences=pattern.occurrences,
-                    is_partially_corrected=is_partial,
-                )
-
+            if best_pattern:
                 candidates.append(
                     CrossSegmentCandidate(
                         segment_n_id=seg_n.id,
-                        segment_n_text=_effective_text(seg_n),
+                        segment_n_text=seg_n_text,
                         segment_n1_id=seg_n1.id,
-                        segment_n1_text=_effective_text(seg_n1),
-                        proposed_correction=pattern.corrected_text,
-                        source_pattern=original,
-                        confidence=round(confidence, 4),
+                        segment_n1_text=seg_n1_text,
+                        proposed_correction=strip_boundary_punctuation(
+                            best_pattern.corrected_text
+                        ),
+                        source_pattern=strip_boundary_punctuation(
+                            best_pattern.original_text
+                        ),
+                        confidence=round(best_score, 4),
                         is_partially_corrected=is_partial,
                         video_id=seg_n.video_id,
                     )
@@ -342,8 +875,6 @@ class CrossSegmentDiscovery:
         seg_n1 = TranscriptSegmentDB.__table__.alias("seg_n1")
 
         # Build effective text expressions for both segments
-        from sqlalchemy import case, literal
-
         eff_text_n = case(
             (seg_n.c.has_correction, seg_n.c.corrected_text),
             else_=seg_n.c.text,

--- a/src/chronovista/services/entity_mention_scan_service.py
+++ b/src/chronovista/services/entity_mention_scan_service.py
@@ -286,12 +286,20 @@ class EntityMentionScanService:
             result.unique_videos = len(matched_video_ids)
 
             # 4. Update entity and alias counters (live mode only)
-            if not dry_run and matched_entity_ids:
+            # On full_rescan we must refresh ALL scanned entities (some may
+            # have had their mentions deleted with nothing new to replace
+            # them, so their counters need to be zeroed).
+            counter_entity_ids: set[uuid.UUID] = set()
+            if full_rescan:
+                counter_entity_ids = set(entity_ids)
+            counter_entity_ids |= matched_entity_ids
+
+            if not dry_run and counter_entity_ids:
                 await self._mention_repo.update_entity_counters(
-                    session, list(matched_entity_ids)
+                    session, list(counter_entity_ids)
                 )
                 await self._mention_repo.update_alias_counters(
-                    session, list(matched_entity_ids)
+                    session, list(counter_entity_ids)
                 )
                 await session.flush()
 
@@ -436,10 +444,13 @@ class EntityMentionScanService:
         if not entities:
             return []
 
-        # Load all aliases for these entities in a single query
+        # Load all aliases for these entities in a single query.
+        # Exclude asr_error aliases — those track what the ASR got wrong
+        # and must NOT be used as scan patterns (they produce false mentions).
         entity_id_list = [e.id for e in entities]
         alias_stmt = select(EntityAliasDB).where(
-            EntityAliasDB.entity_id.in_(entity_id_list)
+            EntityAliasDB.entity_id.in_(entity_id_list),
+            EntityAliasDB.alias_type != "asr_error",
         )
         alias_result = await session.execute(alias_stmt)
         all_aliases = list(alias_result.scalars().all())

--- a/src/chronovista/utils/__init__.py
+++ b/src/chronovista/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility modules for chronovista."""
 
 from chronovista.utils.fuzzy import find_similar, levenshtein_distance
+from chronovista.utils.text import strip_boundary_punctuation
 
-__all__ = ["levenshtein_distance", "find_similar"]
+__all__ = ["levenshtein_distance", "find_similar", "strip_boundary_punctuation"]

--- a/src/chronovista/utils/text.py
+++ b/src/chronovista/utils/text.py
@@ -1,0 +1,48 @@
+"""Text processing utilities for correction and analysis pipelines.
+
+Provides helper functions for normalising text tokens extracted from
+word-level diffs and cross-segment candidates.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Characters to strip from the boundaries of tokens.  Internal punctuation
+# (hyphens in "Iran-Contra", apostrophes in "Khashoggi's") is preserved.
+_BOUNDARY_PUNCT_RE = re.compile(
+    r"^[.,;:!?\"'`()\[\]{}<>…—–\-/\\|@#$%^&*~]+|"
+    r"[.,;:!?\"'`()\[\]{}<>…—–\-/\\|@#$%^&*~]+$"
+)
+
+
+def strip_boundary_punctuation(text: str) -> str:
+    """Strip leading and trailing punctuation from text, preserving internal punctuation.
+
+    Characters such as ``.``, ``,``, ``;``, ``:``, ``!``, ``?``, ``"``,
+    ``'``, ``(``, ``)`` and similar are removed from the boundaries only.
+    Internal punctuation (e.g., hyphens in "Iran-Contra" or apostrophes
+    in "Khashoggi's") is preserved.
+
+    Parameters
+    ----------
+    text : str
+        The input text to clean.
+
+    Returns
+    -------
+    str
+        The text with boundary punctuation removed.
+
+    Examples
+    --------
+    >>> strip_boundary_punctuation('"Sheinbaum"')
+    'Sheinbaum'
+    >>> strip_boundary_punctuation("Iran-Contra")
+    'Iran-Contra'
+    >>> strip_boundary_punctuation("Khashoggi's")
+    "Khashoggi's"
+    >>> strip_boundary_punctuation("...hello...")
+    'hello'
+    """
+    return _BOUNDARY_PUNCT_RE.sub("", text)

--- a/tests/integration/services/test_entity_mention_scan_integration.py
+++ b/tests/integration/services/test_entity_mention_scan_integration.py
@@ -19,7 +19,7 @@ Test coverage:
 4. Word boundary matching: "Aaronson" must NOT match entity "Aaron"
 5. Multiple aliases: all aliases of an entity trigger mentions
 6. Incremental scan: new_entities_only scans only newly added entity
-7. ASR-error alias exclusion: asr_error alias mentions excluded from counters (T011)
+7. ASR-error alias exclusion: asr_error aliases excluded from scan patterns and counters (T011)
 """
 
 from __future__ import annotations
@@ -934,29 +934,29 @@ class TestCorrectedSegmentText:
 
 
 class TestASRErrorAliasCounterExclusion:
-    """Verify that ASR-error aliases are excluded from mention_count / video_count.
+    """Verify that ASR-error aliases are fully excluded from scanning.
 
-    Feature 044 US2 modified ``update_entity_counters()`` so that only
-    mentions whose ``mention_text`` matches the entity's canonical name or a
-    non-ASR-error alias are counted.  Mentions matched via ``asr_error``
-    aliases contribute to the ``entity_mentions`` table but must NOT increment
-    ``mention_count`` or ``video_count`` on ``named_entities``.
+    Feature 044 US2 excludes ``asr_error`` aliases from scan patterns so
+    that misspelled ASR forms do not create false ``entity_mentions`` rows.
+    The ``update_entity_counters()`` function also filters by visible names
+    as a defence-in-depth measure, ensuring counters stay consistent.
     """
 
-    async def test_asr_error_alias_mention_excluded_from_mention_count(
+    async def test_asr_error_alias_not_scanned_and_no_mentions_created(
         self, db_session: AsyncSession
     ) -> None:
         """
-        An entity whose mentions are all via ASR-error aliases must end up
-        with mention_count=0 after a full scan.
+        An entity with only ASR-error aliases must produce zero
+        EntityMention rows after a scan (the alias is excluded from
+        scan patterns entirely).
 
         Setup:
         - Entity "Elon Musk" with an ASR-error alias "Elan Musk"
         - Segment text contains "Elan Musk" only (no canonical name)
 
         Expected:
-        - One EntityMention row is created (detection still fires)
-        - mention_count=0 because "elan musk" is an asr_error alias
+        - Zero EntityMention rows (ASR alias not used as scan pattern)
+        - mention_count=0, video_count=0
         """
         vid = video_id(seed="asr_ex_001")
         await _seed_channel(db_session)
@@ -969,7 +969,6 @@ class TestASRErrorAliasCounterExclusion:
             text="Elan Musk announced a new rocket",
         )
         entity = await _seed_entity(db_session, "Elon Musk", entity_type="person")
-        # Register the ASR-error alias so the scanner can match it
         await _seed_alias(db_session, entity.id, "Elan Musk", alias_type="asr_error")
 
         await db_session.commit()
@@ -980,17 +979,17 @@ class TestASRErrorAliasCounterExclusion:
 
         await db_session.refresh(entity)
 
-        # The scan creates a mention row (scan still detects)
+        # ASR-error aliases are excluded from scan patterns, so no mentions
         mention_rows = (
             await db_session.execute(
                 select(EntityMentionDB).where(EntityMentionDB.entity_id == entity.id)
             )
         ).scalars().all()
-        assert len(mention_rows) >= 1, (
-            "Expected at least one EntityMention row for the ASR-alias match"
+        assert len(mention_rows) == 0, (
+            f"Expected 0 EntityMention rows (ASR alias excluded from scan), "
+            f"got {len(mention_rows)}"
         )
 
-        # But the counter must be 0 because all matches were via asr_error alias
         assert entity.mention_count == 0, (
             f"Expected mention_count=0 (ASR-error alias only), got {entity.mention_count}"
         )
@@ -1080,23 +1079,23 @@ class TestASRErrorAliasCounterExclusion:
             f"Expected video_count=1, got {entity.video_count}"
         )
 
-    async def test_mixed_mentions_count_excludes_asr_error_matches(
+    async def test_mixed_segments_only_canonical_matches_create_mentions(
         self, db_session: AsyncSession
     ) -> None:
         """
-        When an entity has both canonical-name matches and ASR-error-alias
-        matches, only canonical-name matches must be counted.
+        When an entity has both canonical-name text and ASR-error-alias text
+        in segments, only canonical-name matches create EntityMention rows.
 
         Setup:
         - Entity "Google" with ASR-error alias "Googel"
         - Three segments:
-            seg1: "Google announced new products"  (canonical → counted)
-            seg2: "Googel launched a service"      (asr_error → excluded)
-            seg3: "Google is a search engine"      (canonical → counted)
+            seg1: "Google announced new products"  (canonical → mention)
+            seg2: "Googel launched a service"      (asr_error → skipped)
+            seg3: "Google is a search engine"      (canonical → mention)
 
         Expected:
-        - EntityMention rows: 3 (scanner detects all)
-        - mention_count: 2 (only the 2 canonical-name segments counted)
+        - EntityMention rows: 2 (only canonical matches)
+        - mention_count: 2
         - video_count: 1 (all in same video)
         """
         vid = video_id(seed="asr_ex_004")
@@ -1143,14 +1142,13 @@ class TestASRErrorAliasCounterExclusion:
             )
         ).scalars().all()
 
-        # All three matches were detected
-        assert len(mention_rows) == 3, (
-            f"Expected 3 EntityMention rows (canonical + asr_error), got {len(mention_rows)}"
+        # Only canonical-name matches create mentions (ASR alias excluded)
+        assert len(mention_rows) == 2, (
+            f"Expected 2 EntityMention rows (canonical only), got {len(mention_rows)}"
         )
 
-        # Only the 2 canonical-name matches count
         assert entity.mention_count == 2, (
-            f"Expected mention_count=2 (excluding asr_error alias), got {entity.mention_count}"
+            f"Expected mention_count=2, got {entity.mention_count}"
         )
         assert entity.video_count == 1, (
             f"Expected video_count=1 (single video), got {entity.video_count}"
@@ -1209,15 +1207,16 @@ class TestASRErrorAliasCounterExclusion:
             f"Expected video_count=1 (Video 2 excluded due to asr_error), got {entity.video_count}"
         )
 
-    async def test_full_rescan_preserves_asr_exclusion_in_counters(
+    async def test_full_rescan_resets_counters_for_asr_only_entities(
         self, db_session: AsyncSession
     ) -> None:
         """
-        A full rescan (full_rescan=True) must also apply ASR-error alias
-        exclusion when recalculating counters.
+        A full rescan (full_rescan=True) must reset counters to 0 for
+        entities whose only aliases are ASR-error type (i.e. no mentions
+        will be created because ASR aliases are excluded from patterns).
 
-        After a first scan followed by a full rescan, an entity with only
-        ASR-error-alias mentions must still end up with mention_count=0.
+        After manually bumping counters to simulate drift, a full rescan
+        must recalculate and restore the correct 0.
         """
         vid = video_id(seed="asr_ex_005")
         await _seed_channel(db_session)
@@ -1237,7 +1236,7 @@ class TestASRErrorAliasCounterExclusion:
         factory = _make_session_factory_from_session(db_session)
         service = EntityMentionScanService(session_factory=factory)
 
-        # First scan
+        # First scan — no mentions created (ASR alias excluded from patterns)
         await service.scan()
         await db_session.refresh(entity)
         assert entity.mention_count == 0, (

--- a/tests/unit/api/test_cross_segment_endpoint.py
+++ b/tests/unit/api/test_cross_segment_endpoint.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for GET /api/v1/corrections/batch/cross-segment/candidates endpoint.
+
+Tests the cross-segment candidates endpoint in:
+  src/chronovista/api/routers/batch_corrections.py
+
+Mounted at: /api/v1/corrections/batch
+
+Scenarios covered:
+- 200 with candidates mapped to response schema
+- 200 with empty results
+- Query parameter forwarding (min_corrections, entity_name)
+- Query parameter validation (min_corrections bounds)
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.main import app
+from chronovista.services.cross_segment_discovery import CrossSegmentCandidate
+
+# CRITICAL: This line ensures async tests work with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _make_candidate(
+    *,
+    segment_n_id: int = 100,
+    segment_n_text: str = "end of seg",
+    segment_n1_id: int = 101,
+    segment_n1_text: str = "ment text",
+    proposed_correction: str = "segment",
+    source_pattern: str = "seg ment",
+    confidence: float = 0.85,
+    is_partially_corrected: bool = False,
+    video_id: str = "abc123",
+) -> CrossSegmentCandidate:
+    """Build a CrossSegmentCandidate with optional overrides."""
+    return CrossSegmentCandidate(
+        segment_n_id=segment_n_id,
+        segment_n_text=segment_n_text,
+        segment_n1_id=segment_n1_id,
+        segment_n1_text=segment_n1_text,
+        proposed_correction=proposed_correction,
+        source_pattern=source_pattern,
+        confidence=confidence,
+        is_partially_corrected=is_partially_corrected,
+        video_id=video_id,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    """Provide a clean AsyncSession mock for each test."""
+    return AsyncMock(spec=AsyncSession)
+
+
+@pytest.fixture
+async def client(mock_session: AsyncMock) -> AsyncGenerator[AsyncClient, None]:
+    """FastAPI test client with DB and auth overridden."""
+
+    async def _get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    async def _require_auth() -> None:
+        return None
+
+    app.dependency_overrides[get_db] = _get_db
+    app.dependency_overrides[require_auth] = _require_auth
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /api/v1/corrections/batch/cross-segment/candidates
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGetCrossSegmentCandidates:
+    """Tests for GET /api/v1/corrections/batch/cross-segment/candidates."""
+
+    BASE_URL = "/api/v1/corrections/batch/cross-segment/candidates"
+
+    @patch(
+        "chronovista.api.routers.batch_corrections.CrossSegmentDiscovery",
+    )
+    async def test_returns_200_with_candidates(
+        self,
+        mock_discovery_cls: MagicMock,
+        client: AsyncClient,
+    ) -> None:
+        """Endpoint returns 200 with candidates mapped to response schema."""
+        candidate = _make_candidate()
+        mock_instance = MagicMock()
+        mock_instance.discover = AsyncMock(return_value=[candidate])
+        mock_discovery_cls.return_value = mock_instance
+
+        response = await client.get(self.BASE_URL)
+
+        assert response.status_code == 200
+        body = response.json()
+        data = body["data"]
+        assert len(data) == 1
+        assert data[0]["segment_n_id"] == 100
+        assert data[0]["segment_n_text"] == "end of seg"
+        assert data[0]["segment_n1_id"] == 101
+        assert data[0]["segment_n1_text"] == "ment text"
+        assert data[0]["proposed_correction"] == "segment"
+        assert data[0]["source_pattern"] == "seg ment"
+        assert data[0]["confidence"] == 0.85
+        assert data[0]["is_partially_corrected"] is False
+        assert data[0]["video_id"] == "abc123"
+
+    @patch(
+        "chronovista.api.routers.batch_corrections.CrossSegmentDiscovery",
+    )
+    async def test_returns_200_empty_results(
+        self,
+        mock_discovery_cls: MagicMock,
+        client: AsyncClient,
+    ) -> None:
+        """Endpoint returns 200 with empty list when no candidates found."""
+        mock_instance = MagicMock()
+        mock_instance.discover = AsyncMock(return_value=[])
+        mock_discovery_cls.return_value = mock_instance
+
+        response = await client.get(self.BASE_URL)
+
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    @patch(
+        "chronovista.api.routers.batch_corrections.CrossSegmentDiscovery",
+    )
+    async def test_passes_query_params(
+        self,
+        mock_discovery_cls: MagicMock,
+        client: AsyncClient,
+    ) -> None:
+        """Query params are forwarded to CrossSegmentDiscovery.discover."""
+        mock_instance = MagicMock()
+        mock_instance.discover = AsyncMock(return_value=[])
+        mock_discovery_cls.return_value = mock_instance
+
+        await client.get(
+            self.BASE_URL,
+            params={"min_corrections": 5, "entity_name": "Sheinbaum"},
+        )
+
+        mock_instance.discover.assert_awaited_once()
+        call_kwargs = mock_instance.discover.call_args.kwargs
+        assert call_kwargs["min_corrections"] == 5
+        assert call_kwargs["entity_name"] == "Sheinbaum"
+
+    async def test_min_corrections_below_minimum(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """min_corrections=0 returns 422."""
+        response = await client.get(
+            self.BASE_URL, params={"min_corrections": 0}
+        )
+        assert response.status_code == 422
+
+    async def test_min_corrections_above_maximum(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """min_corrections=21 returns 422."""
+        response = await client.get(
+            self.BASE_URL, params={"min_corrections": 21}
+        )
+        assert response.status_code == 422
+
+    @patch(
+        "chronovista.api.routers.batch_corrections.CrossSegmentDiscovery",
+    )
+    async def test_multiple_candidates(
+        self,
+        mock_discovery_cls: MagicMock,
+        client: AsyncClient,
+    ) -> None:
+        """Endpoint correctly maps multiple candidates."""
+        candidates = [
+            _make_candidate(segment_n_id=1, video_id="vid1"),
+            _make_candidate(segment_n_id=2, video_id="vid2"),
+        ]
+        mock_instance = MagicMock()
+        mock_instance.discover = AsyncMock(return_value=candidates)
+        mock_discovery_cls.return_value = mock_instance
+
+        response = await client.get(self.BASE_URL)
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert len(data) == 2
+        assert data[0]["video_id"] == "vid1"
+        assert data[1]["video_id"] == "vid2"

--- a/tests/unit/api/test_diff_analysis_endpoint.py
+++ b/tests/unit/api/test_diff_analysis_endpoint.py
@@ -1,0 +1,406 @@
+"""
+Unit tests for GET /api/v1/corrections/batch/diff-analysis endpoint.
+
+Tests the diff analysis endpoint in:
+  src/chronovista/api/routers/batch_corrections.py
+
+Mounted at: /api/v1/corrections/batch
+
+Scenarios covered:
+- 200 with patterns and entity enrichment
+- 200 with entity_name filter applied
+- 200 with empty results
+- Entity enrichment via alias fallback
+- Query parameter validation
+- Token-level remaining_matches computation
+- show_completed filtering at the token level
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.main import app
+from chronovista.models.batch_correction_models import CorrectionPattern
+
+# CRITICAL: This line ensures async tests work with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _make_pattern(
+    *,
+    original_text: str = "shanebam",
+    corrected_text: str = "Sheinbaum",
+    occurrences: int = 5,
+    remaining_matches: int = 3,
+) -> CorrectionPattern:
+    """Build a CorrectionPattern with optional overrides."""
+    return CorrectionPattern(
+        original_text=original_text,
+        corrected_text=corrected_text,
+        occurrences=occurrences,
+        remaining_matches=remaining_matches,
+    )
+
+
+def _mock_session_with_remaining(remaining: int = 3) -> AsyncMock:
+    """Create a mock session that returns a remaining_matches scalar."""
+    mock = AsyncMock(spec=AsyncSession)
+    # session.execute() returns a result with scalar_one()
+    mock_result = MagicMock()
+    mock_result.scalar_one.return_value = remaining
+    mock.execute = AsyncMock(return_value=mock_result)
+    return mock
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    """Provide a clean AsyncSession mock with remaining_matches support."""
+    return _mock_session_with_remaining(remaining=3)
+
+
+@pytest.fixture
+async def client(mock_session: AsyncMock) -> AsyncGenerator[AsyncClient, None]:
+    """FastAPI test client with DB and auth overridden."""
+
+    async def _get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    async def _require_auth() -> None:
+        return None
+
+    app.dependency_overrides[get_db] = _get_db
+    app.dependency_overrides[require_auth] = _require_auth
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _make_client_with_remaining(remaining: int) -> AsyncGenerator[AsyncClient, None]:
+    """Create a client fixture with a specific remaining_matches value."""
+    mock = _mock_session_with_remaining(remaining=remaining)
+
+    async def _gen() -> AsyncGenerator[AsyncClient, None]:
+        async def _get_db() -> AsyncGenerator[AsyncSession, None]:
+            yield mock
+
+        async def _require_auth() -> None:
+            return None
+
+        app.dependency_overrides[get_db] = _get_db
+        app.dependency_overrides[require_auth] = _require_auth
+
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as ac:
+                yield ac
+        finally:
+            app.dependency_overrides.clear()
+
+    return _gen()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /api/v1/corrections/batch/diff-analysis
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGetDiffAnalysis:
+    """Tests for GET /api/v1/corrections/batch/diff-analysis."""
+
+    BASE_URL = "/api/v1/corrections/batch/diff-analysis"
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_returns_200_with_patterns(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+        client: AsyncClient,
+    ) -> None:
+        """Endpoint returns 200 with patterns mapped to response schema."""
+        pattern = _make_pattern()
+        entity_id = uuid.uuid4()
+        mock_service.get_patterns = AsyncMock(return_value=[pattern])
+        mock_find_entity.return_value = (entity_id, "Sheinbaum")
+
+        response = await client.get(self.BASE_URL)
+
+        assert response.status_code == 200
+        body = response.json()
+        data = body["data"]
+        assert len(data) == 1
+        assert data[0]["error_token"] == "shanebam"
+        assert data[0]["canonical_form"] == "Sheinbaum"
+        assert data[0]["frequency"] == 5
+        # remaining_matches is now computed at the token level (mock returns 3)
+        assert data[0]["remaining_matches"] == 3
+        assert data[0]["entity_id"] == str(entity_id)
+        assert data[0]["entity_name"] == "Sheinbaum"
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_returns_200_empty_results(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+        client: AsyncClient,
+    ) -> None:
+        """Endpoint returns 200 with an empty list when no patterns found."""
+        mock_service.get_patterns = AsyncMock(return_value=[])
+
+        response = await client.get(self.BASE_URL)
+
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_entity_name_filter_includes_matching(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+        client: AsyncClient,
+    ) -> None:
+        """Endpoint filters results when entity_name parameter is provided."""
+        entity_id = uuid.uuid4()
+        pattern = _make_pattern(corrected_text="Sheinbaum")
+        mock_service.get_patterns = AsyncMock(return_value=[pattern])
+        mock_find_entity.return_value = (entity_id, "Sheinbaum")
+
+        response = await client.get(
+            self.BASE_URL, params={"entity_name": "Shein"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert len(data) == 1
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_entity_name_filter_excludes_non_matching(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+        client: AsyncClient,
+    ) -> None:
+        """Patterns not matching entity_name filter are excluded."""
+        pattern = _make_pattern(corrected_text="Sheinbaum")
+        mock_service.get_patterns = AsyncMock(return_value=[pattern])
+        mock_find_entity.return_value = (uuid.uuid4(), "Sheinbaum")
+
+        response = await client.get(
+            self.BASE_URL, params={"entity_name": "Trump"}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_entity_name_filter_excludes_no_entity(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+        client: AsyncClient,
+    ) -> None:
+        """Patterns with no entity match are excluded when entity_name filter is set."""
+        pattern = _make_pattern(corrected_text="the")
+        mock_service.get_patterns = AsyncMock(return_value=[pattern])
+        mock_find_entity.return_value = (None, None)
+
+        response = await client.get(
+            self.BASE_URL, params={"entity_name": "Shein"}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_no_entity_association(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+        client: AsyncClient,
+    ) -> None:
+        """Patterns without entity matches return null entity fields."""
+        pattern = _make_pattern(corrected_text="the")
+        mock_service.get_patterns = AsyncMock(return_value=[pattern])
+        mock_find_entity.return_value = (None, None)
+
+        response = await client.get(self.BASE_URL)
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert len(data) == 1
+        assert data[0]["entity_id"] is None
+        assert data[0]["entity_name"] is None
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_passes_show_completed_true_to_service(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+        client: AsyncClient,
+    ) -> None:
+        """Service always receives show_completed=True (filtering happens at token level)."""
+        mock_service.get_patterns = AsyncMock(return_value=[])
+
+        await client.get(
+            self.BASE_URL,
+            params={
+                "min_occurrences": 5,
+                "limit": 50,
+                "show_completed": False,
+            },
+        )
+
+        mock_service.get_patterns.assert_awaited_once()
+        call_kwargs = mock_service.get_patterns.call_args.kwargs
+        assert call_kwargs["min_occurrences"] == 5
+        assert call_kwargs["limit"] == 50
+        # Always True — token-level filtering happens after word_level_diff
+        assert call_kwargs["show_completed"] is True
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_show_completed_false_hides_zero_remaining(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+    ) -> None:
+        """When show_completed=false, patterns with 0 remaining are excluded."""
+        pattern = _make_pattern()
+        mock_service.get_patterns = AsyncMock(return_value=[pattern])
+        mock_find_entity.return_value = (None, None)
+
+        # Create client with remaining=0
+        async for ac in _make_client_with_remaining(0):
+            response = await ac.get(
+                self.BASE_URL, params={"show_completed": "false"}
+            )
+
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_show_completed_true_includes_zero_remaining(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+    ) -> None:
+        """When show_completed=true, patterns with 0 remaining are included."""
+        pattern = _make_pattern()
+        mock_service.get_patterns = AsyncMock(return_value=[pattern])
+        mock_find_entity.return_value = (None, None)
+
+        # Create client with remaining=0
+        async for ac in _make_client_with_remaining(0):
+            response = await ac.get(
+                self.BASE_URL, params={"show_completed": "true"}
+            )
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert len(data) == 1
+        assert data[0]["remaining_matches"] == 0
+
+    async def test_min_occurrences_validation(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """min_occurrences=0 returns 422."""
+        response = await client.get(
+            self.BASE_URL, params={"min_occurrences": 0}
+        )
+        assert response.status_code == 422
+
+    async def test_limit_validation(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """limit=501 returns 422."""
+        response = await client.get(
+            self.BASE_URL, params={"limit": 501}
+        )
+        assert response.status_code == 422

--- a/tests/unit/api/test_phonetic_matches_endpoint.py
+++ b/tests/unit/api/test_phonetic_matches_endpoint.py
@@ -1,0 +1,265 @@
+"""
+Unit tests for GET /api/v1/entities/{entity_id}/phonetic-matches endpoint.
+
+Tests the phonetic matches endpoint in:
+  src/chronovista/api/routers/entity_mentions.py
+
+Mounted at: /api/v1
+
+Scenarios covered:
+- 200 with phonetic matches and video title enrichment
+- 200 with empty results
+- 404 when entity does not exist
+- 422 for invalid threshold values
+- Video title enrichment with missing video entries
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.main import app
+from chronovista.services.phonetic_matcher import PhoneticMatch
+
+# CRITICAL: This line ensures async tests work with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _make_match(
+    *,
+    original_text: str = "shein bomb",
+    proposed_correction: str = "Sheinbaum",
+    confidence: float = 0.78,
+    evidence_description: str = "Phonetic similarity: 0.78",
+    video_id: str = "abc123",
+    segment_id: int = 42,
+) -> PhoneticMatch:
+    """Build a PhoneticMatch with optional overrides."""
+    return PhoneticMatch(
+        original_text=original_text,
+        proposed_correction=proposed_correction,
+        confidence=confidence,
+        evidence_description=evidence_description,
+        video_id=video_id,
+        segment_id=segment_id,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+_ENTITY_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    """Provide a clean AsyncSession mock for each test."""
+    return AsyncMock(spec=AsyncSession)
+
+
+@pytest.fixture
+async def client(mock_session: AsyncMock) -> AsyncGenerator[AsyncClient, None]:
+    """FastAPI test client with DB and auth overridden."""
+
+    async def _get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    async def _require_auth() -> None:
+        return None
+
+    app.dependency_overrides[get_db] = _get_db
+    app.dependency_overrides[require_auth] = _require_auth
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /api/v1/entities/{entity_id}/phonetic-matches
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGetPhoneticMatches:
+    """Tests for GET /api/v1/entities/{entity_id}/phonetic-matches."""
+
+    def _url(self, entity_id: uuid.UUID | None = None) -> str:
+        eid = entity_id or _ENTITY_ID
+        return f"/api/v1/entities/{eid}/phonetic-matches"
+
+    @patch(
+        "chronovista.api.routers.entity_mentions.PhoneticMatcher",
+    )
+    async def test_returns_200_with_matches(
+        self,
+        mock_matcher_cls: MagicMock,
+        client: AsyncClient,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Endpoint returns 200 with phonetic matches and video titles."""
+        # Mock entity existence
+        entity_mock = MagicMock()
+        entity_mock.id = _ENTITY_ID
+        mock_session.get = AsyncMock(return_value=entity_mock)
+
+        # Mock phonetic matcher
+        match = _make_match(video_id="vid1")
+        mock_instance = MagicMock()
+        mock_instance.match_entity = AsyncMock(return_value=[match])
+        mock_matcher_cls.return_value = mock_instance
+
+        # Mock video title query
+        video_row = MagicMock()
+        video_row.video_id = "vid1"
+        video_row.title = "Test Video Title"
+        execute_result = MagicMock()
+        execute_result.all.return_value = [video_row]
+        mock_session.execute = AsyncMock(return_value=execute_result)
+
+        response = await client.get(self._url())
+
+        assert response.status_code == 200
+        body = response.json()
+        data = body["data"]
+        assert len(data) == 1
+        assert data[0]["original_text"] == "shein bomb"
+        assert data[0]["proposed_correction"] == "Sheinbaum"
+        assert data[0]["confidence"] == 0.78
+        assert data[0]["evidence_description"] == "Phonetic similarity: 0.78"
+        assert data[0]["video_id"] == "vid1"
+        assert data[0]["segment_id"] == 42
+        assert data[0]["video_title"] == "Test Video Title"
+
+    @patch(
+        "chronovista.api.routers.entity_mentions.PhoneticMatcher",
+    )
+    async def test_returns_200_empty_matches(
+        self,
+        mock_matcher_cls: MagicMock,
+        client: AsyncClient,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Endpoint returns 200 with empty list when no matches found."""
+        entity_mock = MagicMock()
+        entity_mock.id = _ENTITY_ID
+        mock_session.get = AsyncMock(return_value=entity_mock)
+
+        mock_instance = MagicMock()
+        mock_instance.match_entity = AsyncMock(return_value=[])
+        mock_matcher_cls.return_value = mock_instance
+
+        response = await client.get(self._url())
+
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    async def test_returns_404_entity_not_found(
+        self,
+        client: AsyncClient,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Endpoint returns 404 when entity does not exist."""
+        mock_session.get = AsyncMock(return_value=None)
+
+        response = await client.get(self._url())
+
+        assert response.status_code == 404
+
+    async def test_threshold_below_minimum(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """threshold=-0.1 returns 422."""
+        response = await client.get(
+            self._url(), params={"threshold": -0.1}
+        )
+        assert response.status_code == 422
+
+    async def test_threshold_above_maximum(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """threshold=1.5 returns 422."""
+        response = await client.get(
+            self._url(), params={"threshold": 1.5}
+        )
+        assert response.status_code == 422
+
+    @patch(
+        "chronovista.api.routers.entity_mentions.PhoneticMatcher",
+    )
+    async def test_passes_threshold_to_matcher(
+        self,
+        mock_matcher_cls: MagicMock,
+        client: AsyncClient,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Custom threshold is forwarded to PhoneticMatcher.match_entity."""
+        entity_mock = MagicMock()
+        entity_mock.id = _ENTITY_ID
+        mock_session.get = AsyncMock(return_value=entity_mock)
+
+        mock_instance = MagicMock()
+        mock_instance.match_entity = AsyncMock(return_value=[])
+        mock_matcher_cls.return_value = mock_instance
+
+        await client.get(self._url(), params={"threshold": 0.8})
+
+        mock_instance.match_entity.assert_awaited_once()
+        call_kwargs = mock_instance.match_entity.call_args.kwargs
+        assert call_kwargs["threshold"] == 0.8
+
+    @patch(
+        "chronovista.api.routers.entity_mentions.PhoneticMatcher",
+    )
+    async def test_video_title_missing_for_some_videos(
+        self,
+        mock_matcher_cls: MagicMock,
+        client: AsyncClient,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Matches with no corresponding video entry get null video_title."""
+        entity_mock = MagicMock()
+        entity_mock.id = _ENTITY_ID
+        mock_session.get = AsyncMock(return_value=entity_mock)
+
+        matches = [
+            _make_match(video_id="vid1"),
+            _make_match(video_id="vid_unknown", segment_id=99),
+        ]
+        mock_instance = MagicMock()
+        mock_instance.match_entity = AsyncMock(return_value=matches)
+        mock_matcher_cls.return_value = mock_instance
+
+        # Only vid1 has a title
+        video_row = MagicMock()
+        video_row.video_id = "vid1"
+        video_row.title = "Known Video"
+        execute_result = MagicMock()
+        execute_result.all.return_value = [video_row]
+        mock_session.execute = AsyncMock(return_value=execute_result)
+
+        response = await client.get(self._url())
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert len(data) == 2
+        assert data[0]["video_title"] == "Known Video"
+        assert data[1]["video_title"] is None

--- a/tests/unit/repositories/test_entity_mention_repository.py
+++ b/tests/unit/repositories/test_entity_mention_repository.py
@@ -1596,6 +1596,205 @@ class TestGetEntityVideoList:
         assert total == 2
         assert len(results) == 2
 
+    # ------------------------------------------------------------------
+    # Bug fix: get_entity_video_list must exclude ASR-error alias mentions
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compile_pg_sql(stmt: Any) -> str:
+        """Compile a SQLAlchemy statement to SQL string with the PostgreSQL dialect.
+
+        Uses ``literal_binds=True`` so that enum string values (like
+        ``'asr_error'``) appear literally in the output rather than as
+        ``__[POSTCOMPILE_...]`` placeholders.
+
+        Parameters
+        ----------
+        stmt : Any
+            A SQLAlchemy statement (UPDATE, SELECT, etc.).
+
+        Returns
+        -------
+        str
+            The fully rendered SQL string.
+        """
+        return str(
+            stmt.compile(
+                dialect=pg_dialect.dialect(),  # type: ignore[no-untyped-call]
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    async def test_count_query_references_asr_error_exclusion(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The count query SQL must exclude ASR-error alias mentions via visible_names join.
+
+        Bug fix: before the fix, get_entity_video_list counted ALL mentions for
+        an entity, including those matched only via asr_error aliases.  After the
+        fix, the count query joins a visible_names subquery that excludes
+        alias_type = 'asr_error', so ASR-error-alias-matched mentions do not
+        inflate the video count.
+
+        This test inspects the compiled SQL of the count query (first execute())
+        and confirms the 'asr_error' exclusion filter appears in it.
+        """
+        entity_id = _uuid()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        mock_session.execute.return_value = count_result
+
+        await repository.get_entity_video_list(mock_session, entity_id=entity_id)
+
+        # Only the count query should have been issued (total=0 short-circuits)
+        mock_session.execute.assert_called_once()
+        count_stmt = mock_session.execute.call_args_list[0].args[0]
+        sql_str = self._compile_pg_sql(count_stmt)
+
+        assert "asr_error" in sql_str, (
+            "Expected 'asr_error' exclusion in the count query SQL; "
+            f"got: {sql_str[:700]}"
+        )
+
+    async def test_count_query_visible_names_includes_entity_aliases_table(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The count query must JOIN entity_aliases to build the visible_names subquery.
+
+        The visible_names subquery unions canonical_name rows from named_entities
+        with non-asr_error alias rows from entity_aliases.  The count query SQL
+        must therefore reference the entity_aliases table.
+        """
+        entity_id = _uuid()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        mock_session.execute.return_value = count_result
+
+        await repository.get_entity_video_list(mock_session, entity_id=entity_id)
+
+        count_stmt = mock_session.execute.call_args_list[0].args[0]
+        sql_str = self._compile_pg_sql(count_stmt)
+
+        assert "entity_aliases" in sql_str, (
+            "Expected entity_aliases to appear in the visible_names join of the count query; "
+            f"got: {sql_str[:700]}"
+        )
+        assert "named_entities" in sql_str, (
+            "Expected named_entities to appear (canonical name source) in the count query; "
+            f"got: {sql_str[:700]}"
+        )
+
+    async def test_main_query_visible_names_excludes_asr_error_aliases(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The main group-by query must join visible_names with asr_error exclusion.
+
+        The main query computes mention_count per video_id; only mentions whose
+        mention_text matches a visible name (canonical or non-ASR-error alias)
+        should be counted.  The compiled SQL must contain 'asr_error' to confirm
+        the WHERE clause excludes ASR-alias-matched mentions.
+        """
+        entity_id = _uuid()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1  # non-zero so main query runs
+
+        video_row = self._make_video_row()
+        main_result = MagicMock()
+        main_result.all.return_value = [video_row]
+
+        preview_result = MagicMock()
+        preview_result.all.return_value = []
+
+        mock_session.execute.side_effect = [count_result, main_result, preview_result]
+
+        await repository.get_entity_video_list(mock_session, entity_id=entity_id)
+
+        # count=0, main=1, preview=2
+        assert mock_session.execute.call_count == 3
+        main_stmt = mock_session.execute.call_args_list[1].args[0]
+        sql_str = self._compile_pg_sql(main_stmt)
+
+        assert "asr_error" in sql_str, (
+            "Expected 'asr_error' exclusion in the main group-by query SQL; "
+            f"got: {sql_str[:700]}"
+        )
+
+    async def test_preview_query_visible_names_excludes_asr_error_aliases(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The preview query must also join visible_names and exclude asr_error aliases.
+
+        Preview mentions shown for each video must only include mentions
+        matched via canonical name or non-ASR-error aliases, not via ASR
+        noise forms.  The compiled preview SQL must contain 'asr_error'.
+        """
+        entity_id = _uuid()
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+
+        video_row = self._make_video_row()
+        main_result = MagicMock()
+        main_result.all.return_value = [video_row]
+
+        preview_row = self._make_preview_row(mention_text="Bonaparte")
+        preview_result = MagicMock()
+        preview_result.all.return_value = [preview_row]
+
+        mock_session.execute.side_effect = [count_result, main_result, preview_result]
+
+        await repository.get_entity_video_list(mock_session, entity_id=entity_id)
+
+        preview_stmt = mock_session.execute.call_args_list[2].args[0]
+        sql_str = self._compile_pg_sql(preview_stmt)
+
+        assert "asr_error" in sql_str, (
+            "Expected 'asr_error' exclusion in the preview query SQL; "
+            f"got: {sql_str[:700]}"
+        )
+
+    async def test_count_returns_zero_when_only_asr_alias_mentions_exist(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """When the DB count returns 0, the method returns ([], 0) without running main query.
+
+        This models the scenario after the bug fix: an entity whose only mentions
+        were matched via asr_error aliases will have those mentions excluded by
+        the visible_names join, so the count query returns 0.  The method must
+        short-circuit and return ([], 0) without issuing the main or preview
+        queries.
+        """
+        entity_id = _uuid()
+
+        # DB returns 0 — simulates all mentions being ASR-error-alias-sourced and
+        # thus filtered out by the visible_names join in the real query
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        mock_session.execute.return_value = count_result
+
+        results, total = await repository.get_entity_video_list(
+            mock_session, entity_id=entity_id
+        )
+
+        assert results == [], "No videos should be returned when count is zero"
+        assert total == 0
+        # Only one query should have been issued (the count); the main and preview
+        # queries must be skipped by the early-return guard
+        mock_session.execute.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # TestGetStatistics

--- a/tests/unit/services/test_asr_alias_registry.py
+++ b/tests/unit/services/test_asr_alias_registry.py
@@ -24,6 +24,7 @@ import pytest
 
 from chronovista.models.enums import EntityAliasType
 from chronovista.services.asr_alias_registry import (
+    is_valid_asr_alias,
     register_asr_alias,
     resolve_entity_id_from_text,
 )
@@ -709,3 +710,143 @@ class TestRegisterAsrAlias:
 
         MockRepo.assert_called_once()
         mock_repo_instance.create.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestIsValidAsrAlias
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidAsrAlias:
+    """Tests for ``is_valid_asr_alias`` quality gate.
+
+    Validates that common English phrases and very short strings are
+    rejected, while legitimate ASR error forms pass.
+    """
+
+    def test_rejects_all_stopword_alias(self) -> None:
+        """Alias consisting entirely of stopwords is rejected."""
+        assert is_valid_asr_alias("be out") is False
+
+    def test_rejects_single_stopword(self) -> None:
+        """Single common word is rejected."""
+        assert is_valid_asr_alias("have") is False
+
+    def test_rejects_multi_stopword_phrase(self) -> None:
+        """Multi-word all-stopword phrase is rejected."""
+        assert is_valid_asr_alias("it was on the") is False
+
+    def test_rejects_short_alias(self) -> None:
+        """Alias shorter than 4 characters is rejected."""
+        assert is_valid_asr_alias("abc") is False
+
+    def test_rejects_empty_string(self) -> None:
+        """Empty string is rejected."""
+        assert is_valid_asr_alias("") is False
+
+    def test_rejects_whitespace_only(self) -> None:
+        """Whitespace-only string is rejected."""
+        assert is_valid_asr_alias("   ") is False
+
+    def test_accepts_legitimate_asr_error(self) -> None:
+        """Legitimate ASR error alias is accepted."""
+        assert is_valid_asr_alias("Shainbom") is True
+
+    def test_accepts_multi_word_asr_error(self) -> None:
+        """Multi-word alias with at least one non-stopword is accepted."""
+        assert is_valid_asr_alias("Claudia Shainbom") is True
+
+    def test_accepts_mixed_stopword_and_name(self) -> None:
+        """Alias with both stopwords and non-stopwords is accepted."""
+        assert is_valid_asr_alias("Rick be out") is True
+
+    def test_accepts_four_char_alias(self) -> None:
+        """Alias of exactly 4 characters passes length check."""
+        assert is_valid_asr_alias("Seon") is True
+
+    def test_stopword_check_is_case_insensitive(self) -> None:
+        """Stopword check works regardless of case."""
+        assert is_valid_asr_alias("Be Out") is False
+        assert is_valid_asr_alias("BE OUT") is False
+
+
+# ---------------------------------------------------------------------------
+# TestRegisterAsrAliasQualityGate
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAsrAliasQualityGate:
+    """Tests that ``register_asr_alias`` rejects aliases failing quality gate.
+
+    The quality gate runs before any DB lookups, so the session should
+    never be touched for rejected aliases.
+    """
+
+    async def test_rejects_stopword_alias_no_db_interaction(self) -> None:
+        """Stopword-only alias is rejected before any DB call."""
+        session = AsyncMock()
+
+        await register_asr_alias(
+            session,
+            original_text="be out",
+            corrected_text="Rick Beato",
+        )
+
+        session.execute.assert_not_called()
+
+    async def test_rejects_short_alias_no_db_interaction(self) -> None:
+        """Alias under 4 characters is rejected before any DB call."""
+        session = AsyncMock()
+
+        await register_asr_alias(
+            session,
+            original_text="ab",
+            corrected_text="Claudia Sheinbaum",
+        )
+
+        session.execute.assert_not_called()
+
+    async def test_accepts_legitimate_alias_proceeds_to_db(self) -> None:
+        """Legitimate alias passes the gate and queries the DB."""
+        entity_mock = MagicMock()
+        entity_mock.id = uuid.uuid4()
+        entity_mock.canonical_name = "Claudia Sheinbaum"
+
+        session = _mock_execute_returns(entity_mock, None)
+
+        with patch(
+            "chronovista.services.asr_alias_registry.EntityAliasRepository"
+        ) as MockRepo, patch(
+            "chronovista.services.asr_alias_registry.TagNormalizationService"
+        ) as MockNorm:
+            mock_repo_instance = AsyncMock()
+            MockRepo.return_value = mock_repo_instance
+            MockNorm.return_value.normalize.return_value = "claudia shainbom"
+
+            await register_asr_alias(
+                session,
+                original_text="Claudia Shainbom",
+                corrected_text="Claudia Sheinbaum",
+            )
+
+        mock_repo_instance.create.assert_called_once()
+
+    async def test_rejection_is_logged(self, caplog: Any) -> None:
+        """Rejected alias is logged at DEBUG level."""
+        import logging
+
+        session = AsyncMock()
+
+        with caplog.at_level(
+            logging.DEBUG, logger="chronovista.services.asr_alias_registry"
+        ):
+            await register_asr_alias(
+                session,
+                original_text="be out",
+                corrected_text="Rick Beato",
+            )
+
+        assert any(
+            "rejected alias" in record.message and "quality gate" in record.message
+            for record in caplog.records
+        )

--- a/tests/unit/services/test_cross_segment_discovery.py
+++ b/tests/unit/services/test_cross_segment_discovery.py
@@ -37,6 +37,8 @@ from chronovista.services.cross_segment_discovery import (
     CrossSegmentDiscovery,
     _effective_text,
     _generate_splits,
+    _generate_word_splits,
+    _is_stopword_split,
 )
 
 # ---------------------------------------------------------------------------
@@ -342,12 +344,14 @@ class TestCrossSegmentDiscoveryDiscover:
 
     # (b) No patterns from service → returns empty list
     async def test_no_patterns_returns_empty_list(self) -> None:
-        """discover() returns [] when get_patterns returns no patterns."""
+        """discover() returns [] when get_patterns returns no patterns and no entity aliases."""
         batch_svc = _make_batch_service(patterns=[])
         discovery = CrossSegmentDiscovery(batch_service=batch_svc)
         session = _make_mock_session()
 
-        # No DB query should be needed because patterns list is empty
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
         result = await discovery.discover(session, min_corrections=3)
 
         assert result == []
@@ -365,6 +369,9 @@ class TestCrossSegmentDiscoveryDiscover:
         discovery = CrossSegmentDiscovery(batch_service=batch_svc)
         session = _make_mock_session()
 
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
         await discovery.discover(session, min_corrections=7)
 
         call_kwargs = batch_svc.get_patterns.call_args
@@ -373,13 +380,16 @@ class TestCrossSegmentDiscoveryDiscover:
     # (h) No patterns meeting threshold → empty list (already covered above,
     #     additional explicit check with entity filter returning nothing)
     async def test_entity_filter_with_no_match_returns_empty(self) -> None:
-        """When entity filter matches no patterns, discover() returns []."""
+        """When entity filter matches no patterns and no aliases, discover() returns []."""
         pattern = _make_pattern("Chomski is", "Chomsky is", occurrences=5)
         batch_svc = _make_batch_service(patterns=[pattern])
         discovery = CrossSegmentDiscovery(batch_service=batch_svc)
         session = _make_mock_session()
 
-        # Corrected segment IDs query returns nothing
+        # Entity discovery finds nothing for the filter
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        # Pattern-based: corrected segment IDs query returns nothing
         exec_result = MagicMock()
         exec_result.scalars.return_value.all.return_value = []
         session.execute.return_value = exec_result
@@ -392,9 +402,9 @@ class TestCrossSegmentDiscoveryDiscover:
 
         assert result == []
 
-    # (c) Entity filter case-insensitive match
+    # (c) Entity filter case-insensitive match (pattern path)
     async def test_entity_filter_is_case_insensitive(self) -> None:
-        """Entity filter matches patterns case-insensitively."""
+        """Entity filter matches patterns case-insensitively in the pattern path."""
         pattern_matching = _make_pattern("Chomski is", "Chomsky is", occurrences=5)
         pattern_not_matching = _make_pattern("wrong text", "correct text", occurrences=5)
         batch_svc = _make_batch_service(
@@ -403,6 +413,9 @@ class TestCrossSegmentDiscoveryDiscover:
         discovery = CrossSegmentDiscovery(batch_service=batch_svc)
         session = _make_mock_session()
 
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
         # DB execute returns no adjacent pairs to keep test focused on filter
         exec_result = MagicMock()
         exec_result.scalars.return_value.all.return_value = []
@@ -410,26 +423,29 @@ class TestCrossSegmentDiscoveryDiscover:
         session.execute.return_value = exec_result
 
         # We verify entity_name="chomski" (lower-case) still matches "Chomski is"
-        # by checking _process_pattern is called with the filtered pattern.
-        # We spy by mocking _process_pattern directly.
-        processed_patterns: list[CorrectionPattern] = []
+        # by spying on _find_adjacent_pairs_batched and checking which splits
+        # are passed (only splits from the matching pattern should appear).
+        recorded_pairs: list[tuple[str, str]] = []
 
-        original_process = discovery._process_pattern
-
-        async def _spy(
+        async def _spy_batched(
             s: Any,
-            p: CorrectionPattern,
-            corrected_ids: set[int],
-        ) -> list[CrossSegmentCandidate]:
-            processed_patterns.append(p)
+            pairs: list[tuple[str, str]],
+            limit: int = 500,
+        ) -> list[tuple[Any, Any]]:
+            recorded_pairs.extend(pairs)
             return []
 
-        discovery._process_pattern = _spy  # type: ignore[assignment]
+        async def _fake_corrected_ids(s: Any) -> set[int]:
+            return set()
+
+        discovery._find_adjacent_pairs_batched = _spy_batched  # type: ignore[assignment]
+        discovery._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
 
         await discovery.discover(session, min_corrections=3, entity_name="chomski")
 
-        assert len(processed_patterns) == 1
-        assert processed_patterns[0].original_text == "Chomski is"
+        # Only splits from "Chomski is" should be present (word-boundary: "Chomski"/"is")
+        assert len(recorded_pairs) >= 1
+        assert any("Chomski" in p for p, _ in recorded_pairs)
 
     # (a) Discovers cross-segment split — full pipeline with mocked _find_adjacent_pairs
     async def test_discovers_candidate_from_recurring_pattern(self) -> None:
@@ -454,23 +470,19 @@ class TestCrossSegmentDiscoveryDiscover:
             text="is wrong about that",
         )
 
-        # Corrected segment IDs query returns empty set
-        exec_result = MagicMock()
-        exec_result.scalars.return_value.all.return_value = []
-        session.execute.return_value = exec_result
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
         # Patch _find_adjacent_pairs and _get_corrected_segment_ids
-        async def _fake_find_pairs(
-            s: Any, prefix: str, suffix: str
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
         ) -> list[tuple[Any, Any]]:
-            if "Chomski" in prefix or "is" in suffix:
-                return [(seg_n, seg_n1)]
-            return []
+            return [(seg_n, seg_n1)]
 
         async def _fake_corrected_ids(s: Any) -> set[int]:
             return set()
 
-        discovery._find_adjacent_pairs = _fake_find_pairs  # type: ignore[assignment]
+        discovery._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
         discovery._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
 
         candidates = await discovery.discover(session, min_corrections=3)
@@ -512,16 +524,19 @@ class TestCrossSegmentDiscoveryDiscover:
             corrected_text="is great",
         )
 
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
         # Both segment IDs are in the corrected set
-        async def _fake_find_pairs(
-            s: Any, prefix: str, suffix: str
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
         ) -> list[tuple[Any, Any]]:
             return [(seg_n, seg_n1)]
 
         async def _fake_corrected_ids(s: Any) -> set[int]:
             return {20, 21}
 
-        discovery._find_adjacent_pairs = _fake_find_pairs  # type: ignore[assignment]
+        discovery._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
         discovery._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
 
         candidates = await discovery.discover(session, min_corrections=3)
@@ -541,9 +556,9 @@ class TestCrossSegmentDiscoveryDiscover:
             video_id="vid2",
             language_code="en",
             sequence_number=0,
-            text="He said Chomski",
+            text="he said Chomski",
             has_correction=True,
-            corrected_text="He said Chomsky",
+            corrected_text="He said Chomski",  # capitalisation fix; pattern still matches
         )
         seg_n1 = _make_segment_mock(
             seg_id=31,
@@ -554,16 +569,19 @@ class TestCrossSegmentDiscoveryDiscover:
             has_correction=False,
         )
 
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
         # Only seg_n (id=30) is in the corrected set
-        async def _fake_find_pairs(
-            s: Any, prefix: str, suffix: str
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
         ) -> list[tuple[Any, Any]]:
             return [(seg_n, seg_n1)]
 
         async def _fake_corrected_ids(s: Any) -> set[int]:
             return {30}
 
-        discovery._find_adjacent_pairs = _fake_find_pairs  # type: ignore[assignment]
+        discovery._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
         discovery._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
 
         candidates = await discovery.discover(session, min_corrections=3)
@@ -574,48 +592,43 @@ class TestCrossSegmentDiscoveryDiscover:
     # Results are sorted by confidence descending
     async def test_results_sorted_by_confidence_descending(self) -> None:
         """discover() returns candidates sorted by confidence, highest first."""
-        pattern_wb = _make_pattern("Chomski is", "Chomsky is", occurrences=20)
-        pattern_cl = _make_pattern("abc", "xyz", occurrences=1)
-        batch_svc = _make_batch_service(patterns=[pattern_wb, pattern_cl])
+        # Two word-boundary patterns with different occurrences → different scores
+        pattern_high = _make_pattern("Chomski is", "Chomsky is", occurrences=20)
+        pattern_low = _make_pattern("foo bar", "Foo Bar", occurrences=1)
+        batch_svc = _make_batch_service(patterns=[pattern_high, pattern_low])
         discovery = CrossSegmentDiscovery(batch_service=batch_svc)
         session = _make_mock_session()
 
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
         # Build two fake candidate pairs to ensure different confidence scores
-        seg_wb_n = _make_segment_mock(
+        seg_high_n = _make_segment_mock(
             seg_id=40, video_id="vid3", language_code="en",
             sequence_number=0, text="said Chomski"
         )
-        seg_wb_n1 = _make_segment_mock(
+        seg_high_n1 = _make_segment_mock(
             seg_id=41, video_id="vid3", language_code="en",
             sequence_number=1, text="is important"
         )
-        seg_cl_n = _make_segment_mock(
+        seg_low_n = _make_segment_mock(
             seg_id=50, video_id="vid4", language_code="en",
-            sequence_number=0, text="prefix ab"
+            sequence_number=0, text="prefix foo"
         )
-        seg_cl_n1 = _make_segment_mock(
+        seg_low_n1 = _make_segment_mock(
             seg_id=51, video_id="vid4", language_code="en",
-            sequence_number=1, text="c suffix"
+            sequence_number=1, text="bar suffix"
         )
 
-        call_count = 0
-
-        async def _fake_find_pairs(
-            s: Any, prefix: str, suffix: str
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
         ) -> list[tuple[Any, Any]]:
-            nonlocal call_count
-            call_count += 1
-            # Alternate between word-boundary and char-level patterns
-            if "Chomski" in prefix:
-                return [(seg_wb_n, seg_wb_n1)]
-            if "ab" in prefix:
-                return [(seg_cl_n, seg_cl_n1)]
-            return []
+            return [(seg_high_n, seg_high_n1), (seg_low_n, seg_low_n1)]
 
         async def _fake_corrected_ids(s: Any) -> set[int]:
             return set()
 
-        discovery._find_adjacent_pairs = _fake_find_pairs  # type: ignore[assignment]
+        discovery._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
         discovery._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
 
         candidates = await discovery.discover(session, min_corrections=3)
@@ -625,33 +638,36 @@ class TestCrossSegmentDiscoveryDiscover:
                 assert candidates[i].confidence >= candidates[i + 1].confidence
 
     # (g) Adjacency: only consecutive N, N+1 by sequence_number
-    # This is enforced in the SQL query; we verify via _find_adjacent_pairs signature
+    # This is enforced in the SQL query; we verify via _find_adjacent_pairs_batched args
     async def test_only_adjacent_pairs_considered(self) -> None:
-        """_find_adjacent_pairs is invoked with prefix/suffix derived from split."""
+        """_find_adjacent_pairs_batched receives prefix/suffix splits from patterns."""
         pattern = _make_pattern("hello world", "Hello World", occurrences=5)
         batch_svc = _make_batch_service(patterns=[pattern])
         discovery = CrossSegmentDiscovery(batch_service=batch_svc)
         session = _make_mock_session()
 
-        pairs_args: list[tuple[str, str]] = []
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
-        async def _recording_find_pairs(
-            s: Any, prefix: str, suffix: str
+        recorded_pairs: list[tuple[str, str]] = []
+
+        async def _recording_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
         ) -> list[tuple[Any, Any]]:
-            pairs_args.append((prefix, suffix))
+            recorded_pairs.extend(pairs)
             return []
 
         async def _fake_corrected_ids(s: Any) -> set[int]:
             return set()
 
-        discovery._find_adjacent_pairs = _recording_find_pairs  # type: ignore[assignment]
+        discovery._find_adjacent_pairs_batched = _recording_find_pairs_batched  # type: ignore[assignment]
         discovery._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
 
         await discovery.discover(session, min_corrections=3)
 
         # At minimum the word-boundary split ("hello", "world") must have been tried
-        assert len(pairs_args) > 0
-        prefixes = [p for p, _ in pairs_args]
+        assert len(recorded_pairs) > 0
+        prefixes = [p for p, _ in recorded_pairs]
         assert any("hello" in p.lower() for p in prefixes)
 
     # (f) Cross-language test: same video, different language_code = NOT paired
@@ -665,20 +681,13 @@ class TestCrossSegmentDiscoveryDiscover:
         discovery = CrossSegmentDiscovery(batch_service=batch_svc)
         session = _make_mock_session()
 
-        # Cross-language pair (same video, different language_code)
-        seg_en = _make_segment_mock(
-            seg_id=60, video_id="vid5", language_code="en",
-            sequence_number=0, text="Chomski"
-        )
-        seg_es = _make_segment_mock(
-            seg_id=61, video_id="vid5", language_code="es",
-            sequence_number=1, text="is"
-        )
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
         # Simulate: the SQL query correctly rejects cross-language pairs,
         # so _find_adjacent_pairs returns [] for them.
-        async def _no_cross_lang_pairs(
-            s: Any, prefix: str, suffix: str
+        async def _no_cross_lang_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
         ) -> list[tuple[Any, Any]]:
             # Simulate correct SQL behaviour: cross-language segments not returned
             return []
@@ -686,7 +695,7 @@ class TestCrossSegmentDiscoveryDiscover:
         async def _fake_corrected_ids(s: Any) -> set[int]:
             return set()
 
-        discovery._find_adjacent_pairs = _no_cross_lang_pairs  # type: ignore[assignment]
+        discovery._find_adjacent_pairs_batched = _no_cross_lang_pairs_batched  # type: ignore[assignment]
         discovery._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
 
         candidates = await discovery.discover(session, min_corrections=3)
@@ -711,17 +720,18 @@ class TestCrossSegmentDiscoveryDiscover:
             sequence_number=1, text="is the point"
         )
 
-        async def _fake_find_pairs(
-            s: Any, prefix: str, suffix: str
+        # Isolate pattern path: entity-based discovery returns nothing
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
         ) -> list[tuple[Any, Any]]:
-            if "Chomski" in prefix:
-                return [(seg_n, seg_n1)]
-            return []
+            return [(seg_n, seg_n1)]
 
         async def _fake_corrected_ids(s: Any) -> set[int]:
             return set()
 
-        discovery._find_adjacent_pairs = _fake_find_pairs  # type: ignore[assignment]
+        discovery._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
         discovery._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
 
         candidates = await discovery.discover(session, min_corrections=3)
@@ -794,3 +804,1048 @@ class TestCrossSegmentCandidateModel:
         del kwargs["is_partially_corrected"]
         candidate = CrossSegmentCandidate(**kwargs)
         assert candidate.is_partially_corrected is False
+
+
+# ---------------------------------------------------------------------------
+# New test classes for entity-aware cross-segment discovery
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _generate_word_splits (module-level helper)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateWordSplits:
+    """Tests for the ``_generate_word_splits`` helper function.
+
+    Unlike ``_generate_splits``, this function produces only word-boundary
+    splits (no character-level splits) and returns 2-tuples instead of
+    3-tuples.
+    """
+
+    def test_two_word_text_produces_one_split(self) -> None:
+        """A two-word alias produces exactly one (prefix, suffix) split."""
+        splits = _generate_word_splits("Claudia Shabom")
+        assert len(splits) == 1
+        assert splits[0] == ("Claudia", "Shabom")
+
+    def test_three_word_text_produces_two_splits(self) -> None:
+        """A three-word alias produces N-1=2 splits in left-to-right order."""
+        splits = _generate_word_splits("Claudia Shane Bound")
+        assert len(splits) == 2
+        assert splits[0] == ("Claudia", "Shane Bound")
+        assert splits[1] == ("Claudia Shane", "Bound")
+
+    def test_single_word_returns_empty_list(self) -> None:
+        """A single-word text (no whitespace) produces no splits."""
+        splits = _generate_word_splits("Chomski")
+        assert splits == []
+
+    def test_empty_string_returns_empty_list(self) -> None:
+        """An empty string produces no splits."""
+        splits = _generate_word_splits("")
+        assert splits == []
+
+    def test_preserves_original_casing(self) -> None:
+        """The prefix and suffix preserve the original case of the input."""
+        splits = _generate_word_splits("noam Chomsky")
+        assert len(splits) == 1
+        prefix, suffix = splits[0]
+        assert prefix == "noam"
+        assert suffix == "Chomsky"
+
+    def test_four_word_text_produces_three_splits(self) -> None:
+        """A four-word alias produces N-1=3 splits."""
+        splits = _generate_word_splits("a b c d")
+        assert len(splits) == 3
+
+    def test_all_splits_have_non_empty_parts(self) -> None:
+        """Every split must have a non-empty prefix and a non-empty suffix."""
+        for alias in ["hello world", "one two three"]:
+            for prefix, suffix in _generate_word_splits(alias):
+                assert prefix.strip() != ""
+                assert suffix.strip() != ""
+
+    def test_splits_are_two_tuples(self) -> None:
+        """Every element is a 2-tuple, not a 3-tuple like _generate_splits."""
+        splits = _generate_word_splits("Claudia Shabom")
+        for item in splits:
+            assert len(item) == 2
+
+    def test_multiple_spaces_between_words(self) -> None:
+        """Multiple spaces between words are treated as one boundary."""
+        # _WORD_BOUNDARY_RE uses r"\s+" so this is handled
+        splits = _generate_word_splits("hello  world")
+        # Should still produce one split with the raw joined strings
+        assert len(splits) == 1
+        prefix, suffix = splits[0]
+        assert prefix == "hello"
+        assert suffix == "world"
+
+    def test_prefix_suffix_reconstruct_words(self) -> None:
+        """Joining prefix + ' ' + suffix gives back the space-joined word form."""
+        text = "Anna Maria Contreras"
+        splits = _generate_word_splits(text)
+        # The text joined by a single space
+        normalized = " ".join(text.split())
+        for prefix, suffix in splits:
+            assert f"{prefix} {suffix}" == normalized
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _is_stopword_split
+# ---------------------------------------------------------------------------
+
+
+class TestIsStopwordSplit:
+    """Tests for ``_is_stopword_split`` helper.
+
+    Stopword-only splits (e.g. "be" / "out") are filtered out because
+    they produce overwhelming false positives in cross-segment discovery.
+    """
+
+    def test_both_stopwords_returns_true(self) -> None:
+        assert _is_stopword_split("be", "out") is True
+
+    def test_multi_word_stopwords_returns_true(self) -> None:
+        assert _is_stopword_split("it was", "on the") is True
+
+    def test_one_side_non_stopword_returns_false(self) -> None:
+        assert _is_stopword_split("Chomsk", "i") is False
+
+    def test_proper_name_prefix_returns_false(self) -> None:
+        assert _is_stopword_split("Shein", "baum") is False
+
+    def test_mixed_stopword_and_name_returns_false(self) -> None:
+        assert _is_stopword_split("Rick be", "out") is False
+
+    def test_empty_prefix_returns_false(self) -> None:
+        assert _is_stopword_split("", "out") is False
+
+    def test_empty_suffix_returns_false(self) -> None:
+        assert _is_stopword_split("be", "") is False
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _score_entity_candidate
+# ---------------------------------------------------------------------------
+
+
+class TestScoreEntityCandidate:
+    """Tests for ``CrossSegmentDiscovery._score_entity_candidate``.
+
+    Scoring formula (capped at 1.0):
+      Base:                 0.50
+      Exact boundary:      +0.20 (both ends/starts match)
+      One-side boundary:   +0.10 (only one side matches)
+      Partial correction:  +0.10
+      Person entity type:  +0.10
+      2-word alias:        +0.10
+    """
+
+    @pytest.fixture
+    def service(self) -> CrossSegmentDiscovery:
+        """Provide a CrossSegmentDiscovery with a stub BatchCorrectionService."""
+        return CrossSegmentDiscovery(batch_service=AsyncMock())
+
+    def test_base_score_without_bonuses(self, service: CrossSegmentDiscovery) -> None:
+        """No matching boundary, no partial, non-person, 3-word alias → score == 0.50."""
+        score = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="something else entirely",
+            seg_n1_text="nothing here",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        assert score == pytest.approx(0.50, abs=1e-9)
+
+    def test_entity_base_score_higher_than_pattern_base(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """Entity base (0.50) exceeds pattern word-boundary base (0.40)."""
+        entity_score = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unmatched text",
+            seg_n1_text="unmatched text",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        pattern_score = service._score_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unmatched text",
+            seg_n1_text="unmatched text",
+            is_word_boundary=True,
+            pattern_occurrences=0,
+            is_partially_corrected=False,
+        )
+        assert entity_score > pattern_score
+
+    def test_exact_boundary_adds_0_20(self, service: CrossSegmentDiscovery) -> None:
+        """When seg_n ends with prefix AND seg_n1 starts with suffix, +0.20 is added."""
+        base_score = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        exact_score = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="He said Chomski",
+            seg_n1_text="is the truth",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        assert exact_score == pytest.approx(base_score + 0.20, abs=1e-9)
+
+    def test_one_side_boundary_adds_0_10(self, service: CrossSegmentDiscovery) -> None:
+        """When only one side matches, +0.10 is added (not +0.20)."""
+        base_score = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        one_side_score = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="He said Chomski",  # ends with prefix
+            seg_n1_text="no match here",   # does NOT start with suffix
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        assert one_side_score == pytest.approx(base_score + 0.10, abs=1e-9)
+
+    def test_partial_correction_adds_0_10(self, service: CrossSegmentDiscovery) -> None:
+        """is_partially_corrected=True adds exactly 0.10 to the score."""
+        without = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        with_partial = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=True,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        assert with_partial == pytest.approx(without + 0.10, abs=1e-9)
+
+    def test_person_entity_type_adds_0_10(self, service: CrossSegmentDiscovery) -> None:
+        """entity_type='person' adds exactly 0.10 over a non-person type."""
+        non_person = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        person = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="person",
+            alias_word_count=3,
+        )
+        assert person == pytest.approx(non_person + 0.10, abs=1e-9)
+
+    def test_two_word_alias_adds_0_10(self, service: CrossSegmentDiscovery) -> None:
+        """alias_word_count==2 adds exactly 0.10 over a 3-word alias."""
+        three_word = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        two_word = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=2,
+        )
+        assert two_word == pytest.approx(three_word + 0.10, abs=1e-9)
+
+    def test_three_word_alias_does_not_get_two_word_bonus(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """alias_word_count==3 does NOT receive the 2-word alias bonus."""
+        score = service._score_entity_candidate(
+            prefix="Chomski Shane",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        # Only base: 0.50
+        assert score == pytest.approx(0.50, abs=1e-9)
+
+    def test_score_capped_at_one(self, service: CrossSegmentDiscovery) -> None:
+        """All bonuses stacked together cannot push the score above 1.0."""
+        score = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="He said Chomski",  # exact ends-with
+            seg_n1_text="is the truth",    # exact starts-with
+            is_partially_corrected=True,
+            entity_type="person",
+            alias_word_count=2,
+        )
+        # 0.50 + 0.20 + 0.10 + 0.10 + 0.10 = 1.00 — exactly at cap
+        assert score == pytest.approx(1.0, abs=1e-9)
+        assert score <= 1.0
+
+    def test_score_never_negative(self, service: CrossSegmentDiscovery) -> None:
+        """The entity candidate score is always >= 0.0."""
+        score = service._score_entity_candidate(
+            prefix="x",
+            suffix="y",
+            seg_n_text="not matching",
+            seg_n1_text="not matching",
+            is_partially_corrected=False,
+            entity_type="location",
+            alias_word_count=5,
+        )
+        assert score >= 0.0
+
+    def test_score_is_float(self, service: CrossSegmentDiscovery) -> None:
+        """The return type of _score_entity_candidate is float."""
+        score = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        assert isinstance(score, float)
+
+    def test_all_bonuses_accumulate_correctly(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """Each bonus is independently additive before the cap."""
+        # Apply exactly one bonus at a time and verify the delta
+        base = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="organization",
+            alias_word_count=3,
+        )
+        with_person = service._score_entity_candidate(
+            prefix="Chomski",
+            suffix="is",
+            seg_n_text="unrelated",
+            seg_n1_text="unrelated",
+            is_partially_corrected=False,
+            entity_type="person",
+            alias_word_count=2,
+        )
+        # person bonus + 2-word bonus = 0.20 added
+        assert with_person == pytest.approx(base + 0.20, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for discover_from_entities
+# ---------------------------------------------------------------------------
+
+
+def _make_alias_row(
+    alias_name: str,
+    canonical_name: str,
+    entity_type: str,
+) -> tuple[str, str, str]:
+    """Build a fake alias row as returned by _load_multiword_asr_aliases."""
+    return (alias_name, canonical_name, entity_type)
+
+
+class TestDiscoverFromEntities:
+    """Tests for ``CrossSegmentDiscovery.discover_from_entities``.
+
+    Strategy: patch ``_load_multiword_asr_aliases`` and ``_find_adjacent_pairs``
+    at the instance level so no real DB calls are made.
+    """
+
+    @pytest.fixture
+    def service(self) -> CrossSegmentDiscovery:
+        """Provide a CrossSegmentDiscovery with a stub BatchCorrectionService."""
+        return CrossSegmentDiscovery(batch_service=AsyncMock())
+
+    async def test_no_aliases_returns_empty_list(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """When no multi-word ASR aliases exist, returns empty list."""
+        service._load_multiword_asr_aliases = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        session = _make_mock_session()
+
+        result = await service.discover_from_entities(session)
+
+        assert result == []
+
+    async def test_discovery_source_is_entity_alias(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """All candidates returned have discovery_source='entity_alias'."""
+        aliases = [_make_alias_row("Chomski is", "Chomsky", "person")]
+        service._load_multiword_asr_aliases = AsyncMock(return_value=aliases)  # type: ignore[method-assign]
+
+        seg_n = _make_segment_mock(
+            seg_id=100, video_id="vid10", language_code="en",
+            sequence_number=0, text="He said Chomski"
+        )
+        seg_n1 = _make_segment_mock(
+            seg_id=101, video_id="vid10", language_code="en",
+            sequence_number=1, text="is here"
+        )
+
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
+        ) -> list[tuple[Any, Any]]:
+            return [(seg_n, seg_n1)]
+
+        async def _fake_corrected_ids(s: Any) -> set[int]:
+            return set()
+
+        service._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
+        service._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
+        session = _make_mock_session()
+
+        candidates = await service.discover_from_entities(session)
+
+        assert len(candidates) >= 1
+        for c in candidates:
+            assert c.discovery_source == "entity_alias"
+
+    async def test_proposed_correction_is_canonical_name(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """The proposed_correction field equals the entity's canonical_name."""
+        canonical = "Noam Chomsky"
+        aliases = [_make_alias_row("Chomski is", canonical, "person")]
+        service._load_multiword_asr_aliases = AsyncMock(return_value=aliases)  # type: ignore[method-assign]
+
+        seg_n = _make_segment_mock(
+            seg_id=110, video_id="vid11", language_code="en",
+            sequence_number=0, text="He said Chomski"
+        )
+        seg_n1 = _make_segment_mock(
+            seg_id=111, video_id="vid11", language_code="en",
+            sequence_number=1, text="is wrong"
+        )
+
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
+        ) -> list[tuple[Any, Any]]:
+            return [(seg_n, seg_n1)]
+
+        async def _fake_corrected_ids(s: Any) -> set[int]:
+            return set()
+
+        service._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
+        service._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
+        session = _make_mock_session()
+
+        candidates = await service.discover_from_entities(session)
+
+        assert len(candidates) >= 1
+        assert all(c.proposed_correction == canonical for c in candidates)
+
+    async def test_fully_corrected_pairs_excluded(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """Pairs where both segments are already corrected are excluded."""
+        aliases = [_make_alias_row("Chomski is", "Chomsky", "person")]
+        service._load_multiword_asr_aliases = AsyncMock(return_value=aliases)  # type: ignore[method-assign]
+
+        seg_n = _make_segment_mock(
+            seg_id=120, video_id="vid12", language_code="en",
+            sequence_number=0, text="Chomski", has_correction=True,
+            corrected_text="Chomsky"
+        )
+        seg_n1 = _make_segment_mock(
+            seg_id=121, video_id="vid12", language_code="en",
+            sequence_number=1, text="is", has_correction=True,
+            corrected_text="is"
+        )
+
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
+        ) -> list[tuple[Any, Any]]:
+            return [(seg_n, seg_n1)]
+
+        # Both IDs are corrected
+        async def _fake_corrected_ids(s: Any) -> set[int]:
+            return {120, 121}
+
+        service._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
+        service._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
+        session = _make_mock_session()
+
+        candidates = await service.discover_from_entities(session)
+
+        assert candidates == []
+
+    async def test_partially_corrected_pair_included_with_flag(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """When only one segment is corrected, the candidate is included with is_partially_corrected=True."""
+        aliases = [_make_alias_row("Chomski is", "Chomsky", "person")]
+        service._load_multiword_asr_aliases = AsyncMock(return_value=aliases)  # type: ignore[method-assign]
+
+        # seg_n has a correction for something else (punctuation), but its
+        # effective text still ends with the alias prefix "Chomski".
+        seg_n = _make_segment_mock(
+            seg_id=130, video_id="vid13", language_code="en",
+            sequence_number=0, text="he said Chomski",
+            has_correction=True, corrected_text="He said Chomski"
+        )
+        seg_n1 = _make_segment_mock(
+            seg_id=131, video_id="vid13", language_code="en",
+            sequence_number=1, text="is wrong", has_correction=False
+        )
+
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
+        ) -> list[tuple[Any, Any]]:
+            return [(seg_n, seg_n1)]
+
+        # Only seg_n is corrected
+        async def _fake_corrected_ids(s: Any) -> set[int]:
+            return {130}
+
+        service._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
+        service._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
+        session = _make_mock_session()
+
+        candidates = await service.discover_from_entities(session)
+
+        assert len(candidates) >= 1
+        assert any(c.is_partially_corrected for c in candidates)
+
+    async def test_entity_name_filter_forwarded_to_load_aliases(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """The entity_name argument is forwarded to _load_multiword_asr_aliases."""
+        service._load_multiword_asr_aliases = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        session = _make_mock_session()
+
+        await service.discover_from_entities(session, entity_name="Chomsky")
+
+        service._load_multiword_asr_aliases.assert_awaited_once_with(
+            session, "Chomsky"
+        )
+
+    async def test_no_multiword_aliases_returns_empty(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """When all aliases are single-word (no spaces), no splits are generated."""
+        # _generate_word_splits("Chomski") returns [] for single-word aliases.
+        # Simulate this by providing an alias that produces no splits.
+        aliases = [_make_alias_row("Chomski", "Chomsky", "person")]
+        service._load_multiword_asr_aliases = AsyncMock(return_value=aliases)  # type: ignore[method-assign]
+
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
+        ) -> list[tuple[Any, Any]]:
+            return []
+
+        async def _fake_corrected_ids(s: Any) -> set[int]:
+            return set()
+
+        service._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
+        service._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
+        session = _make_mock_session()
+
+        result = await service.discover_from_entities(session)
+
+        assert result == []
+
+    async def test_confidence_in_valid_range(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """All returned candidates have confidence in [0.0, 1.0]."""
+        aliases = [_make_alias_row("Chomski is", "Chomsky", "person")]
+        service._load_multiword_asr_aliases = AsyncMock(return_value=aliases)  # type: ignore[method-assign]
+
+        seg_n = _make_segment_mock(
+            seg_id=140, video_id="vid14", language_code="en",
+            sequence_number=0, text="He said Chomski"
+        )
+        seg_n1 = _make_segment_mock(
+            seg_id=141, video_id="vid14", language_code="en",
+            sequence_number=1, text="is the point"
+        )
+
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
+        ) -> list[tuple[Any, Any]]:
+            return [(seg_n, seg_n1)]
+
+        async def _fake_corrected_ids(s: Any) -> set[int]:
+            return set()
+
+        service._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
+        service._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
+        session = _make_mock_session()
+
+        candidates = await service.discover_from_entities(session)
+
+        for c in candidates:
+            assert 0.0 <= c.confidence <= 1.0, (
+                f"Candidate confidence {c.confidence} is out of range"
+            )
+
+    async def test_returns_list_of_cross_segment_candidates(
+        self, service: CrossSegmentDiscovery
+    ) -> None:
+        """discover_from_entities returns a list of CrossSegmentCandidate instances."""
+        aliases = [_make_alias_row("Chomski is", "Chomsky", "person")]
+        service._load_multiword_asr_aliases = AsyncMock(return_value=aliases)  # type: ignore[method-assign]
+
+        seg_n = _make_segment_mock(
+            seg_id=150, video_id="vid15", language_code="en",
+            sequence_number=0, text="He said Chomski"
+        )
+        seg_n1 = _make_segment_mock(
+            seg_id=151, video_id="vid15", language_code="en",
+            sequence_number=1, text="is here"
+        )
+
+        async def _fake_find_pairs_batched(
+            s: Any, pairs: Any, limit: int = 500
+        ) -> list[tuple[Any, Any]]:
+            return [(seg_n, seg_n1)]
+
+        async def _fake_corrected_ids(s: Any) -> set[int]:
+            return set()
+
+        service._find_adjacent_pairs_batched = _fake_find_pairs_batched  # type: ignore[assignment]
+        service._get_corrected_segment_ids = _fake_corrected_ids  # type: ignore[assignment]
+        session = _make_mock_session()
+
+        result = await service.discover_from_entities(session)
+
+        assert isinstance(result, list)
+        assert all(isinstance(c, CrossSegmentCandidate) for c in result)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _merge_candidates (static method)
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(
+    *,
+    seg_n_id: int,
+    seg_n1_id: int,
+    confidence: float = 0.75,
+    discovery_source: str = "correction_pattern",
+    proposed_correction: str = "Chomsky is",
+) -> CrossSegmentCandidate:
+    """Build a CrossSegmentCandidate for merge tests."""
+    return CrossSegmentCandidate(
+        segment_n_id=seg_n_id,
+        segment_n_text="prefix text",
+        segment_n1_id=seg_n1_id,
+        segment_n1_text="suffix text",
+        proposed_correction=proposed_correction,
+        source_pattern="Chomski is",
+        confidence=confidence,
+        is_partially_corrected=False,
+        video_id="dQw4w9WgXcQ",
+        discovery_source=discovery_source,
+    )
+
+
+class TestMergeCandidates:
+    """Tests for ``CrossSegmentDiscovery._merge_candidates`` static method."""
+
+    def test_entity_candidate_wins_over_pattern_for_same_pair(self) -> None:
+        """When entity and pattern candidates share the same (n, n+1) pair,
+        the entity candidate is kept and the pattern candidate is dropped."""
+        entity_c = _make_candidate(
+            seg_n_id=1, seg_n1_id=2,
+            discovery_source="entity_alias",
+            confidence=0.80,
+        )
+        pattern_c = _make_candidate(
+            seg_n_id=1, seg_n1_id=2,
+            discovery_source="correction_pattern",
+            confidence=0.65,
+        )
+
+        merged = CrossSegmentDiscovery._merge_candidates([entity_c], [pattern_c])
+
+        assert len(merged) == 1
+        assert merged[0].discovery_source == "entity_alias"
+        assert merged[0].confidence == pytest.approx(0.80, abs=1e-9)
+
+    def test_unique_pairs_from_both_sources_all_included(self) -> None:
+        """Different (n, n+1) pairs from both sources are all included."""
+        entity_c = _make_candidate(seg_n_id=1, seg_n1_id=2,
+                                   discovery_source="entity_alias")
+        pattern_c = _make_candidate(seg_n_id=3, seg_n1_id=4,
+                                    discovery_source="correction_pattern")
+
+        merged = CrossSegmentDiscovery._merge_candidates([entity_c], [pattern_c])
+
+        assert len(merged) == 2
+        pair_keys = {(c.segment_n_id, c.segment_n1_id) for c in merged}
+        assert (1, 2) in pair_keys
+        assert (3, 4) in pair_keys
+
+    def test_empty_entity_list_returns_all_pattern_candidates(self) -> None:
+        """When entity_candidates is empty, all pattern candidates are returned."""
+        pattern_c1 = _make_candidate(seg_n_id=5, seg_n1_id=6,
+                                     discovery_source="correction_pattern")
+        pattern_c2 = _make_candidate(seg_n_id=7, seg_n1_id=8,
+                                     discovery_source="correction_pattern")
+
+        merged = CrossSegmentDiscovery._merge_candidates([], [pattern_c1, pattern_c2])
+
+        assert len(merged) == 2
+
+    def test_empty_pattern_list_returns_all_entity_candidates(self) -> None:
+        """When pattern_candidates is empty, all entity candidates are returned."""
+        entity_c1 = _make_candidate(seg_n_id=9, seg_n1_id=10,
+                                    discovery_source="entity_alias")
+        entity_c2 = _make_candidate(seg_n_id=11, seg_n1_id=12,
+                                    discovery_source="entity_alias")
+
+        merged = CrossSegmentDiscovery._merge_candidates(
+            [entity_c1, entity_c2], []
+        )
+
+        assert len(merged) == 2
+
+    def test_both_empty_returns_empty_list(self) -> None:
+        """When both inputs are empty, the result is an empty list."""
+        merged = CrossSegmentDiscovery._merge_candidates([], [])
+        assert merged == []
+
+    def test_no_duplicates_in_result(self) -> None:
+        """No pair key appears twice in the merged output."""
+        entity_c = _make_candidate(seg_n_id=13, seg_n1_id=14,
+                                   discovery_source="entity_alias")
+        pattern_c = _make_candidate(seg_n_id=13, seg_n1_id=14,
+                                    discovery_source="correction_pattern")
+        extra = _make_candidate(seg_n_id=15, seg_n1_id=16,
+                                discovery_source="correction_pattern")
+
+        merged = CrossSegmentDiscovery._merge_candidates(
+            [entity_c], [pattern_c, extra]
+        )
+
+        pair_keys = [(c.segment_n_id, c.segment_n1_id) for c in merged]
+        assert len(pair_keys) == len(set(pair_keys))
+
+    def test_entity_candidates_preserve_insertion_order(self) -> None:
+        """Entity candidates appear before pattern candidates in the merged list."""
+        entity_c = _make_candidate(seg_n_id=17, seg_n1_id=18,
+                                   discovery_source="entity_alias")
+        pattern_c = _make_candidate(seg_n_id=19, seg_n1_id=20,
+                                    discovery_source="correction_pattern")
+
+        merged = CrossSegmentDiscovery._merge_candidates([entity_c], [pattern_c])
+
+        # Entity candidate should come first (entity is processed first)
+        assert merged[0].discovery_source == "entity_alias"
+        assert merged[1].discovery_source == "correction_pattern"
+
+    def test_multiple_entity_candidates_same_pair_first_wins(self) -> None:
+        """If entity_candidates itself has duplicate pairs, only the first is kept."""
+        entity_c1 = _make_candidate(seg_n_id=21, seg_n1_id=22,
+                                    discovery_source="entity_alias",
+                                    confidence=0.90)
+        entity_c2 = _make_candidate(seg_n_id=21, seg_n1_id=22,
+                                    discovery_source="entity_alias",
+                                    confidence=0.70)
+
+        merged = CrossSegmentDiscovery._merge_candidates(
+            [entity_c1, entity_c2], []
+        )
+
+        assert len(merged) == 1
+        assert merged[0].confidence == pytest.approx(0.90, abs=1e-9)
+
+    def test_returns_list_type(self) -> None:
+        """_merge_candidates always returns a list."""
+        result = CrossSegmentDiscovery._merge_candidates([], [])
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the updated discover() — combining entity + pattern paths
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverCombined:
+    """Tests for the updated ``discover()`` that combines entity and pattern discovery.
+
+    Unlike ``TestCrossSegmentDiscoveryDiscover`` (which isolates the pattern path),
+    these tests verify the interaction between both discovery strategies.
+    """
+
+    async def test_discover_calls_both_strategies(self) -> None:
+        """discover() calls both discover_from_entities and _discover_from_patterns."""
+        batch_svc = _make_batch_service(patterns=[])
+        discovery = CrossSegmentDiscovery(batch_service=batch_svc)
+        session = _make_mock_session()
+
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        discovery._discover_from_patterns = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        await discovery.discover(session, min_corrections=3)
+
+        discovery.discover_from_entities.assert_awaited_once()
+        discovery._discover_from_patterns.assert_awaited_once()
+
+    async def test_entity_candidates_ranked_higher_when_same_pair(self) -> None:
+        """When the same pair is found by both strategies, entity candidate is kept."""
+        entity_c = _make_candidate(
+            seg_n_id=200, seg_n1_id=201,
+            discovery_source="entity_alias",
+            confidence=0.85,
+        )
+        pattern_c = _make_candidate(
+            seg_n_id=200, seg_n1_id=201,
+            discovery_source="correction_pattern",
+            confidence=0.60,
+        )
+
+        batch_svc = _make_batch_service(patterns=[])
+        discovery = CrossSegmentDiscovery(batch_service=batch_svc)
+        session = _make_mock_session()
+
+        discovery.discover_from_entities = AsyncMock(return_value=[entity_c])  # type: ignore[method-assign]
+        discovery._discover_from_patterns = AsyncMock(return_value=[pattern_c])  # type: ignore[method-assign]
+
+        result = await discovery.discover(session, min_corrections=3)
+
+        assert len(result) == 1
+        assert result[0].discovery_source == "entity_alias"
+        assert result[0].confidence == pytest.approx(0.85, abs=1e-9)
+
+    async def test_results_sorted_by_confidence_descending(self) -> None:
+        """discover() returns results sorted by confidence descending."""
+        high_entity = _make_candidate(
+            seg_n_id=210, seg_n1_id=211,
+            discovery_source="entity_alias",
+            confidence=0.90,
+        )
+        low_pattern = _make_candidate(
+            seg_n_id=212, seg_n1_id=213,
+            discovery_source="correction_pattern",
+            confidence=0.55,
+        )
+        mid_entity = _make_candidate(
+            seg_n_id=214, seg_n1_id=215,
+            discovery_source="entity_alias",
+            confidence=0.70,
+        )
+
+        batch_svc = _make_batch_service(patterns=[])
+        discovery = CrossSegmentDiscovery(batch_service=batch_svc)
+        session = _make_mock_session()
+
+        discovery.discover_from_entities = AsyncMock(  # type: ignore[method-assign]
+            return_value=[high_entity, mid_entity]
+        )
+        discovery._discover_from_patterns = AsyncMock(  # type: ignore[method-assign]
+            return_value=[low_pattern]
+        )
+
+        result = await discovery.discover(session, min_corrections=3)
+
+        assert len(result) == 3
+        confidences = [c.confidence for c in result]
+        assert confidences == sorted(confidences, reverse=True)
+
+    async def test_unique_pairs_from_both_sources_included(self) -> None:
+        """Unique pairs from entity and pattern strategies are all included."""
+        entity_c = _make_candidate(
+            seg_n_id=220, seg_n1_id=221,
+            discovery_source="entity_alias",
+            confidence=0.80,
+        )
+        pattern_c = _make_candidate(
+            seg_n_id=222, seg_n1_id=223,
+            discovery_source="correction_pattern",
+            confidence=0.65,
+        )
+
+        batch_svc = _make_batch_service(patterns=[])
+        discovery = CrossSegmentDiscovery(batch_service=batch_svc)
+        session = _make_mock_session()
+
+        discovery.discover_from_entities = AsyncMock(return_value=[entity_c])  # type: ignore[method-assign]
+        discovery._discover_from_patterns = AsyncMock(return_value=[pattern_c])  # type: ignore[method-assign]
+
+        result = await discovery.discover(session, min_corrections=3)
+
+        assert len(result) == 2
+        sources = {c.discovery_source for c in result}
+        assert "entity_alias" in sources
+        assert "correction_pattern" in sources
+
+    async def test_both_empty_returns_empty_list(self) -> None:
+        """discover() returns [] when both strategies find no candidates."""
+        batch_svc = _make_batch_service(patterns=[])
+        discovery = CrossSegmentDiscovery(batch_service=batch_svc)
+        session = _make_mock_session()
+
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        discovery._discover_from_patterns = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        result = await discovery.discover(session, min_corrections=3)
+
+        assert result == []
+
+    async def test_entity_name_forwarded_to_both_strategies(self) -> None:
+        """The entity_name kwarg is passed to both discover_from_entities and _discover_from_patterns."""
+        batch_svc = _make_batch_service(patterns=[])
+        discovery = CrossSegmentDiscovery(batch_service=batch_svc)
+        session = _make_mock_session()
+
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        discovery._discover_from_patterns = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        await discovery.discover(session, min_corrections=5, entity_name="Chomsky")
+
+        entity_call = discovery.discover_from_entities.call_args
+        pattern_call = discovery._discover_from_patterns.call_args
+
+        assert entity_call.kwargs.get("entity_name") == "Chomsky"
+        assert pattern_call.kwargs.get("entity_name") == "Chomsky"
+
+    async def test_min_corrections_forwarded_to_pattern_strategy(self) -> None:
+        """min_corrections is forwarded to _discover_from_patterns."""
+        batch_svc = _make_batch_service(patterns=[])
+        discovery = CrossSegmentDiscovery(batch_service=batch_svc)
+        session = _make_mock_session()
+
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        discovery._discover_from_patterns = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        await discovery.discover(session, min_corrections=7)
+
+        pattern_call = discovery._discover_from_patterns.call_args
+        assert pattern_call.kwargs.get("min_corrections") == 7
+
+    async def test_discover_returns_list_type(self) -> None:
+        """discover() always returns a list, even when both strategies are empty."""
+        batch_svc = _make_batch_service(patterns=[])
+        discovery = CrossSegmentDiscovery(batch_service=batch_svc)
+        session = _make_mock_session()
+
+        discovery.discover_from_entities = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        discovery._discover_from_patterns = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        result = await discovery.discover(session)
+
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for CrossSegmentCandidate.discovery_source field
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSegmentCandidateDiscoverySource:
+    """Tests for the ``discovery_source`` field on ``CrossSegmentCandidate``.
+
+    This is a new field added in the entity-aware refactor.
+    """
+
+    def _valid_kwargs(self) -> dict[str, Any]:
+        return {
+            "segment_n_id": 1,
+            "segment_n_text": "He said Chomski",
+            "segment_n1_id": 2,
+            "segment_n1_text": "is great",
+            "proposed_correction": "Chomsky is",
+            "source_pattern": "Chomski is",
+            "confidence": 0.75,
+            "is_partially_corrected": False,
+            "video_id": "dQw4w9WgXcQ",
+        }
+
+    def test_default_discovery_source_is_correction_pattern(self) -> None:
+        """When discovery_source is not specified, it defaults to 'correction_pattern'."""
+        candidate = CrossSegmentCandidate(**self._valid_kwargs())
+        assert candidate.discovery_source == "correction_pattern"
+
+    def test_discovery_source_can_be_set_to_entity_alias(self) -> None:
+        """discovery_source can be explicitly set to 'entity_alias'."""
+        kwargs = self._valid_kwargs()
+        kwargs["discovery_source"] = "entity_alias"
+        candidate = CrossSegmentCandidate(**kwargs)
+        assert candidate.discovery_source == "entity_alias"
+
+    def test_discovery_source_is_string(self) -> None:
+        """discovery_source is always a string value."""
+        candidate = CrossSegmentCandidate(**self._valid_kwargs())
+        assert isinstance(candidate.discovery_source, str)
+
+    def test_discovery_source_included_in_model_dump(self) -> None:
+        """discovery_source appears in model_dump() output."""
+        candidate = CrossSegmentCandidate(**self._valid_kwargs())
+        dumped = candidate.model_dump()
+        assert "discovery_source" in dumped
+        assert dumped["discovery_source"] == "correction_pattern"
+
+    def test_entity_alias_discovery_source_in_model_dump(self) -> None:
+        """discovery_source='entity_alias' is preserved in model_dump()."""
+        kwargs = self._valid_kwargs()
+        kwargs["discovery_source"] = "entity_alias"
+        candidate = CrossSegmentCandidate(**kwargs)
+        dumped = candidate.model_dump()
+        assert dumped["discovery_source"] == "entity_alias"
+
+    def test_discovery_source_immutable_on_frozen_model(self) -> None:
+        """discovery_source cannot be reassigned because the model is frozen."""
+        candidate = CrossSegmentCandidate(**self._valid_kwargs())
+        with pytest.raises(Exception):
+            candidate.discovery_source = "entity_alias"
+
+    def test_custom_discovery_source_string_accepted(self) -> None:
+        """Any string value is accepted for discovery_source (no enum restriction)."""
+        kwargs = self._valid_kwargs()
+        kwargs["discovery_source"] = "custom_strategy"
+        candidate = CrossSegmentCandidate(**kwargs)
+        assert candidate.discovery_source == "custom_strategy"

--- a/tests/unit/services/test_entity_mention_scan_service.py
+++ b/tests/unit/services/test_entity_mention_scan_service.py
@@ -239,6 +239,103 @@ class TestPatternConstruction:
         assert len(patterns) == 1
         assert patterns[0].alias_names.count("Google") == 1
 
+    # ------------------------------------------------------------------
+    # Bug fix: asr_error aliases must be excluded from scan patterns
+    # ------------------------------------------------------------------
+
+    async def test_alias_query_excludes_asr_error_type_in_sql(self) -> None:
+        """The alias query emitted by _load_entity_patterns must filter out asr_error aliases.
+
+        Bug fix (Feature 038/044): Before the fix, alias_stmt had no alias_type
+        filter, so ASR-error aliases (e.g. "Bonazo") were included in scan
+        patterns and created false rule_match mentions.  After the fix the WHERE
+        clause must contain ``alias_type != 'asr_error'`` (or equivalent NOT
+        IN / != expression).
+
+        This test inspects the compiled SQL of the *second* execute() call
+        (the alias query) to confirm the exclusion filter is present.
+        """
+        from sqlalchemy.dialects import postgresql as pg_dialect
+
+        entity_id = _make_uuid()
+        entity_row = _make_entity_row(entity_id=entity_id, canonical_name="Bonaparte")
+
+        session = AsyncMock()
+        entity_result = _scalars_execute([entity_row])
+        alias_result = _scalars_execute([])
+        session.execute = AsyncMock(side_effect=[entity_result, alias_result])
+
+        svc = _build_service(MagicMock())
+        await svc._load_entity_patterns(session, entity_type=None, new_entities_only=False)
+
+        # The alias query is the second execute() call
+        assert session.execute.call_count == 2, (
+            "Expected exactly two execute() calls: one for entities, one for aliases"
+        )
+        alias_stmt = session.execute.call_args_list[1].args[0]
+        sql_str = str(
+            alias_stmt.compile(
+                dialect=pg_dialect.dialect(),  # type: ignore[no-untyped-call]
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+        assert "asr_error" in sql_str, (
+            "Expected 'asr_error' exclusion filter in the alias query SQL; "
+            f"got: {sql_str[:600]}"
+        )
+
+    async def test_non_asr_error_aliases_are_included_as_scan_patterns(self) -> None:
+        """Aliases with types other than asr_error must appear in scan patterns.
+
+        The fix must only exclude asr_error aliases; name_variant, abbreviation,
+        nickname, translated_name, and former_name aliases must still be returned
+        by the alias query and contribute to pg_pattern.
+        """
+        entity_id = _make_uuid()
+        entity_row = _make_entity_row(entity_id=entity_id, canonical_name="Napoleon")
+        # Simulate DB returning non-ASR-error aliases (after SQL filter is applied)
+        name_variant_alias = _make_alias_row(entity_id=entity_id, alias_name="Nap")
+        abbreviation_alias = _make_alias_row(entity_id=entity_id, alias_name="NB")
+
+        patterns = await self._call_load_patterns(
+            entity_row, [name_variant_alias, abbreviation_alias]
+        )
+
+        assert len(patterns) == 1
+        pat = patterns[0]
+        # Both non-ASR-error aliases must appear in the pattern
+        assert "Nap" in pat.alias_names, "name_variant alias 'Nap' must be in alias_names"
+        assert "NB" in pat.alias_names, "abbreviation alias 'NB' must be in alias_names"
+        assert re.escape("Nap") in pat.pg_pattern
+        assert re.escape("NB") in pat.pg_pattern
+
+    async def test_asr_error_alias_not_present_in_pattern_names(self) -> None:
+        """When the DB returns only non-ASR-error aliases, no ASR noise forms appear.
+
+        This models the post-fix behaviour: the alias query WHERE clause filters
+        out asr_error rows at the database level.  If the DB correctly excludes
+        them, the resulting alias_names list must not contain ASR noise forms.
+
+        The test simulates the DB having applied the filter already (returning
+        only non-asr_error aliases) and confirms the service builds patterns
+        from those aliases only.
+        """
+        entity_id = _make_uuid()
+        entity_row = _make_entity_row(entity_id=entity_id, canonical_name="Bonanza")
+        # Simulates DB returning zero aliases after WHERE alias_type != 'asr_error'
+        # filters out the only alias ("Bonazo") which was an asr_error alias
+        patterns = await self._call_load_patterns(entity_row, [])
+
+        assert len(patterns) == 1
+        pat = patterns[0]
+        # Only the canonical name must appear — no ASR noise forms
+        assert pat.alias_names == ["Bonanza"], (
+            f"Expected only canonical name in alias_names; got: {pat.alias_names}"
+        )
+        # The ASR-error form "Bonazo" must not appear in pg_pattern
+        assert "Bonazo" not in pat.pg_pattern
+
 
 # ---------------------------------------------------------------------------
 # TestEntityStatusFiltering


### PR DESCRIPTION
## Summary

- **Batch History Page (US1, #92)**: Paginated list of past batch operations at `/corrections/batch/history` with revert button, confirmation dialog, TanStack Query cache invalidation, and user-friendly error messages for 404/409 responses
- **Cross-Segment Discovery UI (US2, #91)**: Collapsible panel on `/corrections/batch` showing AI-ranked cross-segment candidates with confidence scores; clicking a candidate pre-fills the find-replace form with pattern, replacement, and cross-segment toggle
- **Word-Level Diff Analysis Dashboard (US3, #93)**: New `/corrections/diff-analysis` page with sortable/filterable table of ASR error patterns; "Find & Replace" action wraps error tokens in `\b...\b` word-boundary regex to prevent partial matches
- **Phonetic ASR Variant Suggestions (US4, #94)**: Lazy-loaded "Suspected ASR Variants" section on entity detail page with confidence threshold slider, "Register as Alias" and "Find & Replace" action buttons
- **Sidebar Navigation**: Collapsible "Transcripts" nav group organizing Search, Find & Replace, Correction Stats, and Language Preferences
- **Bug Fix**: ASR-error aliases excluded from entity mention scan patterns to prevent false `rule_match` mentions (917 false mentions cleaned up); full_rescan now resets counters for entities with zero post-scan matches; entity video list count uses visible-names filter for consistency

- Closes #93 Closes #92 Closes #91 Closes #94 

### Backend
- 3 new API endpoints: `GET /corrections/cross-segment/candidates`, `GET /corrections/diff-analysis`, `GET /entities/{id}/phonetic-matches`
- `CrossSegmentDiscovery` service rewrite with batch processing and confidence scoring
- ASR alias registry improvements with text normalization utilities

### Frontend
- 5 new pages/panels, 6 custom hooks, 3 icon components, `NavGroup` component
- ~2,400 new test lines across 20+ test files

### Versions
- Backend: 0.46.0 → 0.47.0
- Frontend: 0.15.0 → 0.16.0

## Test plan
- [x] Run full backend test suite (`pytest`) — 6,900+ tests pass
- [x] Run full frontend test suite (`npm test`) — 2,500+ tests pass
- [x] Verify Batch History page loads at `/corrections/batch/history` with pagination and revert functionality
- [x] Verify Cross-Segment Candidates panel loads on `/corrections/batch` and pre-fills form on click
- [x] Verify Diff Analysis dashboard at `/corrections/diff-analysis` with sorting, filtering, and word-boundary regex pre-fill
- [x] Verify Phonetic Variants section on entity detail page with lazy-load, confidence slider, alias registration
- [x] Verify sidebar "Transcripts" nav group collapses/expands correctly
- [x] Verify entity mention scan excludes ASR-error aliases (re-run `entities scan`)
- [x] Verify entity detail page shows consistent mention_count vs video_count