### PR TITLE
fix(onboarding): resolve pool exhaustion, polling storm, and blocking API calls

### DIFF
--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -10,7 +10,7 @@
  * @module hooks/useOnboarding
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   useMutation,
   UseMutationResult,
@@ -49,9 +49,9 @@ export const taskStatusKey = (taskId: string | null) =>
  * Hook that fetches the full onboarding pipeline status.
  *
  * Polling behaviour:
- * - When `active_task` is non-null, the query re-fetches every 5 seconds to
- *   reflect task progress and eventual step-status transitions.
- * - When no task is active, polling is disabled.
+ * - No polling interval — status updates are driven by explicit invalidation
+ *   from useTaskStatus when a task reaches a terminal state.
+ * - staleTime of 10 s prevents redundant background refetches between events.
  *
  * @returns Standard TanStack Query UseQueryResult for OnboardingStatus
  *
@@ -66,18 +66,10 @@ export function useOnboardingStatus(): UseQueryResult<OnboardingStatus, Error> {
     queryKey: ONBOARDING_STATUS_KEY,
     // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
     queryFn: ({ signal }) => fetchOnboardingStatus(signal),
-    refetchInterval: (query) => {
-      // Poll every 5 s while a task is active; disable otherwise.
-      const data = query.state.data;
-      if (data?.active_task !== null && data?.active_task !== undefined) {
-        return 5_000;
-      }
-      return false;
-    },
-    staleTime: 10 * 1000, // 10 seconds — short because status changes frequently
-    gcTime: 5 * 60 * 1000, // 5 minutes
-    // Retry up to 2 times on transient failures (e.g. brief API timeout during
-    // a heavy enrichment run) before surfacing the connection error banner.
+    // No refetchInterval — status updates are driven by invalidation from
+    // useTaskStatus when a task finishes.  This avoids polling storms.
+    staleTime: 10 * 1000,
+    gcTime: 5 * 60 * 1000,
     retry: 2,
   });
 }
@@ -129,8 +121,11 @@ export function useStartTask(): UseMutationResult<
  * - The query is disabled when `taskId` is null.
  * - Polls every 2 seconds while the task status is "queued" or "running".
  * - Stops polling when status transitions to "completed" or "failed".
- * - On completion or failure, invalidates the onboarding status query so step
- *   statuses are refreshed to reflect the finished operation.
+ * - On completion or failure, invalidates the onboarding status query ONCE so
+ *   that pipeline step statuses are refreshed to reflect the finished operation.
+ *
+ * The single-invalidation guarantee is implemented with a ref keyed to the
+ * taskId so the guard resets correctly when a new task begins.
  *
  * @param taskId - UUID of the task to poll, or null to disable the query
  * @returns Standard TanStack Query UseQueryResult for BackgroundTask
@@ -166,14 +161,25 @@ export function useTaskStatus(
     gcTime: 5 * 60 * 1000,
   });
 
-  // When the task transitions to a terminal state, invalidate the onboarding
-  // status so that pipeline step statuses are refreshed immediately.
+  // Track which taskId we have already invalidated for, so we only fire once
+  // per task completion regardless of how many times the component re-renders
+  // with the same terminal status.
+  const invalidatedForTaskRef = useRef<string | null>(null);
+
   const taskStatus = result.data?.status;
+
   useEffect(() => {
-    if (taskStatus === "completed" || taskStatus === "failed") {
+    if (
+      taskId !== null &&
+      (taskStatus === "completed" || taskStatus === "failed") &&
+      invalidatedForTaskRef.current !== taskId
+    ) {
+      // Record BEFORE the async invalidation so concurrent re-renders of this
+      // effect (while the fetch is in-flight) do not queue duplicate requests.
+      invalidatedForTaskRef.current = taskId;
       void queryClient.invalidateQueries({ queryKey: ONBOARDING_STATUS_KEY });
     }
-  }, [taskStatus, queryClient]);
+  }, [taskId, taskStatus, queryClient]);
 
   return result;
 }

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -11,7 +11,7 @@
  * - Active task progress via useTaskStatus() polling
  *
  * State:
- * - activeTaskId: tracked locally; set when a task is started, cleared on completion/failure
+ * - activeTaskId: derived from status.active_task (server is the sole source of truth)
  *
  * Accessibility:
  * - <main> landmark with tabIndex={-1} for skip-link focus
@@ -19,7 +19,7 @@
  * - Data export guidance uses role="status"
  */
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { PipelineStepCard } from "../components/onboarding/PipelineStepCard";
 import { SkipLink } from "../components/SkipLink";
@@ -263,9 +263,15 @@ function PipelineLoadingState() {
  * It fetches the pipeline status, renders five PipelineStepCard components,
  * tracks the active task with real-time polling, and shows a connection error
  * banner when the API is unreachable.
+ *
+ * Active task identity is derived entirely from the server's authoritative
+ * `status.active_task` field, which only contains tasks in an active state
+ * (queued/running). This avoids the stale-data oscillation that occurs when
+ * local state is used as a secondary source of truth and lags behind the
+ * server's view of task completion.
  */
 export function OnboardingPage() {
-  // Pipeline status query (includes polling while a task is active)
+  // Pipeline status query — source of truth for active task identity.
   const {
     data: status,
     isLoading,
@@ -273,34 +279,18 @@ export function OnboardingPage() {
     refetch,
   } = useOnboardingStatus();
 
-  // Local state: the ID of the task that was started in this session
-  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+  // The active task ID comes exclusively from the server. The backend only
+  // populates active_task for QUEUED or RUNNING tasks; once a task completes
+  // or fails the field is null. No local state or clearing effects are needed.
+  const activeTaskId = status?.active_task?.id ?? null;
 
   // Start task mutation
   const startTask = useStartTask();
 
-  // Poll the active task while it runs
+  // Poll the individual task for granular progress while it runs.
+  // When the task reaches a terminal state, useTaskStatus will invalidate the
+  // onboarding status query, causing it to refetch and clear active_task.
   const { data: activeTaskPoll } = useTaskStatus(activeTaskId);
-
-  // Auto-populate activeTaskId from backend status when not set locally.
-  // This handles page refresh and connection drop/recovery — if the backend
-  // reports an active_task but the local state is null (e.g. the user reloaded
-  // the page mid-run), we pick it up so polling and progress display resume.
-  useEffect(() => {
-    if (status?.active_task && activeTaskId === null) {
-      setActiveTaskId(status.active_task.id);
-    }
-  }, [status?.active_task, activeTaskId]);
-
-  // Clear activeTaskId when the polled task reaches a terminal state
-  useEffect(() => {
-    if (
-      activeTaskPoll?.status === "completed" ||
-      activeTaskPoll?.status === "failed"
-    ) {
-      setActiveTaskId(null);
-    }
-  }, [activeTaskPoll?.status]);
 
   // Set page title
   useEffect(() => {
@@ -310,47 +300,43 @@ export function OnboardingPage() {
     };
   }, []);
 
-  // Handlers
+  // Handlers — mutations invalidate the status query via useStartTask.onSuccess,
+  // so the UI will pick up the new active_task on the next refetch automatically.
   const handleStart = (operationType: OperationType) => {
-    startTask.mutate(
-      { operation_type: operationType },
-      {
-        onSuccess: (task) => {
-          setActiveTaskId(task.id);
-        },
-      }
-    );
+    startTask.mutate({ operation_type: operationType });
   };
 
   const handleRetry = (operationType: OperationType) => {
-    startTask.mutate(
-      { operation_type: operationType },
-      {
-        onSuccess: (task) => {
-          setActiveTaskId(task.id);
-        },
-      }
-    );
+    startTask.mutate({ operation_type: operationType });
   };
 
   /**
    * Resolves which BackgroundTask is "active" for a given step.
-   * Prefers the locally polled task; falls back to status.active_task if it
-   * matches the step's operation_type.
+   *
+   * Prefers the granular polled task data (more frequent updates, includes
+   * progress percentage) when it matches the step. Falls back to the status's
+   * active_task when the polled data is not yet available.
+   *
+   * Only returns tasks in an active state (queued/running). The server's
+   * active_task field already enforces this contract, but we double-check
+   * against the polled data to guard against a brief window where the poll
+   * still has terminal-state data while the status query is revalidating.
    */
   const getActiveTaskForStep = (
     operationType: OperationType
   ): BackgroundTask | null => {
-    // Prefer the polled task if it matches this step
+    // Prefer the polled task when it is active and matches this step.
     if (
       activeTaskPoll !== undefined &&
-      activeTaskPoll.operation_type === operationType
+      activeTaskPoll.operation_type === operationType &&
+      (activeTaskPoll.status === "queued" || activeTaskPoll.status === "running")
     ) {
       return activeTaskPoll;
     }
-    // Fall back to the status's active_task
-    if (status?.active_task?.operation_type === operationType) {
-      return status.active_task;
+    // Fall back to the server's active_task (always active by contract).
+    const backendTask = status?.active_task;
+    if (backendTask?.operation_type === operationType) {
+      return backendTask;
     }
     return null;
   };

--- a/frontend/src/tests/pages/OnboardingPage.test.tsx
+++ b/frontend/src/tests/pages/OnboardingPage.test.tsx
@@ -117,15 +117,6 @@ const mockStatus: OnboardingStatus = {
   },
 };
 
-const mockTask: BackgroundTask = {
-  id: "task-uuid-001",
-  operation_type: "seed_reference",
-  status: "queued",
-  progress: 0,
-  error: null,
-  started_at: null,
-  completed_at: null,
-};
 
 // ---------------------------------------------------------------------------
 // Render helper
@@ -317,13 +308,14 @@ describe("OnboardingPage", () => {
       await user.click(startButton);
 
       expect(mockMutate).toHaveBeenCalledOnce();
-      expect(mockMutate).toHaveBeenCalledWith(
-        { operation_type: "seed_reference" },
-        expect.any(Object)
-      );
+      // The page derives activeTaskId from the server (status.active_task), so
+      // mutate is called with only the payload — no local onSuccess callback.
+      expect(mockMutate).toHaveBeenCalledWith({
+        operation_type: "seed_reference",
+      });
     });
 
-    it("calls mutate with the onSuccess callback that sets the active task id", async () => {
+    it("calls mutate with only the operation_type payload (no local onSuccess callback)", async () => {
       await setupHooks({ status: mockStatus });
       const user = userEvent.setup();
 
@@ -334,32 +326,40 @@ describe("OnboardingPage", () => {
       });
       await user.click(startButton);
 
-      // Verify the mutation was called and the second arg is an options object
-      // containing an onSuccess handler (page uses it to track activeTaskId)
+      // activeTaskId is server-derived (status.active_task), so the page does
+      // NOT pass a second argument to mutate. Asserting the call has exactly
+      // one argument confirms no vestigial local-state-setter callback exists.
+      expect(mockMutate).toHaveBeenCalledOnce();
       const callArgs = mockMutate.mock.calls[0];
-      expect(callArgs).toBeDefined();
-      expect(callArgs?.[1]).toHaveProperty("onSuccess");
-      expect(typeof callArgs?.[1]?.onSuccess).toBe("function");
+      expect(callArgs).toHaveLength(1);
+      expect(callArgs?.[0]).toEqual({ operation_type: "seed_reference" });
     });
 
-    it("sets activeTaskId when onSuccess is invoked with the returned task", async () => {
-      await setupHooks({ status: mockStatus });
+    it("calls mutate for the handleRetry path with correct operation_type", async () => {
+      // Build a status where "seed_reference" is completed with an error so
+      // the Retry button is rendered instead of Start.
+      const statusWithError = {
+        ...mockStatus,
+        steps: mockStatus.steps.map((s) =>
+          s.operation_type === "seed_reference"
+            ? { ...s, status: "completed" as const, error: "Something failed" }
+            : s
+        ),
+      };
+      await setupHooks({ status: statusWithError });
       const user = userEvent.setup();
 
       renderPage();
 
-      const startButton = screen.getByRole("button", {
-        name: /Start Seed Reference Data/i,
+      const retryButton = screen.getByRole("button", {
+        name: /Retry Seed Reference Data/i,
       });
-      await user.click(startButton);
+      await user.click(retryButton);
 
-      // Simulate the onSuccess callback being called with a task
-      const onSuccess = mockMutate.mock.calls[0]?.[1]?.onSuccess as (
-        task: BackgroundTask
-      ) => void;
-      expect(onSuccess).toBeDefined();
-      // Calling it should not throw
-      expect(() => onSuccess(mockTask)).not.toThrow();
+      expect(mockMutate).toHaveBeenCalledOnce();
+      expect(mockMutate).toHaveBeenCalledWith({
+        operation_type: "seed_reference",
+      });
     });
   });
 

--- a/src/chronovista/config/database.py
+++ b/src/chronovista/config/database.py
@@ -29,29 +29,30 @@ class DatabaseManager:
         self._engine: AsyncEngine | None = None
         self._session_factory: async_sessionmaker[AsyncSession] | None = None
 
+    @staticmethod
+    def _pool_kwargs() -> dict[str, int]:
+        """Return connection pool settings based on environment.
+
+        Development uses a small pool with no overflow for fast failure.
+        Production uses a larger pool to handle concurrent status polling
+        alongside long-running background tasks that hold sessions open.
+        """
+        if settings.is_development_database:
+            return {"pool_size": 5, "max_overflow": 0, "pool_timeout": 10}
+        return {"pool_size": 10, "max_overflow": 20, "pool_timeout": 30}
+
     def get_engine(self) -> AsyncEngine:
         """Get or create async database engine."""
         if self._engine is None:
-            # Use development database URL when in development mode
             database_url = settings.effective_database_url
 
-            # Development-specific engine configuration
             engine_kwargs = {
                 "echo": settings.db_log_queries,
                 "future": True,
                 "pool_pre_ping": True,
                 "pool_recycle": 3600,
+                **self._pool_kwargs(),
             }
-
-            # Optimize for development if using dev database
-            if settings.is_development_database:
-                engine_kwargs.update(
-                    {
-                        "pool_size": 5,  # Smaller pool for development
-                        "max_overflow": 0,  # No overflow for development
-                        "pool_timeout": 10,  # Shorter timeout for development
-                    }
-                )
 
             self._engine = create_async_engine(database_url, **engine_kwargs)
         return self._engine
@@ -81,15 +82,8 @@ class DatabaseManager:
                 "future": True,
                 "pool_pre_ping": True,
                 "pool_recycle": 3600,
+                **self._pool_kwargs(),
             }
-            if settings.is_development_database:
-                engine_kwargs.update(
-                    {
-                        "pool_size": 5,
-                        "max_overflow": 0,
-                        "pool_timeout": 10,
-                    }
-                )
 
             temp_engine = create_async_engine(database_url, **engine_kwargs)
             temp_session_factory = async_sessionmaker(

--- a/src/chronovista/services/onboarding_service.py
+++ b/src/chronovista/services/onboarding_service.py
@@ -174,12 +174,11 @@ class OnboardingService:
             Full pipeline state including step statuses, counts, auth
             state, and any currently active task.
         """
-        counts = await self._get_counts()
+        counts, last_loaded_at = await self._get_counts_and_last_loaded()
         is_authenticated = self._check_auth()
         data_export_path = self._get_data_export_path()
         data_export_detected = self._detect_data_export(data_export_path)
         export_mtime = self._get_export_mtime(data_export_path)
-        last_loaded_at = await self._get_last_loaded_at()
         new_data_available = self._detect_new_data(
             data_export_detected=data_export_detected,
             export_mtime=export_mtime,
@@ -255,14 +254,20 @@ class OnboardingService:
     # Count queries
     # ------------------------------------------------------------------
 
-    async def _get_counts(self) -> OnboardingCounts:
-        """Query aggregate record counts from the database.
+    async def _get_counts_and_last_loaded(
+        self,
+    ) -> tuple[OnboardingCounts, float | None]:
+        """Query counts and last-loaded timestamp in a single session.
+
+        Consolidates what were previously two separate session opens
+        (``_get_counts`` + ``_get_last_loaded_at``) to reduce connection
+        pool pressure during status polling.
 
         Returns
         -------
-        OnboardingCounts
-            Counts for channels, videos, playlists, transcripts,
-            categories, and canonical_tags.
+        tuple[OnboardingCounts, float | None]
+            The aggregate counts and the epoch timestamp of the most
+            recently created video (or ``None``).
         """
         async with self._session_factory() as session:
             channels = await self._count(session, Channel)
@@ -274,7 +279,14 @@ class OnboardingService:
             categories = await self._count(session, VideoCategory)
             canonical_tags = await self._count(session, CanonicalTag)
 
-        return OnboardingCounts(
+            # Also fetch last-loaded timestamp in the same session
+            result = await session.execute(
+                select(func.max(Video.created_at))
+            )
+            latest = result.scalar_one_or_none()
+            last_loaded_at = latest.timestamp() if latest is not None else None
+
+        counts = OnboardingCounts(
             channels=channels,
             videos=videos,
             available_videos=available_videos,
@@ -284,6 +296,19 @@ class OnboardingService:
             categories=categories,
             canonical_tags=canonical_tags,
         )
+        return counts, last_loaded_at
+
+    async def _get_counts(self) -> OnboardingCounts:
+        """Query aggregate record counts from the database.
+
+        Returns
+        -------
+        OnboardingCounts
+            Counts for channels, videos, playlists, transcripts,
+            categories, and canonical_tags.
+        """
+        counts, _ = await self._get_counts_and_last_loaded()
+        return counts
 
     @staticmethod
     async def _count(session: AsyncSession, model: type) -> int:
@@ -338,25 +363,6 @@ class OnboardingService:
         )
         return result.scalar_one()
 
-    async def _get_last_loaded_at(self) -> float | None:
-        """Return the epoch timestamp of the most recently created video.
-
-        Used to compare against the takeout directory mtime to decide
-        whether new export data has appeared since the last load.
-
-        Returns
-        -------
-        float | None
-            Epoch timestamp, or ``None`` if no videos exist.
-        """
-        async with self._session_factory() as session:
-            result = await session.execute(
-                select(func.max(Video.created_at))
-            )
-            latest = result.scalar_one_or_none()
-            if latest is None:
-                return None
-            return latest.timestamp()
 
     # ------------------------------------------------------------------
     # Filesystem / auth checks

--- a/src/chronovista/services/youtube_service.py
+++ b/src/chronovista/services/youtube_service.py
@@ -13,12 +13,16 @@ instead of Dict[str, Any] for improved type safety and runtime validation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any, List, Optional
 
 from googleapiclient.errors import HttpError
 from pydantic import ValidationError as PydanticValidationError
+
+# Suppress noisy "file_cache is only supported with oauth2client<4.0.0" warning
+logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)
 
 from chronovista.auth import youtube_oauth
 from chronovista.config.settings import settings
@@ -177,13 +181,12 @@ class YouTubeService(YouTubeServiceInterface):
             pass
         return None
 
-    def _execute_with_retry(self, request: Any) -> Any:
+    async def _execute_with_retry(self, request: Any) -> Any:
         """
-        Execute a YouTube API request with retry logic.
+        Execute a YouTube API request with retry logic (non-blocking).
 
-        Implements exponential backoff retry (1s, 2s, 4s) for transient
-        failures per FR-052. Raises QuotaExceededException for quota
-        errors per FR-051.
+        Runs the synchronous Google API call in a thread via
+        ``asyncio.to_thread`` so the event loop stays responsive.
 
         Parameters
         ----------
@@ -201,6 +204,14 @@ class YouTubeService(YouTubeServiceInterface):
             If YouTube API quota is exceeded.
         NetworkError
             If all retry attempts fail.
+        """
+        return await asyncio.to_thread(self._execute_with_retry_sync, request)
+
+    def _execute_with_retry_sync(self, request: Any) -> Any:
+        """
+        Synchronous implementation of retry logic.
+
+        Called via ``asyncio.to_thread`` from ``_execute_with_retry``.
         """
         last_error: Exception | None = None
 
@@ -287,7 +298,7 @@ class YouTubeService(YouTubeServiceInterface):
             part="id,snippet,statistics,contentDetails,status,brandingSettings,topicDetails",
             mine=True,
         )
-        response = request.execute()
+        response = await asyncio.to_thread(request.execute)
 
         if not response.get("items"):
             raise YouTubeAPIError(
@@ -336,7 +347,7 @@ class YouTubeService(YouTubeServiceInterface):
             part="id,snippet,statistics,contentDetails,status,brandingSettings,topicDetails",
             id=channel_ids_str,
         )
-        response = request.execute()
+        response = await asyncio.to_thread(request.execute)
 
         if not response.get("items"):
             # Return empty list when no channels found — the caller (enrichment
@@ -385,7 +396,7 @@ class YouTubeService(YouTubeServiceInterface):
         """
         # First get the uploads playlist ID
         request = self.service.channels().list(part="contentDetails", id=channel_id)
-        response = request.execute()
+        response = await asyncio.to_thread(request.execute)
 
         if not response.get("items"):
             raise YouTubeAPIError(
@@ -404,7 +415,7 @@ class YouTubeService(YouTubeServiceInterface):
             playlistId=uploads_playlist_id,
             maxResults=max_results,
         )
-        response = request.execute()
+        response = await asyncio.to_thread(request.execute)
 
         results: list[YouTubePlaylistItemResponse] = []
         for item in response.get("items", []):
@@ -452,7 +463,7 @@ class YouTubeService(YouTubeServiceInterface):
             part="id,snippet,statistics,contentDetails,status,localizations,topicDetails",
             id=",".join(video_ids),
         )
-        response = self._execute_with_retry(request)
+        response = await self._execute_with_retry(request)
 
         results: list[YouTubeVideoResponse] = []
         for item in response.get("items", []):
@@ -623,7 +634,7 @@ class YouTubeService(YouTubeServiceInterface):
                 maxResults=page_size,
                 pageToken=page_token,
             )
-            response = request.execute()
+            response = await asyncio.to_thread(request.execute)
 
             for item in response.get("items", []):
                 try:
@@ -695,7 +706,7 @@ class YouTubeService(YouTubeServiceInterface):
                 maxResults=page_size,
                 pageToken=page_token,
             )
-            response = request.execute()
+            response = await asyncio.to_thread(request.execute)
 
             for item in response.get("items", []):
                 try:
@@ -743,7 +754,7 @@ class YouTubeService(YouTubeServiceInterface):
             type="video",
             maxResults=max_results,
         )
-        response = request.execute()
+        response = await asyncio.to_thread(request.execute)
 
         results: list[YouTubeSearchResponse] = []
         for item in response.get("items", []):
@@ -771,7 +782,7 @@ class YouTubeService(YouTubeServiceInterface):
         """
         try:
             request = self.service.captions().list(part="id,snippet", videoId=video_id)
-            response = request.execute()
+            response = await asyncio.to_thread(request.execute)
 
             results: list[YouTubeCaptionResponse] = []
             for item in response.get("items", []):
@@ -805,7 +816,7 @@ class YouTubeService(YouTubeServiceInterface):
         """
         try:
             request = self.service.captions().download(id=caption_id, tfmt=fmt)
-            caption_content = request.execute()
+            caption_content = await asyncio.to_thread(request.execute)
 
             # The response should be the caption content as bytes
             if isinstance(caption_content, bytes):
@@ -860,7 +871,7 @@ class YouTubeService(YouTubeServiceInterface):
                 playlistId=watch_later_playlist_id,
                 maxResults=max_results,
             )
-            response = request.execute()
+            response = await asyncio.to_thread(request.execute)
 
             results: list[YouTubePlaylistItemResponse] = []
             for item in response.get("items", []):
@@ -898,7 +909,7 @@ class YouTubeService(YouTubeServiceInterface):
                 videoId=video_id,
                 maxResults=1,
             )
-            response = request.execute()
+            response = await asyncio.to_thread(request.execute)
 
             return len(response.get("items", [])) > 0
         except Exception as e:
@@ -969,7 +980,7 @@ class YouTubeService(YouTubeServiceInterface):
         try:
             # First get the liked videos playlist ID
             request = self.service.channels().list(part="contentDetails", mine=True)
-            response = self._execute_with_retry(request)
+            response = await self._execute_with_retry(request)
 
             if not response.get("items"):
                 raise YouTubeAPIError(
@@ -1013,7 +1024,7 @@ class YouTubeService(YouTubeServiceInterface):
                     maxResults=page_size,
                     pageToken=page_token,
                 )
-                response = self._execute_with_retry(request)
+                response = await self._execute_with_retry(request)
 
                 playlist_items = response.get("items", [])
                 items_in_page = len(playlist_items)
@@ -1103,7 +1114,7 @@ class YouTubeService(YouTubeServiceInterface):
         request = self.service.subscriptions().list(
             part="id,snippet,subscriberSnippet", mine=True, maxResults=max_results
         )
-        response = request.execute()
+        response = await asyncio.to_thread(request.execute)
 
         results: list[YouTubeSubscriptionResponse] = []
         for item in response.get("items", []):
@@ -1150,7 +1161,7 @@ class YouTubeService(YouTubeServiceInterface):
             part="id,snippet,status,contentDetails",
             id=",".join(playlist_ids),
         )
-        response = self._execute_with_retry(request)
+        response = await self._execute_with_retry(request)
 
         results: list[YouTubePlaylistResponse] = []
         for item in response.get("items", []):
@@ -1247,7 +1258,7 @@ class YouTubeService(YouTubeServiceInterface):
             request = self.service.videoCategories().list(
                 part="id,snippet", regionCode=region_code.upper()
             )
-            response = request.execute()
+            response = await asyncio.to_thread(request.execute)
 
             items = response.get("items", [])
             if not items:


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  - **Pool exhaustion**: Consolidated two separate DB session opens in `get_status()` into one and extracted `_pool_kwargs()` for consistent pool config (prod: pool_size=10, max_overflow=20)                   
  - **Frontend polling storm (4,000+ req/s)**: Replaced `useState` for `activeTaskId` with server-derived constant, eliminating state oscillation between competing `useEffect` hooks; added single-invalidation
  ref guard in `useTaskStatus`                                                                                                                                                                                   
  - **Blocking event loop**: Wrapped synchronous `httplib2`-based YouTube API calls with `asyncio.to_thread()` to prevent blocking the FastAPI event loop during enrichment
                                                                                                                                                                                                                 
  ## Test plan                                              
                                                                                                                                                                                                                 
  - [x] Backend tests pass (6,000+)                         
  - [x] Frontend tests pass (2,945)
  - [x] mypy clean, TypeScript clean                                                                                                                                                                             
  - [x] Full onboarding flow validated on fresh Docker DB:
    - Seed Reference Data: completed in ~2s, no flickering                                                                                                                                                       
    - Load Data Export: 52,402 videos loaded in 15 min, no errors
    - Enrich Metadata: completed in 33 min, no pool exhaustion or connection errors                                                                                                                              
    - Tag Normalization: completed in ~2 min
    - Second enrichment pass: multi-cycle unavailability confirmation working correctly                                                                                                                          

                                                                                                                                                                                                                 
  