### PR TITLE
feat(settings): add Settings page with preferences, cache, and app info (Feature 049)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.50.0] - 2026-03-21
+
+### Added
+- **Feature 049: Settings & Preferences Page**
+  - **Language Preferences UI (US1)**: Settings page at `/settings` with full language preference management; preferences grouped by type (Fluent, Learning, Curious, Exclude) with color-coded pills showing display name and code; add preference via searchable language combobox with preference type selector; remove individual preferences; reset all with confirmation `alertdialog`; learning goal input conditionally shown for "learning" type; empty state explaining each preference type's effect on transcript downloading; `DuplicateLanguageError` validation (FR-009); `aria-live` region for preference change announcements; `useLanguagePreferences` hook with PUT replace-all semantics and priority renumbering
+  - **Preference-Aware Transcript Download (US2)**: Frontend transcript download now respects configured language preferences; backend `download_transcript()` consults `PreferenceAwareTranscriptFilter` to determine which languages to download (fluent → learning → curious, skipping excluded); `?language` query parameter continues to work as override; error message lists attempted languages when no transcripts available; `model_validate()` conversion from ORM to Pydantic domain models
+  - **Cache Status & Management (US3)**: "Cache" section on Settings page showing cached image count and total disk space; "Clear Cache" button with confirmation `alertdialog`; Escape key dismisses dialog; loading skeleton, error state with retry, empty cache state ("No cached images"); `useCacheStatus` hook with purge mutation and query invalidation
+  - **Application Info (US4)**: "About" section with backend version, frontend version, database statistics (videos, channels, playlists, transcripts, corrections, canonical tags) in `dl/dt/dd` markup; last sync timestamps for 5 data types with "Never synced" fallback; `useAppInfo` hook with 30s staleTime
+  - **Settings API Endpoints**: `GET /api/v1/settings/supported-languages` (all BCP-47 codes with display names, no auth required); `GET /api/v1/settings/cache-status` (image count, disk size); `DELETE /api/v1/settings/cache` (purge all cached images); `GET /api/v1/settings/app-info` (version, DB stats, sync timestamps)
+  - **Sidebar Navigation**: Settings entry added below separator alongside Setup; `NavSeparator` component with `kind: "separator"` entry type; content navigation (Videos, Transcripts, Channels, Playlists, Entities, Search) above separator, configuration items (Setup, Settings) below
+
+### Changed
+- Sidebar restructured: Setup moved below separator to group with Settings (content above, config below)
+- Transcript language display on video cards changed from plain text to indigo pills (`bg-indigo-50 text-indigo-700`) with up to 5 visible and `+N` overflow; "N transcripts" count text removed
+
+### Fixed
+- `download_transcript()` type mismatch: SQLAlchemy ORM models passed where Pydantic domain models expected by `PreferenceAwareTranscriptFilter` — added `model_validate()` conversion
+- Stale `# type: ignore[return-value]` on `ProblemJSONResponse` in settings router
+
+### Technical
+- 4 new backend endpoints, 3 new frontend hooks, 4 new frontend components, 1 new page
+- 150 new tests (38 backend + 112 frontend across 7 test files)
+- 3,277 total frontend tests, 6,000+ total backend tests
+- Frontend version: 0.18.0 → 0.19.0
+- TypeScript strict mode (0 errors), mypy strict compliance (0 errors)
+- No new dependencies, no database migrations
+- GitHub issue #102 created for sync timestamp persistence
+
 ## [0.49.0] - 2026-03-20
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.50.0] - 2026-03-21
+
+### Added
+- **Feature 049: Settings & Preferences Page**
+  - **Language Preferences UI (US1)**: Settings page at `/settings` with full language preference management; preferences grouped by type (Fluent, Learning, Curious, Exclude) with color-coded pills showing display name and code; add preference via searchable language combobox with preference type selector; remove individual preferences; reset all with confirmation `alertdialog`; learning goal input conditionally shown for "learning" type; empty state explaining each preference type's effect on transcript downloading; `DuplicateLanguageError` validation (FR-009); `aria-live` region for preference change announcements; `useLanguagePreferences` hook with PUT replace-all semantics and priority renumbering
+  - **Preference-Aware Transcript Download (US2)**: Frontend transcript download now respects configured language preferences; backend `download_transcript()` consults `PreferenceAwareTranscriptFilter` to determine which languages to download (fluent → learning → curious, skipping excluded); `?language` query parameter continues to work as override; error message lists attempted languages when no transcripts available; `model_validate()` conversion from ORM to Pydantic domain models
+  - **Cache Status & Management (US3)**: "Cache" section on Settings page showing cached image count and total disk space; "Clear Cache" button with confirmation `alertdialog`; Escape key dismisses dialog; loading skeleton, error state with retry, empty cache state ("No cached images"); `useCacheStatus` hook with purge mutation and query invalidation
+  - **Application Info (US4)**: "About" section with backend version, frontend version, database statistics (videos, channels, playlists, transcripts, corrections, canonical tags) in `dl/dt/dd` markup; last sync timestamps for 5 data types with "Never synced" fallback; `useAppInfo` hook with 30s staleTime
+  - **Settings API Endpoints**: `GET /api/v1/settings/supported-languages` (all BCP-47 codes with display names, no auth required); `GET /api/v1/settings/cache-status` (image count, disk size); `DELETE /api/v1/settings/cache` (purge all cached images); `GET /api/v1/settings/app-info` (version, DB stats, sync timestamps)
+  - **Sidebar Navigation**: Settings entry added below separator alongside Setup; `NavSeparator` component with `kind: "separator"` entry type; content navigation (Videos, Transcripts, Channels, Playlists, Entities, Search) above separator, configuration items (Setup, Settings) below
+
+### Changed
+- Sidebar restructured: Setup moved below separator to group with Settings (content above, config below)
+- Transcript language display on video cards changed from plain text to indigo pills (`bg-indigo-50 text-indigo-700`) with up to 5 visible and `+N` overflow; "N transcripts" count text removed
+
+### Fixed
+- `download_transcript()` type mismatch: SQLAlchemy ORM models passed where Pydantic domain models expected by `PreferenceAwareTranscriptFilter` — added `model_validate()` conversion
+- Stale `# type: ignore[return-value]` on `ProblemJSONResponse` in settings router
+
+### Technical
+- 4 new backend endpoints, 3 new frontend hooks, 4 new frontend components, 1 new page
+- 150 new tests (38 backend + 112 frontend across 7 test files)
+- 3,277 total frontend tests, 6,000+ total backend tests
+- Frontend version: 0.18.0 → 0.19.0
+- TypeScript strict mode (0 errors), mypy strict compliance (0 errors)
+- No new dependencies, no database migrations
+- GitHub issue #102 created for sync timestamp persistence
+
 ## [0.49.0] - 2026-03-20
 
 ### Added

--- a/docs/user-guide/rest-api.md
+++ b/docs/user-guide/rest-api.md
@@ -2003,6 +2003,125 @@ Returns the updated preferences in the same format as GET.
 
 ---
 
+### Settings
+
+#### Get Supported Languages
+
+Get all supported BCP-47 language codes with human-readable display names. No authentication required.
+
+```
+GET /api/v1/settings/supported-languages
+```
+
+##### Response
+
+```json
+{
+  "data": [
+    { "code": "af", "display_name": "Afrikaans" },
+    { "code": "ar", "display_name": "Arabic" },
+    { "code": "en", "display_name": "English" },
+    { "code": "es", "display_name": "Spanish" },
+    { "code": "fr", "display_name": "French" },
+    "..."
+  ]
+}
+```
+
+#### Get Cache Status
+
+Get the current image cache status including file count and disk usage.
+
+```
+GET /api/v1/settings/cache-status
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "total_files": 342,
+    "total_size_bytes": 24576000,
+    "total_size_display": "23.4 MB",
+    "last_modified": "2026-03-21T10:30:00Z"
+  }
+}
+```
+
+##### Notes
+
+- Returns `total_files: 0` and `total_size_bytes: 0` when the cache directory is empty or does not exist
+- `last_modified` is `null` when no cached files exist
+
+#### Clear Cache
+
+Purge all cached images (channel avatars and video thumbnails).
+
+```
+DELETE /api/v1/settings/cache
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "files_deleted": 342,
+    "space_freed_bytes": 24576000,
+    "space_freed_display": "23.4 MB"
+  }
+}
+```
+
+##### Errors
+
+| Status | Code | Description |
+|--------|------|-------------|
+| 500 | `INTERNAL_ERROR` | Cache directory could not be purged |
+
+#### Get Application Info
+
+Get application version, database statistics, and last sync timestamps.
+
+```
+GET /api/v1/settings/app-info
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "backend_version": "0.50.0",
+    "frontend_version": "0.19.0",
+    "database_stats": {
+      "videos": 1523,
+      "channels": 87,
+      "playlists": 12,
+      "transcripts": 943,
+      "corrections": 156,
+      "canonical_tags": 124686
+    },
+    "sync_timestamps": {
+      "subscriptions": null,
+      "videos": "2026-03-20T15:30:00Z",
+      "transcripts": null,
+      "playlists": null,
+      "topics": null
+    }
+  }
+}
+```
+
+##### Notes
+
+- `sync_timestamps` values are `null` when a data type has never been synced (displayed as "Never synced" in the UI)
+- Sync timestamps are currently stored in-memory only and reset on server restart (see [GitHub #102](https://github.com/aucontraire/chronovista/issues/102))
+- `frontend_version` is read from the compiled frontend build; returns `"unknown"` if the build metadata file is not found
+
+---
+
 ### Recovery
 
 Recover metadata for unavailable (deleted, private, or terminated) videos and channels using the Internet Archive's Wayback Machine.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/PlaylistVideoCard.tsx
+++ b/frontend/src/components/PlaylistVideoCard.tsx
@@ -132,7 +132,7 @@ export function PlaylistVideoCard({ video }: PlaylistVideoCardProps) {
 
             {/* Transcript Info (only if transcripts available) */}
             {transcript_summary.count > 0 && (
-              <div className="mt-2">
+              <div className="mt-2 flex flex-wrap items-center gap-1.5">
                 <span
                   className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
                     transcript_summary.has_manual
@@ -143,6 +143,27 @@ export function PlaylistVideoCard({ video }: PlaylistVideoCardProps) {
                 >
                   {transcript_summary.has_manual ? "Manual CC" : "Auto CC"}
                 </span>
+                {transcript_summary.languages.length > 0 && (
+                  <span className="flex flex-wrap items-center gap-1" aria-label="Available transcript languages">
+                    {transcript_summary.languages.slice(0, 5).map((lang) => (
+                      <span
+                        key={lang}
+                        className="inline-flex items-center bg-indigo-50 text-indigo-700 px-1.5 py-0.5 rounded text-xs font-mono"
+                      >
+                        {lang}
+                      </span>
+                    ))}
+                    {transcript_summary.languages.length > 5 && (
+                      <span
+                        className="inline-flex items-center bg-indigo-50 text-indigo-700 px-1.5 py-0.5 rounded text-xs"
+                        title={`Also: ${transcript_summary.languages.slice(5).join(", ")}`}
+                        aria-label={`${transcript_summary.languages.length - 5} more languages`}
+                      >
+                        +{transcript_summary.languages.length - 5}
+                      </span>
+                    )}
+                  </span>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -199,16 +199,27 @@ export function VideoCard({ video }: VideoCardProps) {
                 Corrections
               </span>
             )}
-            <span className={`text-${colorTokens.text.tertiary}`}>
-              {transcript_summary.count} transcript
-              {transcript_summary.count !== 1 ? "s" : ""}
-              {transcript_summary.languages.length > 0 && (
-                <span className="ml-1">
-                  ({transcript_summary.languages.slice(0, 3).join(", ")}
-                  {transcript_summary.languages.length > 3 && "..."})
-                </span>
-              )}
-            </span>
+            {transcript_summary.languages.length > 0 && (
+              <span className="flex flex-wrap items-center gap-1" aria-label="Available transcript languages">
+                {transcript_summary.languages.slice(0, 5).map((lang) => (
+                  <span
+                    key={lang}
+                    className="inline-flex items-center bg-indigo-50 text-indigo-700 px-1.5 py-0.5 rounded text-xs font-mono"
+                  >
+                    {lang}
+                  </span>
+                ))}
+                {transcript_summary.languages.length > 5 && (
+                  <span
+                    className="inline-flex items-center bg-indigo-50 text-indigo-700 px-1.5 py-0.5 rounded text-xs"
+                    title={`Also: ${transcript_summary.languages.slice(5).join(", ")}`}
+                    aria-label={`${transcript_summary.languages.length - 5} more languages`}
+                  >
+                    +{transcript_summary.languages.length - 5}
+                  </span>
+                )}
+              </span>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/components/icons/SettingsIcon.tsx
+++ b/frontend/src/components/icons/SettingsIcon.tsx
@@ -1,0 +1,25 @@
+/**
+ * SettingsIcon component - a gear/cog icon for settings and preferences navigation.
+ */
+
+/**
+ * SettingsIcon displays a gear icon for settings-related navigation and UI elements.
+ * Designed for use in navigation and settings/preferences pages.
+ *
+ * @param props - Standard SVG props for customization
+ */
+export const SettingsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    aria-hidden="true"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+    <path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+  </svg>
+);

--- a/frontend/src/components/icons/index.ts
+++ b/frontend/src/components/icons/index.ts
@@ -11,4 +11,5 @@ export { PlaylistIcon } from "./PlaylistIcon";
 export { SearchIcon } from "./SearchIcon";
 export { TranscriptsIcon } from "./TranscriptsIcon";
 export { SetupIcon } from "./SetupIcon";
+export { SettingsIcon } from "./SettingsIcon";
 export { VideoIcon } from "./VideoIcon";

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -59,7 +59,15 @@ export function Sidebar() {
     >
       {/* Navigation items */}
       <ul className="flex flex-col" role="list">
-        {navRoutes.map((entry) => {
+        {navRoutes.map((entry, index) => {
+          if (entry.kind === "separator") {
+            return (
+              <li key={`separator-${index}`} role="separator" aria-hidden="true">
+                <hr className="mx-3 my-2 border-slate-700" />
+              </li>
+            );
+          }
+
           if (entry.kind === "group") {
             return (
               <NavGroup

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -128,9 +128,9 @@ describe("Sidebar — Transcripts group", () => {
 });
 
 describe("Sidebar — total top-level nav item count", () => {
-  it("top-level list contains 7 entries (Videos, Transcripts group, Channels, Playlists, Entities, Search, Setup)", () => {
+  it("top-level list contains 9 entries (Videos, Transcripts group, Channels, Playlists, Entities, Search, separator, Setup, Settings)", () => {
     renderSidebar();
-    // The outer <ul role="list"> has exactly 7 <li> children (6 flat routes + 1 group)
+    // The outer <ul role="list"> has 9 children (6 flat routes + 1 group + 1 separator + 2 config routes)
     const nav = screen.getByRole("navigation", { name: "Main navigation" });
     // The direct child ul has role="list" — query it within the nav
     const outerList = nav.querySelector("ul[role='list']");
@@ -138,6 +138,6 @@ describe("Sidebar — total top-level nav item count", () => {
     const directLiChildren = outerList
       ? Array.from(outerList.children).filter((el) => el.tagName === "LI")
       : [];
-    expect(directLiChildren).toHaveLength(7);
+    expect(directLiChildren).toHaveLength(9);
   });
 });

--- a/frontend/src/components/settings/AboutSection.tsx
+++ b/frontend/src/components/settings/AboutSection.tsx
@@ -1,0 +1,460 @@
+/**
+ * AboutSection — displays application version, database statistics, and
+ * last-sync timestamps within the Settings page.
+ *
+ * Implements Feature 049 requirements:
+ * - FR-018: Backend and frontend version display
+ * - FR-019: Database entity counts (Videos, Channels, Playlists, Transcripts,
+ *            Corrections, Canonical Tags) in a responsive grid
+ * - FR-020: Last-sync timestamps per data type, formatted as relative time
+ * - FR-021: Loading skeleton while fetching
+ * - FR-022: Inline error with retry button on API failure
+ * - FR-025: "Never synced" for null sync timestamps
+ * - FR-029: ARIA labels for statistic sections, semantic dl/dt/dd markup
+ *
+ * @module components/settings/AboutSection
+ */
+
+import { useCallback } from "react";
+
+import { useAppInfo } from "../../hooks/useAppInfo";
+import type { DatabaseStats } from "../../api/settings";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface StatItem {
+  label: string;
+  value: number;
+}
+
+interface SyncItem {
+  key: string;
+  label: string;
+  timestamp: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Relative time formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats a UTC ISO-8601 timestamp string as a relative time string
+ * (e.g. "2 hours ago", "3 days ago").
+ *
+ * Returns null when the input is null (never synced).
+ * Falls back to the raw ISO string if the date is unparseable.
+ *
+ * Parameters
+ * ----------
+ * isoString : string | null
+ *   The UTC timestamp string from the backend, or null.
+ *
+ * Returns
+ * -------
+ * string | null
+ *   A human-readable relative string, or null for a null input.
+ */
+function formatRelativeTime(isoString: string | null): string | null {
+  if (isoString === null) return null;
+
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return isoString;
+
+  const nowMs = Date.now();
+  const diffMs = nowMs - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+  if (Math.abs(diffSeconds) < 60) {
+    return rtf.format(-diffSeconds, "second");
+  }
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  if (Math.abs(diffMinutes) < 60) {
+    return rtf.format(-diffMinutes, "minute");
+  }
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (Math.abs(diffHours) < 24) {
+    return rtf.format(-diffHours, "hour");
+  }
+  const diffDays = Math.floor(diffHours / 24);
+  if (Math.abs(diffDays) < 30) {
+    return rtf.format(-diffDays, "day");
+  }
+  const diffMonths = Math.floor(diffDays / 30);
+  if (Math.abs(diffMonths) < 12) {
+    return rtf.format(-diffMonths, "month");
+  }
+  const diffYears = Math.floor(diffMonths / 12);
+  return rtf.format(-diffYears, "year");
+}
+
+/**
+ * Formats a UTC ISO-8601 timestamp string as an absolute locale string for
+ * use in the `title` tooltip attribute.
+ *
+ * Parameters
+ * ----------
+ * isoString : string | null
+ *   The UTC timestamp string from the backend, or null.
+ *
+ * Returns
+ * -------
+ * string
+ *   A locale-formatted date-time string, or an empty string for null input.
+ */
+function formatAbsoluteTime(isoString: string | null): string {
+  if (isoString === null) return "";
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return isoString;
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Icons (inline SVG — no icon library dependency)
+// ---------------------------------------------------------------------------
+
+function ExclamationTriangleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function AboutSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading application information"
+      aria-busy="true"
+      className="animate-pulse space-y-6"
+    >
+      {/* Version skeleton */}
+      <div>
+        <div className="h-4 bg-slate-200 rounded w-32 mb-2" />
+        <div className="h-3 bg-slate-100 rounded w-56" />
+      </div>
+
+      {/* Database stats skeleton — 6 cards */}
+      <div>
+        <div className="h-4 bg-slate-200 rounded w-40 mb-3" />
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="bg-slate-100 rounded-lg p-4">
+              <div className="h-6 bg-slate-200 rounded w-12 mb-1" />
+              <div className="h-3 bg-slate-100 rounded w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Sync timestamps skeleton */}
+      <div>
+        <div className="h-4 bg-slate-200 rounded w-36 mb-3" />
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="flex justify-between">
+              <div className="h-3 bg-slate-100 rounded w-28" />
+              <div className="h-3 bg-slate-100 rounded w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <span className="sr-only">Loading application information…</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Version display (FR-018)
+// ---------------------------------------------------------------------------
+
+interface VersionDisplayProps {
+  backendVersion: string;
+  frontendVersion: string;
+}
+
+function VersionDisplay({ backendVersion, frontendVersion }: VersionDisplayProps) {
+  return (
+    <div>
+      <h4
+        id="about-version-heading"
+        className="text-sm font-semibold text-slate-700 mb-1"
+      >
+        Version
+      </h4>
+      <dl
+        aria-labelledby="about-version-heading"
+        className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-slate-600"
+      >
+        <div className="flex items-center gap-1.5">
+          <dt className="font-medium text-slate-800">Backend:</dt>
+          <dd className="font-mono">{backendVersion}</dd>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <dt className="font-medium text-slate-800">Frontend:</dt>
+          <dd className="font-mono">{frontendVersion}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Database statistics grid (FR-019)
+// ---------------------------------------------------------------------------
+
+const DB_STAT_LABELS: { key: keyof DatabaseStats; label: string }[] = [
+  { key: "videos", label: "Videos" },
+  { key: "channels", label: "Channels" },
+  { key: "playlists", label: "Playlists" },
+  { key: "transcripts", label: "Transcripts" },
+  { key: "corrections", label: "Corrections" },
+  { key: "canonical_tags", label: "Canonical Tags" },
+];
+
+interface DatabaseStatsGridProps {
+  stats: DatabaseStats;
+}
+
+function DatabaseStatsGrid({ stats }: DatabaseStatsGridProps) {
+  const items: StatItem[] = DB_STAT_LABELS.map(({ key, label }) => ({
+    label,
+    value: stats[key],
+  }));
+
+  return (
+    <div>
+      <h4
+        id="about-db-stats-heading"
+        className="text-sm font-semibold text-slate-700 mb-3"
+      >
+        Database Statistics
+      </h4>
+
+      <dl
+        aria-labelledby="about-db-stats-heading"
+        className="grid grid-cols-2 sm:grid-cols-3 gap-3"
+      >
+        {items.map(({ label, value }) => (
+          <div
+            key={label}
+            className="bg-slate-50 border border-slate-100 rounded-lg px-4 py-3"
+          >
+            <dt className="text-xs font-medium text-slate-500 mb-0.5">
+              {label}
+            </dt>
+            <dd className="text-xl font-semibold text-slate-900 tabular-nums">
+              {value.toLocaleString()}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sync timestamps (FR-020, FR-025)
+// ---------------------------------------------------------------------------
+
+/** Maps backend sync_timestamps keys to human-readable labels. */
+const SYNC_KEY_LABELS: Record<string, string> = {
+  subscriptions: "Subscriptions",
+  videos: "Videos",
+  transcripts: "Transcripts",
+  playlists: "Playlists",
+  topics: "Topics",
+};
+
+/** Preferred display order for sync keys. */
+const SYNC_KEY_ORDER = [
+  "subscriptions",
+  "videos",
+  "transcripts",
+  "playlists",
+  "topics",
+];
+
+interface SyncTimestampsProps {
+  syncTimestamps: Record<string, string | null>;
+}
+
+function SyncTimestamps({ syncTimestamps }: SyncTimestampsProps) {
+  // Build ordered list: known keys first (in SYNC_KEY_ORDER), then any extras
+  const knownKeys = SYNC_KEY_ORDER.filter((k) => k in syncTimestamps);
+  const extraKeys = Object.keys(syncTimestamps).filter(
+    (k) => !SYNC_KEY_ORDER.includes(k)
+  );
+  const orderedKeys = [...knownKeys, ...extraKeys];
+
+  const items: SyncItem[] = orderedKeys.map((key) => ({
+    key,
+    label: SYNC_KEY_LABELS[key] ?? key,
+    timestamp: syncTimestamps[key] ?? null,
+  }));
+
+  return (
+    <div>
+      <h4
+        id="about-sync-heading"
+        className="text-sm font-semibold text-slate-700 mb-3"
+      >
+        Last Synced
+      </h4>
+
+      <dl
+        aria-labelledby="about-sync-heading"
+        className="divide-y divide-slate-100"
+      >
+        {items.map(({ key, label, timestamp }) => {
+          const relative = formatRelativeTime(timestamp);
+          const absolute = formatAbsoluteTime(timestamp);
+
+          return (
+            <div
+              key={key}
+              className="flex items-center justify-between py-2 first:pt-0 last:pb-0"
+            >
+              <dt className="text-sm text-slate-600">{label}</dt>
+              <dd
+                className="text-sm font-medium text-slate-800 text-right"
+                title={absolute !== "" ? absolute : undefined}
+              >
+                {relative !== null ? (
+                  <time dateTime={timestamp ?? undefined}>{relative}</time>
+                ) : (
+                  <span className="text-slate-400 font-normal italic">
+                    Never synced
+                  </span>
+                )}
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * AboutSection renders the application info card within the Settings page.
+ * It is fully self-contained — all data comes from the `useAppInfo` hook.
+ *
+ * Displays:
+ * - Backend and frontend version strings (FR-018)
+ * - Database entity counts in a responsive grid (FR-019)
+ * - Per-data-type last-sync timestamps with relative formatting (FR-020, FR-025)
+ * - Loading skeleton (FR-021) and inline error with retry (FR-022)
+ *
+ * @example
+ * ```tsx
+ * <AboutSection />
+ * ```
+ */
+export function AboutSection() {
+  const { appInfo, isLoading, error } = useAppInfo();
+
+  const handleRetry = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  return (
+    <section aria-labelledby="about-heading">
+      <div className="bg-white rounded-xl border border-slate-200 shadow-sm p-6">
+        {/* ---------------------------------------------------------------- */}
+        {/* Section header                                                   */}
+        {/* ---------------------------------------------------------------- */}
+        <div className="mb-6">
+          <h3
+            id="about-heading"
+            className="text-lg font-semibold text-slate-900"
+          >
+            About
+          </h3>
+          <p className="text-sm text-slate-500 mt-1">
+            Application version, database statistics, and last sync times.
+          </p>
+        </div>
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Loading state (FR-021)                                           */}
+        {/* ---------------------------------------------------------------- */}
+        {isLoading && <AboutSkeleton />}
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Error state (FR-022)                                             */}
+        {/* ---------------------------------------------------------------- */}
+        {!isLoading && error !== null && (
+          <div
+            role="alert"
+            className="flex items-start gap-3 bg-rose-50 border border-rose-200 rounded-lg px-4 py-3"
+          >
+            <ExclamationTriangleIcon className="w-5 h-5 text-rose-600 flex-shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-rose-800">
+                Failed to load application information
+              </p>
+              <p className="text-xs text-rose-700 mt-1">{error.message}</p>
+            </div>
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="flex-shrink-0 text-sm font-medium text-rose-700 hover:text-rose-900 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 transition-colors"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Main content (once loaded and no error)                         */}
+        {/* ---------------------------------------------------------------- */}
+        {!isLoading && error === null && appInfo !== undefined && (
+          <div className="space-y-6">
+            {/* Version (FR-018) */}
+            <VersionDisplay
+              backendVersion={appInfo.backend_version}
+              frontendVersion={appInfo.frontend_version}
+            />
+
+            <hr className="border-slate-100" aria-hidden="true" />
+
+            {/* Database statistics (FR-019) */}
+            <DatabaseStatsGrid stats={appInfo.database_stats} />
+
+            <hr className="border-slate-100" aria-hidden="true" />
+
+            {/* Sync timestamps (FR-020, FR-025) */}
+            <SyncTimestamps syncTimestamps={appInfo.sync_timestamps} />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/settings/CacheSection.tsx
+++ b/frontend/src/components/settings/CacheSection.tsx
@@ -1,0 +1,341 @@
+/**
+ * CacheSection — displays local image cache statistics and provides a
+ * "Clear Cache" action within the Settings page.
+ *
+ * Implements Feature 049 requirements:
+ * - FR-016: Show number of cached images and total disk space used
+ * - FR-017: "Clear Cache" button with confirmation dialog
+ * - FR-021: Loading skeleton while fetching
+ * - FR-022: Inline error with retry button on API failure
+ * - FR-029: ARIA labels for cache statistics area and clear button
+ * - US3-AS3: Empty state when total_count is 0
+ *
+ * @module components/settings/CacheSection
+ */
+
+import { useState, useRef, useEffect } from "react";
+
+import { useCacheStatus } from "../../hooks/useCacheStatus";
+
+// ---------------------------------------------------------------------------
+// Icons (inline SVG — no icon library dependency)
+// ---------------------------------------------------------------------------
+
+function ExclamationTriangleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function SpinnerIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function CacheSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading cache statistics"
+      aria-busy="true"
+      className="animate-pulse"
+    >
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <div className="h-4 bg-slate-200 rounded w-48" />
+          <div className="h-3 bg-slate-100 rounded w-32" />
+        </div>
+        <div className="h-9 bg-slate-200 rounded-md w-28" />
+      </div>
+      <span className="sr-only">Loading cache statistics…</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Clear cache confirmation dialog (inline, matching LanguagePreferencesSection)
+// ---------------------------------------------------------------------------
+
+interface ClearConfirmationProps {
+  isPurging: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ClearConfirmation({
+  isPurging,
+  onConfirm,
+  onCancel,
+}: ClearConfirmationProps) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  // WCAG 2.4.3: Focus the Confirm button on mount
+  useEffect(() => {
+    confirmRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      onCancel();
+    }
+  };
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="false"
+      aria-labelledby="cache-clear-confirm-label"
+      aria-describedby="cache-clear-confirm-desc"
+      className="flex flex-wrap items-center gap-3 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mt-4"
+      onKeyDown={handleKeyDown}
+    >
+      <ExclamationTriangleIcon className="w-5 h-5 text-amber-600 flex-shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p
+          id="cache-clear-confirm-label"
+          className="text-sm font-semibold text-amber-900"
+        >
+          Clear all cached images?
+        </p>
+        <p
+          id="cache-clear-confirm-desc"
+          className="text-xs text-amber-700 mt-0.5"
+        >
+          Cached images will need to be re-downloaded on next access.
+        </p>
+      </div>
+      <div className="flex gap-2 flex-shrink-0">
+        <button
+          ref={confirmRef}
+          type="button"
+          onClick={onConfirm}
+          disabled={isPurging}
+          aria-busy={isPurging}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-rose-600 hover:bg-rose-700 disabled:bg-rose-400 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 transition-colors"
+        >
+          {isPurging && <SpinnerIcon className="w-3.5 h-3.5 animate-spin" />}
+          {isPurging ? "Clearing…" : "Yes, clear cache"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPurging}
+          className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-slate-700 bg-white hover:bg-slate-50 border border-slate-300 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2 disabled:opacity-50 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * CacheSection renders the image cache card within the Settings page.
+ * It is fully self-contained — all data and mutations come from the
+ * `useCacheStatus` hook.
+ *
+ * @example
+ * ```tsx
+ * <CacheSection />
+ * ```
+ */
+export function CacheSection() {
+  const { cacheStatus, isLoading, error, purgeCache, isPurging } =
+    useCacheStatus();
+
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+
+  // Ref to the "Clear Cache" button so focus can be restored after the
+  // confirmation dialog is dismissed (WCAG 2.4.3).
+  const clearButtonRef = useRef<HTMLButtonElement>(null);
+
+  // aria-live announcement after a successful purge
+  const [announcement, setAnnouncement] = useState("");
+
+  // Announce when isPurging transitions from true → false (purge completed)
+  const wasPurgingRef = useRef(false);
+  useEffect(() => {
+    if (wasPurgingRef.current && !isPurging) {
+      setAnnouncement("Image cache cleared.");
+      const t = setTimeout(() => setAnnouncement(""), 3000);
+      return () => clearTimeout(t);
+    }
+    wasPurgingRef.current = isPurging;
+  }, [isPurging]);
+
+  function handleConfirmClear() {
+    purgeCache();
+    setShowClearConfirm(false);
+  }
+
+  function handleCancelClear() {
+    setShowClearConfirm(false);
+    // WCAG 2.4.3: Return focus to the button that opened the confirmation.
+    clearButtonRef.current?.focus();
+  }
+
+  // Derive cache statistics display text
+  const hasImages = cacheStatus !== undefined && cacheStatus.total_count > 0;
+  const statisticsText =
+    cacheStatus === undefined
+      ? null
+      : cacheStatus.total_count === 0
+      ? "No cached images"
+      : `${cacheStatus.total_count.toLocaleString()} ${
+          cacheStatus.total_count === 1 ? "image" : "images"
+        }, ${cacheStatus.total_size_display}`;
+
+  return (
+    <section aria-labelledby="cache-heading">
+      <div className="bg-white rounded-xl border border-slate-200 shadow-sm p-6">
+        {/* ---------------------------------------------------------------- */}
+        {/* Section header                                                   */}
+        {/* ---------------------------------------------------------------- */}
+        <div className="mb-6">
+          <h3
+            id="cache-heading"
+            className="text-lg font-semibold text-slate-900"
+          >
+            Cache
+          </h3>
+          <p className="text-sm text-slate-500 mt-1">
+            Locally cached thumbnail images used to reduce network requests.
+          </p>
+        </div>
+
+        {/* ---------------------------------------------------------------- */}
+        {/* aria-live region for purge completion announcements (FR-029)    */}
+        {/* ---------------------------------------------------------------- */}
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {announcement}
+        </div>
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Loading state (FR-021)                                           */}
+        {/* ---------------------------------------------------------------- */}
+        {isLoading && <CacheSkeleton />}
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Error state (FR-022)                                             */}
+        {/* ---------------------------------------------------------------- */}
+        {!isLoading && error !== null && (
+          <div
+            role="alert"
+            className="flex items-start gap-3 bg-rose-50 border border-rose-200 rounded-lg px-4 py-3"
+          >
+            <ExclamationTriangleIcon className="w-5 h-5 text-rose-600 flex-shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-rose-800">
+                Failed to load cache statistics
+              </p>
+              <p className="text-xs text-rose-700 mt-1">{error.message}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="flex-shrink-0 text-sm font-medium text-rose-700 hover:text-rose-900 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 transition-colors"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Main content (once loaded and no error)                         */}
+        {/* ---------------------------------------------------------------- */}
+        {!isLoading && error === null && cacheStatus !== undefined && (
+          <>
+            {/* Statistics row + Clear Cache button (FR-016, FR-017) */}
+            <div className="flex items-center justify-between gap-4">
+              {/* Cache statistics display (FR-016, US3-AS3) */}
+              <dl aria-label="Cache statistics">
+                <div>
+                  <dt className="sr-only">Cached images</dt>
+                  <dd
+                    className={`text-sm font-medium ${
+                      hasImages ? "text-slate-800" : "text-slate-500 italic"
+                    }`}
+                  >
+                    {statisticsText}
+                  </dd>
+                </div>
+              </dl>
+
+              {/* Clear Cache button — only shown when images are cached (FR-017) */}
+              {hasImages && !showClearConfirm && (
+                <button
+                  ref={clearButtonRef}
+                  type="button"
+                  onClick={() => setShowClearConfirm(true)}
+                  disabled={isPurging}
+                  aria-label="Clear all cached images"
+                  className="flex-shrink-0 inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-slate-700 bg-white hover:bg-slate-50 border border-slate-300 disabled:opacity-50 disabled:cursor-not-allowed rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2 transition-colors"
+                >
+                  {isPurging && (
+                    <SpinnerIcon className="w-3.5 h-3.5 animate-spin" />
+                  )}
+                  {isPurging ? "Clearing…" : "Clear Cache"}
+                </button>
+              )}
+            </div>
+
+            {/* Confirmation dialog (FR-017) */}
+            {showClearConfirm && (
+              <ClearConfirmation
+                isPurging={isPurging}
+                onConfirm={handleConfirmClear}
+                onCancel={handleCancelClear}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/settings/LanguagePreferencesSection.tsx
+++ b/frontend/src/components/settings/LanguagePreferencesSection.tsx
@@ -1,0 +1,980 @@
+/**
+ * LanguagePreferencesSection — displays and manages user language preferences
+ * within the Settings page.
+ *
+ * Implements Feature 049 requirements:
+ * - FR-002: Group existing preferences into 4 sections (Fluent, Learning, Curious, Exclude)
+ * - FR-005: Per-preference remove button
+ * - FR-006: "Reset All" button with confirmation dialog
+ * - FR-007: Language display name with muted code in parentheses
+ * - FR-008: Descriptive heading per preference type group
+ * - FR-009: Inline duplicate validation error from DuplicateLanguageError
+ * - FR-010: Empty state with explanatory text when no preferences exist
+ * - FR-021: Loading skeleton while fetching
+ * - FR-022: Inline error with retry button on API failure
+ * - FR-023: Searchable language dropdown (filterable combobox)
+ * - FR-024: Preferences displayed in priority order within each group
+ * - FR-029: Full accessibility — ARIA groups, labels, keyboard nav, aria-live
+ *
+ * @module components/settings/LanguagePreferencesSection
+ */
+
+import { useState, useRef, useId, useEffect, useCallback } from "react";
+
+import {
+  useLanguagePreferences,
+  DuplicateLanguageError,
+} from "../../hooks/useLanguagePreferences";
+import type { LanguagePreferenceItem } from "../../hooks/useLanguagePreferences";
+import type { SupportedLanguage } from "../../api/settings";
+
+// ---------------------------------------------------------------------------
+// Constants — preference type metadata
+// ---------------------------------------------------------------------------
+
+const PREFERENCE_TYPES = [
+  { value: "fluent", label: "Fluent" },
+  { value: "learning", label: "Learning" },
+  { value: "curious", label: "Curious" },
+  { value: "exclude", label: "Exclude" },
+] as const;
+
+type PreferenceTypeValue = (typeof PREFERENCE_TYPES)[number]["value"];
+
+interface PreferenceTypeConfig {
+  label: string;
+  description: string;
+  pillClasses: string;
+  badgeClasses: string;
+}
+
+const PREFERENCE_TYPE_CONFIG: Record<PreferenceTypeValue, PreferenceTypeConfig> =
+  {
+    fluent: {
+      label: "Fluent",
+      description: "Always download transcripts in these languages",
+      pillClasses:
+        "bg-emerald-50 border-emerald-200 text-emerald-800",
+      badgeClasses:
+        "text-emerald-700 hover:bg-emerald-100 hover:text-emerald-900 focus-visible:ring-emerald-500",
+    },
+    learning: {
+      label: "Learning",
+      description: "Download if available",
+      pillClasses:
+        "bg-blue-50 border-blue-200 text-blue-800",
+      badgeClasses:
+        "text-blue-700 hover:bg-blue-100 hover:text-blue-900 focus-visible:ring-blue-500",
+    },
+    curious: {
+      label: "Curious",
+      description:
+        "Never auto-download; available on-demand only via explicit language selection",
+      pillClasses:
+        "bg-violet-50 border-violet-200 text-violet-800",
+      badgeClasses:
+        "text-violet-700 hover:bg-violet-100 hover:text-violet-900 focus-visible:ring-violet-500",
+    },
+    exclude: {
+      label: "Exclude",
+      description: "Never download",
+      pillClasses:
+        "bg-rose-50 border-rose-200 text-rose-800",
+      badgeClasses:
+        "text-rose-700 hover:bg-rose-100 hover:text-rose-900 focus-visible:ring-rose-500",
+    },
+  };
+
+// ---------------------------------------------------------------------------
+// Icons (inline SVG — no icon library dependency)
+// ---------------------------------------------------------------------------
+
+function XMarkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 18 18 6M6 6l12 12"
+      />
+    </svg>
+  );
+}
+
+function ExclamationTriangleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function SpinnerIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function LanguagePreferencesSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading language preferences"
+      aria-busy="true"
+      className="animate-pulse space-y-4"
+    >
+      {/* Skeleton preference groups */}
+      {[1, 2, 3].map((i) => (
+        <div key={i}>
+          <div className="h-4 bg-slate-200 rounded w-24 mb-2" />
+          <div className="h-3 bg-slate-100 rounded w-48 mb-3" />
+          <div className="flex gap-2">
+            <div className="h-8 bg-slate-200 rounded-full w-28" />
+            <div className="h-8 bg-slate-200 rounded-full w-24" />
+          </div>
+        </div>
+      ))}
+      {/* Skeleton form */}
+      <div className="pt-4 border-t border-slate-100 flex gap-2">
+        <div className="h-9 bg-slate-200 rounded-md flex-1" />
+        <div className="h-9 bg-slate-200 rounded-md w-32" />
+        <div className="h-9 bg-slate-200 rounded-md w-20" />
+      </div>
+      <span className="sr-only">Loading language preferences…</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Single preference pill (language name + remove button)
+// ---------------------------------------------------------------------------
+
+interface PreferencePillProps {
+  item: LanguagePreferenceItem;
+  displayName: string;
+  onRemove: (languageCode: string) => void;
+  isRemoving: boolean;
+  config: PreferenceTypeConfig;
+}
+
+function PreferencePill({
+  item,
+  displayName,
+  onRemove,
+  isRemoving,
+  config,
+}: PreferencePillProps) {
+  return (
+    <li>
+      <div
+        className={`inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 border rounded-full text-sm font-medium ${config.pillClasses}`}
+      >
+        {/* Language name + muted code */}
+        <span>
+          {displayName}{" "}
+          <span className="opacity-60 font-normal">({item.language_code})</span>
+        </span>
+
+        {/* Remove button */}
+        <button
+          type="button"
+          onClick={() => onRemove(item.language_code)}
+          disabled={isRemoving}
+          aria-label={`Remove ${displayName} (${item.language_code}) from ${config.label}`}
+          className={`flex-shrink-0 flex items-center justify-center w-5 h-5 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${config.badgeClasses}`}
+        >
+          {isRemoving ? (
+            <SpinnerIcon className="w-3 h-3 animate-spin" />
+          ) : (
+            <XMarkIcon className="w-3.5 h-3.5" />
+          )}
+          <span className="sr-only">
+            {isRemoving ? "Removing…" : `Remove ${displayName}`}
+          </span>
+        </button>
+      </div>
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Preference type group (heading + pills)
+// ---------------------------------------------------------------------------
+
+interface PreferenceGroupProps {
+  typeValue: PreferenceTypeValue;
+  items: LanguagePreferenceItem[];
+  supportedLanguages: SupportedLanguage[];
+  onRemove: (languageCode: string) => void;
+  isRemoving: boolean;
+  headingId: string;
+}
+
+function PreferenceGroup({
+  typeValue,
+  items,
+  supportedLanguages,
+  onRemove,
+  isRemoving,
+  headingId,
+}: PreferenceGroupProps) {
+  const config = PREFERENCE_TYPE_CONFIG[typeValue];
+
+  // Build a lookup map for fast display name resolution
+  const langMap = new Map(supportedLanguages.map((l) => [l.code, l.display_name]));
+
+  return (
+    <div role="group" aria-labelledby={headingId} className="space-y-2">
+      {/* Group heading + description */}
+      <div>
+        <h4
+          id={headingId}
+          className="text-sm font-semibold text-slate-800"
+        >
+          {config.label}
+        </h4>
+        <p className="text-xs text-slate-500 mt-0.5">{config.description}</p>
+      </div>
+
+      {/* Pills — ordered by priority (items already arrive sorted) */}
+      {items.length > 0 ? (
+        <ul className="flex flex-wrap gap-2" aria-label={`${config.label} languages`}>
+          {items.map((item) => (
+            <PreferencePill
+              key={item.language_code}
+              item={item}
+              displayName={
+                langMap.get(item.language_code) ?? item.language_code
+              }
+              onRemove={onRemove}
+              isRemoving={isRemoving}
+              config={config}
+            />
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-slate-400 italic">
+          No {config.label.toLowerCase()} languages configured.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state (when ALL preference groups are empty)
+// ---------------------------------------------------------------------------
+
+function EmptyState() {
+  return (
+    <div className="py-6 text-center">
+      <p className="text-slate-500 text-sm mb-4">
+        No language preferences configured yet. Use the form below to add
+        languages and choose how transcripts should be downloaded for each.
+      </p>
+      <dl className="text-left max-w-md mx-auto space-y-2 text-sm">
+        <div className="flex gap-2">
+          <dt className="font-semibold text-emerald-700 shrink-0">Fluent:</dt>
+          <dd className="text-slate-600">
+            Always download transcripts in these languages
+          </dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="font-semibold text-blue-700 shrink-0">Learning:</dt>
+          <dd className="text-slate-600">Download if available</dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="font-semibold text-violet-700 shrink-0">Curious:</dt>
+          <dd className="text-slate-600">
+            Never auto-download; available on-demand only via explicit language
+            selection
+          </dd>
+        </div>
+        <div className="flex gap-2">
+          <dt className="font-semibold text-rose-700 shrink-0">Exclude:</dt>
+          <dd className="text-slate-600">Never download</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reset all confirmation dialog (inline, not a modal)
+// ---------------------------------------------------------------------------
+
+interface ResetConfirmationProps {
+  isPending: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ResetConfirmation({
+  isPending,
+  onConfirm,
+  onCancel,
+}: ResetConfirmationProps) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  // WCAG 2.4.3: Focus the Confirm button on mount
+  useEffect(() => {
+    confirmRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      onCancel();
+    }
+  };
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="false"
+      aria-labelledby="reset-confirm-label"
+      aria-describedby="reset-confirm-desc"
+      className="flex flex-wrap items-center gap-3 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mt-4"
+      onKeyDown={handleKeyDown}
+    >
+      <ExclamationTriangleIcon className="w-5 h-5 text-amber-600 flex-shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p id="reset-confirm-label" className="text-sm font-semibold text-amber-900">
+          Remove all language preferences?
+        </p>
+        <p id="reset-confirm-desc" className="text-xs text-amber-700 mt-0.5">
+          This will permanently remove all configured language preferences. This
+          action cannot be undone.
+        </p>
+      </div>
+      <div className="flex gap-2 flex-shrink-0">
+        <button
+          ref={confirmRef}
+          type="button"
+          onClick={onConfirm}
+          disabled={isPending}
+          aria-busy={isPending}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-rose-600 hover:bg-rose-700 disabled:bg-rose-400 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 transition-colors"
+        >
+          {isPending && (
+            <SpinnerIcon className="w-3.5 h-3.5 animate-spin" />
+          )}
+          {isPending ? "Resetting…" : "Yes, remove all"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-slate-700 bg-white hover:bg-slate-50 border border-slate-300 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2 disabled:opacity-50 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add preference form (searchable language dropdown + type selector)
+// ---------------------------------------------------------------------------
+
+interface AddPreferenceFormProps {
+  supportedLanguages: SupportedLanguage[];
+  usedLanguageCodes: Set<string>;
+  onAdd: (
+    languageCode: string,
+    preferenceType: string,
+    learningGoal?: string | null
+  ) => void;
+  isMutating: boolean;
+}
+
+function AddPreferenceForm({
+  supportedLanguages,
+  usedLanguageCodes,
+  onAdd,
+  isMutating,
+}: AddPreferenceFormProps) {
+  const formId = useId();
+
+  const [search, setSearch] = useState("");
+  const [selectedCode, setSelectedCode] = useState("");
+  const [preferenceType, setPreferenceType] =
+    useState<PreferenceTypeValue>("fluent");
+  const [learningGoal, setLearningGoal] = useState("");
+  const [duplicateError, setDuplicateError] = useState<string | null>(null);
+  const [isListOpen, setIsListOpen] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
+
+  // Alphabetically sorted languages filtered by search term
+  const filteredLanguages: SupportedLanguage[] = [...supportedLanguages]
+    .sort((a, b) => a.display_name.localeCompare(b.display_name))
+    .filter((lang) => {
+      const q = search.toLowerCase();
+      return (
+        lang.display_name.toLowerCase().includes(q) ||
+        lang.code.toLowerCase().includes(q)
+      );
+    });
+
+  // The display name for the currently selected code
+  const selectedDisplayName =
+    supportedLanguages.find((l) => l.code === selectedCode)?.display_name ?? "";
+
+  function selectLanguage(lang: SupportedLanguage) {
+    setSelectedCode(lang.code);
+    setSearch(lang.display_name);
+    setIsListOpen(false);
+    setDuplicateError(null);
+  }
+
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+    setSearch(value);
+    setDuplicateError(null);
+
+    // If user edits the text, clear the previously selected code unless
+    // the text still exactly matches that language's display name.
+    if (value !== selectedDisplayName) {
+      setSelectedCode("");
+    }
+
+    setIsListOpen(true);
+  }
+
+  const handleSearchFocus = useCallback(() => {
+    if (search) setIsListOpen(true);
+  }, [search]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!isListOpen) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        !inputRef.current?.parentElement?.contains(e.target as Node) &&
+        !listboxRef.current?.contains(e.target as Node)
+      ) {
+        setIsListOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isListOpen]);
+
+  function handleKeyDownOnInput(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Escape") {
+      setIsListOpen(false);
+    } else if (e.key === "ArrowDown" && isListOpen) {
+      e.preventDefault();
+      const firstItem = listboxRef.current?.querySelector<HTMLElement>(
+        "[role='option']"
+      );
+      firstItem?.focus();
+    }
+  }
+
+  function handleKeyDownOnOption(
+    e: React.KeyboardEvent<HTMLLIElement>,
+    lang: SupportedLanguage,
+    index: number
+  ) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      selectLanguage(lang);
+      inputRef.current?.focus();
+    } else if (e.key === "Escape") {
+      setIsListOpen(false);
+      inputRef.current?.focus();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const items = listboxRef.current?.querySelectorAll<HTMLElement>(
+        "[role='option']"
+      );
+      if (items && index < items.length - 1) {
+        items[index + 1]?.focus();
+      }
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (index === 0) {
+        inputRef.current?.focus();
+      } else {
+        const items = listboxRef.current?.querySelectorAll<HTMLElement>(
+          "[role='option']"
+        );
+        items?.[index - 1]?.focus();
+      }
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setDuplicateError(null);
+
+    if (!selectedCode) return;
+
+    try {
+      onAdd(
+        selectedCode,
+        preferenceType,
+        preferenceType === "learning" && learningGoal.trim()
+          ? learningGoal.trim()
+          : null
+      );
+      // Reset form on success
+      setSearch("");
+      setSelectedCode("");
+      setLearningGoal("");
+      inputRef.current?.focus();
+    } catch (err) {
+      if (err instanceof DuplicateLanguageError) {
+        setDuplicateError(err.message);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const isAlreadyUsed = selectedCode !== "" && usedLanguageCodes.has(selectedCode);
+  const canSubmit =
+    selectedCode !== "" && !isAlreadyUsed && !isMutating;
+
+  const listboxId = `${formId}-listbox`;
+  const languageInputId = `${formId}-language`;
+  const typeSelectId = `${formId}-type`;
+  const goalInputId = `${formId}-goal`;
+
+  return (
+    <div className="pt-4 mt-4 border-t border-slate-100">
+      <h4 className="text-sm font-semibold text-slate-800 mb-3">
+        Add Language Preference
+      </h4>
+
+      <form onSubmit={handleSubmit} noValidate aria-label="Add language preference">
+        <div className="flex flex-wrap gap-3 items-start">
+
+          {/* --- Language search combobox --- */}
+          <div className="flex-1 min-w-[200px] relative">
+            <label
+              htmlFor={languageInputId}
+              className="block text-xs font-medium text-slate-600 mb-1"
+            >
+              Language
+            </label>
+            <input
+              ref={inputRef}
+              id={languageInputId}
+              type="text"
+              role="combobox"
+              autoComplete="off"
+              aria-autocomplete="list"
+              aria-controls={listboxId}
+              aria-expanded={isListOpen && filteredLanguages.length > 0}
+              aria-haspopup="listbox"
+              aria-label="Search and select a language"
+              value={search}
+              onChange={handleSearchChange}
+              onFocus={handleSearchFocus}
+              onKeyDown={handleKeyDownOnInput}
+              placeholder="Search language…"
+              disabled={isMutating}
+              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-slate-50 disabled:text-slate-400"
+            />
+
+            {/* Dropdown listbox */}
+            {isListOpen && filteredLanguages.length > 0 && (
+              <ul
+                id={listboxId}
+                ref={listboxRef}
+                role="listbox"
+                aria-label="Available languages"
+                className="absolute z-20 mt-1 w-full max-h-52 overflow-y-auto bg-white border border-slate-200 rounded-md shadow-lg py-1 text-sm"
+              >
+                {filteredLanguages.map((lang, index) => {
+                  const isUsed = usedLanguageCodes.has(lang.code);
+                  const isSelected = lang.code === selectedCode;
+                  return (
+                    <li
+                      key={lang.code}
+                      role="option"
+                      aria-selected={isSelected}
+                      aria-disabled={isUsed}
+                      tabIndex={isUsed ? -1 : 0}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        if (!isUsed) selectLanguage(lang);
+                      }}
+                      onKeyDown={(e) => {
+                        if (!isUsed) handleKeyDownOnOption(e, lang, index);
+                      }}
+                      className={`flex items-center justify-between px-3 py-1.5 cursor-pointer ${
+                        isUsed
+                          ? "text-slate-400 cursor-default"
+                          : isSelected
+                          ? "bg-indigo-50 text-indigo-900"
+                          : "text-slate-800 hover:bg-slate-50 focus:bg-slate-50 focus:outline-none"
+                      }`}
+                    >
+                      <span>
+                        {lang.display_name}{" "}
+                        <span className="text-slate-400">({lang.code})</span>
+                      </span>
+                      {isUsed && (
+                        <span className="text-xs text-slate-400 ml-2">
+                          already added
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          {/* --- Preference type selector --- */}
+          <div className="flex-1 min-w-[140px]">
+            <label
+              htmlFor={typeSelectId}
+              className="block text-xs font-medium text-slate-600 mb-1"
+            >
+              Type
+            </label>
+            <select
+              id={typeSelectId}
+              value={preferenceType}
+              onChange={(e) =>
+                setPreferenceType(e.target.value as PreferenceTypeValue)
+              }
+              disabled={isMutating}
+              aria-label="Preference type"
+              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-slate-50 disabled:text-slate-400"
+            >
+              {PREFERENCE_TYPES.map((type) => (
+                <option key={type.value} value={type.value}>
+                  {type.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* --- Add button --- */}
+          <div className="flex items-end">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              aria-label={
+                selectedCode
+                  ? `Add ${selectedDisplayName || selectedCode} as ${preferenceType}`
+                  : "Add language preference (select a language first)"
+              }
+              className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 disabled:cursor-not-allowed rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition-colors"
+            >
+              {isMutating && (
+                <SpinnerIcon className="w-3.5 h-3.5 animate-spin" />
+              )}
+              {isMutating ? "Adding…" : "Add"}
+            </button>
+          </div>
+        </div>
+
+        {/* --- Learning goal input (only when type = learning) --- */}
+        {preferenceType === "learning" && (
+          <div className="mt-3">
+            <label
+              htmlFor={goalInputId}
+              className="block text-xs font-medium text-slate-600 mb-1"
+            >
+              Learning goal{" "}
+              <span className="text-slate-400 font-normal">(optional)</span>
+            </label>
+            <input
+              id={goalInputId}
+              type="text"
+              value={learningGoal}
+              onChange={(e) => setLearningGoal(e.target.value)}
+              placeholder="e.g. JLPT N3 goal, travel Spanish, …"
+              maxLength={300}
+              disabled={isMutating}
+              className="w-full max-w-md rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-slate-50 disabled:text-slate-400"
+            />
+          </div>
+        )}
+
+        {/* --- Inline duplicate error (FR-009) --- */}
+        {duplicateError !== null && (
+          <p role="alert" className="mt-2 text-sm text-rose-600">
+            {duplicateError}
+          </p>
+        )}
+
+        {/* --- Inline "already added" hint --- */}
+        {isAlreadyUsed && !duplicateError && (
+          <p role="status" className="mt-2 text-sm text-amber-700">
+            This language is already in your preferences. Remove it from its
+            current group first.
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * LanguagePreferencesSection renders the language preferences card within
+ * the Settings page. It is fully self-contained — all data and mutations come
+ * from the `useLanguagePreferences` hook.
+ *
+ * @example
+ * ```tsx
+ * <LanguagePreferencesSection />
+ * ```
+ */
+export function LanguagePreferencesSection() {
+  const {
+    preferences,
+    supportedLanguages,
+    isLoading,
+    error,
+    addPreference,
+    removePreference,
+    resetAll,
+    isMutating,
+  } = useLanguagePreferences();
+
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+
+  // Ref to the "Reset All" button so focus can be restored after the
+  // confirmation dialog is dismissed (WCAG 2.4.3).
+  const resetButtonRef = useRef<HTMLButtonElement>(null);
+
+  // aria-live announcement for preference changes (FR-029)
+  const [announcement, setAnnouncement] = useState("");
+
+  // Announce after isMutating transitions from true → false
+  const wasMutatingRef = useRef(false);
+  useEffect(() => {
+    if (wasMutatingRef.current && !isMutating) {
+      setAnnouncement("Language preferences updated.");
+      const t = setTimeout(() => setAnnouncement(""), 3000);
+      return () => clearTimeout(t);
+    }
+    wasMutatingRef.current = isMutating;
+  }, [isMutating]);
+
+  // Group preferences by type, preserving priority order
+  const grouped = {
+    fluent: preferences
+      .filter((p) => p.preference_type === "fluent")
+      .sort((a, b) => a.priority - b.priority),
+    learning: preferences
+      .filter((p) => p.preference_type === "learning")
+      .sort((a, b) => a.priority - b.priority),
+    curious: preferences
+      .filter((p) => p.preference_type === "curious")
+      .sort((a, b) => a.priority - b.priority),
+    exclude: preferences
+      .filter((p) => p.preference_type === "exclude")
+      .sort((a, b) => a.priority - b.priority),
+  };
+
+  const hasAnyPreferences = preferences.length > 0;
+  const usedLanguageCodes = new Set(preferences.map((p) => p.language_code));
+
+  // Stable heading IDs for aria-labelledby on each group
+  const headingIdPrefix = useId();
+  const headingIds: Record<PreferenceTypeValue, string> = {
+    fluent: `${headingIdPrefix}-fluent`,
+    learning: `${headingIdPrefix}-learning`,
+    curious: `${headingIdPrefix}-curious`,
+    exclude: `${headingIdPrefix}-exclude`,
+  };
+
+  function handleRemove(languageCode: string) {
+    removePreference(languageCode);
+  }
+
+  function handleResetConfirm() {
+    resetAll();
+    setShowResetConfirm(false);
+    // Focus is lost when the dialog unmounts; return it to the page heading
+    // since the "Reset All" button is no longer rendered after a successful reset.
+  }
+
+  function handleResetCancel() {
+    setShowResetConfirm(false);
+    // WCAG 2.4.3: Return focus to the button that opened the confirmation.
+    resetButtonRef.current?.focus();
+  }
+
+  return (
+    <section aria-labelledby="language-preferences-heading">
+      <div className="bg-white rounded-xl border border-slate-200 shadow-sm p-6">
+        {/* ---------------------------------------------------------------- */}
+        {/* Section header                                                   */}
+        {/* ---------------------------------------------------------------- */}
+        <div className="flex items-start justify-between gap-4 mb-6">
+          <div>
+            <h3
+              id="language-preferences-heading"
+              className="text-lg font-semibold text-slate-900"
+            >
+              Language Preferences
+            </h3>
+            <p className="text-sm text-slate-500 mt-1">
+              Control which languages ChronoVista downloads transcripts for and
+              how they are prioritised.
+            </p>
+          </div>
+
+          {/* Reset All — only visible when preferences exist (FR-006) */}
+          {hasAnyPreferences && !showResetConfirm && (
+            <button
+              ref={resetButtonRef}
+              type="button"
+              onClick={() => setShowResetConfirm(true)}
+              aria-label="Reset all language preferences"
+              disabled={isMutating}
+              className="flex-shrink-0 text-sm font-medium text-rose-600 hover:text-rose-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              Reset All
+            </button>
+          )}
+        </div>
+
+        {/* ---------------------------------------------------------------- */}
+        {/* aria-live region for preference change announcements (FR-029)   */}
+        {/* ---------------------------------------------------------------- */}
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {announcement}
+        </div>
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Loading state (FR-021)                                           */}
+        {/* ---------------------------------------------------------------- */}
+        {isLoading && <LanguagePreferencesSkeleton />}
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Error state (FR-022)                                             */}
+        {/* ---------------------------------------------------------------- */}
+        {!isLoading && error !== null && (
+          <div
+            role="alert"
+            className="flex items-start gap-3 bg-rose-50 border border-rose-200 rounded-lg px-4 py-3"
+          >
+            <ExclamationTriangleIcon className="w-5 h-5 text-rose-600 flex-shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-rose-800">
+                Failed to load language preferences
+              </p>
+              <p className="text-xs text-rose-700 mt-1">{error.message}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="flex-shrink-0 text-sm font-medium text-rose-700 hover:text-rose-900 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 transition-colors"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Main content (once loaded and no error)                         */}
+        {/* ---------------------------------------------------------------- */}
+        {!isLoading && error === null && (
+          <>
+            {/* Empty state (FR-010) */}
+            {!hasAnyPreferences && <EmptyState />}
+
+            {/* Grouped preferences (FR-002, FR-007, FR-008, FR-024) */}
+            {hasAnyPreferences && (
+              <div className="space-y-6">
+                {PREFERENCE_TYPES.map((type) => (
+                  <PreferenceGroup
+                    key={type.value}
+                    typeValue={type.value}
+                    items={grouped[type.value]}
+                    supportedLanguages={supportedLanguages}
+                    onRemove={handleRemove}
+                    isRemoving={isMutating}
+                    headingId={headingIds[type.value]}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Reset All confirmation (FR-006) */}
+            {showResetConfirm && (
+              <ResetConfirmation
+                isPending={isMutating}
+                onConfirm={handleResetConfirm}
+                onCancel={handleResetCancel}
+              />
+            )}
+
+            {/* Add preference form (FR-023, FR-009) */}
+            <AddPreferenceForm
+              supportedLanguages={supportedLanguages}
+              usedLanguageCodes={usedLanguageCodes}
+              onAdd={addPreference}
+              isMutating={isMutating}
+            />
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/settings/__tests__/AboutSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/AboutSection.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * Tests for AboutSection component.
+ *
+ * Coverage:
+ * - Loading skeleton shown when isLoading=true (role="status" with aria-label)
+ * - Error state shows alert with error message and Retry button
+ * - Version display shows backend and frontend versions using dl/dt/dd markup
+ * - Database statistics grid shows all 6 entity counts
+ * - Sync timestamps display with relative formatting
+ * - "Never synced" shown for null sync timestamps (italic text)
+ * - 0 counts display correctly (fresh install edge case)
+ * - Section has aria-labelledby="about-heading"
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+vi.mock("../../../hooks/useAppInfo", () => ({
+  useAppInfo: vi.fn(),
+}));
+
+import { useAppInfo } from "../../../hooks/useAppInfo";
+import { AboutSection } from "../AboutSection";
+import type { UseAppInfoReturn } from "../../../hooks/useAppInfo";
+import type { AppInfo } from "../../../api/settings";
+
+const mockedUseAppInfo = vi.mocked(useAppInfo);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildHookReturn(
+  overrides: Partial<UseAppInfoReturn> = {}
+): UseAppInfoReturn {
+  return {
+    appInfo: undefined,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function makeAppInfo(overrides: Partial<AppInfo> = {}): AppInfo {
+  return {
+    backend_version: "0.49.0",
+    frontend_version: "0.18.0",
+    database_stats: {
+      videos: 1234,
+      channels: 56,
+      playlists: 12,
+      transcripts: 987,
+      corrections: 45,
+      canonical_tags: 678,
+    },
+    sync_timestamps: {
+      subscriptions: "2020-01-01T00:00:00Z",
+      videos: "2020-01-02T00:00:00Z",
+      transcripts: null,
+      playlists: "2020-01-03T00:00:00Z",
+      topics: null,
+    },
+    ...overrides,
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderComponent(hookReturn: Partial<UseAppInfoReturn> = {}) {
+  mockedUseAppInfo.mockReturnValue(buildHookReturn(hookReturn));
+  const queryClient = createQueryClient();
+  render(
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(AboutSection)
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AboutSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("shows loading skeleton with role=status when isLoading=true", () => {
+    renderComponent({ isLoading: true });
+    const skeleton = screen.getByRole("status", {
+      name: "Loading application information",
+    });
+    expect(skeleton).toBeDefined();
+  });
+
+  it("does not show version information while loading", () => {
+    renderComponent({ isLoading: true });
+    expect(screen.queryByText(/Backend:/i)).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it("shows error alert with the error message", () => {
+    renderComponent({ error: new Error("App info unavailable") });
+    const alert = screen.getByRole("alert");
+    expect(within(alert).getByText("App info unavailable")).toBeDefined();
+  });
+
+  it("shows a Retry button in the error state", () => {
+    renderComponent({ error: new Error("Timeout") });
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
+  });
+
+  it("shows the error heading for app info failure", () => {
+    renderComponent({ error: new Error("Boom") });
+    expect(
+      screen.getByText(/Failed to load application information/i)
+    ).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Version display
+  // -------------------------------------------------------------------------
+
+  it("renders backend version in a dd element", () => {
+    renderComponent({ appInfo: makeAppInfo({ backend_version: "1.0.0" }) });
+    // Find dd for backend version
+    const dd = screen.getByText("1.0.0");
+    expect(dd.tagName.toLowerCase()).toBe("dd");
+  });
+
+  it("renders frontend version in a dd element", () => {
+    renderComponent({ appInfo: makeAppInfo({ frontend_version: "2.0.0" }) });
+    const dd = screen.getByText("2.0.0");
+    expect(dd.tagName.toLowerCase()).toBe("dd");
+  });
+
+  it("renders 'Backend:' and 'Frontend:' dt labels", () => {
+    renderComponent({ appInfo: makeAppInfo() });
+    expect(screen.getByText("Backend:")).toBeDefined();
+    expect(screen.getByText("Frontend:")).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Database statistics
+  // -------------------------------------------------------------------------
+
+  it("shows all 6 database entity type labels", () => {
+    renderComponent({ appInfo: makeAppInfo() });
+    // "Videos" and "Transcripts" appear in both the stats grid and the sync
+    // timestamps list, so use getAllByText and verify at least one match exists
+    for (const label of [
+      "Videos",
+      "Channels",
+      "Playlists",
+      "Transcripts",
+      "Corrections",
+      "Canonical Tags",
+    ]) {
+      expect(screen.getAllByText(label).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("displays the Videos count", () => {
+    renderComponent({
+      appInfo: makeAppInfo({
+        database_stats: {
+          videos: 500,
+          channels: 0,
+          playlists: 0,
+          transcripts: 0,
+          corrections: 0,
+          canonical_tags: 0,
+        },
+      }),
+    });
+    expect(screen.getByText("500")).toBeDefined();
+  });
+
+  it("displays 0 counts correctly for a fresh install", () => {
+    renderComponent({
+      appInfo: makeAppInfo({
+        database_stats: {
+          videos: 0,
+          channels: 0,
+          playlists: 0,
+          transcripts: 0,
+          corrections: 0,
+          canonical_tags: 0,
+        },
+      }),
+    });
+    // All 6 zero values should be present in dd elements
+    const zeros = screen
+      .getAllByText("0")
+      .filter((el) => el.tagName.toLowerCase() === "dd");
+    expect(zeros.length).toBe(6);
+  });
+
+  // -------------------------------------------------------------------------
+  // Sync timestamps
+  // -------------------------------------------------------------------------
+
+  it("renders sync timestamp labels: Subscriptions, Videos, Transcripts, Playlists, Topics", () => {
+    renderComponent({ appInfo: makeAppInfo() });
+    // "Videos" and "Transcripts" appear in both the stats grid and sync list;
+    // use getAllByText and confirm at least one match
+    for (const label of [
+      "Subscriptions",
+      "Videos",
+      "Transcripts",
+      "Playlists",
+      "Topics",
+    ]) {
+      expect(screen.getAllByText(label).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("shows 'Never synced' italic text for null sync timestamps", () => {
+    renderComponent({
+      appInfo: makeAppInfo({
+        sync_timestamps: {
+          subscriptions: null,
+          videos: null,
+          transcripts: null,
+          playlists: null,
+          topics: null,
+        },
+      }),
+    });
+    const neverSyncedItems = screen.getAllByText("Never synced");
+    // All 5 timestamps are null
+    expect(neverSyncedItems.length).toBe(5);
+  });
+
+  it("renders a relative time element (time tag) for non-null timestamps", () => {
+    renderComponent({
+      appInfo: makeAppInfo({
+        sync_timestamps: {
+          subscriptions: "2020-01-01T00:00:00Z",
+          videos: null,
+          transcripts: null,
+          playlists: null,
+          topics: null,
+        },
+      }),
+    });
+    // The non-null timestamp renders as a <time> element
+    const timeEl = document.querySelector("time");
+    expect(timeEl).not.toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Accessibility
+  // -------------------------------------------------------------------------
+
+  it("section has aria-labelledby pointing to about-heading", () => {
+    renderComponent({ appInfo: makeAppInfo() });
+    const section = document.querySelector("section[aria-labelledby='about-heading']");
+    expect(section).not.toBeNull();
+  });
+
+  it("renders the About heading text", () => {
+    renderComponent({ appInfo: makeAppInfo() });
+    expect(screen.getByText("About")).toBeDefined();
+  });
+
+  it("renders 'Database Statistics' heading", () => {
+    renderComponent({ appInfo: makeAppInfo() });
+    expect(screen.getByText("Database Statistics")).toBeDefined();
+  });
+
+  it("renders 'Last Synced' heading", () => {
+    renderComponent({ appInfo: makeAppInfo() });
+    expect(screen.getByText("Last Synced")).toBeDefined();
+  });
+});

--- a/frontend/src/components/settings/__tests__/CacheSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/CacheSection.test.tsx
@@ -1,0 +1,348 @@
+/**
+ * Tests for CacheSection component.
+ *
+ * Coverage:
+ * - Loading skeleton shown when isLoading=true (role="status" with aria-label)
+ * - Error state shows alert with error message and Retry button
+ * - Empty cache shows "No cached images" text
+ * - Populated cache shows count and size text
+ * - "Clear Cache" button only appears when images exist
+ * - Clicking "Clear Cache" shows confirmation alertdialog
+ * - Confirmation dialog contains warning text about re-downloading
+ * - Confirming calls purgeCache()
+ * - Canceling hides the confirmation dialog
+ * - Escape key closes the confirmation dialog
+ * - aria-live region exists for purge completion announcements
+ * - Singular "image" when count is 1
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+// Mock the hook — component is only responsible for rendering
+vi.mock("../../../hooks/useCacheStatus", () => ({
+  useCacheStatus: vi.fn(),
+}));
+
+import { useCacheStatus } from "../../../hooks/useCacheStatus";
+import { CacheSection } from "../CacheSection";
+import type { UseCacheStatusReturn } from "../../../hooks/useCacheStatus";
+
+const mockedUseCacheStatus = vi.mocked(useCacheStatus);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildHookReturn(
+  overrides: Partial<UseCacheStatusReturn> = {}
+): UseCacheStatusReturn {
+  return {
+    cacheStatus: undefined,
+    isLoading: false,
+    error: null,
+    purgeCache: vi.fn(),
+    isPurging: false,
+    purgeResult: undefined,
+    ...overrides,
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderComponent(hookReturn: Partial<UseCacheStatusReturn> = {}) {
+  mockedUseCacheStatus.mockReturnValue(buildHookReturn(hookReturn));
+  const queryClient = createQueryClient();
+  render(
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(CacheSection)
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CacheSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("shows loading skeleton with role=status and aria-label when isLoading=true", () => {
+    renderComponent({ isLoading: true });
+    const skeleton = screen.getByRole("status", {
+      name: "Loading cache statistics",
+    });
+    expect(skeleton).toBeDefined();
+  });
+
+  it("does not show statistics text while loading", () => {
+    renderComponent({ isLoading: true });
+    expect(screen.queryByText(/cached images/i)).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it("shows error alert with the error message", () => {
+    renderComponent({ error: new Error("Cache endpoint failed") });
+    const alert = screen.getByRole("alert");
+    expect(within(alert).getByText("Cache endpoint failed")).toBeDefined();
+  });
+
+  it("shows a Retry button in the error state", () => {
+    renderComponent({ error: new Error("Oops") });
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
+  });
+
+  it("shows the error heading text", () => {
+    renderComponent({ error: new Error("Something broke") });
+    expect(
+      screen.getByText(/Failed to load cache statistics/i)
+    ).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty cache
+  // -------------------------------------------------------------------------
+
+  it("shows 'No cached images' when total_count is 0", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 0,
+        video_count: 0,
+        total_count: 0,
+        total_size_bytes: 0,
+        total_size_display: "0 B",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    expect(screen.getByText("No cached images")).toBeDefined();
+  });
+
+  it("does not show Clear Cache button when cache is empty", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 0,
+        video_count: 0,
+        total_count: 0,
+        total_size_bytes: 0,
+        total_size_display: "0 B",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    expect(
+      screen.queryByRole("button", { name: /clear/i })
+    ).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Populated cache
+  // -------------------------------------------------------------------------
+
+  it("shows count and size text for a populated cache", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 10,
+        video_count: 132,
+        total_count: 142,
+        total_size_bytes: 24_500_000,
+        total_size_display: "23.4 MB",
+        oldest_file: "2024-01-01T00:00:00Z",
+        newest_file: "2024-06-01T00:00:00Z",
+      },
+    });
+    expect(screen.getByText(/142 images, 23.4 MB/)).toBeDefined();
+  });
+
+  it("uses singular 'image' when total_count is 1", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 1,
+        video_count: 0,
+        total_count: 1,
+        total_size_bytes: 12_000,
+        total_size_display: "11.7 KB",
+        oldest_file: "2024-01-01T00:00:00Z",
+        newest_file: "2024-01-01T00:00:00Z",
+      },
+    });
+    expect(screen.getByText(/1 image, 11\.7 KB/)).toBeDefined();
+  });
+
+  it("shows 'Clear Cache' button when images exist", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 5,
+        video_count: 20,
+        total_count: 25,
+        total_size_bytes: 500_000,
+        total_size_display: "488 KB",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    expect(
+      screen.getByRole("button", { name: /clear all cached images/i })
+    ).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Confirmation dialog
+  // -------------------------------------------------------------------------
+
+  it("clicking Clear Cache opens an alertdialog", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 5,
+        video_count: 20,
+        total_count: 25,
+        total_size_bytes: 500_000,
+        total_size_display: "488 KB",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /clear all cached images/i })
+    );
+    expect(screen.getByRole("alertdialog")).toBeDefined();
+  });
+
+  it("confirmation dialog has warning text about re-downloading", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 5,
+        video_count: 20,
+        total_count: 25,
+        total_size_bytes: 500_000,
+        total_size_display: "488 KB",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /clear all cached images/i })
+    );
+    expect(
+      screen.getByText(/Cached images will need to be re-downloaded/i)
+    ).toBeDefined();
+  });
+
+  it("clicking 'Yes, clear cache' calls purgeCache()", () => {
+    const purgeCache = vi.fn();
+    renderComponent({
+      purgeCache,
+      cacheStatus: {
+        channel_count: 5,
+        video_count: 20,
+        total_count: 25,
+        total_size_bytes: 500_000,
+        total_size_display: "488 KB",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /clear all cached images/i })
+    );
+    fireEvent.click(screen.getByText(/Yes, clear cache/i));
+    expect(purgeCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking Cancel hides the confirmation dialog", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 5,
+        video_count: 20,
+        total_count: 25,
+        total_size_bytes: 500_000,
+        total_size_display: "488 KB",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /clear all cached images/i })
+    );
+    expect(screen.getByRole("alertdialog")).toBeDefined();
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("pressing Escape closes the confirmation dialog", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 5,
+        video_count: 20,
+        total_count: 25,
+        total_size_bytes: 500_000,
+        total_size_display: "488 KB",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /clear all cached images/i })
+    );
+    const dialog = screen.getByRole("alertdialog");
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // aria-live region
+  // -------------------------------------------------------------------------
+
+  it("renders an aria-live polite region for purge completion announcements", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 0,
+        video_count: 0,
+        total_count: 0,
+        total_size_bytes: 0,
+        total_size_display: "0 B",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    // The sr-only div has role="status" and aria-live="polite"
+    const liveRegions = document.querySelectorAll('[aria-live="polite"]');
+    expect(liveRegions.length).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Section heading
+  // -------------------------------------------------------------------------
+
+  it("renders the section heading 'Cache'", () => {
+    renderComponent({
+      cacheStatus: {
+        channel_count: 0,
+        video_count: 0,
+        total_count: 0,
+        total_size_bytes: 0,
+        total_size_display: "0 B",
+        oldest_file: null,
+        newest_file: null,
+      },
+    });
+    expect(screen.getByText("Cache")).toBeDefined();
+  });
+});

--- a/frontend/src/components/settings/__tests__/LanguagePreferencesSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/LanguagePreferencesSection.test.tsx
@@ -1,0 +1,456 @@
+/**
+ * Tests for LanguagePreferencesSection component.
+ *
+ * Coverage:
+ * - Loading skeleton shown when isLoading=true
+ * - Error state shows alert with error message and Retry button
+ * - Empty state shows preference type explanations (Fluent, Learning, Curious, Exclude)
+ * - Preferences grouped by type with correct headings
+ * - Language pills show display name with code in parentheses
+ * - Remove button on each pill has a correct aria-label
+ * - "Reset All" button only appears when preferences exist
+ * - Clicking "Reset All" shows confirmation alertdialog
+ * - Confirmation warns about permanently removing all preferences
+ * - Confirming calls resetAll()
+ * - Canceling hides the confirmation dialog
+ * - Escape closes the confirmation dialog
+ * - Add form has searchable language combobox
+ * - Preference type selector has 4 options (Fluent, Learning, Curious, Exclude)
+ * - Learning goal input only visible when type is "learning"
+ * - aria-live region for preference change announcements
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+vi.mock("../../../hooks/useLanguagePreferences", () => ({
+  useLanguagePreferences: vi.fn(),
+  DuplicateLanguageError: class DuplicateLanguageError extends Error {
+    languageCode: string;
+    existingType: string;
+    constructor(code: string, type: string) {
+      super(`Language "${code}" already in "${type}"`);
+      this.name = "DuplicateLanguageError";
+      this.languageCode = code;
+      this.existingType = type;
+    }
+  },
+}));
+
+import { useLanguagePreferences } from "../../../hooks/useLanguagePreferences";
+import { LanguagePreferencesSection } from "../LanguagePreferencesSection";
+import type { UseLanguagePreferencesReturn } from "../../../hooks/useLanguagePreferences";
+import type { SupportedLanguage } from "../../../api/settings";
+
+const mockedUseLanguagePreferences = vi.mocked(useLanguagePreferences);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SUPPORTED_LANGUAGES: SupportedLanguage[] = [
+  { code: "en", display_name: "English" },
+  { code: "es", display_name: "Spanish" },
+  { code: "fr", display_name: "French" },
+  { code: "ja", display_name: "Japanese" },
+];
+
+function buildHookReturn(
+  overrides: Partial<UseLanguagePreferencesReturn> = {}
+): UseLanguagePreferencesReturn {
+  return {
+    preferences: [],
+    supportedLanguages: SUPPORTED_LANGUAGES,
+    isLoading: false,
+    error: null,
+    addPreference: vi.fn(),
+    removePreference: vi.fn(),
+    resetAll: vi.fn(),
+    isMutating: false,
+    ...overrides,
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderComponent(
+  hookReturn: Partial<UseLanguagePreferencesReturn> = {}
+) {
+  mockedUseLanguagePreferences.mockReturnValue(buildHookReturn(hookReturn));
+  const queryClient = createQueryClient();
+  render(
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(LanguagePreferencesSection)
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LanguagePreferencesSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("shows loading skeleton with role=status when isLoading=true", () => {
+    renderComponent({ isLoading: true });
+    const skeleton = screen.getByRole("status", {
+      name: "Loading language preferences",
+    });
+    expect(skeleton).toBeDefined();
+  });
+
+  it("does not show the add form while loading", () => {
+    renderComponent({ isLoading: true });
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state
+  // -------------------------------------------------------------------------
+
+  it("shows error alert with the error message", () => {
+    renderComponent({ error: new Error("Preferences endpoint failed") });
+    const alert = screen.getByRole("alert");
+    expect(
+      within(alert).getByText("Preferences endpoint failed")
+    ).toBeDefined();
+  });
+
+  it("shows a Retry button in the error state", () => {
+    renderComponent({ error: new Error("Timeout") });
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+
+  it("shows empty state description when preferences is empty", () => {
+    renderComponent({ preferences: [] });
+    expect(
+      screen.getByText(/No language preferences configured yet/i)
+    ).toBeDefined();
+  });
+
+  it("shows Fluent description in the empty state", () => {
+    renderComponent({ preferences: [] });
+    expect(
+      screen.getByText(/Always download transcripts in these languages/i)
+    ).toBeDefined();
+  });
+
+  it("shows Learning description in the empty state", () => {
+    renderComponent({ preferences: [] });
+    expect(screen.getByText(/Download if available/i)).toBeDefined();
+  });
+
+  it("shows Curious description in the empty state", () => {
+    renderComponent({ preferences: [] });
+    expect(screen.getByText(/Never auto-download/i)).toBeDefined();
+  });
+
+  it("shows Exclude description in the empty state", () => {
+    renderComponent({ preferences: [] });
+    expect(screen.getByText(/Never download/i)).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Grouped preferences
+  // -------------------------------------------------------------------------
+
+  it("shows language pill with display name and code in parentheses", () => {
+    renderComponent({
+      preferences: [
+        {
+          language_code: "es",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+    });
+    // "Spanish" appears in both the visible pill span and an sr-only span;
+    // use getAllByText to confirm at least one visible match
+    expect(screen.getAllByText(/Spanish/i).length).toBeGreaterThanOrEqual(1);
+    // The language code is rendered in parentheses within the pill
+    expect(screen.getAllByText("(es)").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows remove button with correct aria-label on a pill", () => {
+    renderComponent({
+      preferences: [
+        {
+          language_code: "es",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+    });
+    expect(
+      screen.getByRole("button", {
+        name: /Remove Spanish \(es\) from Fluent/i,
+      })
+    ).toBeDefined();
+  });
+
+  it("clicking remove button calls removePreference with the language code", () => {
+    const removePreference = vi.fn();
+    renderComponent({
+      preferences: [
+        {
+          language_code: "es",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+      removePreference,
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Remove Spanish \(es\) from Fluent/i,
+      })
+    );
+    expect(removePreference).toHaveBeenCalledWith("es");
+  });
+
+  it("shows the Fluent group heading", () => {
+    renderComponent({
+      preferences: [
+        {
+          language_code: "en",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+    });
+    // The group heading for Fluent is an h4
+    const fluent = screen.getAllByText("Fluent")[0];
+    expect(fluent).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Reset All
+  // -------------------------------------------------------------------------
+
+  it("does not show Reset All button when preferences is empty", () => {
+    renderComponent({ preferences: [] });
+    expect(
+      screen.queryByRole("button", { name: /reset all/i })
+    ).toBeNull();
+  });
+
+  it("shows Reset All button when preferences exist", () => {
+    renderComponent({
+      preferences: [
+        {
+          language_code: "en",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+    });
+    expect(
+      screen.getByRole("button", { name: /reset all language preferences/i })
+    ).toBeDefined();
+  });
+
+  it("clicking Reset All shows confirmation alertdialog", () => {
+    renderComponent({
+      preferences: [
+        {
+          language_code: "en",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /reset all language preferences/i })
+    );
+    expect(screen.getByRole("alertdialog")).toBeDefined();
+  });
+
+  it("confirmation dialog warns about permanently removing all preferences", () => {
+    renderComponent({
+      preferences: [
+        {
+          language_code: "en",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /reset all language preferences/i })
+    );
+    expect(
+      screen.getByText(
+        /This will permanently remove all configured language preferences/i
+      )
+    ).toBeDefined();
+  });
+
+  it("confirming reset calls resetAll()", () => {
+    const resetAll = vi.fn();
+    renderComponent({
+      preferences: [
+        {
+          language_code: "en",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+      resetAll,
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /reset all language preferences/i })
+    );
+    fireEvent.click(screen.getByText(/Yes, remove all/i));
+    expect(resetAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("canceling the reset confirmation hides the dialog", () => {
+    renderComponent({
+      preferences: [
+        {
+          language_code: "en",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /reset all language preferences/i })
+    );
+    expect(screen.getByRole("alertdialog")).toBeDefined();
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("pressing Escape closes the reset confirmation dialog", () => {
+    renderComponent({
+      preferences: [
+        {
+          language_code: "en",
+          preference_type: "fluent",
+          priority: 1,
+          learning_goal: null,
+        },
+      ],
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /reset all language preferences/i })
+    );
+    const dialog = screen.getByRole("alertdialog");
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Add preference form
+  // -------------------------------------------------------------------------
+
+  it("renders a combobox input for language search", () => {
+    renderComponent({ preferences: [] });
+    const combobox = screen.getByRole("combobox", {
+      name: /Search and select a language/i,
+    });
+    expect(combobox).toBeDefined();
+  });
+
+  it("renders a preference type select with 4 options", () => {
+    renderComponent({ preferences: [] });
+    // Select also uses combobox role in some implementations; find by label
+    const typeSelect = screen.getByLabelText(/Preference type/i);
+    expect(typeSelect).toBeDefined();
+    const options = within(typeSelect as HTMLElement).getAllByRole("option");
+    expect(options.length).toBe(4);
+  });
+
+  it("preference type options are Fluent, Learning, Curious, Exclude", () => {
+    renderComponent({ preferences: [] });
+    const typeSelect = screen.getByLabelText(/Preference type/i);
+    const options = within(typeSelect as HTMLElement).getAllByRole("option");
+    const optionTexts = options.map((o) => o.textContent);
+    expect(optionTexts).toContain("Fluent");
+    expect(optionTexts).toContain("Learning");
+    expect(optionTexts).toContain("Curious");
+    expect(optionTexts).toContain("Exclude");
+  });
+
+  it("does not render learning goal input when type is 'fluent' (default)", () => {
+    renderComponent({ preferences: [] });
+    expect(screen.queryByLabelText(/Learning goal/i)).toBeNull();
+  });
+
+  it("renders learning goal input when preference type is changed to 'learning'", () => {
+    renderComponent({ preferences: [] });
+    const typeSelect = screen.getByLabelText(/Preference type/i);
+    fireEvent.change(typeSelect, { target: { value: "learning" } });
+    expect(screen.getByLabelText(/Learning goal/i)).toBeDefined();
+  });
+
+  it("learning goal input disappears when type is changed from 'learning' to another", () => {
+    renderComponent({ preferences: [] });
+    const typeSelect = screen.getByLabelText(/Preference type/i);
+    fireEvent.change(typeSelect, { target: { value: "learning" } });
+    expect(screen.getByLabelText(/Learning goal/i)).toBeDefined();
+    fireEvent.change(typeSelect, { target: { value: "curious" } });
+    expect(screen.queryByLabelText(/Learning goal/i)).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // aria-live region
+  // -------------------------------------------------------------------------
+
+  it("renders an aria-live polite region for preference change announcements", () => {
+    renderComponent({ preferences: [] });
+    const liveRegions = document.querySelectorAll('[aria-live="polite"]');
+    expect(liveRegions.length).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Section accessibility
+  // -------------------------------------------------------------------------
+
+  it("section has aria-labelledby='language-preferences-heading'", () => {
+    renderComponent({ preferences: [] });
+    const section = document.querySelector(
+      "section[aria-labelledby='language-preferences-heading']"
+    );
+    expect(section).not.toBeNull();
+  });
+
+  it("renders the Language Preferences heading", () => {
+    renderComponent({ preferences: [] });
+    expect(screen.getByText("Language Preferences")).toBeDefined();
+  });
+});

--- a/frontend/src/hooks/__tests__/useAppInfo.test.ts
+++ b/frontend/src/hooks/__tests__/useAppInfo.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for useAppInfo hook.
+ *
+ * Coverage:
+ * - Initial loading state while the app-info query is pending
+ * - Successful fetch returns populated appInfo
+ * - Error handling when the fetch fails
+ * - staleTime is set (30 seconds) — verified via query options indirectly
+ * - appInfo is undefined while loading and on error
+ * - All AppInfo fields are accessible after a successful fetch
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+vi.mock("../../api/settings", () => ({
+  fetchAppInfo: vi.fn(),
+}));
+
+import { fetchAppInfo } from "../../api/settings";
+import { useAppInfo } from "../useAppInfo";
+import type { AppInfo } from "../../api/settings";
+
+const mockedFetchAppInfo = vi.mocked(fetchAppInfo);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeAppInfoResponse(overrides: Partial<AppInfo> = {}): {
+  data: AppInfo;
+  pagination: null;
+} {
+  return {
+    data: {
+      backend_version: "0.49.0",
+      frontend_version: "0.18.0",
+      database_stats: {
+        videos: 1234,
+        channels: 56,
+        playlists: 12,
+        transcripts: 987,
+        corrections: 45,
+        canonical_tags: 678,
+      },
+      sync_timestamps: {
+        subscriptions: "2024-06-01T10:00:00Z",
+        videos: "2024-06-02T08:30:00Z",
+        transcripts: null,
+        playlists: "2024-05-28T15:45:00Z",
+        topics: null,
+      },
+      ...overrides,
+    },
+    pagination: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Wrapper & QueryClient helpers
+// ---------------------------------------------------------------------------
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useAppInfo", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+    mockedFetchAppInfo.mockResolvedValue(makeAppInfoResponse());
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("returns isLoading=true and appInfo=undefined while fetching", () => {
+    mockedFetchAppInfo.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.appInfo).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns isLoading=false after the query resolves", async () => {
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful data fetch
+  // -------------------------------------------------------------------------
+
+  it("populates appInfo with backend_version from the API response", async () => {
+    mockedFetchAppInfo.mockResolvedValue(
+      makeAppInfoResponse({ backend_version: "1.2.3" })
+    );
+
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.appInfo?.backend_version).toBe("1.2.3");
+  });
+
+  it("populates appInfo with frontend_version", async () => {
+    mockedFetchAppInfo.mockResolvedValue(
+      makeAppInfoResponse({ frontend_version: "0.18.0" })
+    );
+
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.appInfo?.frontend_version).toBe("0.18.0");
+  });
+
+  it("populates appInfo with all 6 database_stats fields", async () => {
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const stats = result.current.appInfo?.database_stats;
+    expect(stats?.videos).toBe(1234);
+    expect(stats?.channels).toBe(56);
+    expect(stats?.playlists).toBe(12);
+    expect(stats?.transcripts).toBe(987);
+    expect(stats?.corrections).toBe(45);
+    expect(stats?.canonical_tags).toBe(678);
+  });
+
+  it("populates appInfo.sync_timestamps with both ISO strings and null values", async () => {
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const timestamps = result.current.appInfo?.sync_timestamps;
+    expect(timestamps?.subscriptions).toBe("2024-06-01T10:00:00Z");
+    expect(timestamps?.transcripts).toBeNull();
+    expect(timestamps?.topics).toBeNull();
+  });
+
+  it("returns error=null on a successful fetch", async () => {
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  it("returns error when the fetch fails", async () => {
+    const fetchError = new Error("App info endpoint unavailable");
+    mockedFetchAppInfo.mockRejectedValue(fetchError);
+
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("App info endpoint unavailable");
+  });
+
+  it("returns appInfo=undefined on error", async () => {
+    mockedFetchAppInfo.mockRejectedValue(new Error("Server error"));
+
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.appInfo).toBeUndefined();
+  });
+
+  it("returns isLoading=false when query settles with an error", async () => {
+    mockedFetchAppInfo.mockRejectedValue(new Error("500 Internal Server Error"));
+
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).not.toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // staleTime behavior
+  // -------------------------------------------------------------------------
+
+  it("uses the app-info query key ['app-info']", async () => {
+    const { result } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // The query data is in the cache under the 'app-info' key
+    const cached = queryClient.getQueryData(["app-info"]);
+    expect(cached).toBeDefined();
+  });
+
+  it("does not re-fetch immediately on a second render (staleTime = 30s)", async () => {
+    const { result, rerender } = renderHook(() => useAppInfo(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const callCountAfterFirstFetch = mockedFetchAppInfo.mock.calls.length;
+
+    rerender();
+
+    // Should not have triggered another fetch within staleTime
+    expect(mockedFetchAppInfo.mock.calls.length).toBe(callCountAfterFirstFetch);
+  });
+});

--- a/frontend/src/hooks/__tests__/useCacheStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useCacheStatus.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for useCacheStatus hook.
+ *
+ * Coverage:
+ * - Initial loading state while the cache-status query is pending
+ * - Successful cache status fetch populates cacheStatus
+ * - purgeCache() triggers the DELETE mutation and sets isPurging
+ * - Successful purge invalidates the cache-status query key
+ * - Error handling from the fetch query
+ * - purgeResult is populated after a successful purge
+ * - cacheStatus is undefined while loading
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+// Mock at module level so all consumers see the mock
+vi.mock("../../api/settings", () => ({
+  fetchCacheStatus: vi.fn(),
+  purgeCache: vi.fn(),
+}));
+
+import { fetchCacheStatus, purgeCache } from "../../api/settings";
+import {
+  useCacheStatus,
+  CACHE_STATUS_KEY,
+} from "../useCacheStatus";
+import type {
+  CacheStatus,
+  CachePurgeResult,
+} from "../../api/settings";
+
+const mockedFetchCacheStatus = vi.mocked(fetchCacheStatus);
+const mockedPurgeCache = vi.mocked(purgeCache);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeCacheStatusResponse(
+  overrides: Partial<CacheStatus> = {}
+): { data: CacheStatus; pagination: null } {
+  return {
+    data: {
+      channel_count: 10,
+      video_count: 132,
+      total_count: 142,
+      total_size_bytes: 24_500_000,
+      total_size_display: "23.4 MB",
+      oldest_file: "2024-01-01T00:00:00Z",
+      newest_file: "2024-06-01T00:00:00Z",
+      ...overrides,
+    },
+    pagination: null,
+  };
+}
+
+function makePurgeResponse(
+  overrides: Partial<CachePurgeResult> = {}
+): { data: CachePurgeResult; pagination: null } {
+  return {
+    data: {
+      purged: true,
+      message: "Cache cleared successfully",
+      ...overrides,
+    },
+    pagination: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Wrapper & QueryClient helpers
+// ---------------------------------------------------------------------------
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useCacheStatus", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+
+    // Default: fetch resolves with a populated cache status
+    mockedFetchCacheStatus.mockResolvedValue(makeCacheStatusResponse());
+    mockedPurgeCache.mockResolvedValue(makePurgeResponse());
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("returns isLoading=true and cacheStatus=undefined while fetching", () => {
+    mockedFetchCacheStatus.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.cacheStatus).toBeUndefined();
+  });
+
+  it("returns isLoading=false once the query resolves", async () => {
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful data fetch
+  // -------------------------------------------------------------------------
+
+  it("populates cacheStatus with data from the API response", async () => {
+    mockedFetchCacheStatus.mockResolvedValue(
+      makeCacheStatusResponse({ total_count: 142, total_size_display: "23.4 MB" })
+    );
+
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.cacheStatus).toBeDefined();
+    expect(result.current.cacheStatus?.total_count).toBe(142);
+    expect(result.current.cacheStatus?.total_size_display).toBe("23.4 MB");
+  });
+
+  it("returns all CacheStatus fields correctly", async () => {
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const status = result.current.cacheStatus!;
+    expect(status.channel_count).toBe(10);
+    expect(status.video_count).toBe(132);
+    expect(status.total_count).toBe(142);
+    expect(status.total_size_bytes).toBe(24_500_000);
+    expect(typeof status.total_size_display).toBe("string");
+  });
+
+  // -------------------------------------------------------------------------
+  // purgeCache mutation
+  // -------------------------------------------------------------------------
+
+  it("isPurging transitions to true while the DELETE is in flight", async () => {
+    let resolveDelete!: (value: unknown) => void;
+    const pendingDelete = new Promise((resolve) => {
+      resolveDelete = resolve;
+    });
+
+    mockedPurgeCache.mockReturnValue(
+      pendingDelete as ReturnType<typeof purgeCache>
+    );
+
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isPurging).toBe(false);
+
+    act(() => {
+      result.current.purgeCache();
+    });
+
+    await waitFor(() => expect(result.current.isPurging).toBe(true));
+
+    // Clean up
+    resolveDelete(makePurgeResponse());
+    await waitFor(() => expect(result.current.isPurging).toBe(false));
+  });
+
+  it("purgeCache() calls the purgeCache API function", async () => {
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.purgeCache();
+    });
+
+    await waitFor(() => expect(mockedPurgeCache).toHaveBeenCalledTimes(1));
+  });
+
+  it("successful purge invalidates the CACHE_STATUS_KEY query", async () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.purgeCache();
+    });
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: CACHE_STATUS_KEY })
+      )
+    );
+
+    invalidateSpy.mockRestore();
+  });
+
+  it("purgeResult is populated after a successful purge", async () => {
+    mockedPurgeCache.mockResolvedValue(
+      makePurgeResponse({ purged: true, message: "All 142 files deleted" })
+    );
+
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.purgeResult).toBeUndefined();
+
+    act(() => {
+      result.current.purgeCache();
+    });
+
+    await waitFor(() => expect(result.current.purgeResult).toBeDefined());
+    expect(result.current.purgeResult?.purged).toBe(true);
+    expect(result.current.purgeResult?.message).toBe("All 142 files deleted");
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  it("returns error when the cache-status fetch fails", async () => {
+    const fetchError = new Error("Cache endpoint unavailable");
+    mockedFetchCacheStatus.mockRejectedValue(fetchError);
+
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("Cache endpoint unavailable");
+    expect(result.current.cacheStatus).toBeUndefined();
+  });
+
+  it("returns error=null and no cacheStatus when still loading", () => {
+    mockedFetchCacheStatus.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.cacheStatus).toBeUndefined();
+  });
+
+  it("returns isPurging=false initially", async () => {
+    const { result } = renderHook(() => useCacheStatus(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isPurging).toBe(false);
+  });
+});

--- a/frontend/src/hooks/__tests__/useLanguagePreferences.test.ts
+++ b/frontend/src/hooks/__tests__/useLanguagePreferences.test.ts
@@ -1,0 +1,571 @@
+/**
+ * Tests for useLanguagePreferences hook.
+ *
+ * Coverage:
+ * - Initial loading state while both queries are fetching
+ * - Successful fetch of preferences and supported languages
+ * - addPreference() — calls PUT with full list including new item and correct priority
+ * - addPreference() with DuplicateLanguageError (FR-009)
+ * - removePreference() — filters out language and renumbers priorities within groups
+ * - resetAll() — calls PUT with empty preferences list
+ * - isMutating state transitions during mutation lifecycle
+ * - Error propagation from preferences query
+ * - Error propagation from supported-languages query
+ * - Mutation success invalidates the LANGUAGE_PREFERENCES_KEY query
+ * - Priority renumbering: removing middle item compacts remaining priorities
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+// Mock apiFetch and fetchSupportedLanguages before the hook import
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("../../api/settings", () => ({
+  fetchSupportedLanguages: vi.fn(),
+}));
+
+import { apiFetch } from "../../api/config";
+import { fetchSupportedLanguages } from "../../api/settings";
+import {
+  useLanguagePreferences,
+  DuplicateLanguageError,
+  LANGUAGE_PREFERENCES_KEY,
+} from "../useLanguagePreferences";
+import type { LanguagePreferencesResponse } from "../useLanguagePreferences";
+import type { SupportedLanguage } from "../../api/settings";
+
+const mockedApiFetch = vi.mocked(apiFetch);
+const mockedFetchSupportedLanguages = vi.mocked(fetchSupportedLanguages);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makePreferencesResponse(
+  items: LanguagePreferencesResponse["data"] = []
+): LanguagePreferencesResponse {
+  return { data: items, pagination: null };
+}
+
+function makeSupportedLanguagesResponse(
+  languages: SupportedLanguage[] = []
+): { data: SupportedLanguage[]; pagination: null } {
+  return { data: languages, pagination: null };
+}
+
+const DEFAULT_SUPPORTED_LANGUAGES: SupportedLanguage[] = [
+  { code: "en", display_name: "English" },
+  { code: "es", display_name: "Spanish" },
+  { code: "fr", display_name: "French" },
+  { code: "ja", display_name: "Japanese" },
+];
+
+// ---------------------------------------------------------------------------
+// Wrapper & QueryClient helpers
+// ---------------------------------------------------------------------------
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useLanguagePreferences", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+
+    // Default: both queries resolve successfully with empty data
+    mockedApiFetch.mockResolvedValue(makePreferencesResponse());
+    mockedFetchSupportedLanguages.mockResolvedValue(
+      makeSupportedLanguagesResponse(DEFAULT_SUPPORTED_LANGUAGES)
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it("returns isLoading=true while queries are pending", () => {
+    // Keep queries pending indefinitely
+    mockedApiFetch.mockReturnValue(new Promise(() => {}));
+    mockedFetchSupportedLanguages.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.preferences).toEqual([]);
+    expect(result.current.supportedLanguages).toEqual([]);
+  });
+
+  it("returns isLoading=false once both queries have resolved", async () => {
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful data fetch
+  // -------------------------------------------------------------------------
+
+  it("exposes preferences from the GET /preferences/languages response", async () => {
+    const prefs = [
+      {
+        language_code: "en",
+        preference_type: "fluent",
+        priority: 1,
+        learning_goal: null,
+      },
+      {
+        language_code: "ja",
+        preference_type: "learning",
+        priority: 1,
+        learning_goal: "JLPT N3",
+      },
+    ];
+    mockedApiFetch.mockResolvedValue(makePreferencesResponse(prefs));
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.preferences).toEqual(prefs);
+  });
+
+  it("exposes supportedLanguages from fetchSupportedLanguages", async () => {
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.supportedLanguages).toEqual(DEFAULT_SUPPORTED_LANGUAGES);
+  });
+
+  // -------------------------------------------------------------------------
+  // addPreference
+  // -------------------------------------------------------------------------
+
+  it("addPreference() fires PUT with existing items plus new item at next priority", async () => {
+    const existingPrefs = [
+      {
+        language_code: "en",
+        preference_type: "fluent",
+        priority: 1,
+        learning_goal: null,
+      },
+    ];
+    mockedApiFetch
+      .mockResolvedValueOnce(makePreferencesResponse(existingPrefs))
+      .mockResolvedValueOnce(makePreferencesResponse(existingPrefs)); // after mutation invalidate
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.addPreference("es", "fluent");
+    });
+
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/preferences/languages",
+        expect.objectContaining({ method: "PUT" })
+      )
+    );
+
+    const putCall = mockedApiFetch.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === "PUT"
+    );
+    expect(putCall).toBeDefined();
+    const body = JSON.parse((putCall![1] as { body: string }).body);
+    expect(body.preferences).toContainEqual(
+      expect.objectContaining({
+        language_code: "es",
+        preference_type: "fluent",
+        priority: 2, // next after existing fluent priority=1
+      })
+    );
+    // Original item is preserved
+    expect(body.preferences).toContainEqual(
+      expect.objectContaining({ language_code: "en", preference_type: "fluent" })
+    );
+  });
+
+  it("addPreference() assigns priority=1 when the type group is empty", async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce(makePreferencesResponse([]))
+      .mockResolvedValueOnce(makePreferencesResponse([]));
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.addPreference("ja", "learning", "JLPT N3");
+    });
+
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/preferences/languages",
+        expect.objectContaining({ method: "PUT" })
+      )
+    );
+
+    const putCall = mockedApiFetch.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === "PUT"
+    );
+    const body = JSON.parse((putCall![1] as { body: string }).body);
+    expect(body.preferences).toContainEqual(
+      expect.objectContaining({
+        language_code: "ja",
+        preference_type: "learning",
+        priority: 1,
+        learning_goal: "JLPT N3",
+      })
+    );
+  });
+
+  it("addPreference() throws DuplicateLanguageError (FR-009) when language already exists", async () => {
+    const existingPrefs = [
+      {
+        language_code: "fr",
+        preference_type: "fluent",
+        priority: 1,
+        learning_goal: null,
+      },
+    ];
+    mockedApiFetch.mockResolvedValueOnce(makePreferencesResponse(existingPrefs));
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let thrown: unknown = null;
+    act(() => {
+      try {
+        result.current.addPreference("fr", "learning");
+      } catch (e) {
+        thrown = e;
+      }
+    });
+
+    expect(thrown).toBeInstanceOf(DuplicateLanguageError);
+    expect((thrown as DuplicateLanguageError).languageCode).toBe("fr");
+    expect((thrown as DuplicateLanguageError).existingType).toBe("fluent");
+    // No PUT should have been fired
+    const putCalls = mockedApiFetch.mock.calls.filter(
+      (c) => c[1] && (c[1] as { method?: string }).method === "PUT"
+    );
+    expect(putCalls).toHaveLength(0);
+  });
+
+  it("DuplicateLanguageError contains a human-readable message", async () => {
+    const existingPrefs = [
+      {
+        language_code: "es",
+        preference_type: "curious",
+        priority: 1,
+        learning_goal: null,
+      },
+    ];
+    mockedApiFetch.mockResolvedValueOnce(makePreferencesResponse(existingPrefs));
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let err: DuplicateLanguageError | undefined;
+    act(() => {
+      try {
+        result.current.addPreference("es", "fluent");
+      } catch (e) {
+        if (e instanceof DuplicateLanguageError) err = e;
+      }
+    });
+
+    expect(err?.message).toContain("es");
+    expect(err?.message).toContain("curious");
+  });
+
+  // -------------------------------------------------------------------------
+  // removePreference
+  // -------------------------------------------------------------------------
+
+  it("removePreference() fires PUT without the removed language", async () => {
+    const existingPrefs = [
+      {
+        language_code: "en",
+        preference_type: "fluent",
+        priority: 1,
+        learning_goal: null,
+      },
+      {
+        language_code: "es",
+        preference_type: "fluent",
+        priority: 2,
+        learning_goal: null,
+      },
+    ];
+    mockedApiFetch
+      .mockResolvedValueOnce(makePreferencesResponse(existingPrefs))
+      .mockResolvedValueOnce(makePreferencesResponse(existingPrefs));
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.removePreference("en");
+    });
+
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/preferences/languages",
+        expect.objectContaining({ method: "PUT" })
+      )
+    );
+
+    const putCall = mockedApiFetch.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === "PUT"
+    );
+    const body = JSON.parse((putCall![1] as { body: string }).body);
+    const codes = body.preferences.map(
+      (p: { language_code: string }) => p.language_code
+    );
+    expect(codes).not.toContain("en");
+    expect(codes).toContain("es");
+  });
+
+  it("removePreference() renumbers priorities after removal", async () => {
+    const existingPrefs = [
+      {
+        language_code: "es",
+        preference_type: "fluent",
+        priority: 1,
+        learning_goal: null,
+      },
+      {
+        language_code: "fr",
+        preference_type: "fluent",
+        priority: 2,
+        learning_goal: null,
+      },
+      {
+        language_code: "ja",
+        preference_type: "fluent",
+        priority: 3,
+        learning_goal: null,
+      },
+    ];
+    mockedApiFetch
+      .mockResolvedValueOnce(makePreferencesResponse(existingPrefs))
+      .mockResolvedValueOnce(makePreferencesResponse(existingPrefs));
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.removePreference("fr"); // remove middle item
+    });
+
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/preferences/languages",
+        expect.objectContaining({ method: "PUT" })
+      )
+    );
+
+    const putCall = mockedApiFetch.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === "PUT"
+    );
+    const body = JSON.parse((putCall![1] as { body: string }).body);
+
+    // After removing fr(2), es should be 1 and ja should be 2
+    const esItem = body.preferences.find(
+      (p: { language_code: string }) => p.language_code === "es"
+    );
+    const jaItem = body.preferences.find(
+      (p: { language_code: string }) => p.language_code === "ja"
+    );
+    expect(esItem?.priority).toBe(1);
+    expect(jaItem?.priority).toBe(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // resetAll
+  // -------------------------------------------------------------------------
+
+  it("resetAll() fires PUT with an empty preferences list", async () => {
+    const existingPrefs = [
+      {
+        language_code: "en",
+        preference_type: "fluent",
+        priority: 1,
+        learning_goal: null,
+      },
+    ];
+    mockedApiFetch
+      .mockResolvedValueOnce(makePreferencesResponse(existingPrefs))
+      .mockResolvedValueOnce(makePreferencesResponse([]));
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.resetAll();
+    });
+
+    await waitFor(() =>
+      expect(mockedApiFetch).toHaveBeenCalledWith(
+        "/preferences/languages",
+        expect.objectContaining({ method: "PUT" })
+      )
+    );
+
+    const putCall = mockedApiFetch.mock.calls.find(
+      (c) => c[1] && (c[1] as { method?: string }).method === "PUT"
+    );
+    const body = JSON.parse((putCall![1] as { body: string }).body);
+    expect(body.preferences).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // isMutating
+  // -------------------------------------------------------------------------
+
+  it("isMutating is true while the PUT is in flight and false when settled", async () => {
+    let resolveMutation!: (value: unknown) => void;
+    const pendingMutation = new Promise((resolve) => {
+      resolveMutation = resolve;
+    });
+
+    mockedApiFetch
+      .mockResolvedValueOnce(makePreferencesResponse([]))
+      .mockReturnValueOnce(pendingMutation as Promise<LanguagePreferencesResponse>);
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isMutating).toBe(false);
+
+    act(() => {
+      result.current.resetAll();
+    });
+
+    await waitFor(() => expect(result.current.isMutating).toBe(true));
+
+    // Resolve and verify isMutating returns to false
+    resolveMutation(makePreferencesResponse([]));
+    await waitFor(() => expect(result.current.isMutating).toBe(false));
+  });
+
+  // -------------------------------------------------------------------------
+  // Error propagation
+  // -------------------------------------------------------------------------
+
+  it("returns error from the preferences query", async () => {
+    const apiError = new Error("Network failure");
+    mockedApiFetch.mockRejectedValue(apiError);
+    mockedFetchSupportedLanguages.mockResolvedValue(
+      makeSupportedLanguagesResponse([])
+    );
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("Network failure");
+  });
+
+  it("returns error from the supported-languages query", async () => {
+    mockedApiFetch.mockResolvedValue(makePreferencesResponse([]));
+    mockedFetchSupportedLanguages.mockRejectedValue(
+      new Error("Languages endpoint down")
+    );
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("Languages endpoint down");
+  });
+
+  // -------------------------------------------------------------------------
+  // Cache invalidation on success
+  // -------------------------------------------------------------------------
+
+  it("mutation success calls invalidateQueries on LANGUAGE_PREFERENCES_KEY", async () => {
+    mockedApiFetch
+      .mockResolvedValueOnce(makePreferencesResponse([]))
+      .mockResolvedValueOnce(makePreferencesResponse([]));
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useLanguagePreferences(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.resetAll();
+    });
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: LANGUAGE_PREFERENCES_KEY })
+      )
+    );
+
+    invalidateSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -43,3 +43,21 @@ export {
   ONBOARDING_STATUS_KEY,
   taskStatusKey,
 } from "./useOnboarding";
+export {
+  useLanguagePreferences,
+  DuplicateLanguageError,
+  LANGUAGE_PREFERENCES_KEY,
+  SUPPORTED_LANGUAGES_KEY,
+  type LanguagePreferenceItem,
+  type UseLanguagePreferencesReturn,
+} from "./useLanguagePreferences";
+export {
+  useAppInfo,
+  APP_INFO_KEY,
+  type UseAppInfoReturn,
+} from "./useAppInfo";
+export {
+  useCacheStatus,
+  CACHE_STATUS_KEY,
+  type UseCacheStatusReturn,
+} from "./useCacheStatus";

--- a/frontend/src/hooks/useAppInfo.ts
+++ b/frontend/src/hooks/useAppInfo.ts
@@ -1,0 +1,71 @@
+/**
+ * useAppInfo hook for fetching application version and database statistics.
+ *
+ * Implements:
+ * - GET /api/v1/settings/app-info — backend version, frontend version,
+ *   database entity counts, and last-sync timestamps
+ *
+ * This is a read-only hook; no mutations are needed for app info.
+ *
+ * @module hooks/useAppInfo
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchAppInfo, type AppInfo } from "../api/settings";
+
+// ---------------------------------------------------------------------------
+// Query key constant
+// ---------------------------------------------------------------------------
+
+export const APP_INFO_KEY = ["app-info"] as const;
+
+// ---------------------------------------------------------------------------
+// Public hook return type
+// ---------------------------------------------------------------------------
+
+export interface UseAppInfoReturn {
+  /** Application version and database statistics, or undefined while loading. */
+  appInfo: AppInfo | undefined;
+  /** True while the query is fetching for the first time. */
+  isLoading: boolean;
+  /** Any error thrown during the fetch, or null. */
+  error: Error | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches application info from the backend with a 30-second stale time.
+ *
+ * App info changes rarely (deploys, sync operations) so a moderate stale
+ * window avoids unnecessary round-trips while keeping data reasonably fresh.
+ *
+ * @example
+ * ```tsx
+ * const { appInfo, isLoading, error } = useAppInfo();
+ *
+ * if (isLoading) return <Spinner />;
+ * if (error) return <ErrorMessage error={error} />;
+ *
+ * return <p>Backend v{appInfo?.backend_version}</p>;
+ * ```
+ */
+export function useAppInfo(): UseAppInfoReturn {
+  const query = useQuery<
+    Awaited<ReturnType<typeof fetchAppInfo>>,
+    Error
+  >({
+    queryKey: APP_INFO_KEY,
+    queryFn: ({ signal }) => fetchAppInfo(signal),
+    staleTime: 30 * 1000, // 30 seconds — app info changes only on deploy/sync
+  });
+
+  return {
+    appInfo: query.data?.data,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}

--- a/frontend/src/hooks/useCacheStatus.ts
+++ b/frontend/src/hooks/useCacheStatus.ts
@@ -1,0 +1,127 @@
+/**
+ * useCacheStatus hook for querying and purging the local image cache.
+ *
+ * Implements:
+ * - GET /api/v1/settings/cache — image cache statistics
+ * - DELETE /api/v1/settings/cache — purge all cached images
+ *
+ * On a successful purge the cache-status query is invalidated so the UI
+ * immediately reflects the empty cache without a manual refresh.
+ *
+ * @module hooks/useCacheStatus
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  fetchCacheStatus,
+  purgeCache as purgeCacheApi,
+  type CacheStatus,
+  type CachePurgeResult,
+} from "../api/settings";
+
+// ---------------------------------------------------------------------------
+// Query key constant
+// ---------------------------------------------------------------------------
+
+export const CACHE_STATUS_KEY = ["cache-status"] as const;
+
+// ---------------------------------------------------------------------------
+// Public hook return type
+// ---------------------------------------------------------------------------
+
+export interface UseCacheStatusReturn {
+  /** Current image cache statistics, or undefined while loading. */
+  cacheStatus: CacheStatus | undefined;
+  /** True while the cache-status query is fetching for the first time. */
+  isLoading: boolean;
+  /** Error from the cache-status query, or null. */
+  error: Error | null;
+  /**
+   * Trigger a full cache purge (DELETE /api/v1/settings/cache).
+   * The cache-status query is automatically invalidated on success.
+   */
+  purgeCache: () => void;
+  /** True while the purge mutation is in flight. */
+  isPurging: boolean;
+  /** The result data from the most recent successful purge, or undefined. */
+  purgeResult: CachePurgeResult | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Provides cache statistics and a purge action for the local image cache.
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   cacheStatus,
+ *   isLoading,
+ *   error,
+ *   purgeCache,
+ *   isPurging,
+ * } = useCacheStatus();
+ *
+ * if (isLoading) return <Spinner />;
+ * if (error) return <ErrorMessage error={error} />;
+ *
+ * return (
+ *   <div>
+ *     <p>{cacheStatus?.total_size_display}</p>
+ *     <button onClick={purgeCache} disabled={isPurging}>
+ *       {isPurging ? "Purging…" : "Clear cache"}
+ *     </button>
+ *   </div>
+ * );
+ * ```
+ */
+export function useCacheStatus(): UseCacheStatusReturn {
+  const queryClient = useQueryClient();
+
+  // ------------------------------------------------------------------
+  // Query: cache statistics
+  // ------------------------------------------------------------------
+  const cacheStatusQuery = useQuery<
+    Awaited<ReturnType<typeof fetchCacheStatus>>,
+    Error
+  >({
+    queryKey: CACHE_STATUS_KEY,
+    queryFn: ({ signal }) => fetchCacheStatus(signal),
+    staleTime: 30 * 1000, // 30 seconds — cache size can change frequently
+  });
+
+  // ------------------------------------------------------------------
+  // Mutation: purge cache
+  // ------------------------------------------------------------------
+  const purgeMutation = useMutation<
+    Awaited<ReturnType<typeof purgeCacheApi>>,
+    Error,
+    void
+  >({
+    mutationFn: () => purgeCacheApi(),
+    onSuccess: () => {
+      // Invalidate so the GET query re-fetches and reflects the cleared cache
+      queryClient.invalidateQueries({ queryKey: CACHE_STATUS_KEY });
+    },
+  });
+
+  // ------------------------------------------------------------------
+  // Derived state
+  // ------------------------------------------------------------------
+  const cacheStatus = cacheStatusQuery.data?.data;
+  const isLoading = cacheStatusQuery.isLoading;
+  const error: Error | null = cacheStatusQuery.error as Error | null;
+  const purgeResult = purgeMutation.data?.data;
+
+  return {
+    cacheStatus,
+    isLoading,
+    error,
+    purgeCache: () => purgeMutation.mutate(),
+    isPurging: purgeMutation.isPending,
+    purgeResult,
+  };
+}

--- a/frontend/src/hooks/useLanguagePreferences.ts
+++ b/frontend/src/hooks/useLanguagePreferences.ts
@@ -1,0 +1,345 @@
+/**
+ * useLanguagePreferences hook for managing language preferences in settings.
+ *
+ * Implements:
+ * - GET /api/v1/preferences/languages — current user preferences
+ * - GET /api/v1/settings/supported-languages — all available languages (static)
+ * - PUT /api/v1/preferences/languages — replace-all semantics for updates
+ * - FR-009: Duplicate validation before adding a language
+ *
+ * Priority numbering is maintained locally:
+ * - On add: new item receives next sequential priority within its type group
+ * - On remove: remaining items are re-numbered 1..N within each type group
+ * - On resetAll: empty list replaces all preferences
+ *
+ * @module hooks/useLanguagePreferences
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { apiFetch } from "../api/config";
+import {
+  fetchSupportedLanguages,
+  type SupportedLanguage,
+} from "../api/settings";
+
+// ---------------------------------------------------------------------------
+// Query key constants
+// ---------------------------------------------------------------------------
+
+export const LANGUAGE_PREFERENCES_KEY = ["language-preferences"] as const;
+export const SUPPORTED_LANGUAGES_KEY = ["supported-languages"] as const;
+
+// ---------------------------------------------------------------------------
+// Types matching backend schemas (preferences.py)
+// ---------------------------------------------------------------------------
+
+export interface LanguagePreferenceItem {
+  /** BCP-47 language code (e.g. "en", "es", "ja") */
+  language_code: string;
+  /** One of: "fluent", "learning", "curious", "exclude" */
+  preference_type: string;
+  /** 1 = highest priority within the preference type group */
+  priority: number;
+  /** Goal text for the "learning" type; null otherwise */
+  learning_goal: string | null;
+}
+
+export interface LanguagePreferencesResponse {
+  data: LanguagePreferenceItem[];
+  pagination: null;
+}
+
+export interface LanguagePreferenceUpdate {
+  language_code: string;
+  preference_type: string;
+  /** Omit to let the backend auto-assign within its group */
+  priority?: number;
+  learning_goal?: string | null;
+}
+
+export interface LanguagePreferencesUpdateRequest {
+  preferences: LanguagePreferenceUpdate[];
+}
+
+// ---------------------------------------------------------------------------
+// Error type for duplicate validation (FR-009)
+// ---------------------------------------------------------------------------
+
+export class DuplicateLanguageError extends Error {
+  readonly languageCode: string;
+  readonly existingType: string;
+
+  constructor(languageCode: string, existingType: string) {
+    super(
+      `Language "${languageCode}" is already configured as "${existingType}". ` +
+        `Remove it from that group before adding it here.`
+    );
+    this.name = "DuplicateLanguageError";
+    this.languageCode = languageCode;
+    this.existingType = existingType;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public hook return type
+// ---------------------------------------------------------------------------
+
+export interface UseLanguagePreferencesReturn {
+  /** Current language preferences, ordered by priority. */
+  preferences: LanguagePreferenceItem[];
+  /** Full list of all language codes supported by the backend. */
+  supportedLanguages: SupportedLanguage[];
+  /** True while either query is fetching for the first time. */
+  isLoading: boolean;
+  /** First error from either query, or null. */
+  error: Error | null;
+  /**
+   * Add a language preference.
+   *
+   * Throws DuplicateLanguageError (FR-009) if the language code already
+   * exists in any preference type group.
+   *
+   * @param languageCode - BCP-47 code
+   * @param preferenceType - "fluent" | "learning" | "curious" | "exclude"
+   * @param learningGoal - Optional goal text (only relevant for "learning")
+   */
+  addPreference: (
+    languageCode: string,
+    preferenceType: string,
+    learningGoal?: string | null
+  ) => void;
+  /**
+   * Remove a language preference by its language code.
+   * Re-numbers priorities within each type group after removal.
+   */
+  removePreference: (languageCode: string) => void;
+  /** Replace all preferences with an empty list. */
+  resetAll: () => void;
+  /** True while a PUT mutation is in flight. */
+  isMutating: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function fetchLanguagePreferences(
+  signal?: AbortSignal
+): Promise<LanguagePreferencesResponse> {
+  return apiFetch<LanguagePreferencesResponse>("/preferences/languages", {
+    ...(signal !== undefined ? { externalSignal: signal } : {}),
+  });
+}
+
+async function putLanguagePreferences(
+  body: LanguagePreferencesUpdateRequest
+): Promise<LanguagePreferencesResponse> {
+  return apiFetch<LanguagePreferencesResponse>("/preferences/languages", {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Priority renumbering helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-numbers priorities 1..N within each preference_type group.
+ * The relative order of items is preserved; only their priority numbers
+ * are normalised to be contiguous starting from 1.
+ */
+function renumberPriorities(
+  items: LanguagePreferenceItem[]
+): LanguagePreferenceItem[] {
+  // Group items by preference_type while preserving insertion order
+  const byType = new Map<string, LanguagePreferenceItem[]>();
+  for (const item of items) {
+    const group = byType.get(item.preference_type);
+    if (group !== undefined) {
+      group.push(item);
+    } else {
+      byType.set(item.preference_type, [item]);
+    }
+  }
+
+  const result: LanguagePreferenceItem[] = [];
+  for (const group of byType.values()) {
+    // Sort within type by existing priority so relative order is stable
+    const sorted = [...group].sort((a, b) => a.priority - b.priority);
+    sorted.forEach((item, index) => {
+      result.push({ ...item, priority: index + 1 });
+    });
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages language preferences with TanStack Query for caching and mutation.
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   preferences,
+ *   supportedLanguages,
+ *   isLoading,
+ *   error,
+ *   addPreference,
+ *   removePreference,
+ *   resetAll,
+ *   isMutating,
+ * } = useLanguagePreferences();
+ *
+ * // Add a new preference
+ * try {
+ *   addPreference("ja", "learning", "JLPT N3 goal");
+ * } catch (e) {
+ *   if (e instanceof DuplicateLanguageError) {
+ *     showError(e.message);
+ *   }
+ * }
+ *
+ * // Remove by language code
+ * removePreference("en");
+ *
+ * // Reset everything
+ * resetAll();
+ * ```
+ */
+export function useLanguagePreferences(): UseLanguagePreferencesReturn {
+  const queryClient = useQueryClient();
+
+  // ------------------------------------------------------------------
+  // Query: current preferences
+  // ------------------------------------------------------------------
+  const preferencesQuery = useQuery<LanguagePreferencesResponse, Error>({
+    queryKey: LANGUAGE_PREFERENCES_KEY,
+    queryFn: ({ signal }) => fetchLanguagePreferences(signal),
+    staleTime: 60 * 1000, // 1 minute — preferences change infrequently
+  });
+
+  // ------------------------------------------------------------------
+  // Query: supported languages (static, cache forever during the session)
+  // ------------------------------------------------------------------
+  const supportedLanguagesQuery = useQuery({
+    queryKey: SUPPORTED_LANGUAGES_KEY,
+    queryFn: ({ signal }) => fetchSupportedLanguages(signal),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  // ------------------------------------------------------------------
+  // Mutation: replace-all PUT
+  // ------------------------------------------------------------------
+  const mutation = useMutation<
+    LanguagePreferencesResponse,
+    Error,
+    LanguagePreferencesUpdateRequest
+  >({
+    mutationFn: (body) => putLanguagePreferences(body),
+    onSuccess: () => {
+      // Invalidate so the GET query re-fetches with the server's canonical data
+      queryClient.invalidateQueries({ queryKey: LANGUAGE_PREFERENCES_KEY });
+    },
+  });
+
+  // ------------------------------------------------------------------
+  // Derived state
+  // ------------------------------------------------------------------
+  const preferences = preferencesQuery.data?.data ?? [];
+  const supportedLanguages = supportedLanguagesQuery.data?.data ?? [];
+
+  const isLoading =
+    preferencesQuery.isLoading || supportedLanguagesQuery.isLoading;
+
+  const error: Error | null =
+    (preferencesQuery.error as Error | null) ??
+    (supportedLanguagesQuery.error as Error | null);
+
+  // ------------------------------------------------------------------
+  // Helper: addPreference
+  // ------------------------------------------------------------------
+  function addPreference(
+    languageCode: string,
+    preferenceType: string,
+    learningGoal?: string | null
+  ): void {
+    // FR-009: Reject if the language already exists in any preference type
+    const existing = preferences.find(
+      (p) => p.language_code === languageCode
+    );
+    if (existing !== undefined) {
+      throw new DuplicateLanguageError(languageCode, existing.preference_type);
+    }
+
+    // Compute the next priority within the target type group
+    const existingInType = preferences.filter(
+      (p) => p.preference_type === preferenceType
+    );
+    const nextPriority = existingInType.length + 1;
+
+    const newItem: LanguagePreferenceUpdate = {
+      language_code: languageCode,
+      preference_type: preferenceType,
+      priority: nextPriority,
+      learning_goal: learningGoal ?? null,
+    };
+
+    // Build the updated full list (keep existing items + new one)
+    const updated: LanguagePreferenceUpdate[] = [
+      ...preferences.map((p) => ({
+        language_code: p.language_code,
+        preference_type: p.preference_type,
+        priority: p.priority,
+        learning_goal: p.learning_goal ?? null,
+      })),
+      newItem,
+    ];
+
+    mutation.mutate({ preferences: updated });
+  }
+
+  // ------------------------------------------------------------------
+  // Helper: removePreference
+  // ------------------------------------------------------------------
+  function removePreference(languageCode: string): void {
+    const filtered = preferences.filter(
+      (p) => p.language_code !== languageCode
+    );
+
+    // Re-number priorities so they remain contiguous within each type group
+    const renumbered = renumberPriorities(filtered);
+
+    const updated: LanguagePreferenceUpdate[] = renumbered.map((p) => ({
+      language_code: p.language_code,
+      preference_type: p.preference_type,
+      priority: p.priority,
+      learning_goal: p.learning_goal ?? null,
+    }));
+
+    mutation.mutate({ preferences: updated });
+  }
+
+  // ------------------------------------------------------------------
+  // Helper: resetAll
+  // ------------------------------------------------------------------
+  function resetAll(): void {
+    mutation.mutate({ preferences: [] });
+  }
+
+  return {
+    preferences,
+    supportedLanguages,
+    isLoading,
+    error,
+    addPreference,
+    removePreference,
+    resetAll,
+    isMutating: mutation.isPending,
+  };
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,62 @@
+/**
+ * SettingsPage — main settings and preferences page.
+ *
+ * Route: /settings
+ *
+ * Feature 049 (Settings & Preferences Page):
+ * - T005: Page skeleton with three section placeholders
+ *
+ * Section placeholders (to be replaced in later tasks):
+ * - Language Preferences (T010: LanguagePreferencesSection)
+ * - Cache (T017: CacheSection)
+ * - About (T021: AboutSection)
+ */
+
+import { useEffect } from "react";
+
+import { AboutSection } from "../components/settings/AboutSection";
+import { CacheSection } from "../components/settings/CacheSection";
+import { LanguagePreferencesSection } from "../components/settings/LanguagePreferencesSection";
+
+/**
+ * SettingsPage displays user-configurable preferences and application info.
+ * Rendered within the AppShell layout which provides the header and sidebar.
+ */
+export function SettingsPage() {
+  // Set page title on mount; restore the default on unmount.
+  useEffect(() => {
+    document.title = "Settings - ChronoVista";
+    return () => {
+      document.title = "ChronoVista";
+    };
+  }, []);
+
+  return (
+    <div className="p-6 lg:p-8">
+      {/* Page Header */}
+      <div className="mb-8">
+        <h2 className="text-2xl font-bold text-slate-900">Settings</h2>
+        <p className="text-slate-600 mt-1">
+          Manage your language preferences, cache, and application information.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        {/* ------------------------------------------------------------------ */}
+        {/* Language Preferences section (T009)                                */}
+        {/* ------------------------------------------------------------------ */}
+        <LanguagePreferencesSection />
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Cache section (T016)                                               */}
+        {/* ------------------------------------------------------------------ */}
+        <CacheSection />
+
+        {/* ------------------------------------------------------------------ */}
+        {/* About section (T020)                                               */}
+        {/* ------------------------------------------------------------------ */}
+        <AboutSection />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Tests for SettingsPage component.
+ *
+ * Coverage:
+ * - Page renders with "Settings" heading
+ * - Document title is set to "Settings - ChronoVista" on mount
+ * - Document title is restored to "ChronoVista" on unmount
+ * - All 3 section components are rendered
+ * - Page has correct padding classes (p-6 lg:p-8)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+// Mock all three section components to keep tests isolated and fast
+vi.mock("../../components/settings/LanguagePreferencesSection", () => ({
+  LanguagePreferencesSection: () =>
+    React.createElement("div", { "data-testid": "language-preferences-section" }),
+}));
+
+vi.mock("../../components/settings/CacheSection", () => ({
+  CacheSection: () =>
+    React.createElement("div", { "data-testid": "cache-section" }),
+}));
+
+vi.mock("../../components/settings/AboutSection", () => ({
+  AboutSection: () =>
+    React.createElement("div", { "data-testid": "about-section" }),
+}));
+
+import { SettingsPage } from "../SettingsPage";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderPage() {
+  const queryClient = createQueryClient();
+  return render(
+    React.createElement(
+      MemoryRouter,
+      null,
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(SettingsPage)
+      )
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SettingsPage", () => {
+  const originalTitle = document.title;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore title after each test in case unmount was not called
+    document.title = originalTitle;
+  });
+
+  // -------------------------------------------------------------------------
+  // Page heading
+  // -------------------------------------------------------------------------
+
+  it("renders the 'Settings' page heading", () => {
+    renderPage();
+    expect(screen.getByText("Settings")).toBeDefined();
+  });
+
+  it("renders the subtitle text", () => {
+    renderPage();
+    expect(
+      screen.getByText(
+        /Manage your language preferences, cache, and application information/i
+      )
+    ).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Document title lifecycle
+  // -------------------------------------------------------------------------
+
+  it("sets document.title to 'Settings - ChronoVista' on mount", () => {
+    renderPage();
+    expect(document.title).toBe("Settings - ChronoVista");
+  });
+
+  it("restores document.title to 'ChronoVista' on unmount", () => {
+    const { unmount } = renderPage();
+    expect(document.title).toBe("Settings - ChronoVista");
+    unmount();
+    expect(document.title).toBe("ChronoVista");
+  });
+
+  // -------------------------------------------------------------------------
+  // Section components
+  // -------------------------------------------------------------------------
+
+  it("renders the LanguagePreferencesSection", () => {
+    renderPage();
+    expect(
+      screen.getByTestId("language-preferences-section")
+    ).toBeDefined();
+  });
+
+  it("renders the CacheSection", () => {
+    renderPage();
+    expect(screen.getByTestId("cache-section")).toBeDefined();
+  });
+
+  it("renders the AboutSection", () => {
+    renderPage();
+    expect(screen.getByTestId("about-section")).toBeDefined();
+  });
+
+  it("renders all 3 sections together", () => {
+    renderPage();
+    expect(screen.getByTestId("language-preferences-section")).toBeDefined();
+    expect(screen.getByTestId("cache-section")).toBeDefined();
+    expect(screen.getByTestId("about-section")).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Layout
+  // -------------------------------------------------------------------------
+
+  it("outer div has p-6 padding class", () => {
+    const { container } = renderPage();
+    const outer = container.firstChild as HTMLElement;
+    expect(outer.className).toContain("p-6");
+  });
+
+  it("outer div has lg:p-8 responsive padding class", () => {
+    const { container } = renderPage();
+    const outer = container.firstChild as HTMLElement;
+    expect(outer.className).toContain("lg:p-8");
+  });
+});

--- a/frontend/src/router/__tests__/routes.test.ts
+++ b/frontend/src/router/__tests__/routes.test.ts
@@ -7,6 +7,7 @@
  * - Flat nav items remain as NavRoute (kind: "route")
  * - The Transcripts group is a NavGroupRoute (kind: "group")
  * - Each child of Transcripts group carries correct paths and labels
+ * - Setup and Settings appear after the separator (admin/config section)
  */
 
 import { describe, it, expect } from "vitest";
@@ -43,8 +44,8 @@ function findGroup(entries: NavEntry[], label: string): NavGroupRoute | undefine
 // ---------------------------------------------------------------------------
 
 describe("navRoutes — top-level structure", () => {
-  it("has exactly 7 top-level entries", () => {
-    expect(navRoutes).toHaveLength(7);
+  it("has exactly 9 top-level entries", () => {
+    expect(navRoutes).toHaveLength(9);
   });
 
   it("first entry is Videos flat route", () => {
@@ -130,11 +131,48 @@ describe("navRoutes — flat NavRoute entries", () => {
 
   it("/search route is a top-level flat route (not nested under Transcripts)", () => {
     const topLevel = navRoutes.find(
-      (e) => e.kind === "route" && e.path === "/search"
+      (e): e is NavRoute => e.kind === "route" && e.path === "/search"
     );
     expect(topLevel).toBeDefined();
     expect(topLevel?.label).toBe("Search");
     expect(topLevel?.icon).toBeDefined();
+  });
+});
+
+describe("navRoutes — config section order", () => {
+  it("separator appears at index 6", () => {
+    expect(navRoutes[6]?.kind).toBe("separator");
+  });
+
+  it("Setup route appears at index 7, after the separator", () => {
+    const entry = navRoutes[7];
+    expect(entry?.kind).toBe("route");
+    if (entry?.kind === "route") {
+      expect(entry.path).toBe("/onboarding");
+      expect(entry.label).toBe("Setup");
+    }
+  });
+
+  it("Settings route appears at index 8, after Setup", () => {
+    const entry = navRoutes[8];
+    expect(entry?.kind).toBe("route");
+    if (entry?.kind === "route") {
+      expect(entry.path).toBe("/settings");
+      expect(entry.label).toBe("Settings");
+    }
+  });
+
+  it("Setup and Settings are both below the separator", () => {
+    const separatorIndex = navRoutes.findIndex((e) => e.kind === "separator");
+    const setupIndex = navRoutes.findIndex(
+      (e): e is NavRoute => e.kind === "route" && e.path === "/onboarding"
+    );
+    const settingsIndex = navRoutes.findIndex(
+      (e): e is NavRoute => e.kind === "route" && e.path === "/settings"
+    );
+    expect(setupIndex).toBeGreaterThan(separatorIndex);
+    expect(settingsIndex).toBeGreaterThan(separatorIndex);
+    expect(settingsIndex).toBeGreaterThan(setupIndex);
   });
 });
 

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -24,6 +24,7 @@ import { OnboardingPage } from "../pages/OnboardingPage";
 import { PlaylistDetailPage } from "../pages/PlaylistDetailPage";
 import { PlaylistsPage } from "../pages/PlaylistsPage";
 import { SearchPage } from "../pages/SearchPage";
+import { SettingsPage } from "../pages/SettingsPage";
 import { VideoDetailPage } from "../pages/VideoDetailPage";
 
 /**
@@ -119,6 +120,10 @@ export const router = createBrowserRouter([
       {
         path: "onboarding",
         element: <OnboardingPage />,
+      },
+      {
+        path: "settings",
+        element: <SettingsPage />,
       },
       {
         path: "*",

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -13,6 +13,7 @@ import {
   PlaylistIcon,
   SearchIcon,
   SetupIcon,
+  SettingsIcon,
   TranscriptsIcon,
   VideoIcon,
 } from "../components/icons";
@@ -54,9 +55,17 @@ export interface NavGroupRoute {
 }
 
 /**
+ * NavSeparator defines a visual divider between navigation sections.
+ */
+export interface NavSeparator {
+  /** Discriminant tag for the discriminated union */
+  kind: "separator";
+}
+
+/**
  * Union type for top-level navigation entries.
  */
-export type NavEntry = NavRoute | NavGroupRoute;
+export type NavEntry = NavRoute | NavGroupRoute | NavSeparator;
 
 /**
  * Main navigation entries for the application sidebar.
@@ -129,10 +138,20 @@ export const navRoutes: NavEntry[] = [
     icon: SearchIcon,
   },
   {
+    kind: "separator",
+  },
+  {
     kind: "route",
     path: "/onboarding",
     label: "Setup",
     tooltip: "Data onboarding pipeline — import and enrich your YouTube data",
     icon: SetupIcon,
+  },
+  {
+    kind: "route",
+    path: "/settings",
+    label: "Settings",
+    tooltip: "Application settings and preferences",
+    icon: SettingsIcon,
   },
 ];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.49.0"
+version = "0.50.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.49.0"
+__version__ = "0.50.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/main.py
+++ b/src/chronovista/api/main.py
@@ -27,6 +27,7 @@ from chronovista.api.routers import (
     playlists,
     preferences,
     search,
+    settings,
     sidebar,
     sync,
     tags,
@@ -231,6 +232,7 @@ app.include_router(sidebar.router, prefix="/api/v1", tags=["sidebar"])
 app.include_router(images.router, prefix="/api/v1", tags=["images"])
 app.include_router(entity_mentions.router, prefix="/api/v1", tags=["entity-mentions"])
 app.include_router(batch_corrections.router, prefix="/api/v1/corrections/batch", tags=["batch-corrections"])
+app.include_router(settings.router, prefix="/api/v1", tags=["settings"])
 app.include_router(onboarding.router, prefix="/api/v1", tags=["onboarding"])
 app.include_router(tasks.router, prefix="/api/v1", tags=["tasks"])
 

--- a/src/chronovista/api/routers/settings.py
+++ b/src/chronovista/api/routers/settings.py
@@ -1,0 +1,299 @@
+"""Settings and application configuration endpoints."""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista import __version__
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.schemas.responses import (
+    ApiResponse,
+    ErrorCode,
+    ERROR_TITLES,
+    ProblemJSONResponse,
+    get_error_type_uri,
+)
+from chronovista.api.schemas.settings import (
+    AppInfoResponse,
+    CachePurgeResponse,
+    CacheStatusResponse,
+    DatabaseStats,
+    SupportedLanguage,
+)
+from chronovista.api.schemas.sync import SyncOperationType
+from chronovista.api.services.sync_manager import sync_manager
+from chronovista.cli.language_commands import LANGUAGE_NAMES
+from chronovista.config.settings import settings
+from chronovista.db.models import (
+    CanonicalTag,
+    Channel,
+    Playlist,
+    TranscriptCorrection,
+    Video,
+    VideoTranscript,
+)
+from chronovista.models.enums import LanguageCode
+from chronovista.services.image_cache import ImageCacheConfig, ImageCacheService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Module-level image cache service singleton
+# ---------------------------------------------------------------------------
+_image_cache_config = ImageCacheConfig(
+    cache_dir=settings.cache_dir,
+    channels_dir=settings.cache_dir / "images" / "channels",
+    videos_dir=settings.cache_dir / "images" / "videos",
+)
+
+_image_cache_service = ImageCacheService(config=_image_cache_config)
+
+
+def _format_size_display(size_bytes: int) -> str:
+    """Format byte count as human-readable string.
+
+    Parameters
+    ----------
+    size_bytes : int
+        Size in bytes.
+
+    Returns
+    -------
+    str
+        Human-readable size string (e.g., "23.4 MB").
+    """
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    else:
+        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+
+
+@router.get(
+    "/settings/supported-languages",
+    response_model=ApiResponse[list[SupportedLanguage]],
+    summary="Get all supported language codes",
+)
+async def get_supported_languages() -> ApiResponse[list[SupportedLanguage]]:
+    """Get all supported language codes with display names.
+
+    Returns a sorted list of all supported BCP-47 language codes
+    and their human-readable display names. No authentication required.
+
+    Returns
+    -------
+    ApiResponse[list[SupportedLanguage]]
+        Alphabetically sorted list of supported languages.
+    """
+    languages = [
+        SupportedLanguage(
+            code=lang.value,
+            display_name=LANGUAGE_NAMES.get(lang.value, lang.value),
+        )
+        for lang in LanguageCode
+    ]
+    languages.sort(key=lambda lang: lang.display_name)
+    return ApiResponse[list[SupportedLanguage]](data=languages)
+
+
+@router.get(
+    "/settings/cache",
+    response_model=ApiResponse[CacheStatusResponse],
+    dependencies=[Depends(require_auth)],
+    summary="Get image cache status and statistics",
+)
+async def get_cache_status() -> ApiResponse[CacheStatusResponse]:
+    """Get image cache status and statistics.
+
+    Returns counts for cached channel and video images, total disk usage,
+    and timestamps for the oldest and newest cached files.
+
+    Returns
+    -------
+    ApiResponse[CacheStatusResponse]
+        Cache statistics including counts, size, and file timestamps.
+    """
+    # ImageCacheService.get_stats() uses pathlib.rglob which fails on Docker
+    # overlayfs with many prefix directories.  Use os.walk instead.
+    channel_count = 0
+    video_count = 0
+    total_size_bytes = 0
+    oldest_mtime: float | None = None
+    newest_mtime: float | None = None
+
+    def _update_mtime(mtime: float) -> None:
+        nonlocal oldest_mtime, newest_mtime
+        if oldest_mtime is None or mtime < oldest_mtime:
+            oldest_mtime = mtime
+        if newest_mtime is None or mtime > newest_mtime:
+            newest_mtime = mtime
+
+    channels_dir = _image_cache_config.channels_dir
+    if channels_dir.is_dir():
+        for entry in os.scandir(channels_dir):
+            if entry.name.endswith(".jpg") and entry.is_file():
+                channel_count += 1
+                stat = entry.stat()
+                total_size_bytes += stat.st_size
+                _update_mtime(stat.st_mtime)
+
+    videos_dir = _image_cache_config.videos_dir
+    if videos_dir.is_dir():
+        for root, _dirs, files in os.walk(videos_dir):
+            for fname in files:
+                if fname.endswith(".jpg"):
+                    video_count += 1
+                    fpath = os.path.join(root, fname)
+                    try:
+                        stat = os.stat(fpath)
+                        total_size_bytes += stat.st_size
+                        _update_mtime(stat.st_mtime)
+                    except OSError:
+                        pass
+
+    oldest_file = (
+        datetime.fromtimestamp(oldest_mtime) if oldest_mtime is not None else None
+    )
+    newest_file = (
+        datetime.fromtimestamp(newest_mtime) if newest_mtime is not None else None
+    )
+
+    response = CacheStatusResponse(
+        channel_count=channel_count,
+        video_count=video_count,
+        total_count=channel_count + video_count,
+        total_size_bytes=total_size_bytes,
+        total_size_display=_format_size_display(total_size_bytes),
+        oldest_file=oldest_file,
+        newest_file=newest_file,
+    )
+    return ApiResponse[CacheStatusResponse](data=response)
+
+
+@router.delete(
+    "/settings/cache",
+    response_model=ApiResponse[CachePurgeResponse],
+    dependencies=[Depends(require_auth)],
+    summary="Clear the local image cache",
+)
+async def clear_cache() -> ApiResponse[CachePurgeResponse] | ProblemJSONResponse:
+    """Clear the local image cache.
+
+    Purges all cached channel and video thumbnail images from disk.
+    The cache directories themselves are preserved.
+
+    Returns
+    -------
+    ApiResponse[CachePurgeResponse]
+        Confirmation that the cache was purged.
+    """
+    try:
+        await _image_cache_service.purge(type_="all")
+        response = CachePurgeResponse(
+            purged=True,
+            message="Image cache cleared successfully",
+        )
+        return ApiResponse[CachePurgeResponse](data=response)
+    except Exception as exc:
+        logger.exception("Failed to clear image cache: %s", exc)
+        return ProblemJSONResponse(
+            status_code=500,
+            content={
+                "type": get_error_type_uri(ErrorCode.INTERNAL_ERROR),
+                "title": ERROR_TITLES[ErrorCode.INTERNAL_ERROR],
+                "status": 500,
+                "detail": f"Failed to clear image cache: {exc}",
+                "instance": "/api/v1/settings/cache",
+                "code": ErrorCode.INTERNAL_ERROR.value,
+                "request_id": str(uuid.uuid4()),
+            },
+        )
+
+
+@router.get(
+    "/settings/app-info",
+    response_model=ApiResponse[AppInfoResponse],
+    summary="Get application version, database stats, and sync timestamps",
+    dependencies=[Depends(require_auth)],
+)
+async def get_app_info(
+    session: AsyncSession = Depends(get_db),
+) -> ApiResponse[AppInfoResponse]:
+    """Get application version and system information.
+
+    Returns backend/frontend versions, aggregate database record counts,
+    and the last successful sync timestamp for each sync operation type.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session injected via FastAPI dependency.
+
+    Returns
+    -------
+    ApiResponse[AppInfoResponse]
+        Application info including versions, database stats, and sync timestamps.
+    """
+    # Query counts for each table
+    video_count = await session.scalar(
+        select(func.count()).select_from(Video)
+    )
+    channel_count = await session.scalar(
+        select(func.count()).select_from(Channel)
+    )
+    playlist_count = await session.scalar(
+        select(func.count()).select_from(Playlist)
+    )
+    transcript_count = await session.scalar(
+        select(func.count()).select_from(VideoTranscript)
+    )
+    correction_count = await session.scalar(
+        select(func.count()).select_from(TranscriptCorrection)
+    )
+    canonical_tag_count = await session.scalar(
+        select(func.count()).select_from(CanonicalTag)
+    )
+
+    database_stats = DatabaseStats(
+        videos=video_count or 0,
+        channels=channel_count or 0,
+        playlists=playlist_count or 0,
+        transcripts=transcript_count or 0,
+        corrections=correction_count or 0,
+        canonical_tags=canonical_tag_count or 0,
+    )
+
+    # Gather last successful sync timestamps
+    sync_types = [
+        SyncOperationType.SUBSCRIPTIONS,
+        SyncOperationType.VIDEOS,
+        SyncOperationType.TRANSCRIPTS,
+        SyncOperationType.PLAYLISTS,
+        SyncOperationType.TOPICS,
+    ]
+    sync_timestamps: dict[str, Optional[datetime]] = {
+        op_type.value: sync_manager.get_last_successful_sync(op_type)
+        for op_type in sync_types
+    }
+
+    app_info = AppInfoResponse(
+        backend_version=__version__,
+        frontend_version="0.18.0",
+        database_stats=database_stats,
+        sync_timestamps=sync_timestamps,
+    )
+
+    return ApiResponse[AppInfoResponse](data=app_info)

--- a/src/chronovista/api/routers/transcripts.py
+++ b/src/chronovista/api/routers/transcripts.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 from fastapi import APIRouter, Depends, Path, Query
 from sqlalchemy import func, select
@@ -19,6 +19,10 @@ from chronovista.api.routers.responses import (
     VALIDATION_ERROR_RESPONSE,
 )
 from chronovista.api.schemas.responses import ApiResponse, PaginationMeta
+from chronovista.api.schemas.settings import (
+    MultiTranscriptDownloadResponse,
+    TranscriptDownloadResult,
+)
 from chronovista.api.schemas.transcripts import (
     SegmentListResponse,
     TranscriptDownloadResponse,
@@ -39,9 +43,18 @@ from chronovista.exceptions import (
     RateLimitError,
 )
 from chronovista.models.enums import AvailabilityStatus
+from chronovista.models.user_language_preference import (
+    UserLanguagePreference as UserLanguagePreferenceDomain,
+)
 from chronovista.models.video_transcript import VideoTranscriptCreate
+from chronovista.repositories.user_language_preference_repository import (
+    UserLanguagePreferenceRepository,
+)
 from chronovista.repositories.video_transcript_repository import (
     VideoTranscriptRepository,
+)
+from chronovista.services.preference_aware_transcript_filter import (
+    PreferenceAwareTranscriptFilter,
 )
 from chronovista.services.transcript_service import (
     TranscriptNotFoundError,
@@ -63,6 +76,11 @@ _downloads_in_progress: set[str] = set()
 # Module-level service/repository singletons
 _transcript_service = TranscriptService()
 _transcript_repo = VideoTranscriptRepository()
+_pref_repo = UserLanguagePreferenceRepository()
+_pref_filter = PreferenceAwareTranscriptFilter()
+
+# Default user_id for single-user app
+DEFAULT_USER_ID = "default_user"
 
 
 def get_language_name(code: str) -> str:
@@ -393,7 +411,6 @@ _DOWNLOAD_ERRORS = {
 
 @router.post(
     "/videos/{video_id}/transcript/download",
-    response_model=ApiResponse[TranscriptDownloadResponse],
     status_code=200,
     responses=_DOWNLOAD_ERRORS,
     summary="Download transcript from YouTube",
@@ -404,11 +421,16 @@ async def download_transcript(
         None, description="BCP-47 language code (default: user's preferred language)"
     ),
     session: AsyncSession = Depends(get_db),
-) -> ApiResponse[TranscriptDownloadResponse]:
+) -> Union[ApiResponse[TranscriptDownloadResponse], ApiResponse[MultiTranscriptDownloadResponse]]:
     """Download a transcript from YouTube for the given video.
 
     Fetches the transcript from YouTube's transcript API and saves it
     to the local database. Returns metadata about the downloaded transcript.
+
+    When ``language`` is provided, downloads that single language (backward
+    compatible). When omitted, checks user language preferences and downloads
+    all FLUENT + LEARNING languages automatically (CURIOUS excluded). If no
+    preferences are configured, falls back to English (FR-013).
 
     Parameters
     ----------
@@ -416,14 +438,15 @@ async def download_transcript(
         YouTube video ID (exactly 11 characters, ``[A-Za-z0-9_-]``).
     language : Optional[str]
         BCP-47 language code to prefer. When omitted the user's preferred
-        language is used.
+        languages are used.
     session : AsyncSession
         Database session (injected).
 
     Returns
     -------
-    ApiResponse[TranscriptDownloadResponse]
-        Metadata about the downloaded transcript.
+    ApiResponse[TranscriptDownloadResponse] | ApiResponse[MultiTranscriptDownloadResponse]
+        Single-language metadata when ``language`` is provided, or
+        multi-language result when preference-aware download is used.
 
     Raises
     ------
@@ -432,7 +455,7 @@ async def download_transcript(
     NotFoundError
         If no transcript is available on YouTube (404).
     ConflictError
-        If the video already has a transcript in the database (409).
+        If the transcript already exists in the database (409).
     RateLimitError
         If a download is already in progress for this video (429).
     TranscriptServiceUnavailableError
@@ -454,35 +477,278 @@ async def download_transcript(
 
     _downloads_in_progress.add(video_id)
     try:
-        # 3. Check if transcript already exists in the database
+        # 3. Get existing transcripts for this video
         existing_transcripts = await _transcript_repo.get_video_transcripts(
             session, video_id
         )
-        if existing_transcripts:
-            raise ConflictError(
-                message=f"Video '{video_id}' already has a transcript. "
-                "Delete it first if you want to re-download.",
-                details={"video_id": video_id},
-            )
+        existing_lang_codes = {
+            t.language_code.lower() for t in existing_transcripts
+        }
 
-        # 4. Build language_codes list for the service call
-        language_codes: list[str] | None = None
+        # --- Path A: Explicit language override (FR-014) ---
         if language:
-            language_codes = [language]
+            # Per-language 409 check (FR-028)
+            if language.lower() in existing_lang_codes:
+                raise ConflictError(
+                    message=(
+                        f"Video '{video_id}' already has a transcript in "
+                        f"'{language}'. Delete it first if you want to re-download."
+                    ),
+                    details={"video_id": video_id, "language": language},
+                )
 
-        # 5. Download from YouTube via TranscriptService
-        try:
-            enhanced_transcript = await _transcript_service.get_transcript(
+            # Download single language (existing behavior)
+            return await _download_single_language(
                 video_id=video_id,
-                language_codes=language_codes,
+                language=language,
+                session=session,
             )
-        except TranscriptNotFoundError as exc:
+
+        # --- Check for user preferences ---
+        user_prefs = await _pref_repo.get_user_preferences(
+            session, DEFAULT_USER_ID
+        )
+
+        # --- Path C: No preferences → preserve existing default behavior (FR-013) ---
+        if not user_prefs:
+            # Original behavior: reject if ANY transcript exists
+            if existing_transcripts:
+                raise ConflictError(
+                    message=f"Video '{video_id}' already has a transcript. "
+                    "Delete it first if you want to re-download.",
+                    details={"video_id": video_id},
+                )
+            return await _download_single_language(
+                video_id=video_id,
+                language=None,
+                session=session,
+            )
+
+        # --- Path B: Preference-aware multi-language download (FR-011, FR-012) ---
+        # Convert DB ORM models to Pydantic domain models for the filter service
+        domain_prefs = [
+            UserLanguagePreferenceDomain.model_validate(p) for p in user_prefs
+        ]
+        # Compute target languages from preferences (Fluent + Learning only)
+        preferred_languages = _pref_filter.get_download_languages(
+            # Pass preference language codes as "available" so the filter
+            # returns Fluent + Learning codes. Actual YouTube availability
+            # is checked per-language during download.
+            available_languages=[
+                str(p.language_code) for p in domain_prefs
+            ],
+            user_preferences=domain_prefs,
+        )
+
+        if not preferred_languages:
+            # No Fluent/Learning preferences → fall back to default (English)
+            if existing_transcripts:
+                raise ConflictError(
+                    message=f"Video '{video_id}' already has a transcript. "
+                    "Delete it first if you want to re-download.",
+                    details={"video_id": video_id},
+                )
+            return await _download_single_language(
+                video_id=video_id,
+                language=None,
+                session=session,
+            )
+
+        # Filter out already-downloaded languages
+        remaining_languages = [
+            lang for lang in preferred_languages
+            if lang.lower() not in existing_lang_codes
+        ]
+
+        # All preferred languages already downloaded → 409
+        if not remaining_languages:
+            already_names = [
+                f"{get_language_name(lang)} ({lang})"
+                for lang in preferred_languages
+            ]
+            raise ConflictError(
+                message=(
+                    "All preferred language transcripts already exist for "
+                    f"video '{video_id}': {', '.join(already_names)}."
+                ),
+                details={
+                    "video_id": video_id,
+                    "existing_languages": preferred_languages,
+                },
+            )
+
+        # Download each remaining language
+        downloaded: list[TranscriptDownloadResult] = []
+        skipped: list[str] = []
+        failed: list[str] = []
+
+        for lang_code in remaining_languages:
+            try:
+                enhanced_transcript = await _transcript_service.get_transcript(
+                    video_id=video_id,
+                    language_codes=[lang_code],
+                )
+
+                transcript_create = VideoTranscriptCreate(
+                    video_id=enhanced_transcript.video_id,
+                    language_code=enhanced_transcript.language_code,
+                    transcript_text=enhanced_transcript.transcript_text,
+                    transcript_type=enhanced_transcript.transcript_type,
+                    download_reason=enhanced_transcript.download_reason,
+                    confidence_score=enhanced_transcript.confidence_score,
+                    is_cc=enhanced_transcript.is_cc,
+                    is_auto_synced=enhanced_transcript.is_auto_synced,
+                    track_kind=enhanced_transcript.track_kind,
+                    caption_name=enhanced_transcript.caption_name,
+                )
+
+                db_transcript = await _transcript_repo.create_or_update(
+                    session,
+                    transcript_create,
+                    raw_transcript_data=(
+                        enhanced_transcript.raw_transcript_data
+                        if enhanced_transcript.raw_transcript_data
+                        else None
+                    ),
+                )
+
+                transcript_type_display = (
+                    "manual"
+                    if db_transcript.is_cc
+                    or db_transcript.transcript_type == "MANUAL"
+                    else "auto_generated"
+                )
+
+                downloaded.append(
+                    TranscriptDownloadResult(
+                        language_code=db_transcript.language_code,
+                        language_name=get_language_name(
+                            db_transcript.language_code
+                        ),
+                        transcript_type=transcript_type_display,
+                        segment_count=db_transcript.segment_count or 0,
+                        downloaded_at=db_transcript.downloaded_at,
+                    )
+                )
+
+            except TranscriptNotFoundError:
+                skipped.append(lang_code)
+                logger.info(
+                    "No transcript available in '%s' for video %s — skipped",
+                    lang_code,
+                    video_id,
+                )
+
+            except (
+                TranscriptServiceUnavailableError,
+                TranscriptServiceError,
+            ):
+                failed.append(lang_code)
+                logger.warning(
+                    "Failed to download '%s' transcript for video %s",
+                    lang_code,
+                    video_id,
+                    exc_info=True,
+                )
+
+        # Commit all successful downloads in one transaction
+        if downloaded:
+            await session.commit()
+
+        # Build attempted languages list with display names (FR-015)
+        attempted_languages = [
+            f"{get_language_name(lang)} ({lang})"
+            for lang in remaining_languages
+        ]
+
+        # If NOTHING was downloaded and everything was skipped/failed → 404
+        if not downloaded:
             raise NotFoundError(
                 resource_type="Transcript",
                 identifier=video_id,
-                hint="No transcript is available on YouTube for this video.",
-            ) from exc
-        except TranscriptServiceUnavailableError as exc:
+                hint=(
+                    "No transcript available on YouTube for any of the "
+                    f"preferred languages: {', '.join(attempted_languages)}."
+                ),
+            )
+
+        response_data = MultiTranscriptDownloadResponse(
+            video_id=video_id,
+            downloaded=downloaded,
+            skipped=skipped,
+            failed=failed,
+            attempted_languages=attempted_languages,
+        )
+
+        return ApiResponse[MultiTranscriptDownloadResponse](data=response_data)
+
+    finally:
+        _downloads_in_progress.discard(video_id)
+
+
+async def _download_single_language(
+    video_id: str,
+    language: Optional[str],
+    session: AsyncSession,
+) -> ApiResponse[TranscriptDownloadResponse]:
+    """Download a single language transcript and return the standard response.
+
+    This is the original download path extracted into a helper so it can be
+    reused by both the explicit-language and no-preferences code paths.
+
+    Parameters
+    ----------
+    video_id : str
+        YouTube video ID.
+    language : Optional[str]
+        BCP-47 language code, or None for default (English).
+    session : AsyncSession
+        Database session.
+
+    Returns
+    -------
+    ApiResponse[TranscriptDownloadResponse]
+        Metadata about the downloaded transcript.
+    """
+    language_codes: list[str] | None = None
+    if language:
+        language_codes = [language]
+
+    try:
+        enhanced_transcript = await _transcript_service.get_transcript(
+            video_id=video_id,
+            language_codes=language_codes,
+        )
+    except TranscriptNotFoundError as exc:
+        raise NotFoundError(
+            resource_type="Transcript",
+            identifier=video_id,
+            hint="No transcript is available on YouTube for this video.",
+        ) from exc
+    except TranscriptServiceUnavailableError as exc:
+        from chronovista.api.schemas.responses import (
+            ErrorCode,
+            ProblemJSONResponse,
+            get_error_type_uri,
+            ERROR_TITLES,
+        )
+        import uuid
+
+        return ProblemJSONResponse(  # type: ignore[return-value]
+            status_code=503,
+            content={
+                "type": get_error_type_uri(ErrorCode.SERVICE_UNAVAILABLE),
+                "title": ERROR_TITLES[ErrorCode.SERVICE_UNAVAILABLE],
+                "status": 503,
+                "detail": f"YouTube transcript service is unavailable: {exc}",
+                "instance": f"/api/v1/videos/{video_id}/transcript/download",
+                "code": ErrorCode.SERVICE_UNAVAILABLE.value,
+                "request_id": str(uuid.uuid4()),
+            },
+        )
+    except TranscriptServiceError as exc:
+        error_msg = str(exc).lower()
+        if any(kw in error_msg for kw in ["rate limit", "too many", "quota"]):
             from chronovista.api.schemas.responses import (
                 ErrorCode,
                 ProblemJSONResponse,
@@ -497,84 +763,54 @@ async def download_transcript(
                     "type": get_error_type_uri(ErrorCode.SERVICE_UNAVAILABLE),
                     "title": ERROR_TITLES[ErrorCode.SERVICE_UNAVAILABLE],
                     "status": 503,
-                    "detail": f"YouTube transcript service is unavailable: {exc}",
+                    "detail": f"YouTube is rate-limiting transcript requests: {exc}",
                     "instance": f"/api/v1/videos/{video_id}/transcript/download",
                     "code": ErrorCode.SERVICE_UNAVAILABLE.value,
                     "request_id": str(uuid.uuid4()),
                 },
             )
-        except TranscriptServiceError as exc:
-            # Catch-all for other transcript service errors (e.g. rate limiting)
-            error_msg = str(exc).lower()
-            if any(kw in error_msg for kw in ["rate limit", "too many", "quota"]):
-                from chronovista.api.schemas.responses import (
-                    ErrorCode,
-                    ProblemJSONResponse,
-                    get_error_type_uri,
-                    ERROR_TITLES,
-                )
-                import uuid
+        raise
 
-                return ProblemJSONResponse(  # type: ignore[return-value]
-                    status_code=503,
-                    content={
-                        "type": get_error_type_uri(ErrorCode.SERVICE_UNAVAILABLE),
-                        "title": ERROR_TITLES[ErrorCode.SERVICE_UNAVAILABLE],
-                        "status": 503,
-                        "detail": f"YouTube is rate-limiting transcript requests: {exc}",
-                        "instance": f"/api/v1/videos/{video_id}/transcript/download",
-                        "code": ErrorCode.SERVICE_UNAVAILABLE.value,
-                        "request_id": str(uuid.uuid4()),
-                    },
-                )
-            raise
+    transcript_create = VideoTranscriptCreate(
+        video_id=enhanced_transcript.video_id,
+        language_code=enhanced_transcript.language_code,
+        transcript_text=enhanced_transcript.transcript_text,
+        transcript_type=enhanced_transcript.transcript_type,
+        download_reason=enhanced_transcript.download_reason,
+        confidence_score=enhanced_transcript.confidence_score,
+        is_cc=enhanced_transcript.is_cc,
+        is_auto_synced=enhanced_transcript.is_auto_synced,
+        track_kind=enhanced_transcript.track_kind,
+        caption_name=enhanced_transcript.caption_name,
+    )
 
-        # 6. Build VideoTranscriptCreate from the enhanced transcript
-        transcript_create = VideoTranscriptCreate(
-            video_id=enhanced_transcript.video_id,
-            language_code=enhanced_transcript.language_code,
-            transcript_text=enhanced_transcript.transcript_text,
-            transcript_type=enhanced_transcript.transcript_type,
-            download_reason=enhanced_transcript.download_reason,
-            confidence_score=enhanced_transcript.confidence_score,
-            is_cc=enhanced_transcript.is_cc,
-            is_auto_synced=enhanced_transcript.is_auto_synced,
-            track_kind=enhanced_transcript.track_kind,
-            caption_name=enhanced_transcript.caption_name,
-        )
+    db_transcript = await _transcript_repo.create_or_update(
+        session,
+        transcript_create,
+        raw_transcript_data=(
+            enhanced_transcript.raw_transcript_data
+            if enhanced_transcript.raw_transcript_data
+            else None
+        ),
+    )
+    await session.commit()
 
-        # 7. Save via repository
-        db_transcript = await _transcript_repo.create_or_update(
-            session,
-            transcript_create,
-            raw_transcript_data=(
-                enhanced_transcript.raw_transcript_data
-                if enhanced_transcript.raw_transcript_data
-                else None
-            ),
-        )
-        await session.commit()
+    transcript_type_display = (
+        "manual"
+        if db_transcript.is_cc or db_transcript.transcript_type == "MANUAL"
+        else "auto_generated"
+    )
 
-        # 8. Determine transcript_type display string
-        transcript_type_display = (
-            "manual" if db_transcript.is_cc or db_transcript.transcript_type == "MANUAL"
-            else "auto_generated"
-        )
+    lang_code = db_transcript.language_code
+    lang_name = get_language_name(lang_code)
 
-        # 9. Resolve language name
-        lang_code = db_transcript.language_code
-        lang_name = get_language_name(lang_code)
+    response_data = TranscriptDownloadResponse(
+        video_id=db_transcript.video_id,
+        language_code=lang_code,
+        language_name=lang_name,
+        transcript_type=transcript_type_display,
+        segment_count=db_transcript.segment_count or 0,
+        downloaded_at=db_transcript.downloaded_at,
+    )
 
-        response_data = TranscriptDownloadResponse(
-            video_id=db_transcript.video_id,
-            language_code=lang_code,
-            language_name=lang_name,
-            transcript_type=transcript_type_display,
-            segment_count=db_transcript.segment_count or 0,
-            downloaded_at=db_transcript.downloaded_at,
-        )
-
-        return ApiResponse[TranscriptDownloadResponse](data=response_data)
-
-    finally:
-        _downloads_in_progress.discard(video_id)
+    return ApiResponse[TranscriptDownloadResponse](data=response_data)

--- a/src/chronovista/api/schemas/__init__.py
+++ b/src/chronovista/api/schemas/__init__.py
@@ -54,6 +54,15 @@ from chronovista.api.schemas.playlists import (
     PlaylistVideoListItem,
     PlaylistVideoListResponse,
 )
+from chronovista.api.schemas.settings import (
+    AppInfoResponse,
+    CachePurgeResponse,
+    CacheStatusResponse,
+    DatabaseStats,
+    MultiTranscriptDownloadResponse,
+    SupportedLanguage,
+    TranscriptDownloadResult,
+)
 from chronovista.api.schemas.responses import (
     ApiError,
     ApiResponse,
@@ -130,6 +139,14 @@ __all__ = [
     "PlaylistListResponse",
     "PlaylistVideoListItem",
     "PlaylistVideoListResponse",
+    # Settings (Feature 049)
+    "AppInfoResponse",
+    "CachePurgeResponse",
+    "CacheStatusResponse",
+    "DatabaseStats",
+    "MultiTranscriptDownloadResponse",
+    "SupportedLanguage",
+    "TranscriptDownloadResult",
     # Responses
     "ApiError",
     "ApiResponse",

--- a/src/chronovista/api/schemas/settings.py
+++ b/src/chronovista/api/schemas/settings.py
@@ -1,0 +1,93 @@
+"""Settings API schemas for the settings and preferences page.
+
+This module defines Pydantic models for the settings endpoints,
+including supported languages, cache management, app info, and
+multi-language transcript downloads.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SupportedLanguage(BaseModel):
+    """A supported language with its BCP-47 code and display name."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    code: str
+    display_name: str
+
+
+class CacheStatusResponse(BaseModel):
+    """Image cache statistics."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    channel_count: int
+    video_count: int
+    total_count: int
+    total_size_bytes: int
+    total_size_display: str
+    oldest_file: Optional[datetime] = None
+    newest_file: Optional[datetime] = None
+
+
+class CachePurgeResponse(BaseModel):
+    """Result of a cache purge operation."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    purged: bool
+    message: str
+
+
+class DatabaseStats(BaseModel):
+    """Aggregate database record counts."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    videos: int
+    channels: int
+    playlists: int
+    transcripts: int
+    corrections: int
+    canonical_tags: int
+
+
+class AppInfoResponse(BaseModel):
+    """Application version, database stats, and sync timestamps."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    backend_version: str
+    frontend_version: str
+    database_stats: DatabaseStats
+    sync_timestamps: dict[str, Optional[datetime]]
+
+
+class TranscriptDownloadResult(BaseModel):
+    """Result of downloading a single language transcript."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    language_code: str
+    language_name: str
+    transcript_type: str
+    segment_count: int
+    downloaded_at: datetime
+
+
+class MultiTranscriptDownloadResponse(BaseModel):
+    """Response for multi-language transcript download."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    video_id: str
+    downloaded: list[TranscriptDownloadResult]
+    skipped: list[str]
+    failed: list[str]
+    attempted_languages: list[str]

--- a/src/chronovista/repositories/video_transcript_repository.py
+++ b/src/chronovista/repositories/video_transcript_repository.py
@@ -100,6 +100,40 @@ class VideoTranscriptRepository(
         """
         return await self.get(session, (video_id, language_code))
 
+    async def get_transcript_by_language(
+        self,
+        session: AsyncSession,
+        video_id: str,
+        language_code: str,
+    ) -> Optional[VideoTranscriptDB]:
+        """
+        Get a single transcript for a video by language code (case-insensitive).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        video_id : str
+            YouTube video identifier.
+        language_code : str
+            BCP-47 language code (matched case-insensitively).
+
+        Returns
+        -------
+        Optional[VideoTranscriptDB]
+            Video transcript if found, None otherwise.
+        """
+        result = await session.execute(
+            select(VideoTranscriptDB).where(
+                and_(
+                    VideoTranscriptDB.video_id == video_id,
+                    func.lower(VideoTranscriptDB.language_code)
+                    == language_code.lower(),
+                )
+            )
+        )
+        return result.scalar_one_or_none()
+
     async def exists(self, session: AsyncSession, id: Tuple[str, str]) -> bool:
         """
         Check if video transcript exists.

--- a/tests/unit/api/routers/test_settings.py
+++ b/tests/unit/api/routers/test_settings.py
@@ -1,0 +1,954 @@
+"""
+Unit tests for settings and preferences API endpoints.
+
+Tests all four settings endpoints including supported languages,
+cache status and management, and application info.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.main import app
+from chronovista.api.schemas.sync import SyncOperationType
+from chronovista.models.enums import LanguageCode
+
+# CRITICAL: This line ensures async tests work with coverage
+pytestmark = pytest.mark.asyncio
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+async def async_client() -> AsyncGenerator[AsyncClient, None]:
+    """Create async test client for FastAPI testing with auth and DB overrides."""
+
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    async def mock_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    async def mock_require_auth() -> None:
+        return None
+
+    app.dependency_overrides[get_db] = mock_get_db
+    app.dependency_overrides[require_auth] = mock_require_auth
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def async_client_no_auth() -> AsyncGenerator[AsyncClient, None]:
+    """Create async test client WITHOUT auth override to test 401 responses."""
+
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    async def mock_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    # Only override DB, NOT require_auth
+    app.dependency_overrides[get_db] = mock_get_db
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /settings/supported-languages Tests (no auth required)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGetSupportedLanguages:
+    """Tests for GET /api/v1/settings/supported-languages endpoint."""
+
+    async def test_returns_200_with_api_response_envelope(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test endpoint returns 200 with data wrapped in ApiResponse envelope."""
+        response = await async_client.get("/api/v1/settings/supported-languages")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "data" in body
+        assert isinstance(body["data"], list)
+
+    async def test_returns_all_language_codes(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test returned language count matches the LanguageCode enum member count."""
+        response = await async_client.get("/api/v1/settings/supported-languages")
+
+        assert response.status_code == 200
+        languages = response.json()["data"]
+        expected_count = len(list(LanguageCode))
+        assert len(languages) == expected_count
+
+    async def test_each_language_has_code_and_display_name(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test each returned language object has code and display_name fields."""
+        response = await async_client.get("/api/v1/settings/supported-languages")
+
+        assert response.status_code == 200
+        languages = response.json()["data"]
+        for lang in languages:
+            assert "code" in lang, f"Missing 'code' key in: {lang}"
+            assert "display_name" in lang, f"Missing 'display_name' key in: {lang}"
+            assert isinstance(lang["code"], str)
+            assert isinstance(lang["display_name"], str)
+            assert len(lang["code"]) > 0
+            assert len(lang["display_name"]) > 0
+
+    async def test_languages_are_sorted_alphabetically_by_display_name(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test returned languages are sorted alphabetically by display_name."""
+        response = await async_client.get("/api/v1/settings/supported-languages")
+
+        assert response.status_code == 200
+        languages = response.json()["data"]
+        display_names = [lang["display_name"] for lang in languages]
+        assert display_names == sorted(display_names), (
+            "Languages are not sorted alphabetically by display_name. "
+            f"First few: {display_names[:5]}"
+        )
+
+    async def test_language_codes_match_enum_values(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test all returned codes exist in the LanguageCode enum."""
+        response = await async_client.get("/api/v1/settings/supported-languages")
+
+        assert response.status_code == 200
+        languages = response.json()["data"]
+        enum_values = {lc.value for lc in LanguageCode}
+        returned_codes = {lang["code"] for lang in languages}
+        assert returned_codes == enum_values, (
+            f"Returned codes do not match LanguageCode enum values. "
+            f"Missing: {enum_values - returned_codes}, "
+            f"Extra: {returned_codes - enum_values}"
+        )
+
+    async def test_endpoint_accessible_without_authentication(
+        self, async_client_no_auth: AsyncClient
+    ) -> None:
+        """Test endpoint is public — accessible without authentication."""
+        with patch(
+            "chronovista.auth.youtube_oauth.is_authenticated",
+            return_value=True,
+        ):
+            response = await async_client_no_auth.get(
+                "/api/v1/settings/supported-languages"
+            )
+        # Supported languages is a public endpoint — should never require auth
+        assert response.status_code == 200
+
+    async def test_english_present_with_correct_display_name(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test English language code is present and has expected display name."""
+        response = await async_client.get("/api/v1/settings/supported-languages")
+
+        assert response.status_code == 200
+        languages = response.json()["data"]
+        english = next((l for l in languages if l["code"] == "en"), None)
+        assert english is not None, "English ('en') not found in supported languages"
+        assert english["display_name"] == "English"
+
+    async def test_response_does_not_contain_duplicate_codes(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test no duplicate language codes in the response."""
+        response = await async_client.get("/api/v1/settings/supported-languages")
+
+        assert response.status_code == 200
+        languages = response.json()["data"]
+        codes = [lang["code"] for lang in languages]
+        assert len(codes) == len(set(codes)), "Duplicate language codes found in response"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /settings/cache Tests (auth required)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGetCacheStatus:
+    """Tests for GET /api/v1/settings/cache endpoint."""
+
+    async def test_returns_200_with_api_response_envelope(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test endpoint returns 200 with data wrapped in ApiResponse envelope."""
+        mock_entry = MagicMock()
+        mock_entry.name = "UCtest.jpg"
+        mock_entry.is_file.return_value = True
+        mock_stat = MagicMock()
+        mock_stat.st_size = 1024
+        mock_stat.st_mtime = 1700000000.0
+        mock_entry.stat.return_value = mock_stat
+
+        with (
+            patch(
+                "chronovista.api.routers.settings._image_cache_config"
+            ) as mock_config,
+            patch("os.scandir", return_value=[mock_entry]),
+            patch("os.walk", return_value=[]),
+        ):
+            mock_config.channels_dir.is_dir.return_value = True
+            mock_config.videos_dir.is_dir.return_value = False
+
+            response = await async_client.get("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "data" in body
+
+    async def test_response_contains_all_required_fields(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test cache status response includes all required fields."""
+        with (
+            patch(
+                "chronovista.api.routers.settings._image_cache_config"
+            ) as mock_config,
+            patch("os.scandir", return_value=[]),
+            patch("os.walk", return_value=[]),
+        ):
+            mock_config.channels_dir.is_dir.return_value = False
+            mock_config.videos_dir.is_dir.return_value = False
+
+            response = await async_client.get("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        required_fields = [
+            "channel_count",
+            "video_count",
+            "total_count",
+            "total_size_bytes",
+            "total_size_display",
+        ]
+        for field in required_fields:
+            assert field in data, f"Missing required field: {field}"
+
+    async def test_empty_cache_directories_returns_zero_counts(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that empty cache directories result in zero counts."""
+        with (
+            patch(
+                "chronovista.api.routers.settings._image_cache_config"
+            ) as mock_config,
+            patch("os.scandir", return_value=[]),
+            patch("os.walk", return_value=[]),
+        ):
+            mock_config.channels_dir.is_dir.return_value = True
+            mock_config.videos_dir.is_dir.return_value = True
+
+            response = await async_client.get("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["channel_count"] == 0
+        assert data["video_count"] == 0
+        assert data["total_count"] == 0
+        assert data["total_size_bytes"] == 0
+
+    async def test_non_existent_dirs_return_zero_counts(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that non-existent cache directories result in zero counts."""
+        with patch(
+            "chronovista.api.routers.settings._image_cache_config"
+        ) as mock_config:
+            mock_config.channels_dir.is_dir.return_value = False
+            mock_config.videos_dir.is_dir.return_value = False
+
+            response = await async_client.get("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["channel_count"] == 0
+        assert data["video_count"] == 0
+        assert data["total_count"] == 0
+        assert data["total_size_bytes"] == 0
+
+    async def test_channel_images_counted_correctly(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that .jpg files in channels dir are counted correctly."""
+        mtime = 1700000000.0
+
+        def _make_entry(name: str, is_jpg: bool = True) -> MagicMock:
+            entry = MagicMock()
+            entry.name = name
+            entry.is_file.return_value = is_jpg
+            stat = MagicMock()
+            stat.st_size = 2048
+            stat.st_mtime = mtime
+            entry.stat.return_value = stat
+            return entry
+
+        # Two valid .jpg files, one non-jpg that should be skipped
+        entries = [
+            _make_entry("UCchannel1.jpg"),
+            _make_entry("UCchannel2.jpg"),
+            _make_entry("UCchannel3.png"),  # not .jpg — should be skipped
+        ]
+
+        with (
+            patch(
+                "chronovista.api.routers.settings._image_cache_config"
+            ) as mock_config,
+            patch("os.scandir", return_value=entries),
+            patch("os.walk", return_value=[]),
+        ):
+            mock_config.channels_dir.is_dir.return_value = True
+            mock_config.videos_dir.is_dir.return_value = False
+
+            response = await async_client.get("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["channel_count"] == 2
+        assert data["video_count"] == 0
+        assert data["total_count"] == 2
+        assert data["total_size_bytes"] == 4096  # 2 * 2048
+
+    async def test_video_images_counted_correctly(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that .jpg files in videos dir subtree are counted correctly."""
+        mtime = 1700000000.0
+
+        walk_output = [
+            ("/videos/ab", ["c"], ["abcvideo1.jpg", "abcvideo2.jpg"]),
+            ("/videos/cd", [], ["cdvideo3.jpg"]),
+        ]
+
+        video_stat = MagicMock()
+        video_stat.st_size = 4096
+        video_stat.st_mtime = mtime
+
+        with (
+            patch(
+                "chronovista.api.routers.settings._image_cache_config"
+            ) as mock_config,
+            patch("os.scandir", return_value=[]),
+            patch("os.walk", return_value=walk_output),
+            patch("os.path.join", side_effect=lambda *args: "/".join(args)),
+            patch("os.stat", return_value=video_stat),
+        ):
+            mock_config.channels_dir.is_dir.return_value = False
+            mock_config.videos_dir.is_dir.return_value = True
+
+            response = await async_client.get("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["video_count"] == 3
+        assert data["channel_count"] == 0
+        assert data["total_count"] == 3
+
+    async def test_total_count_equals_sum_of_channel_and_video(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test total_count equals channel_count + video_count."""
+        mtime = 1700000000.0
+
+        channel_entry = MagicMock()
+        channel_entry.name = "UCtest.jpg"
+        channel_entry.is_file.return_value = True
+        ch_stat = MagicMock()
+        ch_stat.st_size = 1024
+        ch_stat.st_mtime = mtime
+        channel_entry.stat.return_value = ch_stat
+
+        walk_output: list[tuple[str, list[str], list[str]]] = [("/videos/ab", [], ["abcvideo.jpg"])]
+
+        video_stat = MagicMock()
+        video_stat.st_size = 2048
+        video_stat.st_mtime = mtime
+
+        with (
+            patch(
+                "chronovista.api.routers.settings._image_cache_config"
+            ) as mock_config,
+            patch("os.scandir", return_value=[channel_entry]),
+            patch("os.walk", return_value=walk_output),
+            patch("os.path.join", side_effect=lambda *args: "/".join(args)),
+            patch("os.stat", return_value=video_stat),
+        ):
+            mock_config.channels_dir.is_dir.return_value = True
+            mock_config.videos_dir.is_dir.return_value = True
+
+            response = await async_client.get("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["total_count"] == data["channel_count"] + data["video_count"]
+        assert data["total_count"] == 2
+
+    async def test_oldest_and_newest_file_are_null_when_cache_empty(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test oldest_file and newest_file are null when no cached images exist."""
+        with (
+            patch(
+                "chronovista.api.routers.settings._image_cache_config"
+            ) as mock_config,
+            patch("os.scandir", return_value=[]),
+            patch("os.walk", return_value=[]),
+        ):
+            mock_config.channels_dir.is_dir.return_value = True
+            mock_config.videos_dir.is_dir.return_value = True
+
+            response = await async_client.get("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data.get("oldest_file") is None
+        assert data.get("newest_file") is None
+
+    async def test_size_display_uses_human_readable_format(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test total_size_display is a human-readable string (not raw bytes)."""
+        mtime = 1700000000.0
+
+        entry = MagicMock()
+        entry.name = "UCtest.jpg"
+        entry.is_file.return_value = True
+        stat = MagicMock()
+        # 2 MB
+        stat.st_size = 2 * 1024 * 1024
+        stat.st_mtime = mtime
+        entry.stat.return_value = stat
+
+        with (
+            patch(
+                "chronovista.api.routers.settings._image_cache_config"
+            ) as mock_config,
+            patch("os.scandir", return_value=[entry]),
+            patch("os.walk", return_value=[]),
+        ):
+            mock_config.channels_dir.is_dir.return_value = True
+            mock_config.videos_dir.is_dir.return_value = False
+
+            response = await async_client.get("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        display = data["total_size_display"]
+        assert isinstance(display, str)
+        # 2 MB should be represented with "MB" suffix
+        assert "MB" in display, f"Expected MB in display string, got: {display}"
+
+    async def test_requires_authentication(
+        self, async_client_no_auth: AsyncClient
+    ) -> None:
+        """Test cache status endpoint requires authentication."""
+        with patch(
+            "chronovista.auth.youtube_oauth.is_authenticated",
+            return_value=False,
+        ):
+            response = await async_client_no_auth.get("/api/v1/settings/cache")
+
+        assert response.status_code == 401
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DELETE /settings/cache Tests (auth required)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestClearCache:
+    """Tests for DELETE /api/v1/settings/cache endpoint."""
+
+    async def test_successful_purge_returns_200(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test successful cache purge returns 200 with purged=True."""
+        with patch(
+            "chronovista.api.routers.settings._image_cache_service.purge",
+            new_callable=AsyncMock,
+        ) as mock_purge:
+            response = await async_client.delete("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        mock_purge.assert_called_once_with(type_="all")
+
+    async def test_successful_purge_response_body(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test successful purge response contains purged=True and message."""
+        with patch(
+            "chronovista.api.routers.settings._image_cache_service.purge",
+            new_callable=AsyncMock,
+        ):
+            response = await async_client.delete("/api/v1/settings/cache")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "data" in body
+        data = body["data"]
+        assert data["purged"] is True
+        assert isinstance(data["message"], str)
+        assert len(data["message"]) > 0
+
+    async def test_purge_exception_returns_500(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that an exception during purge returns 500 ProblemJSON response."""
+        with patch(
+            "chronovista.api.routers.settings._image_cache_service.purge",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Disk full"),
+        ):
+            response = await async_client.delete("/api/v1/settings/cache")
+
+        assert response.status_code == 500
+
+    async def test_purge_exception_response_is_problem_json(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 500 response follows RFC 7807 ProblemJSON format."""
+        with patch(
+            "chronovista.api.routers.settings._image_cache_service.purge",
+            new_callable=AsyncMock,
+            side_effect=OSError("Permission denied"),
+        ):
+            response = await async_client.delete("/api/v1/settings/cache")
+
+        assert response.status_code == 500
+        body = response.json()
+        # RFC 7807 fields
+        assert "type" in body
+        assert "title" in body
+        assert "status" in body
+        assert body["status"] == 500
+
+    async def test_purge_error_detail_includes_exception_message(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test 500 response detail includes the underlying exception message."""
+        error_message = "No space left on device"
+        with patch(
+            "chronovista.api.routers.settings._image_cache_service.purge",
+            new_callable=AsyncMock,
+            side_effect=OSError(error_message),
+        ):
+            response = await async_client.delete("/api/v1/settings/cache")
+
+        assert response.status_code == 500
+        body = response.json()
+        assert "detail" in body
+        assert error_message in body["detail"]
+
+    async def test_purge_called_with_type_all(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test purge is called with type_='all' to clear all cache types."""
+        with patch(
+            "chronovista.api.routers.settings._image_cache_service.purge",
+            new_callable=AsyncMock,
+        ) as mock_purge:
+            await async_client.delete("/api/v1/settings/cache")
+
+        mock_purge.assert_called_once()
+        call_kwargs = mock_purge.call_args[1]
+        assert call_kwargs.get("type_") == "all"
+
+    async def test_delete_requires_authentication(
+        self, async_client_no_auth: AsyncClient
+    ) -> None:
+        """Test DELETE cache endpoint requires authentication."""
+        with patch(
+            "chronovista.auth.youtube_oauth.is_authenticated",
+            return_value=False,
+        ):
+            response = await async_client_no_auth.delete("/api/v1/settings/cache")
+
+        assert response.status_code == 401
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /settings/app-info Tests (auth required)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGetAppInfo:
+    """Tests for GET /api/v1/settings/app-info endpoint."""
+
+    def _make_mock_session_with_counts(
+        self,
+        video_count: int = 100,
+        channel_count: int = 20,
+        playlist_count: int = 5,
+        transcript_count: int = 80,
+        correction_count: int = 10,
+        canonical_tag_count: int = 50,
+    ) -> AsyncMock:
+        """Create a mock AsyncSession whose scalar() returns counts in order."""
+        mock_session = AsyncMock(spec=AsyncSession)
+        mock_session.scalar.side_effect = [
+            video_count,
+            channel_count,
+            playlist_count,
+            transcript_count,
+            correction_count,
+            canonical_tag_count,
+        ]
+        return mock_session
+
+    async def test_returns_200_with_api_response_envelope(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test app-info returns 200 with data wrapped in ApiResponse envelope."""
+        mock_session = self._make_mock_session_with_counts()
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "data" in body
+
+    async def test_response_contains_all_required_fields(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test app-info response includes all required top-level fields."""
+        mock_session = self._make_mock_session_with_counts()
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert "backend_version" in data
+        assert "frontend_version" in data
+        assert "database_stats" in data
+        assert "sync_timestamps" in data
+
+    async def test_database_stats_contains_all_table_counts(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test database_stats includes counts for all tracked tables."""
+        mock_session = self._make_mock_session_with_counts(
+            video_count=150,
+            channel_count=30,
+            playlist_count=8,
+            transcript_count=120,
+            correction_count=25,
+            canonical_tag_count=75,
+        )
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        stats = response.json()["data"]["database_stats"]
+        assert stats["videos"] == 150
+        assert stats["channels"] == 30
+        assert stats["playlists"] == 8
+        assert stats["transcripts"] == 120
+        assert stats["corrections"] == 25
+        assert stats["canonical_tags"] == 75
+
+    async def test_empty_tables_return_zero_counts(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that None scalar results (empty tables) are treated as zero."""
+        mock_session = self._make_mock_session_with_counts(
+            video_count=0,
+            channel_count=0,
+            playlist_count=0,
+            transcript_count=0,
+            correction_count=0,
+            canonical_tag_count=0,
+        )
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        stats = response.json()["data"]["database_stats"]
+        assert stats["videos"] == 0
+        assert stats["channels"] == 0
+        assert stats["playlists"] == 0
+        assert stats["transcripts"] == 0
+        assert stats["corrections"] == 0
+        assert stats["canonical_tags"] == 0
+
+    async def test_null_scalar_results_coerced_to_zero(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that None returns from session.scalar() are coerced to 0."""
+        mock_session = AsyncMock(spec=AsyncSession)
+        # Return None for all 6 COUNT queries — simulates tables with no rows
+        mock_session.scalar.side_effect = [None, None, None, None, None, None]
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        stats = response.json()["data"]["database_stats"]
+        for field in ["videos", "channels", "playlists", "transcripts", "corrections", "canonical_tags"]:
+            assert stats[field] == 0, f"Expected 0 for {field}, got {stats[field]}"
+
+    async def test_sync_timestamps_contains_all_sync_types(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test sync_timestamps includes entries for all five sync operation types."""
+        mock_session = self._make_mock_session_with_counts()
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        expected_keys = {
+            SyncOperationType.SUBSCRIPTIONS.value,
+            SyncOperationType.VIDEOS.value,
+            SyncOperationType.TRANSCRIPTS.value,
+            SyncOperationType.PLAYLISTS.value,
+            SyncOperationType.TOPICS.value,
+        }
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        sync_timestamps = response.json()["data"]["sync_timestamps"]
+        returned_keys = set(sync_timestamps.keys())
+        assert expected_keys == returned_keys, (
+            f"sync_timestamps keys mismatch. "
+            f"Expected: {expected_keys}, Got: {returned_keys}"
+        )
+
+    async def test_sync_timestamps_null_when_never_synced(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test sync_timestamps values are null when sync has never run."""
+        mock_session = self._make_mock_session_with_counts()
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        sync_timestamps = response.json()["data"]["sync_timestamps"]
+        for key, value in sync_timestamps.items():
+            assert value is None, (
+                f"Expected None for sync_timestamps['{key}'], got: {value}"
+            )
+
+    async def test_sync_timestamps_include_actual_datetimes_when_synced(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test sync_timestamps contain ISO datetime strings when sync has run."""
+        mock_session = self._make_mock_session_with_counts()
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        last_sync_time = datetime(2026, 1, 15, 12, 0, 0)
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=last_sync_time,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        sync_timestamps = response.json()["data"]["sync_timestamps"]
+        for key, value in sync_timestamps.items():
+            assert value is not None, f"Expected a timestamp for '{key}', got None"
+            # Value should be ISO format datetime string
+            assert isinstance(value, str), f"Expected str timestamp for '{key}', got {type(value)}"
+
+    async def test_backend_version_is_non_empty_string(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test backend_version is a non-empty string from the package version."""
+        mock_session = self._make_mock_session_with_counts()
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert isinstance(data["backend_version"], str)
+        assert len(data["backend_version"]) > 0
+
+    async def test_frontend_version_is_set(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test frontend_version is set to the expected value."""
+        mock_session = self._make_mock_session_with_counts()
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["frontend_version"] == "0.18.0"
+
+    async def test_scalar_called_six_times_for_six_tables(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test that session.scalar() is called exactly 6 times for COUNT queries."""
+        mock_session = self._make_mock_session_with_counts()
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            return_value=None,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        assert mock_session.scalar.call_count == 6, (
+            f"Expected 6 scalar() calls (one per table), "
+            f"got {mock_session.scalar.call_count}"
+        )
+
+    async def test_mixed_sync_timestamps_some_null_some_present(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Test response correctly handles mixed null/non-null sync timestamps."""
+        mock_session = self._make_mock_session_with_counts()
+
+        async def mock_get_db_custom() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db_custom
+
+        last_sync = datetime(2026, 3, 1, 10, 30, 0)
+        # Return non-None only for SUBSCRIPTIONS, None for all others
+        call_count = {"n": 0}
+
+        def side_effect_sync(op_type: SyncOperationType) -> datetime | None:
+            call_count["n"] += 1
+            if op_type == SyncOperationType.SUBSCRIPTIONS:
+                return last_sync
+            return None
+
+        with patch(
+            "chronovista.api.services.sync_manager.sync_manager.get_last_successful_sync",
+            side_effect=side_effect_sync,
+        ):
+            response = await async_client.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 200
+        sync_timestamps = response.json()["data"]["sync_timestamps"]
+        # subscriptions should have a value
+        assert sync_timestamps["subscriptions"] is not None
+        # others should be null
+        assert sync_timestamps["videos"] is None
+        assert sync_timestamps["transcripts"] is None
+        assert sync_timestamps["playlists"] is None
+        assert sync_timestamps["topics"] is None
+
+    async def test_app_info_requires_authentication(
+        self, async_client_no_auth: AsyncClient
+    ) -> None:
+        """Test app-info endpoint requires authentication."""
+        with patch(
+            "chronovista.auth.youtube_oauth.is_authenticated",
+            return_value=False,
+        ):
+            response = await async_client_no_auth.get("/api/v1/settings/app-info")
+
+        assert response.status_code == 401

--- a/tests/unit/api/test_transcript_download.py
+++ b/tests/unit/api/test_transcript_download.py
@@ -272,6 +272,9 @@ class TestDownloadTranscriptVideoIdValidation:
         assert body["status"] == 422
 
     @patch(
+        "chronovista.api.routers.transcripts._pref_repo",
+    )
+    @patch(
         "chronovista.api.routers.transcripts._transcript_repo",
     )
     @patch(
@@ -281,6 +284,7 @@ class TestDownloadTranscriptVideoIdValidation:
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """An 11-character alphanumeric video_id passes format validation.
@@ -290,6 +294,7 @@ class TestDownloadTranscriptVideoIdValidation:
         We short-circuit by having the repo return an existing transcript
         to trigger a 409 (which proves the 422 guard did NOT fire).
         """
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         existing = _make_db_transcript(video_id=VALID_VIDEO_ID)
         mock_repo.get_video_transcripts = AsyncMock(return_value=[existing])
 
@@ -355,15 +360,18 @@ class TestDownloadTranscriptUnauthorized:
 class TestDownloadTranscriptNotFound:
     """Tests for 404 responses when YouTube has no transcript for the video."""
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_transcript_not_found_returns_404(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """404 is returned when TranscriptNotFoundError is raised."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         # No existing transcripts in DB (empty list → skip 409)
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         # Service raises TranscriptNotFoundError
@@ -375,15 +383,18 @@ class TestDownloadTranscriptNotFound:
 
         assert response.status_code == 404
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_transcript_not_found_rfc7807_body(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """404 response body conforms to RFC 7807 Problem Details format."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptNotFoundError("No transcript available")
@@ -399,15 +410,18 @@ class TestDownloadTranscriptNotFound:
         # The exception handler wraps this as NotFoundError for "Transcript"
         assert VALID_VIDEO_ID in body["detail"]
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_get_transcript_called_with_correct_video_id(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """Service.get_transcript is called with the video_id from the URL path."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptNotFoundError("No transcript available")
@@ -419,15 +433,18 @@ class TestDownloadTranscriptNotFound:
         call_kwargs = mock_service.get_transcript.call_args.kwargs
         assert call_kwargs["video_id"] == VALID_VIDEO_ID
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_get_transcript_called_without_language_codes_by_default(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """Without ?language param, service is called with language_codes=None."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptNotFoundError("No transcript available")
@@ -447,15 +464,18 @@ class TestDownloadTranscriptNotFound:
 class TestDownloadTranscriptConflict:
     """Tests for 409 Conflict when the transcript already exists in the DB."""
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_existing_transcript_returns_409(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """409 is returned when the repository already holds a transcript."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         existing = _make_db_transcript(video_id=VALID_VIDEO_ID)
         mock_repo.get_video_transcripts = AsyncMock(return_value=[existing])
 
@@ -463,15 +483,18 @@ class TestDownloadTranscriptConflict:
 
         assert response.status_code == 409
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_conflict_rfc7807_body(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """409 response body has RFC 7807 fields including status and detail."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         existing = _make_db_transcript(video_id=VALID_VIDEO_ID)
         mock_repo.get_video_transcripts = AsyncMock(return_value=[existing])
 
@@ -483,15 +506,18 @@ class TestDownloadTranscriptConflict:
         assert "title" in body
         assert "detail" in body
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_service_not_called_when_transcript_exists(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """When the transcript already exists, get_transcript is never called."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         existing = _make_db_transcript(video_id=VALID_VIDEO_ID)
         mock_repo.get_video_transcripts = AsyncMock(return_value=[existing])
 
@@ -499,15 +525,18 @@ class TestDownloadTranscriptConflict:
 
         mock_service.get_transcript.assert_not_called()
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_conflict_includes_video_id_in_detail(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """409 detail message references the conflicting video_id."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         existing = _make_db_transcript(video_id=VALID_VIDEO_ID)
         mock_repo.get_video_transcripts = AsyncMock(return_value=[existing])
 
@@ -525,15 +554,18 @@ class TestDownloadTranscriptConflict:
 class TestDownloadTranscriptServiceUnavailable:
     """Tests for 503 Service Unavailable from YouTube transcript service."""
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_service_unavailable_error_returns_503(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """503 is returned when TranscriptServiceUnavailableError is raised."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptServiceUnavailableError(
@@ -545,15 +577,18 @@ class TestDownloadTranscriptServiceUnavailable:
 
         assert response.status_code == 503
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_service_unavailable_rfc7807_body(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """503 response has RFC 7807 fields with SERVICE_UNAVAILABLE code."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptServiceUnavailableError("YouTube is down")
@@ -567,15 +602,18 @@ class TestDownloadTranscriptServiceUnavailable:
         assert "title" in body
         assert body["code"] == "SERVICE_UNAVAILABLE"
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_rate_limit_keyword_in_transcript_service_error_returns_503(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """503 is returned when TranscriptServiceError message contains 'rate limit'."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptServiceError(
@@ -587,15 +625,18 @@ class TestDownloadTranscriptServiceUnavailable:
 
         assert response.status_code == 503
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_too_many_keyword_in_error_returns_503(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """503 is returned when TranscriptServiceError message contains 'too many'."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptServiceError("too many requests, slow down")
@@ -605,15 +646,18 @@ class TestDownloadTranscriptServiceUnavailable:
 
         assert response.status_code == 503
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_quota_keyword_in_error_returns_503(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """503 is returned when TranscriptServiceError message contains 'quota'."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptServiceError("quota exceeded for transcript API")
@@ -623,15 +667,18 @@ class TestDownloadTranscriptServiceUnavailable:
 
         assert response.status_code == 503
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_service_unavailable_includes_instance_uri(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """503 response body includes the instance URI for the download endpoint."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptServiceUnavailableError("unavailable")
@@ -653,15 +700,18 @@ class TestDownloadTranscriptServiceUnavailable:
 class TestDownloadTranscriptSuccess:
     """Tests for successful 200 responses from the download endpoint."""
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_successful_download_returns_200(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """200 is returned when the transcript is downloaded and saved."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript()
@@ -673,15 +723,18 @@ class TestDownloadTranscriptSuccess:
 
         assert response.status_code == 200
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_successful_download_response_shape(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """200 response body contains ApiResponse envelope with TranscriptDownloadResponse data."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript()
@@ -704,15 +757,18 @@ class TestDownloadTranscriptSuccess:
         assert isinstance(data["segment_count"], int)
         assert "downloaded_at" in data
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_manual_transcript_type_display(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """is_cc=True maps to transcript_type='manual' in the response."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript(is_cc=True)
@@ -725,15 +781,18 @@ class TestDownloadTranscriptSuccess:
 
         assert data["transcript_type"] == "manual"
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_auto_generated_transcript_type_display(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """is_cc=False + transcript_type='AUTO' maps to 'auto_generated' in response."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript(is_cc=False)
@@ -746,15 +805,18 @@ class TestDownloadTranscriptSuccess:
 
         assert data["transcript_type"] == "auto_generated"
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_segment_count_from_db_transcript(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """segment_count in response matches db_transcript.segment_count."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript()
@@ -767,15 +829,18 @@ class TestDownloadTranscriptSuccess:
 
         assert data["segment_count"] == 99
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_null_segment_count_defaults_to_zero(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """segment_count=None on the DB row is coerced to 0 in the response."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript()
@@ -789,15 +854,18 @@ class TestDownloadTranscriptSuccess:
 
         assert data["segment_count"] == 0
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_language_name_resolved_from_code(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """language_name is resolved from the language_code via get_language_name."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript(language_code="es")
@@ -811,15 +879,18 @@ class TestDownloadTranscriptSuccess:
         assert data["language_code"] == "es"
         assert data["language_name"] == "Spanish"
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_unknown_language_code_returns_code_as_name(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """An unknown language code is returned as-is for language_name."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript(language_code="xx-unknown")
@@ -832,16 +903,19 @@ class TestDownloadTranscriptSuccess:
 
         assert data["language_name"] == "xx-unknown"
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_session_commit_called_after_save(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
         mock_session: AsyncMock,
     ) -> None:
         """session.commit() is called once after a successful transcript save."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript()
@@ -853,15 +927,18 @@ class TestDownloadTranscriptSuccess:
 
         mock_session.commit.assert_awaited_once()
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_create_or_update_called_with_transcript_create(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """repository.create_or_update is called once during a successful download."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript()
@@ -944,6 +1021,7 @@ class TestDownloadTranscriptInFlightGuard:
 
         assert VALID_VIDEO_ID in body["detail"]
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._downloads_in_progress", new_callable=set)
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
@@ -952,9 +1030,11 @@ class TestDownloadTranscriptInFlightGuard:
         mock_service: MagicMock,
         mock_repo: MagicMock,
         mock_in_flight: set[str],
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """A different video_id is NOT blocked by an in-flight download for another video."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         other_video_id = "9bZkp7q19f0"
         mock_in_flight.add(other_video_id)
 
@@ -968,12 +1048,14 @@ class TestDownloadTranscriptInFlightGuard:
         # 409 means we got past the in-flight guard (correct behavior)
         assert response.status_code == 409
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_in_flight_set_cleared_on_success(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """After a successful download the video_id is removed from _downloads_in_progress.
@@ -983,6 +1065,7 @@ class TestDownloadTranscriptInFlightGuard:
         """
         import chronovista.api.routers.transcripts as transcripts_module
 
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript()
@@ -995,12 +1078,14 @@ class TestDownloadTranscriptInFlightGuard:
         # After the request completes the in-flight set must not contain the video_id
         assert VALID_VIDEO_ID not in transcripts_module._downloads_in_progress
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_in_flight_set_cleared_on_404(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """After a 404 error the video_id is removed from _downloads_in_progress.
@@ -1010,6 +1095,7 @@ class TestDownloadTranscriptInFlightGuard:
         """
         import chronovista.api.routers.transcripts as transcripts_module
 
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptNotFoundError("No transcript")
@@ -1047,15 +1133,18 @@ class TestDownloadTranscriptLanguageParam:
         call_kwargs = mock_service.get_transcript.call_args.kwargs
         assert call_kwargs["language_codes"] == ["es"]
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_no_language_param_sends_none(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """Without ?language, get_transcript receives language_codes=None."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptNotFoundError("No transcript")
@@ -1116,17 +1205,20 @@ class TestDownloadTranscriptLanguageNameResolution:
             ("hi", "Hindi"),
         ],
     )
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_language_name_resolution(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
         code: str,
         expected_name: str,
     ) -> None:
         """Each BCP-47 code is resolved to its expected human-readable name."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript(language_code=code)
@@ -1148,15 +1240,18 @@ class TestDownloadTranscriptLanguageNameResolution:
 class TestDownloadTranscriptEdgeCases:
     """Edge cases not covered by the main scenario classes."""
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_transcript_type_manual_when_transcript_type_field_is_manual(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """is_cc=False but transcript_type='MANUAL' on DB row still yields 'manual' display."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         # Enhanced transcript uses enum value 'manual' (lowercase) for Pydantic validation
         mock_service.get_transcript = AsyncMock(
@@ -1171,15 +1266,18 @@ class TestDownloadTranscriptEdgeCases:
 
         assert data["transcript_type"] == "manual"
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_raw_transcript_data_forwarded_to_create_or_update(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """raw_transcript_data from enhanced transcript is passed to create_or_update."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         raw_data = {"snippets": [{"text": "Hello", "start": 0.0, "duration": 1.5}]}
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
@@ -1196,15 +1294,18 @@ class TestDownloadTranscriptEdgeCases:
         called_kwargs = call_args.kwargs
         assert called_kwargs.get("raw_transcript_data") == raw_data
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_none_raw_transcript_data_passes_none(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """When enhanced_transcript.raw_transcript_data is None, None is passed to repo."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             return_value=_make_enhanced_transcript(raw_transcript_data=None)
@@ -1217,15 +1318,18 @@ class TestDownloadTranscriptEdgeCases:
         call_kwargs = mock_repo.create_or_update.call_args.kwargs
         assert call_kwargs.get("raw_transcript_data") is None
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_video_id_with_underscores_and_hyphens_passes(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
     ) -> None:
         """video_id containing underscores and hyphens (valid in YouTube IDs) passes validation."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         vid = "abc_def-ghi"  # Exactly 11 chars with _ and -
         assert len(vid) == 11
 
@@ -1238,16 +1342,19 @@ class TestDownloadTranscriptEdgeCases:
 
         assert response.status_code == 409
 
+    @patch("chronovista.api.routers.transcripts._pref_repo")
     @patch("chronovista.api.routers.transcripts._transcript_repo")
     @patch("chronovista.api.routers.transcripts._transcript_service")
     async def test_get_video_transcripts_called_with_correct_args(
         self,
         mock_service: MagicMock,
         mock_repo: MagicMock,
+        mock_pref_repo: MagicMock,
         client: AsyncClient,
         mock_session: AsyncMock,
     ) -> None:
         """get_video_transcripts is called with the session and the video_id."""
+        mock_pref_repo.get_user_preferences = AsyncMock(return_value=[])
         mock_repo.get_video_transcripts = AsyncMock(return_value=[])
         mock_service.get_transcript = AsyncMock(
             side_effect=TranscriptNotFoundError("not found")


### PR DESCRIPTION
## Summary

- **Language Preferences UI**: Full CRUD for language preferences from the web UI — grouped by type (Fluent/Learning/Curious/Exclude), searchable combobox, duplicate validation, reset-all with confirmation dialog
- **Preference-Aware Transcript Download**: Frontend downloads now respect configured language preferences (fluent → learning → curious, skipping excluded); `?language` override preserved
- **Cache Status & Management**: View cached image count/disk usage and clear cache with confirmation
- **Application Info**: Backend/frontend versions, 6 database statistics, last sync timestamps with "Never synced" fallback
- **4 new API endpoints**: `GET /settings/supported-languages`, `GET /settings/cache-status`, `DELETE /settings/cache`, `GET /settings/app-info`
- **Sidebar restructure**: Setup moved below separator to group with Settings (content above, config below)
- **Transcript language pills**: Plain-text language codes replaced with indigo pills on video cards (up to 5 visible, +N overflow)
- **150 new tests** (38 backend + 112 frontend), 3,277 total frontend tests
- v0.50.0 backend, v0.19.0 frontend

## Test plan

- [x] Verify Settings page renders at `/settings` with all 3 sections (Language Preferences, Cache, About)
- [x] Add/remove language preferences and confirm persistence via API
- [x] Reset all preferences with confirmation dialog
- [x] Download transcript on video detail page — verify it respects configured language preferences
- [x] View cache status, clear cache, confirm status updates to empty
- [x] Verify About section shows correct versions, DB stats, and sync timestamps
- [x] Confirm sidebar shows Setup and Settings below separator
- [x] Verify language pills render on video cards (indigo, up to 5)
- [x] Run `npx vitest run` — 3,277 tests pass, 0 failures
- [x] Run `pytest tests/unit/api/routers/test_settings.py` — 38 tests pass
- [x] Run `npx tsc --noEmit` — 0 TypeScript errors
- [x] Run `mypy src/` — 0 mypy errors