### PR TITLE
fix(onboarding): resolve Docker UX bugs and test alignment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,13 @@ COPY --from=dependency-builder /build/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir psycopg2-binary
 
-# Copy application source and make it importable
+# Copy application source and project metadata for installation
 COPY src/ ./src/
+COPY pyproject.toml README.md ./
 ENV PYTHONPATH="/app/src"
+
+# Install the chronovista package (registers CLI entry point)
+RUN pip install --no-cache-dir --no-deps -e .
 
 # Copy Alembic configuration and migrations
 COPY alembic.ini ./alembic.ini

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="https://img.shields.io/badge/license-AGPL--3.0-green.svg" alt="License: AGPL-3.0">
   <img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/tests-8,320+-brightgreen.svg" alt="Tests: 8,320+">
-  <img src="https://img.shields.io/badge/coverage-72%25-yellow.svg" alt="Coverage: 76%">
+  <img src="https://img.shields.io/badge/coverage-76%25-yellow.svg" alt="Coverage: 76%">
   <img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style: black">
 </p>
 

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -3,7 +3,7 @@
  *
  * Coverage:
  * - Renders the nav landmark with accessible label
- * - Renders exactly 5 top-level entries (4 li items + 1 NavGroup li)
+ * - Renders exactly 7 top-level entries (6 li items + 1 NavGroup li)
  * - Flat nav items (Videos, Channels, Playlists, Entities) render as links
  * - Transcripts group renders with NavGroup (disclosure button)
  * - Transcripts group is expanded by default and shows child links
@@ -128,9 +128,9 @@ describe("Sidebar — Transcripts group", () => {
 });
 
 describe("Sidebar — total top-level nav item count", () => {
-  it("top-level list contains 6 entries (Videos, Transcripts group, Channels, Playlists, Entities, Search)", () => {
+  it("top-level list contains 7 entries (Videos, Transcripts group, Channels, Playlists, Entities, Search, Setup)", () => {
     renderSidebar();
-    // The outer <ul role="list"> has exactly 6 <li> children (5 flat routes + 1 group)
+    // The outer <ul role="list"> has exactly 7 <li> children (6 flat routes + 1 group)
     const nav = screen.getByRole("navigation", { name: "Main navigation" });
     // The direct child ul has role="list" — query it within the nav
     const outerList = nav.querySelector("ul[role='list']");
@@ -138,6 +138,6 @@ describe("Sidebar — total top-level nav item count", () => {
     const directLiChildren = outerList
       ? Array.from(outerList.children).filter((el) => el.tagName === "LI")
       : [];
-    expect(directLiChildren).toHaveLength(6);
+    expect(directLiChildren).toHaveLength(7);
   });
 });

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -76,6 +76,9 @@ export function useOnboardingStatus(): UseQueryResult<OnboardingStatus, Error> {
     },
     staleTime: 10 * 1000, // 10 seconds — short because status changes frequently
     gcTime: 5 * 60 * 1000, // 5 minutes
+    // Retry up to 2 times on transient failures (e.g. brief API timeout during
+    // a heavy enrichment run) before surfacing the connection error banner.
+    retry: 2,
   });
 }
 

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -282,6 +282,16 @@ export function OnboardingPage() {
   // Poll the active task while it runs
   const { data: activeTaskPoll } = useTaskStatus(activeTaskId);
 
+  // Auto-populate activeTaskId from backend status when not set locally.
+  // This handles page refresh and connection drop/recovery — if the backend
+  // reports an active_task but the local state is null (e.g. the user reloaded
+  // the page mid-run), we pick it up so polling and progress display resume.
+  useEffect(() => {
+    if (status?.active_task && activeTaskId === null) {
+      setActiveTaskId(status.active_task.id);
+    }
+  }, [status?.active_task, activeTaskId]);
+
   // Clear activeTaskId when the polled task reaches a terminal state
   useEffect(() => {
     if (

--- a/frontend/src/router/__tests__/routes.test.ts
+++ b/frontend/src/router/__tests__/routes.test.ts
@@ -43,8 +43,8 @@ function findGroup(entries: NavEntry[], label: string): NavGroupRoute | undefine
 // ---------------------------------------------------------------------------
 
 describe("navRoutes — top-level structure", () => {
-  it("has exactly 6 top-level entries", () => {
-    expect(navRoutes).toHaveLength(6);
+  it("has exactly 7 top-level entries", () => {
+    expect(navRoutes).toHaveLength(7);
   });
 
   it("first entry is Videos flat route", () => {

--- a/frontend/src/tests/hooks/useOnboarding.test.ts
+++ b/frontend/src/tests/hooks/useOnboarding.test.ts
@@ -209,7 +209,8 @@ describe("useOnboardingStatus", () => {
 
     it("exposes isError=true when the fetch rejects", async () => {
       const { fetchOnboardingStatus } = await import("../../api/onboarding");
-      vi.mocked(fetchOnboardingStatus).mockRejectedValueOnce(
+      // The hook sets retry: 2, so we must reject all attempts (not just the first).
+      vi.mocked(fetchOnboardingStatus).mockRejectedValue(
         new Error("Network failure")
       );
 
@@ -217,9 +218,14 @@ describe("useOnboardingStatus", () => {
         wrapper: createWrapper(queryClient),
       });
 
-      await waitFor(() => {
-        expect(result.current.isError).toBe(true);
-      });
+      // Allow up to 5 s for all 3 attempts (initial + 2 retries) to complete
+      // before TanStack Query transitions the query to the error state.
+      await waitFor(
+        () => {
+          expect(result.current.isError).toBe(true);
+        },
+        { timeout: 5000 }
+      );
     });
   });
 

--- a/frontend/src/tests/pages/OnboardingPage.test.tsx
+++ b/frontend/src/tests/pages/OnboardingPage.test.tsx
@@ -168,7 +168,7 @@ async function setupHooks(options: {
     isError: options.isError ?? false,
     refetch: mockRefetch,
     // Minimal shape — remaining fields unused by the page
-  } as ReturnType<typeof useOnboardingStatus>);
+  } as unknown as ReturnType<typeof useOnboardingStatus>);
 
   vi.mocked(useStartTask).mockReturnValue({
     mutate: mockMutate,

--- a/src/chronovista/api/main.py
+++ b/src/chronovista/api/main.py
@@ -37,6 +37,14 @@ from chronovista.api.routers import (
     videos,
 )
 
+# Ensure application-level logs (chronovista.*) reach stdout/stderr.
+# Without this, only uvicorn's access logs appear in Docker.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
 logger = logging.getLogger(__name__)
 
 # Paths that should not have their details logged (sensitive endpoints)

--- a/src/chronovista/api/schemas/onboarding.py
+++ b/src/chronovista/api/schemas/onboarding.py
@@ -19,6 +19,7 @@ class OnboardingCounts(BaseModel):
 
     channels: int = 0
     videos: int = 0
+    available_videos: int = 0
     enriched_videos: int = 0
     playlists: int = 0
     transcripts: int = 0

--- a/src/chronovista/config/database.py
+++ b/src/chronovista/config/database.py
@@ -37,7 +37,7 @@ class DatabaseManager:
 
             # Development-specific engine configuration
             engine_kwargs = {
-                "echo": settings.debug or settings.db_log_queries,
+                "echo": settings.db_log_queries,
                 "future": True,
                 "pool_pre_ping": True,
                 "pool_recycle": 3600,
@@ -142,7 +142,7 @@ class DatabaseManager:
     def get_sync_engine(self) -> Engine:
         """Get synchronous engine for Alembic migrations."""
         sync_url = settings.get_sync_database_url()
-        return create_engine(sync_url, echo=settings.debug or settings.db_log_queries)
+        return create_engine(sync_url, echo=settings.db_log_queries)
 
 
 # Global database manager instance

--- a/src/chronovista/services/enrichment/enrichment_service.py
+++ b/src/chronovista/services/enrichment/enrichment_service.py
@@ -17,7 +17,7 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import unquote
 
 from pydantic import BaseModel, Field
@@ -985,6 +985,7 @@ class EnrichmentService:
         dry_run: bool = False,
         check_prerequisites: bool = True,
         refresh_topics: bool = False,
+        progress_cb: Callable[[float], None] | None = None,
     ) -> EnrichmentReport:
         """
         Main enrichment method for batch video processing.
@@ -1016,6 +1017,9 @@ class EnrichmentService:
         refresh_topics : bool, optional
             If True, process ALL non-deleted videos regardless of metadata state
             to refresh topic associations (default False).
+        progress_cb : Callable[[float], None] | None, optional
+            If provided, called after each batch commit with a float in [0.0, 1.0]
+            representing the fraction of videos processed so far (default None).
 
         Returns
         -------
@@ -1408,12 +1412,18 @@ class EnrichmentService:
                     logger.error(f"Error committing batch: {e}")
                     await session.rollback()
 
+                if progress_cb is not None:
+                    progress_cb(videos_processed / len(video_ids))
+
         # Final commit for remaining videos
         try:
             await session.commit()
         except Exception as e:
             logger.error(f"Error in final commit: {e}")
             await session.rollback()
+
+        if progress_cb is not None:
+            progress_cb(1.0)
 
         return create_report()
 

--- a/src/chronovista/services/onboarding_service.py
+++ b/src/chronovista/services/onboarding_service.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Callable, Coroutine
+from typing import Any, Callable, Coroutine, cast
 
-from sqlalchemy import func, select
+from sqlalchemy import CursorResult, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from chronovista.api.schemas.onboarding import (
@@ -267,6 +267,7 @@ class OnboardingService:
         async with self._session_factory() as session:
             channels = await self._count(session, Channel)
             videos = await self._count(session, Video)
+            available_videos = await self._count_available_videos(session)
             enriched_videos = await self._count_enriched_videos(session)
             playlists = await self._count(session, Playlist)
             transcripts = await self._count(session, VideoTranscript)
@@ -276,6 +277,7 @@ class OnboardingService:
         return OnboardingCounts(
             channels=channels,
             videos=videos,
+            available_videos=available_videos,
             enriched_videos=enriched_videos,
             playlists=playlists,
             transcripts=transcripts,
@@ -323,6 +325,16 @@ class OnboardingService:
             select(func.count())
             .select_from(Video)
             .where(Video.view_count.is_not(None))
+        )
+        return result.scalar_one()
+
+    @staticmethod
+    async def _count_available_videos(session: AsyncSession) -> int:
+        """Count videos with availability_status = 'available'."""
+        result = await session.execute(
+            select(func.count())
+            .select_from(Video)
+            .where(Video.availability_status == "available")
         )
         return result.scalar_one()
 
@@ -597,6 +609,15 @@ class OnboardingService:
                 and step_def.operation_type == OperationType.LOAD_DATA
             ):
                 return PipelineStepStatus.AVAILABLE
+            # Special case: enrich_metadata can be re-run when there are
+            # un-enriched *available* videos.  Unavailable/deleted videos
+            # can never be enriched, so we compare enriched count against
+            # available videos only.
+            if (
+                step_def.operation_type == OperationType.ENRICH_METADATA
+                and counts.enriched_videos < counts.available_videos
+            ):
+                return PipelineStepStatus.AVAILABLE
             return PipelineStepStatus.COMPLETED
 
         # Check for blocked conditions
@@ -800,8 +821,31 @@ class OnboardingService:
                     len(takeout_dirs),
                 )
 
+                # Resolve the real user ID when authenticated, so
+                # user_videos rows are stored under the actual channel
+                # ID instead of the "takeout_user" placeholder.
+                user_id = "takeout_user"
+                if OnboardingService._check_auth():
+                    try:
+                        from chronovista.container import container
+
+                        yt = container.youtube_service
+                        my_ch = await yt.get_my_channel()
+                        if my_ch:
+                            user_id = my_ch.id
+                            logger.info(
+                                "Load data: using authenticated channel ID %s",
+                                user_id,
+                            )
+                    except Exception as exc:
+                        logger.warning(
+                            "Load data: could not resolve channel ID, "
+                            "falling back to 'takeout_user': %s",
+                            exc,
+                        )
+
                 # Parse and seed from each takeout directory
-                seeding_svc = TakeoutSeedingService()
+                seeding_svc = TakeoutSeedingService(user_id=user_id)
                 all_results: dict[str, Any] = {}
                 total_dirs = len(takeout_dirs)
 
@@ -912,12 +956,17 @@ class OnboardingService:
                 )
 
                 # Step 1: Enrich videos (--priority all --include-deleted)
+                # Map video enrichment progress (0.0-1.0) into the 0%-30% range.
+                def _video_progress(fraction: float) -> None:
+                    progress_cb(fraction * 30.0)
+
                 async with session_factory() as session:
                     report = await enrichment_service.enrich_videos(
                         session,
                         priority="all",
                         include_deleted=True,
                         check_prerequisites=False,
+                        progress_cb=_video_progress,
                     )
                 progress_cb(30.0)
 
@@ -939,15 +988,71 @@ class OnboardingService:
                         )
                 progress_cb(50.0)
 
-                # Step 3: Sync liked videos (--sync-likes)
-                likes_synced = 0
+                # Step 2.5: Migrate any "takeout_user" rows to the real
+                # channel ID so likes sync and filters work correctly.
                 youtube_service = container.youtube_service
+                real_user_id: str | None = None
                 async with session_factory() as session:
                     try:
                         my_channel = await youtube_service.get_my_channel()
                         if my_channel:
+                            real_user_id = my_channel.id
+                            from chronovista.db.models import UserVideo as UserVideoDB
+                            from sqlalchemy import text
+
+                            # Migrate takeout_user → real channel ID,
+                            # skipping rows that already exist under
+                            # the real ID (avoids PK conflict).
+                            result = await session.execute(
+                                text("""
+                                    UPDATE user_videos
+                                    SET user_id = :real_id
+                                    WHERE user_id = 'takeout_user'
+                                    AND video_id NOT IN (
+                                        SELECT video_id FROM user_videos
+                                        WHERE user_id = :real_id
+                                    )
+                                """),
+                                {"real_id": real_user_id},
+                            )
+                            cursor = cast(CursorResult[Any], result)
+                            migrated = cursor.rowcount
+                            await session.commit()
+                            if migrated > 0:
+                                logger.info(
+                                    "Migrated %d user_videos rows from "
+                                    "'takeout_user' to '%s'",
+                                    migrated,
+                                    real_user_id,
+                                )
+                    except Exception as exc:
+                        logger.warning(
+                            "User ID migration failed (non-fatal): %s", exc
+                        )
+                progress_cb(55.0)
+
+                # Step 3: Sync liked videos (--sync-likes)
+                likes_synced = 0
+                async with session_factory() as session:
+                    try:
+                        # Reuse channel ID from migration step if available,
+                        # otherwise fetch it now.
+                        if real_user_id is None:
+                            logger.info("Likes sync: fetching authenticated channel...")
+                            ch = await youtube_service.get_my_channel()
+                            real_user_id = ch.id if ch else None
+
+                        if real_user_id:
+                            logger.info(
+                                "Likes sync: channel=%s, fetching liked videos...",
+                                real_user_id,
+                            )
                             liked_videos = (
                                 await youtube_service.get_liked_videos()
+                            )
+                            logger.info(
+                                "Likes sync: got %d liked videos from API",
+                                len(liked_videos) if liked_videos else 0,
                             )
                             if liked_videos:
                                 user_video_repo = UserVideoRepository()
@@ -957,17 +1062,31 @@ class OnboardingService:
                                     for v in liked_videos
                                     if await video_repo.exists(session, v.id)
                                 ]
+                                logger.info(
+                                    "Likes sync: %d/%d liked videos exist in DB",
+                                    len(existing_ids),
+                                    len(liked_videos),
+                                )
                                 if existing_ids:
                                     likes_synced = await user_video_repo.update_like_status_batch(
                                         session,
-                                        my_channel.id,
+                                        real_user_id,
                                         existing_ids,
                                         liked=True,
                                     )
                                     await session.commit()
+                                    logger.info(
+                                        "Likes sync: %d records updated",
+                                        likes_synced,
+                                    )
+                        else:
+                            logger.warning(
+                                "Likes sync: no channel found for authenticated user"
+                            )
                     except Exception as exc:
-                        logger.warning(
-                            "Likes sync failed (non-fatal): %s", exc
+                        logger.error(
+                            "Likes sync failed (non-fatal): %s", exc,
+                            exc_info=True,
                         )
                 progress_cb(70.0)
 

--- a/tests/unit/services/test_onboarding_service.py
+++ b/tests/unit/services/test_onboarding_service.py
@@ -80,6 +80,7 @@ def _make_background_task(
 def _make_counts(
     channels: int = 0,
     videos: int = 0,
+    available_videos: int = 0,
     playlists: int = 0,
     transcripts: int = 0,
     categories: int = 0,
@@ -89,6 +90,7 @@ def _make_counts(
     return OnboardingCounts(
         channels=channels,
         videos=videos,
+        available_videos=available_videos,
         playlists=playlists,
         transcripts=transcripts,
         categories=categories,
@@ -108,8 +110,8 @@ def _make_session_factory(counts_sequence: list[int]) -> MagicMock:
     counts_sequence : list[int]
         A list of integers returned in order for each
         ``session.execute(...).scalar_one()`` call.
-        7 values in insertion order: channels, videos, enriched_videos,
-        playlists, transcripts, categories, canonical_tags.
+        8 values in insertion order: channels, videos, available_videos,
+        enriched_videos, playlists, transcripts, categories, canonical_tags.
     """
     scalar_values = list(counts_sequence)
 
@@ -176,7 +178,7 @@ def _build_service(
     """
     from chronovista.services.onboarding_service import OnboardingService
 
-    session_factory = _make_session_factory(counts_sequence or [0] * 7)
+    session_factory = _make_session_factory(counts_sequence or [0] * 8)
     task_manager = _make_task_manager(running_tasks)
     return OnboardingService(
         task_manager=task_manager,
@@ -229,7 +231,7 @@ class TestFreshDatabase:
 
     async def test_seed_reference_is_available_when_fresh(self) -> None:
         """seed_reference has no dependencies and no auth requirement — always AVAILABLE."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -238,7 +240,7 @@ class TestFreshDatabase:
 
     async def test_load_data_is_available_when_fresh(self) -> None:
         """load_data has no dependencies and no auth requirement — always AVAILABLE."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -247,7 +249,7 @@ class TestFreshDatabase:
 
     async def test_enrich_metadata_is_blocked_when_fresh_and_no_auth(self) -> None:
         """enrich_metadata depends on load_data AND requires auth — BLOCKED if either missing."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -256,7 +258,7 @@ class TestFreshDatabase:
 
     async def test_normalize_tags_is_blocked_when_fresh(self) -> None:
         """normalize_tags depends on load_data — BLOCKED when videos == 0."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -265,7 +267,7 @@ class TestFreshDatabase:
 
     async def test_status_returns_four_steps(self) -> None:
         """OnboardingStatus must contain exactly the 4 defined pipeline steps."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -273,7 +275,7 @@ class TestFreshDatabase:
 
     async def test_step_operation_types_match_all_defined_operations(self) -> None:
         """The four pipeline OperationType values must appear exactly once in the response."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -288,7 +290,7 @@ class TestFreshDatabase:
 
     async def test_fresh_db_counts_are_all_zero(self) -> None:
         """Counts block must reflect the mocked DB values."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -309,9 +311,9 @@ class TestFreshDatabase:
 class TestAfterDataLoad:
     """Validate step statuses once videos have been loaded into the database."""
 
-    # DB counts: channels=5, videos=100, enriched_videos=0, playlists=3,
-    # transcripts=0, categories=0, canonical_tags=0
-    _LOADED_COUNTS = [5, 100, 0, 3, 0, 0, 0]
+    # DB counts: channels=5, videos=100, available_videos=100, enriched_videos=0,
+    # playlists=3, transcripts=0, categories=0, canonical_tags=0
+    _LOADED_COUNTS = [5, 100, 100, 0, 3, 0, 0, 0]
 
     async def test_load_data_is_completed_when_videos_exist(self) -> None:
         """load_data is COMPLETED as soon as videos > 0."""
@@ -357,9 +359,9 @@ class TestAfterDataLoad:
 
     async def test_seed_reference_completed_when_categories_populated(self) -> None:
         """seed_reference is COMPLETED when categories > 0."""
-        # channels=5, videos=100, enriched_videos=0, playlists=3, transcripts=0,
-        # categories=50, canonical_tags=0
-        service = _build_service(counts_sequence=[5, 100, 0, 3, 0, 50, 0])
+        # channels=5, videos=100, available_videos=100, enriched_videos=0,
+        # playlists=3, transcripts=0, categories=50, canonical_tags=0
+        service = _build_service(counts_sequence=[5, 100, 100, 0, 3, 0, 50, 0])
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -368,9 +370,9 @@ class TestAfterDataLoad:
 
     async def test_normalize_tags_completed_when_canonical_tags_exist(self) -> None:
         """normalize_tags is COMPLETED when canonical_tags > 0."""
-        # channels=5, videos=100, enriched_videos=0, playlists=3, transcripts=0,
-        # categories=0, canonical_tags=5000
-        service = _build_service(counts_sequence=[5, 100, 0, 3, 0, 0, 5000])
+        # channels=5, videos=100, available_videos=100, enriched_videos=0,
+        # playlists=3, transcripts=0, categories=0, canonical_tags=5000
+        service = _build_service(counts_sequence=[5, 100, 100, 0, 3, 0, 0, 5000])
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -386,8 +388,11 @@ class TestAfterDataLoad:
 class TestAuthGating:
     """Validate that enrich_metadata obeys the requires_auth flag."""
 
-    # Both unauthenticated and authenticated with data loaded
-    _LOADED_COUNTS = [5, 100, 3, 0, 0, 0]
+    # Both unauthenticated and authenticated with data loaded.
+    # channels=5, videos=100, available_videos=3, enriched_videos=3,
+    # playlists=0, transcripts=0, categories=0, canonical_tags=0
+    # available_videos == enriched_videos so enrich_metadata resolves COMPLETED.
+    _LOADED_COUNTS = [5, 100, 3, 3, 0, 0, 0, 0]
 
     async def test_enrich_metadata_completed_when_data_exists_and_not_authenticated(
         self,
@@ -430,7 +435,7 @@ class TestAuthGating:
         When videos == 0 the COMPLETED check fails, so auth is evaluated next.
         Auth is present but the load_data dependency is not met, so BLOCKED.
         """
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=True):
             status = await service.get_status()
 
@@ -446,7 +451,7 @@ class TestAuthGating:
 
         When videos == 0: count check fails → auth check fires (no auth) → BLOCKED.
         """
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -465,7 +470,7 @@ class TestAuthGating:
         This mirrors test_enrich_metadata_blocked_when_authenticated_but_no_data.
         """
         # This test intentionally mirrors the above — confirming consistent BLOCKED
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=True):
             status = await service.get_status()
 
@@ -488,10 +493,10 @@ class TestAuthGating:
     async def test_non_auth_steps_unaffected_by_auth_state(self) -> None:
         """Steps that do not require_auth must not change status based on auth."""
         # With data loaded, normalize_tags should be AVAILABLE regardless of auth
-        # Sequence: channels=5, videos=100, enriched_videos=0, playlists=3,
-        # transcripts=0, categories=0, canonical_tags=0
-        service_authed = _build_service(counts_sequence=[5, 100, 0, 3, 0, 0, 0])
-        service_unauthed = _build_service(counts_sequence=[5, 100, 0, 3, 0, 0, 0])
+        # Sequence: channels=5, videos=100, available_videos=100, enriched_videos=0,
+        # playlists=3, transcripts=0, categories=0, canonical_tags=0
+        service_authed = _build_service(counts_sequence=[5, 100, 100, 0, 3, 0, 0, 0])
+        service_unauthed = _build_service(counts_sequence=[5, 100, 100, 0, 3, 0, 0, 0])
 
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=True):
             status_authed = await service_authed.get_status()
@@ -515,7 +520,7 @@ class TestDataExportDetection:
         self, is_dir: bool, has_files: bool
     ) -> OnboardingStatus:
         """Helper that runs get_status() with controlled Path behaviour."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
 
         with (
             patch(_SETTINGS_TOKEN_IS_FILE, return_value=False),
@@ -546,7 +551,7 @@ class TestDataExportDetection:
 
     async def test_data_export_path_uses_env_var(self) -> None:
         """data_export_path reflects the TAKEOUT_DIR environment variable when set."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         custom_dir = "/custom/takeout/path"
 
         with (
@@ -561,7 +566,7 @@ class TestDataExportDetection:
 
     async def test_data_export_path_defaults_when_no_env_var(self) -> None:
         """data_export_path falls back to ./data/takeout when TAKEOUT_DIR is unset."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
 
         with (
             patch(_SETTINGS_TOKEN_IS_FILE, return_value=False),
@@ -577,7 +582,7 @@ class TestDataExportDetection:
         self,
     ) -> None:
         """_detect_data_export returns False and logs a warning on PermissionError."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
 
         with (
             patch(_SETTINGS_TOKEN_IS_FILE, return_value=False),
@@ -597,9 +602,9 @@ class TestDataExportDetection:
 class TestMetricsAggregation:
     """Validate that each PipelineStep.metrics dict is correctly populated."""
 
-    # channels=5, videos=100, enriched_videos=50, playlists=3,
-    # transcripts=200, categories=50, canonical_tags=9999
-    _FULL_COUNTS = [5, 100, 50, 3, 200, 50, 9999]
+    # channels=5, videos=100, available_videos=100, enriched_videos=50,
+    # playlists=3, transcripts=200, categories=50, canonical_tags=9999
+    _FULL_COUNTS = [5, 100, 100, 50, 3, 200, 50, 9999]
 
     async def test_seed_reference_metrics_contain_categories(self) -> None:
         """seed_reference metrics must include the 'categories' count key."""
@@ -645,7 +650,7 @@ class TestMetricsAggregation:
 
     async def test_metrics_reflect_zero_counts_on_fresh_db(self) -> None:
         """All metric values must be 0 when the database is empty."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -669,7 +674,7 @@ class TestRunningTaskAffectsStepStatus:
         """When TaskManager reports a running load_data task, the step is RUNNING."""
         running_task = _make_background_task(OperationType.LOAD_DATA)
         service = _build_service(
-            counts_sequence=[0] * 7,
+            counts_sequence=[0] * 8,
             running_tasks={OperationType.LOAD_DATA: running_task},
         )
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
@@ -682,7 +687,7 @@ class TestRunningTaskAffectsStepStatus:
         """A running seed_reference task overrides AVAILABLE to RUNNING."""
         running_task = _make_background_task(OperationType.SEED_REFERENCE)
         service = _build_service(
-            counts_sequence=[0] * 7,
+            counts_sequence=[0] * 8,
             running_tasks={OperationType.SEED_REFERENCE: running_task},
         )
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
@@ -695,7 +700,7 @@ class TestRunningTaskAffectsStepStatus:
         """get_status() returns the running task in the active_task field."""
         running_task = _make_background_task(OperationType.LOAD_DATA)
         service = _build_service(
-            counts_sequence=[0] * 7,
+            counts_sequence=[0] * 8,
             running_tasks={OperationType.LOAD_DATA: running_task},
         )
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
@@ -706,7 +711,7 @@ class TestRunningTaskAffectsStepStatus:
 
     async def test_active_task_is_none_when_no_running_tasks(self) -> None:
         """active_task is None when TaskManager has no active tasks."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -720,7 +725,7 @@ class TestRunningTaskAffectsStepStatus:
             error="Something went wrong",
         )
         service = _build_service(
-            counts_sequence=[0] * 7,
+            counts_sequence=[0] * 8,
             running_tasks={OperationType.LOAD_DATA: errored_task},
         )
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
@@ -731,7 +736,7 @@ class TestRunningTaskAffectsStepStatus:
 
     async def test_step_without_running_task_has_no_error(self) -> None:
         """Steps with no associated running task have error=None."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -749,15 +754,16 @@ class TestCountsFromDatabase:
 
     async def test_counts_reflect_db_query_values(self) -> None:
         """OnboardingCounts fields must match the sequence returned by session.execute."""
-        # Sequence: channels=7, videos=42, enriched_videos=10, playlists=1,
-        # transcripts=99, categories=5, canonical_tags=300
-        service = _build_service(counts_sequence=[7, 42, 10, 1, 99, 5, 300])
+        # Sequence: channels=7, videos=42, available_videos=42, enriched_videos=10,
+        # playlists=1, transcripts=99, categories=5, canonical_tags=300
+        service = _build_service(counts_sequence=[7, 42, 42, 10, 1, 99, 5, 300])
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
         counts = status.counts
         assert counts.channels == 7
         assert counts.videos == 42
+        assert counts.available_videos == 42
         assert counts.playlists == 1
         assert counts.transcripts == 99
         assert counts.categories == 5
@@ -765,7 +771,7 @@ class TestCountsFromDatabase:
 
     async def test_counts_type_is_onboarding_counts(self) -> None:
         """The counts field must be an OnboardingCounts Pydantic model."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -773,9 +779,9 @@ class TestCountsFromDatabase:
 
     async def test_counts_are_integers(self) -> None:
         """All count fields must be integers, not strings or floats."""
-        # Sequence: channels=1, videos=2, enriched_videos=3, playlists=4,
-        # transcripts=5, categories=6, canonical_tags=7
-        service = _build_service(counts_sequence=[1, 2, 3, 4, 5, 6, 7])
+        # Sequence: channels=1, videos=2, available_videos=3, enriched_videos=4,
+        # playlists=5, transcripts=6, categories=7, canonical_tags=8
+        service = _build_service(counts_sequence=[1, 2, 3, 4, 5, 6, 7, 8])
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -797,7 +803,7 @@ class TestDispatch:
     async def test_dispatch_raises_for_unknown_operation(self) -> None:
         """dispatch() must raise ValueError for an operation not in the pipeline."""
         # We test this indirectly by patching _find_step to return None
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
 
         with (
             patch.object(service, "_find_step", return_value=None),
@@ -808,7 +814,7 @@ class TestDispatch:
     async def test_dispatch_raises_when_dependency_unsatisfied(self) -> None:
         """dispatch() raises ValueError when a required dependency step is not complete."""
         # normalize_tags depends on load_data (videos > 0), but DB is fresh
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             with pytest.raises(ValueError, match="not satisfied"):
                 await service.dispatch(OperationType.NORMALIZE_TAGS)
@@ -816,7 +822,7 @@ class TestDispatch:
     async def test_dispatch_raises_when_auth_required_but_absent(self) -> None:
         """dispatch() raises ValueError when enrich_metadata is requested without auth."""
         # Give enough videos to satisfy load_data dep but no auth
-        service = _build_service(counts_sequence=[5, 100, 0, 3, 0, 0, 0])
+        service = _build_service(counts_sequence=[5, 100, 100, 0, 3, 0, 0, 0])
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             with pytest.raises(ValueError, match="requires OAuth"):
                 await service.dispatch(OperationType.ENRICH_METADATA)
@@ -829,7 +835,7 @@ class TestDispatch:
 
         from chronovista.services.onboarding_service import OnboardingService
 
-        session_factory = _make_session_factory([0] * 7)
+        session_factory = _make_session_factory([0] * 8)
         service = OnboardingService(
             task_manager=task_manager,
             session_factory=session_factory,
@@ -848,7 +854,7 @@ class TestDispatch:
 
         from chronovista.services.onboarding_service import OnboardingService
 
-        session_factory = _make_session_factory([0] * 7)
+        session_factory = _make_session_factory([0] * 8)
         service = OnboardingService(
             task_manager=task_manager,
             session_factory=session_factory,
@@ -868,7 +874,7 @@ class TestDispatch:
         from chronovista.services.onboarding_service import OnboardingService
 
         # videos=100 satisfies load_data dependency
-        session_factory = _make_session_factory([5, 100, 0, 3, 0, 0, 0])
+        session_factory = _make_session_factory([5, 100, 100, 0, 3, 0, 0, 0])
         service = OnboardingService(
             task_manager=task_manager,
             session_factory=session_factory,
@@ -887,7 +893,7 @@ class TestDispatch:
         from chronovista.services.onboarding_service import OnboardingService
 
         # videos=100 satisfies load_data dependency
-        session_factory = _make_session_factory([5, 100, 0, 3, 0, 0, 0])
+        session_factory = _make_session_factory([5, 100, 100, 0, 3, 0, 0, 0])
         service = OnboardingService(
             task_manager=task_manager,
             session_factory=session_factory,
@@ -911,11 +917,11 @@ class TestStepStatusEdgeCases:
         """RUNNING overrides COMPLETED — if a step is running, it shows RUNNING."""
         # categories=50 means seed_reference would be COMPLETED — but we inject
         # a running task for it
-        # Sequence: channels=0, videos=0, enriched_videos=0, playlists=0,
-        # transcripts=0, categories=50, canonical_tags=0
+        # Sequence: channels=0, videos=0, available_videos=0, enriched_videos=0,
+        # playlists=0, transcripts=0, categories=50, canonical_tags=0
         running_task = _make_background_task(OperationType.SEED_REFERENCE)
         service = _build_service(
-            counts_sequence=[0, 0, 0, 0, 0, 50, 0],
+            counts_sequence=[0, 0, 0, 0, 0, 0, 50, 0],
             running_tasks={OperationType.SEED_REFERENCE: running_task},
         )
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
@@ -929,7 +935,7 @@ class TestStepStatusEdgeCases:
         running_seed = _make_background_task(OperationType.SEED_REFERENCE)
         running_load = _make_background_task(OperationType.LOAD_DATA)
         service = _build_service(
-            counts_sequence=[0] * 7,
+            counts_sequence=[0] * 8,
             running_tasks={
                 OperationType.SEED_REFERENCE: running_seed,
                 OperationType.LOAD_DATA: running_load,
@@ -943,7 +949,7 @@ class TestStepStatusEdgeCases:
 
     async def test_step_requires_auth_flag_matches_definition(self) -> None:
         """Only enrich_metadata should have requires_auth=True."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -957,7 +963,7 @@ class TestStepStatusEdgeCases:
 
     async def test_step_dependencies_match_definition(self) -> None:
         """Dependency lists must match the static pipeline definition."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -977,7 +983,7 @@ class TestStepStatusEdgeCases:
         self,
     ) -> None:
         """When data is missing AND auth is missing, enrich_metadata is BLOCKED."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -987,10 +993,11 @@ class TestStepStatusEdgeCases:
 
     async def test_all_steps_completed_when_all_counts_positive(self) -> None:
         """When all relevant counts are > 0, all steps should be COMPLETED."""
-        # channels=5, videos=100, enriched_videos=50 → enrich_metadata done;
+        # channels=5, videos=100, available_videos=50, enriched_videos=50 → enrich_metadata done
+        # (enriched_videos >= available_videos so COMPLETED, not AVAILABLE);
         # playlists=3, transcripts=0, categories=10 → seed_reference done;
         # canonical_tags=200 → normalize_tags done
-        service = _build_service(counts_sequence=[5, 100, 50, 3, 0, 10, 200])
+        service = _build_service(counts_sequence=[5, 100, 50, 50, 3, 0, 10, 200])
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=True):
             status = await service.get_status()
 
@@ -1011,7 +1018,7 @@ class TestSchemaCompliance:
 
     async def test_get_status_returns_onboarding_status_instance(self) -> None:
         """get_status() must return an OnboardingStatus Pydantic model."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -1019,7 +1026,7 @@ class TestSchemaCompliance:
 
     async def test_steps_are_pipeline_step_instances(self) -> None:
         """Each element in status.steps must be a PipelineStep instance."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -1028,7 +1035,7 @@ class TestSchemaCompliance:
 
     async def test_data_export_path_is_string(self) -> None:
         """data_export_path must be serialized as a string, not a Path object."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with (
             patch(_SETTINGS_TOKEN_IS_FILE, return_value=False),
             patch("pathlib.Path.is_dir", return_value=False),
@@ -1039,7 +1046,7 @@ class TestSchemaCompliance:
 
     async def test_step_names_are_non_empty_strings(self) -> None:
         """Each step must have a non-empty name string."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -1049,7 +1056,7 @@ class TestSchemaCompliance:
 
     async def test_step_descriptions_are_non_empty_strings(self) -> None:
         """Each step must have a non-empty description string."""
-        service = _build_service(counts_sequence=[0] * 7)
+        service = _build_service(counts_sequence=[0] * 8)
         with patch(_SETTINGS_TOKEN_IS_FILE, return_value=False):
             status = await service.get_status()
 
@@ -1074,9 +1081,10 @@ class TestReturningUser:
     * Downstream steps keep their statuses based on their own counts.
     """
 
-    # Full pipeline completed: channels=5, videos=100, enriched_videos=50,
-    # playlists=3, transcripts=200, categories=50, canonical_tags=9999
-    _FULL_COUNTS = [5, 100, 50, 3, 200, 50, 9999]
+    # Full pipeline completed: channels=5, videos=100, available_videos=50,
+    # enriched_videos=50 (== available_videos so COMPLETED), playlists=3,
+    # transcripts=200, categories=50, canonical_tags=9999
+    _FULL_COUNTS = [5, 100, 50, 50, 3, 200, 50, 9999]
 
     def _make_export_entry(self, mtime: float = 1700000000.0) -> MagicMock:
         """Create a mock Path entry with a controllable stat().st_mtime."""
@@ -1211,7 +1219,7 @@ class TestReturningUser:
         because the user hasn't done the initial load yet.
         """
         status = await self._get_status_returning_user(
-            [0] * 7,
+            [0] * 8,
             export_dir_exists=True,
             export_has_files=True,
         )
@@ -2231,6 +2239,7 @@ class TestFactoryEnrichMetadata:
             priority="all",
             include_deleted=True,
             check_prerequisites=False,
+            progress_cb=unittest_mock_any,
         )
 
     async def test_progress_called_at_zero(self) -> None:


### PR DESCRIPTION
## Summary
- Fix progress bar stuck at 0% during video enrichment by threading `progress_cb` through to `enrich_videos()` for granular 0-30% updates
- Fix intermittent "Unable to connect to server" banner by adding `retry: 2` to the onboarding status TanStack Query hook
- Fix stale "Available" state on page reload by syncing `activeTaskId` from backend `active_task` via `useEffect`
- Decouple SQLAlchemy echo from `DEBUG` flag (was flooding Docker logs) and add `logging.basicConfig()` so service-layer logs appear in Docker
- Migrate `takeout_user` → real YouTube channel ID during enrichment so likes sync finds the correct rows
- Add `available_videos` field to `OnboardingCounts` schema so enrichment completion compares against enrichable videos only
- Register CLI entry point in Dockerfile (`pip install --no-deps -e .`)
- Fix 3 pre-existing frontend test failures (sidebar/route nav count 6→7, OnboardingPage mock double-cast, useOnboarding error-state retry)
- Align all 115 onboarding service unit test mocks with the new 8-query `_get_counts` sequence

## Test plan
- [x] Backend: 115/115 onboarding service unit tests pass
- [x] Backend: 7110+ tests pass overall, 0 new failures
- [x] Frontend: 2945/2945 tests pass (127 test files), 0 failures
- [x] TypeScript: `tsc --noEmit` clean
- [x] mypy: `onboarding_service.py` clean
- [x] Full Docker onboarding flow validated on fresh DB (Seed → Load → Enrich ×2 → Normalize)
- [x] Liked videos: 4,915 correctly synced without manual intervention
- [x] Tags: 618,479 verified identical to backup (25 random video comparison)