### PR TITLE
feat(entities): add entity creation form with tag-backed, standalone, and duplicate detection (Feature 051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.52.0] - 2026-03-23
+
+### Added
+- **Feature 051: Entity Creation Form (ADR-006 Increment E)**
+  - **Tag-Backed Entity Creation (US1)**: "Create Entity" button on entities page opens modal form with ARIA `dialog` role and focus trap; name field with autocomplete searching canonical tags by prefix (debounced, 2-char minimum); autocomplete results show canonical form, video count, and alias count; selecting a tag pre-fills name and shows "Creating from tag" chip; entity type selector with all 8 entity-producing types (person, organization, place, event, work, technical_term, concept, other) with tooltips; optional description field; submit calls `POST /api/v1/entities/classify` using TagManagementService.classify(); on success modal closes and entity list refreshes
+  - **Standalone Entity Creation (US2)**: When no matching tag exists, user proceeds with typed name as freeform entry; form indicates "Creating standalone entity (not linked to a tag)"; repeatable alias field (add/remove, max 20) with `aria-live="polite"` mode transition announcements; submit calls `POST /api/v1/entities` with auto-title-casing and normalization; on success modal closes and entity list refreshes
+  - **Duplicate Detection (US3)**: Real-time debounced check via `GET /api/v1/entities/check-duplicate` with normalized name and entity type; warning block with `aria-live="assertive"` showing existing entity's name, type, and description; Link to existing entity detail page; submission blocked when duplicate exists; warning clears when name or type changes
+  - **Entity Creation API**: `POST /api/v1/entities/classify` wraps TagManagementService.classify() with 404/409/400 error mapping; `GET /api/v1/entities/check-duplicate` with in-memory rate limiting (50 req/min); `POST /api/v1/entities` for standalone creation with alias deduplication
+  - **EntityType Enum Expansion**: Added `concept` and `other` entity types across full stack (Pydantic enums, DB check constraints, frontend constants, entity type tabs)
+
+### Fixed
+- Tag normalization idempotency bug: `normalize('´#')` returned `'#'` but `normalize('#')` returned `None`; added second `lstrip('#')` pass after diacritic removal to ensure `normalize(normalize(x)) == normalize(x)` for all inputs
+- `EntitiesPage.test.tsx` missing mock stubs for `useClassifyTag`, `useCreateEntity`, `useCheckDuplicate`, `useCreateManualAssociation`, `useDeleteManualAssociation` — caused 93 test failures when running full suite (CreateEntityModal hooks called outside QueryClientProvider)
+- `EntitiesPage.test.tsx` entity type tab count assertion updated from 7 to 9 tabs (added Technical Term and Concept)
+
+### Technical
+- 3 new API endpoints (classify entity from tag, check duplicate, create standalone entity)
+- 1 new frontend component (`CreateEntityModal`), 3 new TanStack Query hooks (`useClassifyTag`, `useCreateEntity`, `useCheckDuplicate`), 1 new constants module (`entityTypes.ts`)
+- 158 new tests: 49 backend unit, 70 frontend component, 10 backend integration, 29 frontend hook tests
+- 7,403 total backend tests, 3,519 total frontend tests
+- Frontend version: 0.20.0 → 0.21.0
+- TypeScript strict mode (0 errors), mypy strict compliance (0 errors)
+- No new dependencies, no database migrations
+- WCAG 2.1 AA: ARIA dialog, combobox, focus trap, keyboard navigation (Escape/Tab/Arrow), aria-live announcements
+
 ## [0.51.0] - 2026-03-22
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.52.0] - 2026-03-23
+
+### Added
+- **Feature 051: Entity Creation Form (ADR-006 Increment E)**
+  - **Tag-Backed Entity Creation (US1)**: "Create Entity" button on entities page opens modal form with ARIA `dialog` role and focus trap; name field with autocomplete searching canonical tags by prefix (debounced, 2-char minimum); autocomplete results show canonical form, video count, and alias count; selecting a tag pre-fills name and shows "Creating from tag" chip; entity type selector with all 8 entity-producing types (person, organization, place, event, work, technical_term, concept, other) with tooltips; optional description field; submit calls `POST /api/v1/entities/classify` using TagManagementService.classify(); on success modal closes and entity list refreshes
+  - **Standalone Entity Creation (US2)**: When no matching tag exists, user proceeds with typed name as freeform entry; form indicates "Creating standalone entity (not linked to a tag)"; repeatable alias field (add/remove, max 20) with `aria-live="polite"` mode transition announcements; submit calls `POST /api/v1/entities` with auto-title-casing and normalization; on success modal closes and entity list refreshes
+  - **Duplicate Detection (US3)**: Real-time debounced check via `GET /api/v1/entities/check-duplicate` with normalized name and entity type; warning block with `aria-live="assertive"` showing existing entity's name, type, and description; Link to existing entity detail page; submission blocked when duplicate exists; warning clears when name or type changes
+  - **Entity Creation API**: `POST /api/v1/entities/classify` wraps TagManagementService.classify() with 404/409/400 error mapping; `GET /api/v1/entities/check-duplicate` with in-memory rate limiting (50 req/min); `POST /api/v1/entities` for standalone creation with alias deduplication
+  - **EntityType Enum Expansion**: Added `concept` and `other` entity types across full stack (Pydantic enums, DB check constraints, frontend constants, entity type tabs)
+
+### Fixed
+- Tag normalization idempotency bug: `normalize('´#')` returned `'#'` but `normalize('#')` returned `None`; added second `lstrip('#')` pass after diacritic removal to ensure `normalize(normalize(x)) == normalize(x)` for all inputs
+- `EntitiesPage.test.tsx` missing mock stubs for `useClassifyTag`, `useCreateEntity`, `useCheckDuplicate`, `useCreateManualAssociation`, `useDeleteManualAssociation` — caused 93 test failures when running full suite (CreateEntityModal hooks called outside QueryClientProvider)
+- `EntitiesPage.test.tsx` entity type tab count assertion updated from 7 to 9 tabs (added Technical Term and Concept)
+
+### Technical
+- 3 new API endpoints (classify entity from tag, check duplicate, create standalone entity)
+- 1 new frontend component (`CreateEntityModal`), 3 new TanStack Query hooks (`useClassifyTag`, `useCreateEntity`, `useCheckDuplicate`), 1 new constants module (`entityTypes.ts`)
+- 158 new tests: 49 backend unit, 70 frontend component, 10 backend integration, 29 frontend hook tests
+- 7,403 total backend tests, 3,519 total frontend tests
+- Frontend version: 0.20.0 → 0.21.0
+- TypeScript strict mode (0 errors), mypy strict compliance (0 errors)
+- No new dependencies, no database migrations
+- WCAG 2.1 AA: ARIA dialog, combobox, focus trap, keyboard navigation (Escape/Tab/Arrow), aria-live announcements
+
 ## [0.51.0] - 2026-03-22
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,12 @@ chronovista is a CLI application that enables users to access, store, and explor
 
     Edit, revert, and audit transcript corrections via inline web UI or batch CLI tools with full audit trail
 
+-   :material-account-group:{ .lg .middle } **Entity Management**
+
+    ---
+
+    Create and manage named entities from tags or standalone, with duplicate detection, alias tracking, and transcript mention scanning
+
 -   :material-api:{ .lg .middle } **REST API**
 
     ---
@@ -74,13 +80,13 @@ chronovista is a CLI application that enables users to access, store, and explor
 ## Project Status
 
 !!! success "Current Status"
-    - **6,000+ tests** (5,700+ backend, 2,300+ frontend) with **90%+ coverage**
+    - **10,900+ tests** (7,403+ backend, 3,519+ frontend) with **90%+ coverage**
     - **Comprehensive Pydantic models** with advanced validation and type safety
     - **Real API integration testing** with YouTube API data validation
     - **Advanced repository pattern** with async support and composite keys
     - **Rate-limited API service** with intelligent error handling and retry logic
     - **Wayback Machine recovery** for deleted/unavailable video and channel metadata via CLI, REST API, and frontend (v0.28.0)
-    - **React frontend** with video browsing, transcript search, deep link navigation, and recovery UI (v0.7.0)
+    - **React frontend** with video browsing, transcript search, deep link navigation, and recovery UI (v0.21.0)
 
 ## Quick Example
 

--- a/docs/user-guide/cli-overview.md
+++ b/docs/user-guide/cli-overview.md
@@ -725,7 +725,7 @@ chronovista tags classify <NORMALIZED_FORM> --type <TYPE> [OPTIONS]
 chronovista tags classify --top <N>
 ```
 
-Assigns an entity type to a canonical tag. Entity-producing types (person, organization, place, event, work, technical_term) create a `named_entities` record and copy tag aliases as `entity_aliases`. Tag-only types (topic, descriptor) set `entity_type` only.
+Assigns an entity type to a canonical tag. Entity-producing types (person, organization, place, event, work, technical_term, concept, other) create a `named_entities` record and copy tag aliases as `entity_aliases`. Tag-only types (topic, descriptor) set `entity_type` only.
 
 With `--top N`, displays the N highest-video_count unclassified canonical tags for triage.
 
@@ -735,7 +735,7 @@ With `--top N`, displays the N highest-video_count unclassified canonical tags f
 
 **Options:**
 
-- `--type <type>` - Entity type: `person`, `organization`, `place`, `event`, `work`, `technical_term`, `topic`, `descriptor`
+- `--type <type>` - Entity type: `person`, `organization`, `place`, `event`, `work`, `technical_term`, `concept`, `other`, `topic`, `descriptor`
 - `--top <n>` - Show top N unclassified tags by video count
 - `--force` - Reclassify an already-classified tag
 - `--reason <text>` - Reason for the classification (max 1000 chars)
@@ -872,7 +872,7 @@ Creates a standalone named entity (not linked to an existing canonical tag). The
 
 **Options:**
 
-- `--type <type>` - Entity type (required): `person`, `organization`, `place`, `event`, `work`, `technical_term`
+- `--type <type>` - Entity type (required): `person`, `organization`, `place`, `event`, `work`, `technical_term`, `concept`, `other`
 - `--description <text>` - Human-readable description of the entity
 - `--alias <name>` - Additional alias name (repeatable for multiple aliases)
 
@@ -891,7 +891,7 @@ chronovista entities create "Gaza Strip" --type place --description "Palestinian
 
 **Notes:**
 
-- Only entity-producing types are allowed (topic and descriptor are tag-only types — use `tags classify` instead)
+- Only entity-producing types are allowed: person, organization, place, event, work, technical_term, concept, other (topic and descriptor are tag-only types — use `tags classify` instead)
 - Duplicate detection: same normalized name + entity type → error
 - The canonical name alias is automatically created (same pattern as `tags classify`)
 

--- a/docs/user-guide/rest-api.md
+++ b/docs/user-guide/rest-api.md
@@ -1939,6 +1939,136 @@ Each match includes the original transcript N-gram, the entity name it likely re
 
 ---
 
+#### Check Duplicate Entity
+
+Check whether an entity with the same normalized name and type already exists before creating one. Rate-limited to 50 requests per minute per client IP.
+
+```
+GET /api/v1/entities/check-duplicate
+```
+
+##### Query Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `name` | string | Entity name to check (required) | - |
+| `type` | string | Entity type to filter by (required) | - |
+
+##### Response (200 OK)
+
+```json
+{
+  "is_duplicate": true,
+  "existing_entity": {
+    "entity_id": "01936c8a-1234-7000-8000-000000000001",
+    "canonical_name": "Noam Chomsky",
+    "entity_type": "person",
+    "description": "American linguist and political commentator"
+  }
+}
+```
+
+When no duplicate is found, `is_duplicate` is `false` and `existing_entity` is `null`.
+
+| Status | Description |
+|--------|-------------|
+| 429 | Rate limit exceeded (50 req/min per client IP). Includes `Retry-After` header. |
+
+---
+
+#### Classify Tag as Entity
+
+Create a named entity from an existing canonical tag. Delegates to the tag management service which handles entity creation/linking and alias registration.
+
+```
+POST /api/v1/entities/classify
+```
+
+**Request body:**
+
+```json
+{
+  "normalized_form": "noam chomsky",
+  "entity_type": "person",
+  "description": "American linguist and political commentator"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `normalized_form` | string | yes | Normalized form of the canonical tag (1-500 chars) |
+| `entity_type` | string | yes | Entity type: `person`, `organization`, `place`, `event`, `work`, `technical_term`, `concept`, `other` |
+| `description` | string | no | Entity description (max 5000 chars) |
+
+**Response (201 Created):**
+
+```json
+{
+  "entity_id": "01936c8a-1234-7000-8000-000000000001",
+  "canonical_name": "Noam Chomsky",
+  "entity_type": "person",
+  "description": "American linguist and political commentator",
+  "alias_count": 2,
+  "entity_created": true,
+  "operation_id": "01936c8b-5678-7000-8000-000000000002"
+}
+```
+
+| Status | Description |
+|--------|-------------|
+| 400 | Invalid entity_type or other validation error |
+| 404 | Canonical tag not found or inactive |
+| 409 | Tag is already classified as an entity. Response includes `existing_entity` details. |
+
+---
+
+#### Create Standalone Entity
+
+Create a new named entity without linking to a canonical tag. The entity name is auto-title-cased and normalized for duplicate detection.
+
+```
+POST /api/v1/entities
+```
+
+**Request body:**
+
+```json
+{
+  "name": "Noam Chomsky",
+  "entity_type": "person",
+  "description": "American linguist and political commentator",
+  "aliases": ["Chomsky", "N. Chomsky"]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Entity display name (1-500 chars) |
+| `entity_type` | string | yes | Entity type: `person`, `organization`, `place`, `event`, `work`, `technical_term`, `concept`, `other` |
+| `description` | string | no | Entity description (max 5000 chars) |
+| `aliases` | string[] | no | Additional alias names (max 20). Duplicates by normalized form are skipped. |
+
+**Response (201 Created):**
+
+```json
+{
+  "entity_id": "01936c8a-1234-7000-8000-000000000001",
+  "canonical_name": "Noam Chomsky",
+  "entity_type": "person",
+  "description": "American linguist and political commentator",
+  "alias_count": 3
+}
+```
+
+The `alias_count` includes the canonical name plus any unique aliases provided.
+
+| Status | Description |
+|--------|-------------|
+| 409 | An active entity with the same normalized name and type already exists. Response includes `existing_entity` details. |
+| 422 | Entity name normalizes to an empty string |
+
+---
+
 ### Search
 
 #### Search Transcript Segments
@@ -2782,6 +2912,23 @@ curl -X POST http://localhost:8000/api/v1/videos/dQw4w9WgXcQ/entities/01936c8a-1
 curl -X DELETE http://localhost:8000/api/v1/videos/dQw4w9WgXcQ/entities/01936c8a-1234-7000-8000-000000000001/manual
 ```
 
+#### Entity Creation
+
+```bash
+# Check for duplicate entity before creating
+curl "http://localhost:8000/api/v1/entities/check-duplicate?name=Noam%20Chomsky&type=person"
+
+# Classify a canonical tag as an entity
+curl -X POST http://localhost:8000/api/v1/entities/classify \
+  -H "Content-Type: application/json" \
+  -d '{"normalized_form": "noam chomsky", "entity_type": "person", "description": "American linguist"}'
+
+# Create a standalone entity with aliases
+curl -X POST http://localhost:8000/api/v1/entities \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Noam Chomsky", "entity_type": "person", "aliases": ["Chomsky", "N. Chomsky"]}'
+```
+
 #### Recover Video Metadata
 
 ```bash
@@ -2899,7 +3046,7 @@ await updatePreferences([
 
 ## Rate Limiting
 
-The canonical tag search endpoint (`GET /api/v1/canonical-tags?q=...`) and tag search endpoint (`GET /api/v1/tags?q=...`) enforce rate limiting at **50 requests per minute per client IP**. Exceeding this limit returns a `429 Too Many Requests` response with a `Retry-After` header indicating how many seconds to wait.
+The canonical tag search endpoint (`GET /api/v1/canonical-tags?q=...`), tag search endpoint (`GET /api/v1/tags?q=...`), and entity duplicate-check endpoint (`GET /api/v1/entities/check-duplicate`) enforce rate limiting at **50 requests per minute per client IP**. Exceeding this limit returns a `429 Too Many Requests` response with a `Retry-After` header indicating how many seconds to wait.
 
 Other endpoints do not implement rate limiting directly, but be aware of YouTube API quotas when triggering sync operations. See the [Authentication](authentication.md) guide for quota information.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/entity/CreateEntityModal.tsx
+++ b/frontend/src/components/entity/CreateEntityModal.tsx
@@ -1,0 +1,1168 @@
+/**
+ * CreateEntityModal — modal for creating a new named entity.
+ *
+ * Implements:
+ * - T015 [US1]: Modal shell (FR-017, FR-018, FR-019)
+ * - T016 [US1]: Tag autocomplete + entity-type selector (FR-004, FR-005, FR-011, FR-018, FR-020)
+ * - T017 [US1]: Submit handler wired to useClassifyTag mutation (FR-016)
+ *
+ * Features:
+ * - ARIA dialog: role="dialog", aria-modal="true", aria-labelledby
+ * - Semi-transparent backdrop that closes on click
+ * - X button in top-right corner
+ * - Escape key listener closes modal
+ * - Focus trap: Tab cycles within modal; Shift+Tab wraps in reverse
+ * - Focus auto-moves to name field on open
+ * - Focus returns to trigger element on close (via onClose callback)
+ * - Conditional rendering: returns null when isOpen is false
+ * - Portal: rendered via createPortal to document.body
+ * - Form state reset on close
+ *
+ * Tag autocomplete (T016):
+ * - ARIA combobox on the name input (role="combobox", aria-expanded,
+ *   aria-autocomplete="list", aria-controls, aria-activedescendant)
+ * - Triggers after 2+ characters with 300 ms debounce via useCanonicalTags
+ * - ArrowUp/Down/Enter keyboard navigation
+ * - On selection: populates name, shows "Creating from tag" chip (FR-004)
+ * - Editing name after selection clears selectedTag (FR-004 mode transition)
+ * - When no selectedTag and name non-empty: "Creating standalone entity" label (FR-011)
+ *
+ * Entity type selector (T016):
+ * - <select> covering all 8 ENTITY_PRODUCING_TYPES
+ * - Tooltip info icon per option using ENTITY_TYPE_TOOLTIPS (FR-005.1)
+ * - "Other" hint text (FR-005.2)
+ *
+ *
+ * @module components/entity/CreateEntityModal
+ */
+
+import { useState, useEffect, useRef, useCallback, useId } from "react";
+import { createPortal } from "react-dom";
+import { Link } from "react-router-dom";
+import { useCanonicalTags } from "../../hooks/useCanonicalTags";
+import { useClassifyTag, useCheckDuplicate, useCreateEntity } from "../../hooks/useEntityMentions";
+import {
+  ENTITY_PRODUCING_TYPES,
+  ENTITY_TYPE_LABELS,
+  ENTITY_TYPE_TOOLTIPS,
+} from "../../constants/entityTypes";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A canonical tag returned from the tag-resolution autocomplete.
+ * Populated by T016 when the user selects a tag to link this entity to.
+ */
+export interface SelectedTag {
+  canonical_form: string;
+  normalized_form: string;
+  alias_count: number;
+  video_count: number;
+}
+
+export interface CreateEntityModalProps {
+  /** Whether the modal is open. When false the component returns null. */
+  isOpen: boolean;
+  /** Called when the modal should close (X button, backdrop click, Escape key, or Cancel). */
+  onClose: () => void;
+  /**
+   * Called after a successful entity creation so the parent can refresh its
+   * entity list (e.g. invalidate TanStack Query cache).
+   */
+  onSuccess?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns all keyboard-focusable elements inside a container element.
+ * Used by the focus-trap logic.
+ */
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      [
+        "a[href]",
+        "button:not([disabled])",
+        "input:not([disabled])",
+        "select:not([disabled])",
+        "textarea:not([disabled])",
+        '[tabindex]:not([tabindex="-1"])',
+      ].join(", ")
+    )
+  ).filter((el) => !el.hidden);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * CreateEntityModal renders a centred dialog for creating a new named entity.
+ *
+ * The modal shell manages ARIA semantics, backdrop, Escape handling, focus
+ * trap, and form-state lifecycle. T016 adds entity type selector and tag
+ * autocomplete. T017 wires the submit handler to the useClassifyTag mutation.
+ *
+ * @example
+ * ```tsx
+ * const triggerRef = useRef<HTMLButtonElement>(null);
+ * const [isOpen, setIsOpen] = useState(false);
+ *
+ * <button ref={triggerRef} onClick={() => setIsOpen(true)}>
+ *   Create Entity
+ * </button>
+ * <CreateEntityModal
+ *   isOpen={isOpen}
+ *   onClose={() => { setIsOpen(false); triggerRef.current?.focus(); }}
+ *   onSuccess={() => void queryClient.invalidateQueries({ queryKey: ["entities"] })}
+ * />
+ * ```
+ */
+export default function CreateEntityModal({
+  isOpen,
+  onClose,
+  onSuccess,
+}: CreateEntityModalProps) {
+  // ---------------------------------------------------------------------------
+  // Form state
+  // ---------------------------------------------------------------------------
+
+  const [name, setName] = useState("");
+  const [entityType, setEntityType] = useState("");
+  const [description, setDescription] = useState("");
+  const [aliases, setAliases] = useState<string[]>([]);
+  const [selectedTag, setSelectedTag] = useState<SelectedTag | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Mutation
+  // ---------------------------------------------------------------------------
+
+  const classifyTagMutation = useClassifyTag();
+  const createEntityMutation = useCreateEntity();
+
+  // ---------------------------------------------------------------------------
+  // Duplicate detection (T024 [US3])
+  // ---------------------------------------------------------------------------
+
+  const duplicateCheck = useCheckDuplicate(name, entityType);
+
+  // ---------------------------------------------------------------------------
+  // Tag autocomplete state
+  // ---------------------------------------------------------------------------
+
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  // Refs for focus management
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLUListElement>(null);
+
+  // Stable IDs for ARIA relationships
+  const listboxId = useId();
+
+  // ---------------------------------------------------------------------------
+  // Tag search via useCanonicalTags (300 ms debounce built into hook)
+  // ---------------------------------------------------------------------------
+
+  const { tags: tagResults, isLoading: isSearching } = useCanonicalTags(
+    // Only feed the hook when we have 2+ chars and no tag is selected.
+    // When a tag is already selected we don't want to re-query.
+    name.length >= 2 && selectedTag === null ? name : ""
+  );
+
+  // Open the dropdown whenever results arrive for a qualifying query.
+  useEffect(() => {
+    if (name.length >= 2 && selectedTag === null && tagResults.length > 0) {
+      setShowDropdown(true);
+    } else if (name.length < 2 || selectedTag !== null) {
+      setShowDropdown(false);
+      setHighlightedIndex(-1);
+    }
+  }, [tagResults, name, selectedTag]);
+
+  // Reset highlighted index whenever the result list changes.
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [tagResults]);
+
+  // ---------------------------------------------------------------------------
+  // Close dropdown on outside click
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!showDropdown) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        nameInputRef.current &&
+        !nameInputRef.current.contains(target) &&
+        dropdownRef.current &&
+        !dropdownRef.current.contains(target)
+      ) {
+        setShowDropdown(false);
+        setHighlightedIndex(-1);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showDropdown]);
+
+  // ---------------------------------------------------------------------------
+  // Reset form when modal closes
+  // ---------------------------------------------------------------------------
+
+  const resetForm = useCallback(() => {
+    setName("");
+    setEntityType("");
+    setDescription("");
+    setAliases([]);
+    setSelectedTag(null);
+    setIsSubmitting(false);
+    setError(null);
+    setShowDropdown(false);
+    setHighlightedIndex(-1);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      resetForm();
+    }
+  }, [isOpen, resetForm]);
+
+  // ---------------------------------------------------------------------------
+  // Clear error on form modification (FR-016: error persists until retry/edit)
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (error !== null) {
+      setError(null);
+    }
+    // Intentionally depends on the form values only — not `error` itself,
+    // so we don't create a loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name, entityType, description]);
+
+  // ---------------------------------------------------------------------------
+  // Auto-focus name field on open
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (isOpen) {
+      const id = requestAnimationFrame(() => {
+        nameInputRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(id);
+    }
+  }, [isOpen]);
+
+  // ---------------------------------------------------------------------------
+  // Escape to close (also closes dropdown first if open)
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        if (showDropdown) {
+          // First Escape press closes the dropdown only.
+          e.stopPropagation();
+          setShowDropdown(false);
+          setHighlightedIndex(-1);
+        } else {
+          e.stopPropagation();
+          onClose();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose, showDropdown]);
+
+  // ---------------------------------------------------------------------------
+  // Focus trap
+  // ---------------------------------------------------------------------------
+
+  const handleDialogKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== "Tab") return;
+
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+
+      const focusable = getFocusableElements(dialog);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
+    },
+    []
+  );
+
+  // ---------------------------------------------------------------------------
+  // Backdrop click
+  // ---------------------------------------------------------------------------
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Tag selection handler
+  // ---------------------------------------------------------------------------
+
+  const handleTagSelect = useCallback(
+    (tag: SelectedTag) => {
+      setName(tag.canonical_form);
+      setSelectedTag(tag);
+      setAliases([]);
+      setShowDropdown(false);
+      setHighlightedIndex(-1);
+      // Return focus to name input after selection so keyboard users can continue.
+      nameInputRef.current?.focus();
+    },
+    []
+  );
+
+  // ---------------------------------------------------------------------------
+  // Name input change — clears selectedTag if user edits after selection
+  // ---------------------------------------------------------------------------
+
+  const handleNameChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setName(value);
+      // FR-004 mode transition: any manual edit clears the selected tag.
+      if (selectedTag !== null) {
+        setSelectedTag(null);
+      }
+    },
+    [selectedTag]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Keyboard navigation in tag dropdown
+  // ---------------------------------------------------------------------------
+
+  const handleNameKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!showDropdown || tagResults.length === 0) {
+        // Allow Escape to be handled by the document listener above.
+        return;
+      }
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setHighlightedIndex((prev) =>
+            prev < tagResults.length - 1 ? prev + 1 : 0
+          );
+          break;
+
+        case "ArrowUp":
+          e.preventDefault();
+          setHighlightedIndex((prev) =>
+            prev > 0 ? prev - 1 : tagResults.length - 1
+          );
+          break;
+
+        case "Enter":
+          e.preventDefault();
+          if (highlightedIndex >= 0 && highlightedIndex < tagResults.length) {
+            const tag = tagResults[highlightedIndex];
+            if (tag) {
+              handleTagSelect({
+                canonical_form: tag.canonical_form,
+                normalized_form: tag.normalized_form,
+                alias_count: tag.alias_count,
+                video_count: tag.video_count,
+              });
+            }
+          }
+          break;
+
+        case "Escape":
+          e.preventDefault();
+          setShowDropdown(false);
+          setHighlightedIndex(-1);
+          break;
+
+        case "Tab":
+          // Close dropdown; focus moves naturally to next element.
+          setShowDropdown(false);
+          setHighlightedIndex(-1);
+          break;
+      }
+    },
+    [showDropdown, tagResults, highlightedIndex, handleTagSelect]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Derived state
+  // ---------------------------------------------------------------------------
+
+  // FR-012: Only block submit on confirmed duplicate — endpoint failure
+  // falls through as false so submission is still allowed as fallback.
+  const isDuplicate = duplicateCheck.data?.is_duplicate === true;
+
+  // Disable submit while the check is in-flight to prevent a race condition
+  // where the user submits before the duplicate warning appears.
+  const isDuplicateCheckPending =
+    duplicateCheck.isLoading && name.trim().length >= 2 && entityType !== "";
+
+  const isSubmitDisabled =
+    isSubmitting ||
+    name.trim() === "" ||
+    entityType === "" ||
+    isDuplicate ||
+    isDuplicateCheckPending;
+
+  // aria-activedescendant value for keyboard navigation
+  const activeDescendantId =
+    highlightedIndex >= 0
+      ? `${listboxId}-option-${highlightedIndex}`
+      : undefined;
+
+  // Show "Creating standalone entity" label only when name has text and no tag
+  // is selected (FR-011).
+  const showStandaloneLabel = name.trim().length > 0 && selectedTag === null;
+
+  // ---------------------------------------------------------------------------
+  // Conditional render
+  // ---------------------------------------------------------------------------
+
+  if (!isOpen) return null;
+
+  // ---------------------------------------------------------------------------
+  // Portal render
+  // ---------------------------------------------------------------------------
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={handleBackdropClick}
+      style={{ backgroundColor: "rgba(0, 0, 0, 0.45)" }}
+      aria-hidden="false"
+    >
+      {/* Dialog panel */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-entity-title"
+        onKeyDown={handleDialogKeyDown}
+        className="
+          relative
+          w-full max-w-lg
+          bg-white
+          rounded-xl
+          shadow-2xl
+          flex flex-col
+          max-h-[90vh]
+          overflow-hidden
+        "
+      >
+        {/* ------------------------------------------------------------------ */}
+        {/* Header                                                              */}
+        {/* ------------------------------------------------------------------ */}
+        <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-gray-100 flex-shrink-0">
+          <h2
+            id="create-entity-title"
+            className="text-lg font-semibold text-gray-900"
+          >
+            Create Entity
+          </h2>
+
+          {/* Close (X) button */}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="
+              inline-flex items-center justify-center
+              w-8 h-8
+              rounded-full
+              text-gray-400 hover:text-gray-600 hover:bg-gray-100
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1
+              transition-colors
+            "
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Scrollable form body                                                */}
+        {/* ------------------------------------------------------------------ */}
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+
+          {/* Inline error banner */}
+          {error !== null && (
+            <div
+              role="alert"
+              aria-live="polite"
+              className="flex items-start gap-3 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800"
+            >
+              <svg
+                className="w-4 h-4 flex-shrink-0 mt-0.5 text-red-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <span>{error}</span>
+            </div>
+          )}
+
+          {/* ---------------------------------------------------------------- */}
+          {/* Name field with tag autocomplete combobox (T016)                 */}
+          {/* ---------------------------------------------------------------- */}
+          <div>
+            <label
+              htmlFor="create-entity-name"
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
+              Name <span className="text-red-500" aria-hidden="true">*</span>
+              <span className="sr-only">(required)</span>
+            </label>
+
+            {/* Combobox wrapper — position: relative for dropdown positioning */}
+            <div className="relative">
+              <input
+                ref={nameInputRef}
+                id="create-entity-name"
+                type="text"
+                role="combobox"
+                aria-expanded={showDropdown && tagResults.length > 0}
+                aria-autocomplete="list"
+                aria-controls={
+                  showDropdown && tagResults.length > 0
+                    ? listboxId
+                    : undefined
+                }
+                aria-activedescendant={activeDescendantId}
+                aria-busy={isSearching}
+                value={name}
+                onChange={handleNameChange}
+                onKeyDown={handleNameKeyDown}
+                onFocus={() => {
+                  // Re-open dropdown on focus if there are already results.
+                  if (
+                    name.length >= 2 &&
+                    selectedTag === null &&
+                    tagResults.length > 0
+                  ) {
+                    setShowDropdown(true);
+                  }
+                }}
+                disabled={isSubmitting}
+                placeholder="e.g. Alexandria Ocasio-Cortez"
+                autoComplete="off"
+                className="
+                  w-full
+                  px-3 py-2.5
+                  text-sm text-gray-900 placeholder-gray-400
+                  border border-gray-300 rounded-lg
+                  bg-white
+                  focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
+                  disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed
+                  transition-colors
+                "
+              />
+
+              {/* Inline spinner while searching */}
+              {isSearching && name.length >= 2 && selectedTag === null && (
+                <div
+                  className="absolute right-3 top-1/2 -translate-y-1/2"
+                  aria-hidden="true"
+                >
+                  <div className="w-4 h-4 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
+
+              {/* Tag suggestions listbox */}
+              {showDropdown && tagResults.length > 0 && (
+                <ul
+                  ref={dropdownRef}
+                  id={listboxId}
+                  role="listbox"
+                  aria-label="Matching canonical tags"
+                  className="
+                    absolute z-50 left-0 right-0 top-full mt-1
+                    max-h-60 overflow-auto
+                    bg-white border border-gray-200 rounded-lg shadow-lg
+                  "
+                >
+                  {tagResults.map((tag, index) => {
+                    const isHighlighted = index === highlightedIndex;
+                    const optionId = `${listboxId}-option-${index}`;
+                    const aliasLabel =
+                      tag.alias_count > 1
+                        ? `${tag.alias_count - 1} ${tag.alias_count - 1 === 1 ? "alias" : "aliases"}`
+                        : null;
+
+                    return (
+                      <li
+                        key={tag.normalized_form}
+                        id={optionId}
+                        role="option"
+                        aria-selected={isHighlighted}
+                        aria-label={`${tag.canonical_form}, ${tag.video_count} videos${aliasLabel ? `, ${aliasLabel}` : ""}`}
+                        onClick={() =>
+                          handleTagSelect({
+                            canonical_form: tag.canonical_form,
+                            normalized_form: tag.normalized_form,
+                            alias_count: tag.alias_count,
+                            video_count: tag.video_count,
+                          })
+                        }
+                        onMouseEnter={() => setHighlightedIndex(index)}
+                        className={`
+                          px-4 py-2.5 cursor-pointer select-none
+                          ${
+                            isHighlighted
+                              ? "bg-indigo-50 text-indigo-900"
+                              : "text-gray-900 hover:bg-gray-50"
+                          }
+                        `}
+                      >
+                        {/* Line 1: canonical form (bold) + video count */}
+                        <div className="flex items-baseline gap-2">
+                          <span className="text-sm font-semibold leading-tight">
+                            {tag.canonical_form}
+                          </span>
+                          <span className="text-xs text-gray-500 leading-tight">
+                            {tag.video_count} {tag.video_count === 1 ? "video" : "videos"}
+                          </span>
+                          {aliasLabel && (
+                            <span className="text-xs text-gray-400 leading-tight">
+                              {aliasLabel}
+                            </span>
+                          )}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+
+              {/* No results state — shown when search returned empty */}
+              {showDropdown &&
+                tagResults.length === 0 &&
+                !isSearching &&
+                name.length >= 2 &&
+                selectedTag === null && (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="
+                      absolute z-50 left-0 right-0 top-full mt-1
+                      px-4 py-3
+                      bg-white border border-gray-200 rounded-lg shadow-lg
+                      text-sm text-gray-500
+                    "
+                  >
+                    No matching tags — entity will be created standalone.
+                  </div>
+                )}
+            </div>
+
+            {/* ---- Tag chip or standalone label (FR-004 / FR-011) ---- */}
+            {selectedTag !== null ? (
+              /* FR-004: "Creating from tag" chip when a tag is selected */
+              <div className="mt-2 flex items-center gap-2">
+                <span className="text-xs text-gray-500">Creating from tag</span>
+                <span className="
+                  inline-flex items-center gap-1.5
+                  px-2.5 py-0.5
+                  text-xs font-medium
+                  bg-indigo-50 text-indigo-700 border border-indigo-200
+                  rounded-full
+                ">
+                  {selectedTag.canonical_form}
+                  {/* X to clear the tag selection */}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSelectedTag(null);
+                      nameInputRef.current?.focus();
+                    }}
+                    disabled={isSubmitting}
+                    aria-label={`Remove tag link to ${selectedTag.canonical_form}`}
+                    className="
+                      inline-flex items-center justify-center
+                      w-3.5 h-3.5 -mr-0.5
+                      rounded-full
+                      text-indigo-400 hover:text-indigo-700 hover:bg-indigo-100
+                      focus:outline-none focus-visible:ring-1 focus-visible:ring-indigo-500
+                      disabled:opacity-50 disabled:cursor-not-allowed
+                      transition-colors
+                    "
+                  >
+                    <svg
+                      className="w-2.5 h-2.5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2.5}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
+            ) : showStandaloneLabel ? (
+              /* FR-011: "Creating standalone entity" when name has text but no tag */
+              <p className="mt-1.5 text-xs text-gray-400">
+                Creating standalone entity
+              </p>
+            ) : null}
+
+            {/* Screen reader description for the combobox */}
+            <p className="sr-only" id="create-entity-name-desc">
+              Type to search canonical tags. Use arrow keys to navigate results,
+              Enter to select, Escape to close the suggestions.
+            </p>
+          </div>
+
+          {/* ---------------------------------------------------------------- */}
+          {/* Entity type selector (T016)                                      */}
+          {/* ---------------------------------------------------------------- */}
+          <div>
+            <label
+              htmlFor="create-entity-type"
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
+              Entity type{" "}
+              <span className="text-red-500" aria-hidden="true">*</span>
+              <span className="sr-only">(required)</span>
+            </label>
+
+            <select
+              id="create-entity-type"
+              value={entityType}
+              onChange={(e) => setEntityType(e.target.value)}
+              disabled={isSubmitting}
+              aria-required="true"
+              className="
+                w-full
+                px-3 py-2.5
+                text-sm text-gray-900
+                border border-gray-300 rounded-lg
+                bg-white
+                focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
+                disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed
+                transition-colors
+                appearance-none
+              "
+            >
+              <option value="" disabled>
+                Select a type…
+              </option>
+              {ENTITY_PRODUCING_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {ENTITY_TYPE_LABELS[type] ?? type}
+                </option>
+              ))}
+            </select>
+
+            {/* Per-type tooltip info icons (FR-005.1) */}
+            {entityType !== "" && (
+              <div className="mt-2 flex items-start gap-1.5">
+                {/* Info icon */}
+                <svg
+                  className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <p className="text-xs text-gray-500 leading-relaxed">
+                  {ENTITY_TYPE_TOOLTIPS[entityType]}
+                </p>
+              </div>
+            )}
+
+            {/* FR-005.2: Non-blocking "Other" hint */}
+            {entityType === "other" && (
+              <p
+                role="note"
+                className="
+                  mt-2 px-3 py-2
+                  text-xs text-amber-700
+                  bg-amber-50 border border-amber-200
+                  rounded-md
+                "
+              >
+                Consider whether this entity fits one of the specific types
+                above.
+              </p>
+            )}
+          </div>
+
+          {/* ---------------------------------------------------------------- */}
+          {/* Duplicate warning (T024 [US3])                                   */}
+          {/* ---------------------------------------------------------------- */}
+          {isDuplicate && duplicateCheck.data?.existing_entity !== null && duplicateCheck.data?.existing_entity !== undefined && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="bg-amber-50 border border-amber-300 rounded-lg px-4 py-3 text-amber-800 text-sm space-y-1"
+            >
+              <p className="font-medium">
+                An entity with this name and type already exists:
+              </p>
+              <p>
+                <strong>{duplicateCheck.data.existing_entity.canonical_name}</strong>{" "}
+                ({ENTITY_TYPE_LABELS[duplicateCheck.data.existing_entity.entity_type] ?? duplicateCheck.data.existing_entity.entity_type})
+              </p>
+              {duplicateCheck.data.existing_entity.description !== null && (
+                <p className="text-sm text-amber-700">
+                  {duplicateCheck.data.existing_entity.description}
+                </p>
+              )}
+              <Link
+                to={`/entities/${duplicateCheck.data.existing_entity.entity_id}`}
+                className="
+                  inline-block mt-1
+                  text-sm font-medium text-amber-900 underline underline-offset-2
+                  hover:text-amber-700
+                  focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 rounded
+                "
+              >
+                View existing entity
+              </Link>
+            </div>
+          )}
+
+          {/* ---- Description field (optional) ---- */}
+          <div>
+            <label
+              htmlFor="create-entity-description"
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
+              Description{" "}
+              <span className="text-xs font-normal text-gray-400">
+                — optional
+              </span>
+            </label>
+            <textarea
+              id="create-entity-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={isSubmitting}
+              placeholder="Short description of this entity…"
+              rows={3}
+              className="
+                w-full
+                px-3 py-2.5
+                text-sm text-gray-900 placeholder-gray-400
+                border border-gray-300 rounded-lg
+                bg-white
+                resize-none
+                focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
+                disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed
+                transition-colors
+              "
+            />
+          </div>
+
+          {/* ---- Alias fields — standalone mode only (FR-004 / FR-011) ---- */}
+          {selectedTag === null && (
+            <div>
+              <div className="flex items-center justify-between mb-1.5">
+                <label className="text-sm font-medium text-gray-700">
+                  Aliases{" "}
+                  <span className="text-xs font-normal text-gray-400">
+                    — optional
+                  </span>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setAliases([...aliases, ""])}
+                  disabled={isSubmitting || aliases.length >= 20}
+                  className="
+                    text-xs text-indigo-600 hover:text-indigo-700
+                    font-medium
+                    disabled:opacity-50 disabled:cursor-not-allowed
+                    focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 rounded
+                  "
+                >
+                  + Add Alias
+                </button>
+              </div>
+
+              {aliases.map((alias, index) => (
+                <div key={index} className="flex items-center gap-2 mb-2">
+                  <input
+                    type="text"
+                    value={alias}
+                    onChange={(e) => {
+                      const updated = [...aliases];
+                      updated[index] = e.target.value;
+                      setAliases(updated);
+                    }}
+                    placeholder={`Alias ${index + 1}`}
+                    disabled={isSubmitting}
+                    aria-label={`Alias ${index + 1}`}
+                    className="
+                      flex-1
+                      px-3 py-2
+                      text-sm text-gray-900 placeholder-gray-400
+                      border border-gray-300 rounded-lg
+                      bg-white
+                      focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
+                      disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed
+                      transition-colors
+                    "
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setAliases(aliases.filter((_, i) => i !== index))}
+                    disabled={isSubmitting}
+                    aria-label={`Remove alias ${index + 1}`}
+                    className="
+                      inline-flex items-center justify-center
+                      w-8 h-8
+                      rounded-full
+                      text-gray-400 hover:text-red-500 hover:bg-red-50
+                      focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1
+                      disabled:opacity-50 disabled:cursor-not-allowed
+                      transition-colors flex-shrink-0
+                    "
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* aria-live region for mode-transition announcements (FR-004 / FR-011) */}
+          <div
+            aria-live="polite"
+            aria-atomic="true"
+            className="sr-only"
+          >
+            {selectedTag !== null
+              ? `Creating from tag: ${selectedTag.canonical_form}`
+              : showStandaloneLabel
+              ? "Creating standalone entity"
+              : ""}
+          </div>
+
+        </div>
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Footer                                                              */}
+        {/* ------------------------------------------------------------------ */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-100 bg-gray-50 flex-shrink-0">
+          {/* Cancel button */}
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="
+              min-h-[44px]
+              px-4 py-2
+              text-sm font-medium text-gray-700
+              bg-white border border-gray-300 rounded-lg
+              hover:bg-gray-50 hover:text-gray-900
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1
+              disabled:opacity-50 disabled:cursor-not-allowed
+              transition-colors
+            "
+          >
+            Cancel
+          </button>
+
+          {/* Submit button */}
+          <button
+            type="button"
+            disabled={isSubmitDisabled}
+            aria-busy={isSubmitting}
+            aria-disabled={isSubmitDisabled}
+            onClick={() => {
+              if (selectedTag === null) {
+                // Standalone creation path.
+                setIsSubmitting(true);
+                const trimmedDesc = description.trim();
+                const trimmedAliases = aliases
+                  .map((a) => a.trim())
+                  .filter((a) => a.length > 0);
+                createEntityMutation.mutate(
+                  {
+                    name: name.trim(),
+                    entity_type: entityType,
+                    ...(trimmedDesc ? { description: trimmedDesc } : {}),
+                    ...(trimmedAliases.length > 0
+                      ? { aliases: trimmedAliases }
+                      : {}),
+                  },
+                  {
+                    onSuccess: () => {
+                      onSuccess?.();
+                      onClose();
+                    },
+                    onError: (err) => {
+                      setError(
+                        err.message || "Failed to create entity. Please try again."
+                      );
+                    },
+                    onSettled: () => {
+                      setIsSubmitting(false);
+                    },
+                  }
+                );
+                return;
+              }
+
+              setIsSubmitting(true);
+              const trimmedDesc = description.trim();
+              classifyTagMutation.mutate(
+                {
+                  normalized_form: selectedTag.normalized_form,
+                  entity_type: entityType,
+                  ...(trimmedDesc ? { description: trimmedDesc } : {}),
+                },
+                {
+                  onSuccess: () => {
+                    onSuccess?.();
+                    onClose();
+                  },
+                  onError: (err) => {
+                    setError(
+                      err.message.length > 0
+                        ? err.message
+                        : "Failed to create entity. Please try again."
+                    );
+                  },
+                  onSettled: () => {
+                    setIsSubmitting(false);
+                  },
+                }
+              );
+            }}
+            className="
+              min-h-[44px]
+              px-5 py-2
+              text-sm font-medium text-white
+              bg-indigo-600 rounded-lg
+              hover:bg-indigo-700
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1
+              disabled:opacity-50 disabled:cursor-not-allowed
+              transition-colors
+            "
+          >
+            {isSubmitting ? (
+              <span className="inline-flex items-center gap-2">
+                <svg
+                  className="w-4 h-4 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Creating…
+              </span>
+            ) : (
+              "Create Entity"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Named re-export for consumers that prefer named imports
+// ---------------------------------------------------------------------------
+export { CreateEntityModal };

--- a/frontend/src/components/entity/__tests__/CreateEntityModal.test.tsx
+++ b/frontend/src/components/entity/__tests__/CreateEntityModal.test.tsx
@@ -1,0 +1,1326 @@
+/**
+ * Tests for CreateEntityModal — tag-backed creation path.
+ *
+ * Coverage (Feature 038, T019 [US1]):
+ * - Modal opens with focus on name field
+ * - Autocomplete queries useCanonicalTags after 2+ chars
+ * - Tag selection shows "Creating from tag" chip with canonical form (FR-004)
+ * - Entity type selector lists all 8 ENTITY_PRODUCING_TYPES (FR-005)
+ * - Tooltip text appears for a selected type (FR-005.1)
+ * - "Other" type shows non-blocking hint text (FR-005.2)
+ * - Submit calls classifyTag mutation with correct params (tag-backed path)
+ * - Loading state disables fields and changes button text (FR-016)
+ * - Error banner appears on mutation failure and modal stays open (FR-016)
+ * - Modal closes and onSuccess is called after successful submission
+ * - onClose callback is called (parent is responsible for focus return)
+ * - Escape closes the modal when no dropdown is open
+ * - Escape closes the dropdown first when one is open, then the modal
+ * - Focus trap: Tab from last focusable element wraps to first
+ * - Shift+Tab from first focusable element wraps to last
+ * - Backdrop click calls onClose
+ * - X button calls onClose
+ * - Cancel button calls onClose
+ * - Editing name after tag selection clears the tag chip (FR-004 mode transition)
+ * - Submit button is disabled until name and type are both provided
+ * - Form resets when the modal closes and re-opens
+ *
+ * NOTE: The entity type <select> carries the implicit ARIA role "combobox".
+ * To avoid ambiguity with the name <input role="combobox">, all queries that
+ * target the name input use getByLabelText("Name") and queries that target
+ * the type select use getByLabelText(/entity type/i).
+ */
+
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before component imports (vi.mock hoisting)
+// ---------------------------------------------------------------------------
+
+vi.mock("../../../hooks/useCanonicalTags", () => ({
+  useCanonicalTags: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useEntityMentions", () => ({
+  useClassifyTag: vi.fn(),
+  useVideoEntities: vi.fn(),
+  useEntityVideos: vi.fn(),
+  useEntities: vi.fn(),
+  useCreateManualAssociation: vi.fn(),
+  useDeleteManualAssociation: vi.fn(),
+  useCheckDuplicate: vi.fn(),
+  useCreateEntity: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import CreateEntityModal from "../CreateEntityModal";
+import type { CreateEntityModalProps } from "../CreateEntityModal";
+import { useCanonicalTags } from "../../../hooks/useCanonicalTags";
+import { useClassifyTag, useCheckDuplicate, useCreateEntity } from "../../../hooks/useEntityMentions";
+import type { Mock } from "vitest";
+import { ENTITY_PRODUCING_TYPES, ENTITY_TYPE_TOOLTIPS } from "../../../constants/entityTypes";
+
+// ---------------------------------------------------------------------------
+// DOM query helpers
+// ---------------------------------------------------------------------------
+
+/** The name <input role="combobox"> is labelled "Name" via htmlFor. */
+const getNameInput = () => screen.getByLabelText(/^name/i) as HTMLInputElement;
+
+/** The entity-type <select> is labelled "Entity type" via htmlFor. */
+const getTypeSelect = () => screen.getByLabelText(/entity type/i) as HTMLSelectElement;
+
+/** Description textarea. */
+const getDescriptionField = () => screen.getByLabelText(/description/i) as HTMLTextAreaElement;
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeTag(overrides: {
+  canonical_form?: string;
+  normalized_form?: string;
+  alias_count?: number;
+  video_count?: number;
+} = {}) {
+  return {
+    canonical_form: "Garfield",
+    normalized_form: "garfield",
+    alias_count: 3,
+    video_count: 42,
+    ...overrides,
+  };
+}
+
+function makeClassifyTagMutation(overrides: {
+  mutate?: Mock;
+  isPending?: boolean;
+  isError?: boolean;
+  error?: Error | null;
+} = {}) {
+  return {
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function makeCreateEntityMutation(overrides: {
+  mutate?: Mock;
+  isPending?: boolean;
+  isError?: boolean;
+  error?: Error | null;
+} = {}) {
+  return {
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default hook mock values
+// ---------------------------------------------------------------------------
+
+function setupDefaultMocks() {
+  (useCanonicalTags as Mock).mockReturnValue({
+    tags: [],
+    suggestions: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    isRateLimited: false,
+    rateLimitRetryAfter: 0,
+  });
+
+  (useClassifyTag as Mock).mockReturnValue(makeClassifyTagMutation());
+
+  (useCreateEntity as Mock).mockReturnValue(makeCreateEntityMutation());
+
+  // Default: no duplicate found — keeps all pre-existing tests green.
+  (useCheckDuplicate as Mock).mockReturnValue({
+    data: { is_duplicate: false, existing_entity: null },
+    isLoading: false,
+    isError: false,
+  });
+}
+
+function mockTagResults(tags: ReturnType<typeof makeTag>[]) {
+  (useCanonicalTags as Mock).mockReturnValue({
+    tags,
+    suggestions: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    isRateLimited: false,
+    rateLimitRetryAfter: 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function renderModal(props: Partial<CreateEntityModalProps> = {}) {
+  const defaults: CreateEntityModalProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onSuccess: vi.fn(),
+    ...props,
+  };
+  return {
+    onClose: defaults.onClose as Mock,
+    onSuccess: defaults.onSuccess as Mock,
+    ...render(
+      <MemoryRouter>
+        <CreateEntityModal {...defaults} />
+      </MemoryRouter>
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CreateEntityModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Conditional rendering
+  // -------------------------------------------------------------------------
+
+  describe("Conditional rendering", () => {
+    it("renders nothing when isOpen is false", () => {
+      renderModal({ isOpen: false });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("renders the dialog when isOpen is true", () => {
+      renderModal({ isOpen: true });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("dialog has an accessible title 'Create Entity'", () => {
+      renderModal();
+      expect(
+        screen.getByRole("dialog", { name: /create entity/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Auto-focus on open
+  // -------------------------------------------------------------------------
+
+  describe("Focus management", () => {
+    it("moves focus to the name input on open", async () => {
+      renderModal();
+      const nameInput = getNameInput();
+      // The component uses requestAnimationFrame; waitFor polls until it resolves.
+      await waitFor(() => {
+        expect(nameInput).toHaveFocus();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tag autocomplete: query trigger
+  // -------------------------------------------------------------------------
+
+  describe("Tag autocomplete — search trigger", () => {
+    it("passes an empty string to useCanonicalTags on initial render (name is empty)", () => {
+      renderModal();
+      expect(useCanonicalTags).toHaveBeenCalledWith("");
+    });
+
+    it("passes the typed value to useCanonicalTags when name has 2+ chars", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      expect(useCanonicalTags).toHaveBeenCalledWith("gar");
+    });
+
+    it("passes empty string to useCanonicalTags after a tag is selected (prevents re-query)", () => {
+      mockTagResults([makeTag()]);
+
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      // Select the option to set selectedTag
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+
+      // After selection, the hook receives "" so no new search fires
+      const calls = (useCanonicalTags as Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall?.[0]).toBe("");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tag autocomplete: dropdown items
+  // -------------------------------------------------------------------------
+
+  describe("Tag autocomplete — dropdown items", () => {
+    it("shows a listbox of tag results when name has 2+ chars and results arrive", () => {
+      mockTagResults([
+        makeTag({ canonical_form: "Garfield", normalized_form: "garfield" }),
+        makeTag({ canonical_form: "Garmin", normalized_form: "garmin", alias_count: 1, video_count: 5 }),
+      ]);
+
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+
+      expect(
+        screen.getByRole("listbox", { name: /matching canonical tags/i })
+      ).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: /garfield/i })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: /garmin/i })).toBeInTheDocument();
+    });
+
+    it("shows video count inside each dropdown option", () => {
+      mockTagResults([makeTag({ canonical_form: "Mexico", video_count: 910 })]);
+
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "me" } });
+
+      expect(screen.getByText("910 videos")).toBeInTheDocument();
+    });
+
+    it("shows alias count when alias_count is greater than 1", () => {
+      mockTagResults([makeTag({ canonical_form: "AOC", alias_count: 4, video_count: 20 })]);
+
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "ao" } });
+
+      // alias label = alias_count - 1 aliases
+      expect(screen.getByText("3 aliases")).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tag selection — chip and label (FR-004)
+  // -------------------------------------------------------------------------
+
+  describe("Tag selection (FR-004)", () => {
+    beforeEach(() => {
+      mockTagResults([
+        makeTag({
+          canonical_form: "Alexandria Ocasio-Cortez",
+          normalized_form: "alexandria_ocasio_cortez",
+        }),
+      ]);
+    });
+
+    it("shows 'Creating from tag' label after a tag is selected", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "alex" } });
+      fireEvent.click(screen.getByRole("option", { name: /alexandria ocasio-cortez/i }));
+
+      expect(screen.getByText("Creating from tag")).toBeInTheDocument();
+    });
+
+    it("shows a chip with the canonical form after tag selection", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "alex" } });
+      fireEvent.click(screen.getByRole("option", { name: /alexandria ocasio-cortez/i }));
+
+      // The chip text renders the canonical form
+      expect(screen.getAllByText("Alexandria Ocasio-Cortez").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("hides the dropdown after a tag is selected", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "alex" } });
+      fireEvent.click(screen.getByRole("option", { name: /alexandria ocasio-cortez/i }));
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("clears the tag chip and shows 'Creating standalone entity' when name is edited after selection (FR-004 mode transition)", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "alex" } });
+      fireEvent.click(screen.getByRole("option", { name: /alexandria ocasio-cortez/i }));
+
+      // Edit the name — triggers FR-004 mode transition
+      fireEvent.change(getNameInput(), { target: { value: "alexandria modified" } });
+
+      expect(screen.queryByText("Creating from tag")).not.toBeInTheDocument();
+      // Text appears in both the visible <p> and the sr-only aria-live region.
+      expect(screen.getAllByText("Creating standalone entity").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("clicking the chip X button removes the tag link", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "alex" } });
+      fireEvent.click(screen.getByRole("option", { name: /alexandria ocasio-cortez/i }));
+
+      const removeButton = screen.getByRole("button", {
+        name: /remove tag link to alexandria ocasio-cortez/i,
+      });
+      fireEvent.click(removeButton);
+
+      expect(screen.queryByText("Creating from tag")).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Standalone label (FR-011)
+  // -------------------------------------------------------------------------
+
+  describe("Standalone entity label (FR-011)", () => {
+    it("shows 'Creating standalone entity' when name has text but no tag selected", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "new entity name" } });
+      // Text appears in both the visible <p> and the sr-only aria-live region.
+      expect(screen.getAllByText("Creating standalone entity").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("does not show 'Creating standalone entity' when name is empty", () => {
+      renderModal();
+      // name defaults to ""; no changes applied
+      expect(screen.queryByText("Creating standalone entity")).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Entity type selector (FR-005)
+  // -------------------------------------------------------------------------
+
+  describe("Entity type selector (FR-005)", () => {
+    it("renders a type select dropdown", () => {
+      renderModal();
+      expect(getTypeSelect()).toBeInTheDocument();
+    });
+
+    it("includes all 8 entity-producing types as option values", () => {
+      renderModal();
+      const options = Array.from(getTypeSelect().options)
+        .map((opt) => opt.value)
+        .filter(Boolean); // exclude the empty placeholder
+
+      expect(options).toHaveLength(ENTITY_PRODUCING_TYPES.length);
+      ENTITY_PRODUCING_TYPES.forEach((type) => {
+        expect(options).toContain(type);
+      });
+    });
+
+    it("shows tooltip text for a selected type (FR-005.1)", () => {
+      renderModal();
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+      expect(screen.getByText(ENTITY_TYPE_TOOLTIPS["person"]!)).toBeInTheDocument();
+    });
+
+    it("shows tooltip text for 'organization' type", () => {
+      renderModal();
+      fireEvent.change(getTypeSelect(), { target: { value: "organization" } });
+      expect(screen.getByText(ENTITY_TYPE_TOOLTIPS["organization"]!)).toBeInTheDocument();
+    });
+
+    it("shows 'Other' hint text when 'other' type is selected (FR-005.2)", () => {
+      renderModal();
+      fireEvent.change(getTypeSelect(), { target: { value: "other" } });
+      expect(screen.getByRole("note")).toHaveTextContent(
+        /consider whether this entity fits one of the specific types above/i
+      );
+    });
+
+    it("does not show 'Other' hint when a non-other type is selected", () => {
+      renderModal();
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+      expect(screen.queryByRole("note")).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Submit button disabled state
+  // -------------------------------------------------------------------------
+
+  describe("Submit button disabled state", () => {
+    it("submit button is disabled when name is empty", () => {
+      renderModal();
+      expect(screen.getByRole("button", { name: /create entity/i })).toBeDisabled();
+    });
+
+    it("submit button is disabled when entity type is not selected", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "some name" } });
+      // entityType still ""
+      expect(screen.getByRole("button", { name: /create entity/i })).toBeDisabled();
+    });
+
+    it("submit button is enabled when name and type are both provided", () => {
+      mockTagResults([makeTag()]);
+
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      expect(screen.getByRole("button", { name: /create entity/i })).not.toBeDisabled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Submit handler — calls classifyTag with correct params (tag-backed path)
+  // -------------------------------------------------------------------------
+
+  describe("Submit handler (tag-backed path)", () => {
+    function setupForSubmit(mutateMock?: Mock) {
+      const mutate = mutateMock ?? vi.fn();
+      (useClassifyTag as Mock).mockReturnValue(makeClassifyTagMutation({ mutate }));
+      mockTagResults([makeTag({ canonical_form: "Garfield", normalized_form: "garfield" })]);
+      return mutate;
+    }
+
+    it("calls classifyTag.mutate with normalized_form and entity_type", () => {
+      const mutate = setupForSubmit();
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+      fireEvent.click(screen.getByRole("button", { name: /create entity/i }));
+
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          normalized_form: "garfield",
+          entity_type: "person",
+        }),
+        expect.any(Object) // mutation option callbacks
+      );
+    });
+
+    it("includes description when provided", () => {
+      const mutate = setupForSubmit();
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+      fireEvent.change(getDescriptionField(), {
+        target: { value: "Famous cartoon cat" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /create entity/i }));
+
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          normalized_form: "garfield",
+          entity_type: "person",
+          description: "Famous cartoon cat",
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it("omits description key when description field is empty", () => {
+      const mutate = setupForSubmit();
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+      // description left blank
+      fireEvent.click(screen.getByRole("button", { name: /create entity/i }));
+
+      const calledWith = (mutate as Mock).mock.calls[0]?.[0];
+      expect(calledWith).not.toHaveProperty("description");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state during submission (FR-016)
+  // -------------------------------------------------------------------------
+
+  describe("Loading state during submission (FR-016)", () => {
+    function setupSubmittingState() {
+      let capturedCallbacks: { onSettled?: () => void } = {};
+      const mutate = vi.fn((_vars: unknown, callbacks: typeof capturedCallbacks) => {
+        capturedCallbacks = callbacks;
+      });
+      (useClassifyTag as Mock).mockReturnValue(makeClassifyTagMutation({ mutate }));
+      mockTagResults([makeTag()]);
+      return { mutate, getCallbacks: () => capturedCallbacks };
+    }
+
+    function triggerSubmit() {
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+      fireEvent.click(screen.getByRole("button", { name: /create entity/i }));
+    }
+
+    it("shows 'Creating…' text and aria-busy on the submit button while submitting", async () => {
+      const { getCallbacks } = setupSubmittingState();
+      renderModal();
+      triggerSubmit();
+
+      // Wait for the spinner span — its text is the ellipsis character "…" (U+2026),
+      // not the ASCII "..." sequence. The component renders: Creating…
+      await waitFor(() => {
+        expect(screen.getByText("Creating…")).toBeInTheDocument();
+      });
+
+      // The submit button should report aria-busy while isSubmitting is true.
+      // It no longer matches "Create Entity" (that text is gone), so we query
+      // by aria-busy attribute on the button element.
+      const submitBtn = screen
+        .getAllByRole("button")
+        .find((btn) => btn.getAttribute("aria-busy") === "true");
+      expect(submitBtn).toBeDefined();
+      expect(submitBtn).toHaveAttribute("aria-busy", "true");
+
+      // Resolve to avoid act() warnings after test completes
+      act(() => { getCallbacks().onSettled?.(); });
+    });
+
+    it("disables name input, type select, and description textarea while submitting", async () => {
+      const { getCallbacks } = setupSubmittingState();
+      renderModal();
+      triggerSubmit();
+
+      await waitFor(() => {
+        expect(screen.getByText("Creating…")).toBeInTheDocument();
+      });
+
+      // getByLabelText works on disabled elements — it finds by label association
+      expect(getNameInput()).toBeDisabled();
+      expect(getTypeSelect()).toBeDisabled();
+      expect(getDescriptionField()).toBeDisabled();
+
+      act(() => { getCallbacks().onSettled?.(); });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error display on mutation failure (FR-016)
+  // -------------------------------------------------------------------------
+
+  describe("Error display on mutation failure (FR-016)", () => {
+    interface CapturableCallbacks {
+      onError?: (err: Error) => void;
+      onSettled?: () => void;
+    }
+
+    function setupWithCapturableError() {
+      let capturedCallbacks: CapturableCallbacks = {};
+      const mutate = vi.fn((_vars: unknown, callbacks: CapturableCallbacks) => {
+        capturedCallbacks = callbacks;
+      });
+      (useClassifyTag as Mock).mockReturnValue(makeClassifyTagMutation({ mutate }));
+      mockTagResults([makeTag()]);
+
+      return {
+        mutate,
+        fireError: (msg: string) => {
+          act(() => {
+            capturedCallbacks.onError?.(new Error(msg));
+            capturedCallbacks.onSettled?.();
+          });
+        },
+      };
+    }
+
+    function triggerSubmit() {
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+      fireEvent.click(screen.getByRole("button", { name: /create entity/i }));
+    }
+
+    it("shows an error banner with the error message", async () => {
+      const { fireError } = setupWithCapturableError();
+      renderModal();
+      triggerSubmit();
+      fireError("Tag already classified");
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent("Tag already classified");
+      });
+    });
+
+    it("modal stays open and onClose is not called after a mutation error", async () => {
+      const { fireError } = setupWithCapturableError();
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      triggerSubmit();
+      fireError("Something went wrong");
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("uses a fallback message when the error has an empty message string", async () => {
+      const { fireError } = setupWithCapturableError();
+      renderModal();
+      triggerSubmit();
+      fireError("");
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(/failed to create entity/i);
+      });
+    });
+
+    it("clears the error banner when the user edits the name after a failure", async () => {
+      const { fireError } = setupWithCapturableError();
+      renderModal();
+      triggerSubmit();
+      fireError("Server error");
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+      });
+
+      // Editing the name should clear the error
+      fireEvent.change(getNameInput(), { target: { value: "garfield updated" } });
+
+      await waitFor(() => {
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Success: modal closes and onSuccess is called
+  // -------------------------------------------------------------------------
+
+  describe("Success behaviour", () => {
+    it("calls onSuccess and onClose after successful mutation", async () => {
+      interface CapturableCallbacks { onSuccess?: () => void; onSettled?: () => void }
+      let capturedCallbacks: CapturableCallbacks = {};
+      const mutate = vi.fn((_vars: unknown, cbs: CapturableCallbacks) => {
+        capturedCallbacks = cbs;
+      });
+      const onClose = vi.fn();
+      const onSuccess = vi.fn();
+      (useClassifyTag as Mock).mockReturnValue(makeClassifyTagMutation({ mutate }));
+      mockTagResults([makeTag()]);
+
+      renderModal({ onClose, onSuccess });
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+      fireEvent.click(screen.getByRole("button", { name: /create entity/i }));
+
+      act(() => {
+        capturedCallbacks.onSuccess?.();
+        capturedCallbacks.onSettled?.();
+      });
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Close mechanisms
+  // -------------------------------------------------------------------------
+
+  describe("Close mechanisms", () => {
+    it("calls onClose when the X (close dialog) button is clicked", () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      fireEvent.click(screen.getByRole("button", { name: /close dialog/i }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when the Cancel button is clicked", () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when the backdrop wrapper is clicked", () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      // The dialog role element is the inner panel. Its parent is the full-screen backdrop.
+      const backdrop = screen.getByRole("dialog").parentElement!;
+      fireEvent.click(backdrop);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT call onClose when the dialog panel itself is clicked", () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      // Clicking the dialog panel (not the backdrop) should not close the modal.
+      fireEvent.click(screen.getByRole("dialog"));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Escape key behaviour
+  // -------------------------------------------------------------------------
+
+  describe("Escape key", () => {
+    it("calls onClose when Escape is pressed and no dropdown is open", () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the dropdown on first Escape, then the modal on second Escape", () => {
+      const onClose = vi.fn();
+      mockTagResults([makeTag()]);
+
+      renderModal({ onClose });
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+
+      // Dropdown should be visible
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+      // First Escape: closes dropdown only
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+
+      // Second Escape: closes modal
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onClose when Escape is pressed while the modal is closed", () => {
+      const onClose = vi.fn();
+      renderModal({ isOpen: false, onClose });
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Focus trap (Tab/Shift+Tab wrapping)
+  // -------------------------------------------------------------------------
+
+  describe("Focus trap", () => {
+    const FOCUSABLE_SELECTOR = [
+      "a[href]",
+      "button:not([disabled])",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(", ");
+
+    it("Tab from the last focusable element wraps focus to the first", () => {
+      renderModal();
+      const dialog = screen.getByRole("dialog");
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((el) => !el.hidden);
+
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+
+      last.focus();
+      fireEvent.keyDown(dialog, { key: "Tab", shiftKey: false });
+
+      expect(document.activeElement).toBe(first);
+    });
+
+    it("Shift+Tab from the first focusable element wraps focus to the last", () => {
+      renderModal();
+      const dialog = screen.getByRole("dialog");
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((el) => !el.hidden);
+
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+
+      first.focus();
+      fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+
+      expect(document.activeElement).toBe(last);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dropdown keyboard navigation (ArrowDown, ArrowUp, Enter)
+  // -------------------------------------------------------------------------
+
+  describe("Dropdown keyboard navigation", () => {
+    beforeEach(() => {
+      mockTagResults([
+        makeTag({ canonical_form: "Alpha", normalized_form: "alpha" }),
+        makeTag({ canonical_form: "Beta", normalized_form: "beta" }),
+      ]);
+    });
+
+    it("ArrowDown highlights the first option", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "al" } });
+      fireEvent.keyDown(getNameInput(), { key: "ArrowDown" });
+
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("Enter on a highlighted option selects it and shows the chip", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "al" } });
+      fireEvent.keyDown(getNameInput(), { key: "ArrowDown" });
+      fireEvent.keyDown(getNameInput(), { key: "Enter" });
+
+      expect(screen.getByText("Creating from tag")).toBeInTheDocument();
+      expect(getNameInput()).toHaveValue("Alpha");
+    });
+
+    it("Escape when dropdown is open closes the dropdown without closing the modal", () => {
+      const onClose = vi.fn();
+      renderModal({ onClose });
+
+      fireEvent.change(getNameInput(), { target: { value: "al" } });
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+      // Escape on the input element (not document) — component handles it inline
+      fireEvent.keyDown(getNameInput(), { key: "Escape" });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      // Modal stays open
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Form reset on close/re-open
+  // -------------------------------------------------------------------------
+
+  describe("Form reset on close", () => {
+    it("resets the name field when the modal is closed and re-opened", () => {
+      const { rerender } = renderModal({ isOpen: true });
+
+      fireEvent.change(getNameInput(), { target: { value: "some text" } });
+      expect(getNameInput()).toHaveValue("some text");
+
+      // Close
+      rerender(
+        <MemoryRouter>
+          <CreateEntityModal isOpen={false} onClose={vi.fn()} />
+        </MemoryRouter>
+      );
+
+      // Re-open
+      rerender(
+        <MemoryRouter>
+          <CreateEntityModal isOpen={true} onClose={vi.fn()} />
+        </MemoryRouter>
+      );
+
+      expect(getNameInput()).toHaveValue("");
+    });
+
+    it("resets the entity type select when the modal is closed and re-opened", () => {
+      const { rerender } = renderModal({ isOpen: true });
+
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+      expect(getTypeSelect()).toHaveValue("person");
+
+      rerender(
+        <MemoryRouter>
+          <CreateEntityModal isOpen={false} onClose={vi.fn()} />
+        </MemoryRouter>
+      );
+      rerender(
+        <MemoryRouter>
+          <CreateEntityModal isOpen={true} onClose={vi.fn()} />
+        </MemoryRouter>
+      );
+
+      expect(getTypeSelect()).toHaveValue("");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Duplicate Detection (US3)
+  // -------------------------------------------------------------------------
+
+  describe("Duplicate Detection (US3)", () => {
+    /** Shared factory for the existing-entity payload. */
+    function makeExistingEntity(overrides: {
+      entity_id?: string;
+      canonical_name?: string;
+      entity_type?: string;
+      description?: string | null;
+    } = {}) {
+      return {
+        entity_id: "uuid-123",
+        canonical_name: "Garland Nixon",
+        entity_type: "person",
+        description: "Political commentator",
+        ...overrides,
+      };
+    }
+
+    /** Mock useCheckDuplicate to return a confirmed duplicate. */
+    function mockDuplicateFound(overrides: ReturnType<typeof makeExistingEntity> = makeExistingEntity()) {
+      (useCheckDuplicate as Mock).mockReturnValue({
+        data: { is_duplicate: true, existing_entity: overrides },
+        isLoading: false,
+        isError: false,
+      });
+    }
+
+    /** Mock useCheckDuplicate to return no duplicate. */
+    function mockNoDuplicate() {
+      (useCheckDuplicate as Mock).mockReturnValue({
+        data: { is_duplicate: false, existing_entity: null },
+        isLoading: false,
+        isError: false,
+      });
+    }
+
+    it("warning appears when a duplicate is found", () => {
+      mockDuplicateFound();
+      renderModal();
+
+      // Trigger the component to render with a name + type (hook is controlled by mock)
+      fireEvent.change(getNameInput(), { target: { value: "Garland Nixon" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      expect(
+        screen.getByText("An entity with this name and type already exists:")
+      ).toBeInTheDocument();
+    });
+
+    it("submit button is disabled when a duplicate is found", () => {
+      mockDuplicateFound();
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "Garland Nixon" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      expect(screen.getByRole("button", { name: /create entity/i })).toBeDisabled();
+    });
+
+    it("warning contains a link that navigates to the existing entity", () => {
+      mockDuplicateFound();
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "Garland Nixon" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      const link = screen.getByRole("link", { name: /view existing entity/i });
+      expect(link).toHaveAttribute("href", "/entities/uuid-123");
+    });
+
+    it("warning clears when the name is changed and no duplicate exists for the new value", async () => {
+      // First render with duplicate
+      mockDuplicateFound();
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "Garland Nixon" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      expect(
+        screen.getByText("An entity with this name and type already exists:")
+      ).toBeInTheDocument();
+
+      // Simulate the hook returning no duplicate for the updated name
+      mockNoDuplicate();
+
+      fireEvent.change(getNameInput(), { target: { value: "Garland Nixon Jr" } });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("An entity with this name and type already exists:")
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("warning clears when the entity type is changed and no duplicate exists for the new type", async () => {
+      // Start with a duplicate detected for "person"
+      mockDuplicateFound();
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "Garland Nixon" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      expect(
+        screen.getByText("An entity with this name and type already exists:")
+      ).toBeInTheDocument();
+
+      // Simulate the hook returning no duplicate for "organization" type
+      mockNoDuplicate();
+
+      fireEvent.change(getTypeSelect(), { target: { value: "organization" } });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("An entity with this name and type already exists:")
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("fallback: submit is NOT disabled when the duplicate check endpoint fails (FR-012)", () => {
+      // isError = true means the endpoint failed — fallback allows submission
+      (useCheckDuplicate as Mock).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      });
+
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "Garland Nixon" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      expect(screen.getByRole("button", { name: /create entity/i })).not.toBeDisabled();
+    });
+
+    it("duplicate warning element has aria-live='assertive'", () => {
+      mockDuplicateFound();
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "Garland Nixon" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      // The warning div carries both role="alert" and aria-live="assertive".
+      // role="alert" has no computed accessible name from inner text, so we
+      // locate it via role then confirm the attribute directly.
+      const warningEl = screen.getByRole("alert");
+      expect(warningEl).toHaveAttribute("aria-live", "assertive");
+    });
+
+    it("submit button is disabled while the duplicate check is pending", () => {
+      // isLoading = true simulates an in-flight request
+      (useCheckDuplicate as Mock).mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      });
+
+      renderModal();
+
+      // Provide name (2+ chars) and type so isDuplicateCheckPending evaluates to true
+      fireEvent.change(getNameInput(), { target: { value: "Garland Nixon" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      expect(screen.getByRole("button", { name: /create entity/i })).toBeDisabled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Standalone Entity Creation (US2)
+  // -------------------------------------------------------------------------
+
+  describe("Standalone Entity Creation (US2)", () => {
+    // -----------------------------------------------------------------------
+    // 1. "Creating standalone entity" label when no tag match
+    // -----------------------------------------------------------------------
+
+    it("shows 'Creating standalone entity' label when name has text and no tag is selected", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "edward snowden" } });
+      // The text appears in both the visible <p> and the sr-only aria-live region.
+      expect(screen.getAllByText("Creating standalone entity").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // -----------------------------------------------------------------------
+    // 2. Add alias fields (up to 20)
+    // -----------------------------------------------------------------------
+
+    it("shows an alias input after clicking 'Add Alias'", () => {
+      renderModal();
+      const addButton = screen.getByRole("button", { name: /\+ add alias/i });
+      fireEvent.click(addButton);
+      expect(screen.getByLabelText("Alias 1")).toBeInTheDocument();
+    });
+
+    it("shows a second alias input after clicking 'Add Alias' twice", () => {
+      renderModal();
+      const addButton = screen.getByRole("button", { name: /\+ add alias/i });
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+      expect(screen.getByLabelText("Alias 1")).toBeInTheDocument();
+      expect(screen.getByLabelText("Alias 2")).toBeInTheDocument();
+    });
+
+    it("disables 'Add Alias' button after 20 aliases are added", () => {
+      renderModal();
+      const addButton = screen.getByRole("button", { name: /\+ add alias/i });
+      // Click 20 times to reach the cap.
+      for (let i = 0; i < 20; i++) {
+        fireEvent.click(addButton);
+      }
+      expect(addButton).toBeDisabled();
+    });
+
+    // -----------------------------------------------------------------------
+    // 3. Remove alias field
+    // -----------------------------------------------------------------------
+
+    it("removes an alias input when the remove (X) button is clicked", () => {
+      renderModal();
+      const addButton = screen.getByRole("button", { name: /\+ add alias/i });
+      fireEvent.click(addButton);
+
+      const aliasInput = screen.getByLabelText("Alias 1");
+      fireEvent.change(aliasInput, { target: { value: "Ed Snowden" } });
+
+      const removeButton = screen.getByRole("button", { name: "Remove alias 1" });
+      fireEvent.click(removeButton);
+
+      expect(screen.queryByLabelText("Alias 1")).not.toBeInTheDocument();
+    });
+
+    // -----------------------------------------------------------------------
+    // 4. Mode transition: tag-backed → standalone on name edit; aliases cleared
+    //    when switching back to tag-backed mode.
+    // -----------------------------------------------------------------------
+
+    it("transitions from 'Creating from tag' to 'Creating standalone entity' when name is edited", () => {
+      mockTagResults([makeTag({ canonical_form: "Garfield", normalized_form: "garfield" })]);
+      renderModal();
+
+      // Select a tag → tag-backed mode.
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+      expect(screen.getByText("Creating from tag")).toBeInTheDocument();
+
+      // Edit the name → standalone mode.
+      fireEvent.change(getNameInput(), { target: { value: "garfield modified" } });
+      expect(screen.queryByText("Creating from tag")).not.toBeInTheDocument();
+      // Text appears in both the visible <p> and the sr-only aria-live region.
+      expect(screen.getAllByText("Creating standalone entity").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("clears alias inputs when switching back to tag-backed mode via tag selection", () => {
+      mockTagResults([makeTag({ canonical_form: "Garfield", normalized_form: "garfield" })]);
+      renderModal();
+
+      // Add an alias in standalone mode.
+      const addButton = screen.getByRole("button", { name: /\+ add alias/i });
+      fireEvent.click(addButton);
+      expect(screen.getByLabelText("Alias 1")).toBeInTheDocument();
+
+      // Type enough to trigger the dropdown and select a tag (switches to tag-backed mode).
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+
+      // Aliases should be cleared; the alias section is hidden in tag-backed mode.
+      expect(screen.queryByLabelText("Alias 1")).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /\+ add alias/i })).not.toBeInTheDocument();
+    });
+
+    // -----------------------------------------------------------------------
+    // 5. aria-live="polite" announcement on mode switch
+    // -----------------------------------------------------------------------
+
+    it("has an aria-live='polite' region that announces 'Creating standalone entity' when in standalone mode", () => {
+      renderModal();
+      fireEvent.change(getNameInput(), { target: { value: "edward snowden" } });
+
+      // The sr-only div carries aria-live="polite".
+      const liveRegions = document
+        .querySelectorAll('[aria-live="polite"]');
+
+      // At least one live region must contain the standalone announcement.
+      const announcementRegion = Array.from(liveRegions).find(
+        (el) => el.textContent?.includes("Creating standalone entity")
+      );
+      expect(announcementRegion).toBeDefined();
+    });
+
+    it("has an aria-live='polite' region that announces the tag name when a tag is selected", () => {
+      mockTagResults([makeTag({ canonical_form: "Garfield", normalized_form: "garfield" })]);
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+
+      const liveRegions = document.querySelectorAll('[aria-live="polite"]');
+      const announcementRegion = Array.from(liveRegions).find(
+        (el) => el.textContent?.includes("Creating from tag: Garfield")
+      );
+      expect(announcementRegion).toBeDefined();
+    });
+
+    // -----------------------------------------------------------------------
+    // 6. Submit triggers createEntity with correct params including aliases
+    // -----------------------------------------------------------------------
+
+    it("calls createEntity.mutate with name, entity_type, and aliases on submit", () => {
+      const mockMutate = vi.fn();
+      (useCreateEntity as Mock).mockReturnValue(makeCreateEntityMutation({ mutate: mockMutate }));
+
+      renderModal();
+
+      // Fill in the form in standalone mode (no tag selected).
+      fireEvent.change(getNameInput(), { target: { value: "edward snowden" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      // Add two aliases.
+      const addButton = screen.getByRole("button", { name: /\+ add alias/i });
+      fireEvent.click(addButton);
+      fireEvent.change(screen.getByLabelText("Alias 1"), {
+        target: { value: "Ed Snowden" },
+      });
+      fireEvent.click(addButton);
+      fireEvent.change(screen.getByLabelText("Alias 2"), {
+        target: { value: "Snowden" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /create entity/i }));
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "edward snowden",
+          entity_type: "person",
+          aliases: ["Ed Snowden", "Snowden"],
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it("omits aliases key from createEntity payload when all alias inputs are blank", () => {
+      const mockMutate = vi.fn();
+      (useCreateEntity as Mock).mockReturnValue(makeCreateEntityMutation({ mutate: mockMutate }));
+
+      renderModal();
+
+      fireEvent.change(getNameInput(), { target: { value: "edward snowden" } });
+      fireEvent.change(getTypeSelect(), { target: { value: "person" } });
+
+      // Add an alias but leave it blank.
+      const addButton = screen.getByRole("button", { name: /\+ add alias/i });
+      fireEvent.click(addButton);
+      // Alias input left empty — it will be filtered out.
+
+      fireEvent.click(screen.getByRole("button", { name: /create entity/i }));
+
+      const calledWith = (mockMutate as Mock).mock.calls[0]?.[0];
+      expect(calledWith).not.toHaveProperty("aliases");
+    });
+
+    // -----------------------------------------------------------------------
+    // 7. Alias inputs NOT shown in tag-backed mode
+    // -----------------------------------------------------------------------
+
+    it("does not show 'Add Alias' button when a tag is selected (tag-backed mode)", () => {
+      mockTagResults([makeTag({ canonical_form: "Garfield", normalized_form: "garfield" })]);
+      renderModal();
+
+      // Select a tag to enter tag-backed mode.
+      fireEvent.change(getNameInput(), { target: { value: "gar" } });
+      fireEvent.click(screen.getByRole("option", { name: /garfield/i }));
+
+      expect(screen.queryByRole("button", { name: /\+ add alias/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/constants/entityTypes.ts
+++ b/frontend/src/constants/entityTypes.ts
@@ -1,0 +1,128 @@
+/**
+ * Centralized entity type constants for named entity UI.
+ *
+ * These constants are shared across EntitiesPage, EntityDetailPage, and any
+ * future component that renders entity type badges, filter tabs, or tooltips.
+ * Import from here instead of redefining per-file.
+ *
+ * @module constants/entityTypes
+ */
+
+// ---------------------------------------------------------------------------
+// Labels
+// ---------------------------------------------------------------------------
+
+/**
+ * Human-readable display label for each entity_type value from the backend.
+ * Covers all 8 entity-producing types.
+ */
+export const ENTITY_TYPE_LABELS: Record<string, string> = {
+  person: "Person",
+  organization: "Organization",
+  place: "Place",
+  event: "Event",
+  work: "Work",
+  technical_term: "Technical Term",
+  concept: "Concept",
+  other: "Other",
+};
+
+// ---------------------------------------------------------------------------
+// Colors
+// ---------------------------------------------------------------------------
+
+/**
+ * Tailwind CSS badge colour classes for each entity_type value.
+ *
+ * Each value is a space-joined set of bg-, text-, and border- utility classes
+ * suitable for use inside an `<span className={...}>` badge element.
+ * Falls back to slate neutral when the type is unrecognised.
+ */
+export const ENTITY_TYPE_COLORS: Record<string, string> = {
+  person: "bg-indigo-100 text-indigo-700 border-indigo-200",
+  organization: "bg-violet-100 text-violet-700 border-violet-200",
+  place: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  event: "bg-amber-100 text-amber-700 border-amber-200",
+  work: "bg-sky-100 text-sky-700 border-sky-200",
+  technical_term: "bg-teal-100 text-teal-700 border-teal-200",
+  concept: "bg-rose-100 text-rose-700 border-rose-200",
+  other: "bg-slate-100 text-slate-700 border-slate-200",
+};
+
+// ---------------------------------------------------------------------------
+// Tabs
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter tab definitions for the entity list page.
+ *
+ * The first entry ("all") is the unfiltered default; the remaining entries
+ * correspond 1-to-1 with ENTITY_PRODUCING_TYPES.
+ *
+ * `value` is the URL query-param / API filter value.
+ * `label` is the human-readable tab label.
+ */
+export const ENTITY_TYPE_TABS: Array<{ value: string; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "person", label: "Person" },
+  { value: "organization", label: "Organization" },
+  { value: "place", label: "Place" },
+  { value: "event", label: "Event" },
+  { value: "work", label: "Work" },
+  { value: "technical_term", label: "Technical Term" },
+  { value: "concept", label: "Concept" },
+  { value: "other", label: "Other" },
+];
+
+// ---------------------------------------------------------------------------
+// Tooltips
+// ---------------------------------------------------------------------------
+
+/**
+ * Tooltip definition strings for each entity_type value.
+ *
+ * Each value provides a short definition followed by representative examples
+ * drawn from the types of content chronovista transcripts typically cover
+ * (politics, economics, technology, history).
+ */
+export const ENTITY_TYPE_TOOLTIPS: Record<string, string> = {
+  person:
+    "A named human being. Examples: Alexandria Ocasio-Cortez, Edward Snowden, Adam Smith",
+  organization:
+    "A company, institution, government body, or formal group. Examples: Federal Reserve, NATO, OpenAI",
+  place:
+    "A named geographic location or region. Examples: Gaza Strip, Silicon Valley, European Union",
+  event:
+    "A named historical, political, or cultural event. Examples: January 6th, Bretton Woods Conference, Arab Spring",
+  work:
+    "A created artifact: book, film, law, treaty, software, or named project. Examples: The Wealth of Nations, Citizens United, GPT-4",
+  technical_term:
+    "A specific named method, technique, or mechanism from a specialized domain. Examples: GraphRAG, quantitative easing, filibuster",
+  concept:
+    "A broader idea, framework, principle, or abstraction. Examples: regulatory capture, neoliberalism, separation of powers",
+  other:
+    "An entity that doesn't fit the categories above. Review periodically for new type patterns.",
+};
+
+// ---------------------------------------------------------------------------
+// Producing-types list
+// ---------------------------------------------------------------------------
+
+/**
+ * The 8 entity_type keys that can appear as the `entity_type` field on a
+ * NamedEntity record returned from the backend.
+ *
+ * Use this array in selectors, validators, and any component that needs to
+ * enumerate only the concrete entity-producing types (i.e. excluding generic
+ * topic/descriptor meta-types that are not surfaced in the UI).
+ */
+export const ENTITY_PRODUCING_TYPES: string[] = [
+  "person",
+  "organization",
+  "place",
+  "event",
+  "work",
+  "technical_term",
+  "concept",
+  "other",
+];

--- a/frontend/src/hooks/__tests__/useEntityCreation.test.tsx
+++ b/frontend/src/hooks/__tests__/useEntityCreation.test.tsx
@@ -1,0 +1,716 @@
+/**
+ * Tests for entity creation hooks in hooks/useEntityMentions.ts.
+ *
+ * Coverage:
+ * - useClassifyTag: calls classifyTag() and invalidates entities, entitySearch,
+ *   canonical-tags caches on success
+ * - useCreateEntity: calls createEntity() and invalidates entities, entitySearch
+ *   caches on success — canonical-tags is intentionally NOT invalidated
+ * - useCheckDuplicate: query enabled/disabled logic based on name length and
+ *   entityType presence
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+import {
+  classifyTag,
+  checkEntityDuplicate,
+  createEntity,
+} from "../../api/entityMentions";
+import {
+  useClassifyTag,
+  useCreateEntity,
+  useCheckDuplicate,
+} from "../useEntityMentions";
+import type {
+  ClassifyTagResponse,
+  CreateEntityResponse,
+  DuplicateCheckResult,
+} from "../../api/entityMentions";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../api/entityMentions", () => ({
+  classifyTag: vi.fn(),
+  checkEntityDuplicate: vi.fn(),
+  createEntity: vi.fn(),
+  // Other exports that may be imported transitively — provide no-op stubs.
+  fetchVideoEntities: vi.fn(),
+  fetchEntityVideos: vi.fn(),
+  fetchEntities: vi.fn(),
+  createManualAssociation: vi.fn(),
+  deleteManualAssociation: vi.fn(),
+  searchEntities: vi.fn(),
+  createEntityAlias: vi.fn(),
+  fetchEntityDetail: vi.fn(),
+  addExclusionPattern: vi.fn(),
+  removeExclusionPattern: vi.fn(),
+  fetchPhoneticMatches: vi.fn(),
+}));
+
+const mockedClassifyTag = vi.mocked(classifyTag);
+const mockedCreateEntity = vi.mocked(createEntity);
+const mockedCheckEntityDuplicate = vi.mocked(checkEntityDuplicate);
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeClassifyTagResponse(
+  overrides: Partial<ClassifyTagResponse> = {}
+): ClassifyTagResponse {
+  return {
+    entity_id: "ent-uuid-001",
+    canonical_name: "React",
+    entity_type: "organization",
+    description: "JavaScript UI library",
+    alias_count: 1,
+    entity_created: true,
+    operation_id: "op-uuid-001",
+    ...overrides,
+  };
+}
+
+function makeCreateEntityResponse(
+  overrides: Partial<CreateEntityResponse> = {}
+): CreateEntityResponse {
+  return {
+    entity_id: "ent-uuid-002",
+    canonical_name: "Marie Curie",
+    entity_type: "person",
+    description: "Nobel Prize-winning physicist",
+    alias_count: 0,
+    ...overrides,
+  };
+}
+
+function makeDuplicateCheckResult(
+  overrides: Partial<DuplicateCheckResult> = {}
+): DuplicateCheckResult {
+  return {
+    is_duplicate: false,
+    existing_entity: null,
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// useClassifyTag
+// ===========================================================================
+
+describe("useClassifyTag — mutation execution", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+  });
+
+  it("calls classifyTag with the provided variables when mutate is invoked", async () => {
+    mockedClassifyTag.mockResolvedValueOnce(makeClassifyTagResponse());
+
+    const { result } = renderHook(() => useClassifyTag(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({
+        normalized_form: "React",
+        entity_type: "organization",
+        description: "JavaScript UI library",
+      });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(mockedClassifyTag).toHaveBeenCalledOnce();
+    expect(mockedClassifyTag).toHaveBeenCalledWith({
+      normalized_form: "React",
+      entity_type: "organization",
+      description: "JavaScript UI library",
+    });
+  });
+
+  it("transitions to isSuccess and returns the API response data on success", async () => {
+    const response = makeClassifyTagResponse({ entity_created: true });
+    mockedClassifyTag.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useClassifyTag(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ normalized_form: "React", entity_type: "organization" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data?.entity_created).toBe(true);
+  });
+
+  it("transitions to isError when the API call fails", async () => {
+    mockedClassifyTag.mockRejectedValueOnce({
+      type: "server",
+      message: "Conflict",
+      status: 409,
+    });
+
+    const { result } = renderHook(() => useClassifyTag(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ normalized_form: "React", entity_type: "organization" });
+    });
+
+    await waitFor(() => result.current.isError);
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isSuccess).toBe(false);
+  });
+});
+
+describe("useClassifyTag — onSuccess cache invalidation", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+  });
+
+  it("invalidates the entities cache after success", async () => {
+    mockedClassifyTag.mockResolvedValueOnce(makeClassifyTagResponse());
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useClassifyTag(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ normalized_form: "React", entity_type: "organization" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["entities"] })
+    );
+  });
+
+  it("invalidates the entitySearch cache after success", async () => {
+    mockedClassifyTag.mockResolvedValueOnce(makeClassifyTagResponse());
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useClassifyTag(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ normalized_form: "React", entity_type: "organization" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["entitySearch"] })
+    );
+  });
+
+  it("invalidates the canonical-tags cache after success", async () => {
+    mockedClassifyTag.mockResolvedValueOnce(makeClassifyTagResponse());
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useClassifyTag(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ normalized_form: "React", entity_type: "organization" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["canonical-tags"] })
+    );
+  });
+
+  it("invalidates all three caches (entities, entitySearch, canonical-tags) on a single success", async () => {
+    mockedClassifyTag.mockResolvedValueOnce(makeClassifyTagResponse());
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useClassifyTag(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ normalized_form: "TypeScript", entity_type: "product" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey
+    );
+
+    expect(invalidatedKeys).toContainEqual(["entities"]);
+    expect(invalidatedKeys).toContainEqual(["entitySearch"]);
+    expect(invalidatedKeys).toContainEqual(["canonical-tags"]);
+  });
+
+  it("does NOT invalidate canonical-tags when the mutation fails", async () => {
+    mockedClassifyTag.mockRejectedValueOnce({
+      type: "server",
+      message: "Internal Server Error",
+      status: 500,
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useClassifyTag(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ normalized_form: "React", entity_type: "organization" });
+    });
+
+    await waitFor(() => result.current.isError);
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey
+    );
+
+    expect(invalidatedKeys).not.toContainEqual(["canonical-tags"]);
+  });
+});
+
+// ===========================================================================
+// useCreateEntity
+// ===========================================================================
+
+describe("useCreateEntity — mutation execution", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+  });
+
+  it("calls createEntity with the provided payload when mutate is invoked", async () => {
+    mockedCreateEntity.mockResolvedValueOnce(makeCreateEntityResponse());
+
+    const { result } = renderHook(() => useCreateEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({
+        name: "Marie Curie",
+        entity_type: "person",
+        description: "Nobel Prize-winning physicist",
+      });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(mockedCreateEntity).toHaveBeenCalledOnce();
+    expect(mockedCreateEntity).toHaveBeenCalledWith({
+      name: "Marie Curie",
+      entity_type: "person",
+      description: "Nobel Prize-winning physicist",
+    });
+  });
+
+  it("transitions to isSuccess and returns the API response data on success", async () => {
+    const response = makeCreateEntityResponse({ canonical_name: "Marie Curie" });
+    mockedCreateEntity.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useCreateEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ name: "Marie Curie", entity_type: "person" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data?.canonical_name).toBe("Marie Curie");
+  });
+
+  it("transitions to isError when the API call fails", async () => {
+    mockedCreateEntity.mockRejectedValueOnce({
+      type: "server",
+      message: "Conflict — entity already exists",
+      status: 409,
+    });
+
+    const { result } = renderHook(() => useCreateEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ name: "Marie Curie", entity_type: "person" });
+    });
+
+    await waitFor(() => result.current.isError);
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isSuccess).toBe(false);
+  });
+
+  it("forwards optional aliases array to createEntity", async () => {
+    mockedCreateEntity.mockResolvedValueOnce(makeCreateEntityResponse({ alias_count: 2 }));
+
+    const { result } = renderHook(() => useCreateEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({
+        name: "Marie Curie",
+        entity_type: "person",
+        aliases: ["Maria Sklodowska-Curie", "Mme Curie"],
+      });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(mockedCreateEntity).toHaveBeenCalledWith(
+      expect.objectContaining({ aliases: ["Maria Sklodowska-Curie", "Mme Curie"] })
+    );
+  });
+});
+
+describe("useCreateEntity — onSuccess cache invalidation", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
+  });
+
+  it("invalidates the entities cache after success", async () => {
+    mockedCreateEntity.mockResolvedValueOnce(makeCreateEntityResponse());
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ name: "Marie Curie", entity_type: "person" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["entities"] })
+    );
+  });
+
+  it("invalidates the entitySearch cache after success", async () => {
+    mockedCreateEntity.mockResolvedValueOnce(makeCreateEntityResponse());
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ name: "Marie Curie", entity_type: "person" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["entitySearch"] })
+    );
+  });
+
+  it("does NOT invalidate canonical-tags after success — standalone entities are not linked to the tag taxonomy", async () => {
+    mockedCreateEntity.mockResolvedValueOnce(makeCreateEntityResponse());
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ name: "Marie Curie", entity_type: "person" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey
+    );
+
+    expect(invalidatedKeys).not.toContainEqual(["canonical-tags"]);
+  });
+
+  it("invalidates exactly entities and entitySearch — no other caches", async () => {
+    mockedCreateEntity.mockResolvedValueOnce(makeCreateEntityResponse());
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ name: "Marie Curie", entity_type: "person" });
+    });
+
+    await waitFor(() => result.current.isSuccess);
+
+    // Exactly two invalidation calls
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey
+    );
+    expect(invalidatedKeys).toContainEqual(["entities"]);
+    expect(invalidatedKeys).toContainEqual(["entitySearch"]);
+  });
+});
+
+// ===========================================================================
+// useCheckDuplicate
+// ===========================================================================
+
+describe("useCheckDuplicate — enabled/disabled logic", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    // Use resetAllMocks (not just clearAllMocks) so that any unconsumed
+    // mockResolvedValueOnce entries from previous tests are flushed from
+    // the implementation queue before the next test sets up its own mock.
+    vi.resetAllMocks();
+  });
+
+  it("does not fetch when name is empty", () => {
+    const { result } = renderHook(
+      () => useCheckDuplicate("", "person"),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    expect(mockedCheckEntityDuplicate).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("does not fetch when name has fewer than 2 characters", () => {
+    const { result } = renderHook(
+      () => useCheckDuplicate("A", "person"),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    expect(mockedCheckEntityDuplicate).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("does not fetch when name is exactly 1 character", () => {
+    renderHook(
+      () => useCheckDuplicate("X", "organization"),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    expect(mockedCheckEntityDuplicate).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when entityType is empty string even if name is long enough", () => {
+    const { result } = renderHook(
+      () => useCheckDuplicate("Marie Curie", ""),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    expect(mockedCheckEntityDuplicate).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("does not fetch when name is only whitespace (trims to < 2 chars)", () => {
+    renderHook(
+      () => useCheckDuplicate("  ", "person"),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    expect(mockedCheckEntityDuplicate).not.toHaveBeenCalled();
+  });
+
+  it("fires the query when name has at least 2 non-whitespace characters and entityType is present", async () => {
+    mockedCheckEntityDuplicate.mockResolvedValueOnce(makeDuplicateCheckResult());
+
+    const { result } = renderHook(
+      () => useCheckDuplicate("Ma", "person"),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedCheckEntityDuplicate).toHaveBeenCalledOnce();
+  });
+
+  it("fires the query when name has exactly 2 characters and entityType is present", async () => {
+    mockedCheckEntityDuplicate.mockResolvedValueOnce(makeDuplicateCheckResult());
+
+    const { result } = renderHook(
+      () => useCheckDuplicate("Ma", "organization"),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedCheckEntityDuplicate).toHaveBeenCalledOnce();
+  });
+
+  it("calls checkEntityDuplicate with the trimmed name and entityType", async () => {
+    mockedCheckEntityDuplicate.mockResolvedValueOnce(makeDuplicateCheckResult());
+
+    const { result } = renderHook(
+      () => useCheckDuplicate("  Marie Curie  ", "person"),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedCheckEntityDuplicate).toHaveBeenCalledWith(
+      "Marie Curie",
+      "person",
+      expect.any(AbortSignal)
+    );
+  });
+
+  it("returns is_duplicate=true and existing_entity when a duplicate is found", async () => {
+    const duplicateResult = makeDuplicateCheckResult({
+      is_duplicate: true,
+      existing_entity: {
+        entity_id: "ent-existing-001",
+        canonical_name: "Marie Curie",
+        entity_type: "person",
+        description: "Physicist",
+      },
+    });
+    mockedCheckEntityDuplicate.mockResolvedValueOnce(duplicateResult);
+
+    const { result } = renderHook(
+      () => useCheckDuplicate("Marie Curie", "person"),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(duplicateResult));
+
+    expect(result.current.data?.is_duplicate).toBe(true);
+    expect(result.current.data?.existing_entity?.entity_id).toBe("ent-existing-001");
+  });
+
+  it("returns is_duplicate=false and existing_entity=null when no duplicate exists", async () => {
+    const nodupeResult = makeDuplicateCheckResult();
+    mockedCheckEntityDuplicate.mockResolvedValueOnce(nodupeResult);
+
+    const { result } = renderHook(
+      () => useCheckDuplicate("New Entity Name", "place"),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(nodupeResult));
+
+    expect(result.current.data?.is_duplicate).toBe(false);
+    expect(result.current.data?.existing_entity).toBeNull();
+  });
+
+  it("re-fires the query when name changes from short to long enough", async () => {
+    mockedCheckEntityDuplicate.mockResolvedValue(makeDuplicateCheckResult());
+
+    const { result, rerender } = renderHook(
+      ({ name }: { name: string }) => useCheckDuplicate(name, "person"),
+      {
+        wrapper: createWrapper(queryClient),
+        initialProps: { name: "A" },
+      }
+    );
+
+    // Short name — query must be disabled
+    expect(mockedCheckEntityDuplicate).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe("idle");
+
+    // Extend to 2+ characters — query must fire
+    rerender({ name: "Al" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedCheckEntityDuplicate).toHaveBeenCalledOnce();
+  });
+
+  it("does not re-fire the query when name changes but stays below the 2-char threshold", () => {
+    const { rerender } = renderHook(
+      ({ name }: { name: string }) => useCheckDuplicate(name, "person"),
+      {
+        wrapper: createWrapper(queryClient),
+        initialProps: { name: "" },
+      }
+    );
+
+    rerender({ name: "A" });
+
+    expect(mockedCheckEntityDuplicate).not.toHaveBeenCalled();
+  });
+
+  it("becomes idle again when entityType is cleared after previously being set", async () => {
+    mockedCheckEntityDuplicate.mockResolvedValue(makeDuplicateCheckResult());
+
+    const { result, rerender } = renderHook(
+      ({ entityType }: { entityType: string }) =>
+        useCheckDuplicate("Marie Curie", entityType),
+      {
+        wrapper: createWrapper(queryClient),
+        initialProps: { entityType: "person" },
+      }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedCheckEntityDuplicate).toHaveBeenCalledOnce();
+
+    // Clear entity type — query should disable
+    rerender({ entityType: "" });
+
+    // After clearing, the query is no longer enabled
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});

--- a/frontend/src/hooks/useEntityMentions.ts
+++ b/frontend/src/hooks/useEntityMentions.ts
@@ -15,6 +15,9 @@ import {
   fetchEntities,
   createManualAssociation,
   deleteManualAssociation,
+  classifyTag,
+  checkEntityDuplicate,
+  createEntity,
 } from "../api/entityMentions";
 import type {
   VideoEntitySummary,
@@ -23,8 +26,12 @@ import type {
   EntityListItem,
   EntityPaginationMeta,
   ManualAssociationResponse,
+  ClassifyTagResponse,
+  DuplicateCheckResult,
   FetchEntityVideosParams,
   FetchEntitiesParams,
+  CreateEntityRequest,
+  CreateEntityResponse,
 } from "../api/entityMentions";
 import type { ApiError } from "../types/video";
 
@@ -520,5 +527,128 @@ export function useDeleteManualAssociation() {
       void queryClient.invalidateQueries({ queryKey: ["entity-videos"] });
       void queryClient.invalidateQueries({ queryKey: ["entity-detail"] });
     },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useClassifyTag
+// ---------------------------------------------------------------------------
+
+/** Variables passed to the classify tag mutation. */
+export interface ClassifyTagVariables {
+  /** The canonical name / normalized tag text to classify */
+  normalized_form: string;
+  /** Entity type (e.g. "person", "organization", "place") */
+  entity_type: string;
+  /** Optional human-readable description */
+  description?: string;
+}
+
+/**
+ * Mutation hook for classifying a raw tag as a named entity.
+ *
+ * On success, invalidates caches for:
+ * - `entities`       (entity list page refreshes)
+ * - `entitySearch`   (autocomplete results refresh)
+ * - `canonical-tags` (canonical tag data refreshes)
+ *
+ * Error handling is left to the caller — use `mutation.isError` and
+ * `mutation.error` to display inline error messages.
+ *
+ * @returns UseMutationResult with `mutate({ normalized_form, entity_type, description? })`
+ *
+ * @example
+ * ```tsx
+ * const mutation = useClassifyTag();
+ * mutation.mutate({ normalized_form: "React", entity_type: "organization" });
+ * ```
+ */
+export function useClassifyTag() {
+  const queryClient = useQueryClient();
+
+  return useMutation<ClassifyTagResponse, ApiError, ClassifyTagVariables>({
+    mutationFn: (variables: ClassifyTagVariables) => classifyTag(variables),
+
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["entities"] });
+      void queryClient.invalidateQueries({ queryKey: ["entitySearch"] });
+      void queryClient.invalidateQueries({ queryKey: ["canonical-tags"] });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useCreateEntity
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutation hook for creating a standalone named entity.
+ *
+ * On success, invalidates caches for:
+ * - `entities`     (entity list page refreshes)
+ * - `entitySearch` (autocomplete results refresh)
+ *
+ * Note: `canonical-tags` is intentionally NOT invalidated here because
+ * standalone entities are not linked to the tag taxonomy.
+ *
+ * Error handling is left to the caller — use `mutation.isError` and
+ * `mutation.error` to display inline error messages.
+ *
+ * @returns UseMutationResult with `mutate(data: CreateEntityRequest)`
+ *
+ * @example
+ * ```tsx
+ * const mutation = useCreateEntity();
+ * mutation.mutate({ name: "Marie Curie", entity_type: "person" });
+ * ```
+ */
+export function useCreateEntity() {
+  const queryClient = useQueryClient();
+
+  return useMutation<CreateEntityResponse, ApiError, CreateEntityRequest>({
+    mutationFn: (data) => createEntity(data),
+
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["entities"] });
+      void queryClient.invalidateQueries({ queryKey: ["entitySearch"] });
+      // Note: NO ["canonical-tags"] invalidation — standalone entities aren't linked to tags
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useCheckDuplicate
+// ---------------------------------------------------------------------------
+
+/**
+ * Query hook that checks whether a named entity with the given name and type
+ * already exists in the database.
+ *
+ * The query is disabled until `name` has at least 2 non-whitespace characters
+ * and `entityType` is non-empty, avoiding unnecessary requests while the user
+ * is still typing.
+ *
+ * @param name - Candidate canonical name (query fires when trimmed length >= 2)
+ * @param entityType - Entity type string (e.g. "person", "organization")
+ * @returns TanStack Query result containing DuplicateCheckResult
+ *
+ * @example
+ * ```tsx
+ * const { data } = useCheckDuplicate(nameInput, selectedType);
+ * if (data?.is_duplicate) {
+ *   // show warning with data.existing_entity
+ * }
+ * ```
+ */
+export function useCheckDuplicate(name: string, entityType: string) {
+  const enabled = name.trim().length >= 2 && entityType !== "";
+
+  return useQuery<DuplicateCheckResult, ApiError>({
+    queryKey: ["checkDuplicate", name.trim(), entityType],
+    // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+    queryFn: ({ signal }) => checkEntityDuplicate(name.trim(), entityType, signal),
+    enabled,
+    staleTime: 30 * 1000, // 30 seconds
+    gcTime: 60 * 1000,
   });
 }

--- a/frontend/src/pages/EntitiesPage.tsx
+++ b/frontend/src/pages/EntitiesPage.tsx
@@ -16,12 +16,18 @@
  * - SkipLink to main content area (FR-019, NFR-004, NFR-006)
  */
 
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState, useRef } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 
 import { SkipLink } from "../components/SkipLink";
+import { CreateEntityModal } from "../components/entity/CreateEntityModal";
 import { useEntities } from "../hooks/useEntityMentions";
 import type { EntityListItem } from "../api/entityMentions";
+import {
+  ENTITY_TYPE_LABELS,
+  ENTITY_TYPE_COLORS,
+  ENTITY_TYPE_TABS,
+} from "../constants/entityTypes";
 
 /** Stable ID used by SkipLink and main content container (T036, T037). */
 const MAIN_CONTENT_ID = "entities-main-content";
@@ -30,43 +36,12 @@ const MAIN_CONTENT_ID = "entities-main-content";
 // Constants
 // ---------------------------------------------------------------------------
 
-const ENTITY_TYPE_TABS: Array<{ value: string; label: string }> = [
-  { value: "all", label: "All" },
-  { value: "person", label: "Person" },
-  { value: "organization", label: "Organization" },
-  { value: "place", label: "Place" },
-  { value: "event", label: "Event" },
-  { value: "work", label: "Work" },
-  { value: "other", label: "Other" },
-];
-
 const VALID_TYPES = ENTITY_TYPE_TABS.map((t) => t.value);
 
 const SORT_OPTIONS: Array<{ value: string; label: string }> = [
   { value: "mentions", label: "Mentions" },
   { value: "name", label: "Name (A-Z)" },
 ];
-
-/** Badge colour classes by entity type — matches EntityDetailPage */
-const ENTITY_TYPE_COLORS: Record<string, string> = {
-  person: "bg-indigo-100 text-indigo-700 border-indigo-200",
-  organization: "bg-violet-100 text-violet-700 border-violet-200",
-  place: "bg-emerald-100 text-emerald-700 border-emerald-200",
-  event: "bg-amber-100 text-amber-700 border-amber-200",
-  work: "bg-sky-100 text-sky-700 border-sky-200",
-  concept: "bg-rose-100 text-rose-700 border-rose-200",
-  other: "bg-slate-100 text-slate-700 border-slate-200",
-};
-
-const ENTITY_TYPE_LABELS: Record<string, string> = {
-  person: "Person",
-  organization: "Organization",
-  place: "Place",
-  event: "Event",
-  work: "Work",
-  concept: "Concept",
-  other: "Other",
-};
 
 function getTypeBadgeClass(entityType: string): string {
   return (
@@ -321,6 +296,8 @@ function EntitiesEmptyState({
  */
 export function EntitiesPage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const createButtonRef = useRef<HTMLButtonElement>(null);
 
   // Parse type filter from URL
   const typeParam = searchParams.get("type") ?? "all";
@@ -446,6 +423,30 @@ export function EntitiesPage() {
     return "An error occurred while loading entities";
   };
 
+  // Reusable page header — title + "Create Entity" button
+  const pageHeader = (
+    <div className="flex items-center justify-between mb-6">
+      <h1 className="text-3xl font-bold text-gray-900">Entities</h1>
+      <button
+        ref={createButtonRef}
+        type="button"
+        onClick={() => setIsCreateModalOpen(true)}
+        className="inline-flex items-center gap-1.5 bg-indigo-600 text-white hover:bg-indigo-700 rounded-lg px-4 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 transition-colors"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
+          <path d="M10.75 4.75a.75.75 0 0 0-1.5 0v4.5h-4.5a.75.75 0 0 0 0 1.5h4.5v4.5a.75.75 0 0 0 1.5 0v-4.5h4.5a.75.75 0 0 0 0-1.5h-4.5v-4.5Z" />
+        </svg>
+        Create Entity
+      </button>
+    </div>
+  );
+
   // Toolbar (shown in all states)
   const toolbar = (
     <div className="space-y-4 mb-6">
@@ -545,10 +546,17 @@ export function EntitiesPage() {
           tabIndex={-1}
           className="container mx-auto px-4 py-8"
         >
-          <h1 className="text-3xl font-bold text-gray-900 mb-6">Entities</h1>
+          {pageHeader}
           {toolbar}
           <EntityLoadingState count={8} />
         </main>
+        <CreateEntityModal
+          isOpen={isCreateModalOpen}
+          onClose={() => {
+            setIsCreateModalOpen(false);
+            createButtonRef.current?.focus();
+          }}
+        />
       </>
     );
   }
@@ -563,7 +571,7 @@ export function EntitiesPage() {
           tabIndex={-1}
           className="container mx-auto px-4 py-8"
         >
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Entities</h1>
+        {pageHeader}
         {toolbar}
         <div
           className="bg-gradient-to-br from-red-50 to-amber-50 border border-red-200 rounded-xl shadow-lg p-8 text-center"
@@ -619,6 +627,13 @@ export function EntitiesPage() {
           </button>
         </div>
         </main>
+        <CreateEntityModal
+          isOpen={isCreateModalOpen}
+          onClose={() => {
+            setIsCreateModalOpen(false);
+            createButtonRef.current?.focus();
+          }}
+        />
       </>
     );
   }
@@ -633,7 +648,7 @@ export function EntitiesPage() {
           tabIndex={-1}
           className="container mx-auto px-4 py-8"
         >
-          <h1 className="text-3xl font-bold text-gray-900 mb-6">Entities</h1>
+          {pageHeader}
           {toolbar}
           <EntitiesEmptyState
             typeFilter={typeFilter}
@@ -641,6 +656,13 @@ export function EntitiesPage() {
             search={search}
           />
         </main>
+        <CreateEntityModal
+          isOpen={isCreateModalOpen}
+          onClose={() => {
+            setIsCreateModalOpen(false);
+            createButtonRef.current?.focus();
+          }}
+        />
       </>
     );
   }
@@ -654,13 +676,32 @@ export function EntitiesPage() {
         tabIndex={-1}
         className="container mx-auto px-4 py-8"
       >
-      <div className="flex items-baseline justify-between mb-6">
-        <h1 className="text-3xl font-bold text-gray-900">Entities</h1>
-        {countText && (
-          <span className="text-sm text-gray-500 ml-3" aria-hidden="true">
-            {countText}
-          </span>
-        )}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-baseline gap-3">
+          <h1 className="text-3xl font-bold text-gray-900">Entities</h1>
+          {countText && (
+            <span className="text-sm text-gray-500" aria-hidden="true">
+              {countText}
+            </span>
+          )}
+        </div>
+        <button
+          ref={createButtonRef}
+          type="button"
+          onClick={() => setIsCreateModalOpen(true)}
+          className="inline-flex items-center gap-1.5 bg-indigo-600 text-white hover:bg-indigo-700 rounded-lg px-4 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-4 h-4"
+            aria-hidden="true"
+          >
+            <path d="M10.75 4.75a.75.75 0 0 0-1.5 0v4.5h-4.5a.75.75 0 0 0 0 1.5h4.5v4.5a.75.75 0 0 0 1.5 0v-4.5h4.5a.75.75 0 0 0 0-1.5h-4.5v-4.5Z" />
+          </svg>
+          Create Entity
+        </button>
       </div>
 
       {toolbar}
@@ -731,6 +772,13 @@ export function EntitiesPage() {
         )}
       </div>
       </main>
+      <CreateEntityModal
+        isOpen={isCreateModalOpen}
+        onClose={() => {
+          setIsCreateModalOpen(false);
+          createButtonRef.current?.focus();
+        }}
+      />
     </>
   );
 }

--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
+import { ENTITY_TYPE_LABELS, ENTITY_TYPE_COLORS } from "../constants/entityTypes";
 import { useEntityVideos, useDeleteManualAssociation } from "../hooks/useEntityMentions";
 import { apiFetch } from "../api/config";
 import type { EntityDetail, EntityAliasSummary } from "../api/entityMentions";
@@ -43,31 +44,9 @@ interface NamedEntityDetailResponse {
 // Helper functions
 // ---------------------------------------------------------------------------
 
-/** Human-readable label for each entity_type value from the backend. */
-const ENTITY_TYPE_LABELS: Record<string, string> = {
-  person: "Person",
-  organization: "Organization",
-  place: "Place",
-  event: "Event",
-  work: "Work",
-  concept: "Concept",
-  other: "Other",
-};
-
 function getTypeLabel(entityType: string): string {
   return ENTITY_TYPE_LABELS[entityType] ?? entityType;
 }
-
-/** Badge colour by entity type */
-const ENTITY_TYPE_COLORS: Record<string, string> = {
-  person: "bg-indigo-100 text-indigo-700 border-indigo-200",
-  organization: "bg-violet-100 text-violet-700 border-violet-200",
-  place: "bg-emerald-100 text-emerald-700 border-emerald-200",
-  event: "bg-amber-100 text-amber-700 border-amber-200",
-  work: "bg-sky-100 text-sky-700 border-sky-200",
-  concept: "bg-rose-100 text-rose-700 border-rose-200",
-  other: "bg-slate-100 text-slate-700 border-slate-200",
-};
 
 function getTypeBadgeClass(entityType: string): string {
   return (

--- a/frontend/src/pages/__tests__/EntitiesPage.test.tsx
+++ b/frontend/src/pages/__tests__/EntitiesPage.test.tsx
@@ -62,6 +62,39 @@ vi.mock("../../hooks/useEntityMentions", () => ({
     fetchNextPage: vi.fn(),
     loadMoreRef: { current: null },
   })),
+  useCreateManualAssociation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+  })),
+  useDeleteManualAssociation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+  })),
+  useClassifyTag: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+  })),
+  useCreateEntity: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+  })),
+  useCheckDuplicate: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+  })),
 }));
 
 import { useEntities } from "../../hooks/useEntityMentions";
@@ -467,7 +500,7 @@ describe("EntitiesPage", () => {
       );
     });
 
-    it("renders all seven type tabs", () => {
+    it("renders all type tabs", () => {
       renderPage();
       // The <nav> has role="tablist", so query by that explicit role
       const tablist = screen.getByRole("tablist", { name: "Entity type filter" });
@@ -480,6 +513,8 @@ describe("EntitiesPage", () => {
         "Place",
         "Event",
         "Work",
+        "Technical Term",
+        "Concept",
         "Other",
       ]);
     });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.51.0"
+version = "0.52.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.51.0"
+__version__ = "0.52.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -7,22 +7,29 @@ from entity to videos.
 
 from __future__ import annotations
 
+import time
 import uuid
-from typing import Any
+from collections import defaultdict
+from typing import Any, Dict, List, Tuple
 
-from fastapi import APIRouter, Body, Depends, Path, Query, Response
+from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response
+from fastapi.responses import JSONResponse
 from sqlalchemy import distinct, func, or_, select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.api.deps import get_db, require_auth
 from chronovista.api.schemas.entity_mentions import (
+    ClassifyTagRequest,
     CreateEntityAliasRequest,
+    CreateEntityRequest,
+    DuplicateCheckResponse,
     EntityAliasSummary,
     EntitySearchResult,
     EntityVideoResponse,
     EntityVideoResult,
     ExclusionPatternRequest,
+    ExistingEntityInfo,
     ManualAssociationResponse,
     MentionPreview,
     PhoneticMatchResponse,
@@ -33,12 +40,19 @@ from chronovista.api.schemas.responses import ApiResponse, PaginationMeta
 from chronovista.db.models import EntityAlias as EntityAliasDB
 from chronovista.db.models import NamedEntity as NamedEntityDB
 from chronovista.db.models import Video as VideoDB
-from chronovista.exceptions import APIValidationError, ConflictError, NotFoundError
+from chronovista.db.models import CanonicalTag as CanonicalTagDB
+from chronovista.exceptions import APIValidationError, BadRequestError, ConflictError, NotFoundError
 from chronovista.models.entity_alias import EntityAliasCreate
-from chronovista.models.enums import EntityAliasType
+from chronovista.models.enums import DiscoveryMethod, EntityAliasType, EntityType, TagStatus
+from chronovista.models.named_entity import NamedEntityCreate
+from chronovista.repositories.canonical_tag_repository import CanonicalTagRepository
 from chronovista.repositories.entity_alias_repository import EntityAliasRepository
 from chronovista.repositories.entity_mention_repository import EntityMentionRepository
+from chronovista.repositories.named_entity_repository import NamedEntityRepository
+from chronovista.repositories.tag_alias_repository import TagAliasRepository
+from chronovista.repositories.tag_operation_log_repository import TagOperationLogRepository
 from chronovista.services.phonetic_matcher import PhoneticMatcher
+from chronovista.services.tag_management import TagManagementService
 from chronovista.services.tag_normalization import TagNormalizationService
 
 router = APIRouter(dependencies=[Depends(require_auth)])
@@ -46,7 +60,89 @@ router = APIRouter(dependencies=[Depends(require_auth)])
 # Module-level repository / service instantiation (singleton pattern)
 _mention_repo = EntityMentionRepository()
 _alias_repo = EntityAliasRepository()
+_entity_repo = NamedEntityRepository()
 _normalizer = TagNormalizationService()
+_tag_mgmt_service = TagManagementService(
+    canonical_tag_repo=CanonicalTagRepository(),
+    tag_alias_repo=TagAliasRepository(),
+    named_entity_repo=NamedEntityRepository(),
+    entity_alias_repo=EntityAliasRepository(),
+    operation_log_repo=TagOperationLogRepository(),
+)
+
+# Rate limiting configuration for duplicate check (50 req/min per client)
+RATE_LIMIT_DUPLICATE_CHECK = 50
+RATE_LIMIT_WINDOW_SECONDS = 60
+
+# Storage for rate limit tracking
+_duplicate_check_counts: Dict[str, List[float]] = defaultdict(list)
+
+
+def _get_client_id(request: Request) -> str:
+    """Get client identifier from request.
+
+    Uses X-Forwarded-For header for proxied requests, falls back to client host.
+
+    Parameters
+    ----------
+    request : Request
+        FastAPI request object.
+
+    Returns
+    -------
+    str
+        Client identifier (IP address or "unknown").
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _check_rate_limit(
+    client_id: str,
+    request_counts: Dict[str, List[float]],
+    rate_limit: int,
+) -> Tuple[bool, int]:
+    """Check if client has exceeded rate limit.
+
+    Cleans up old entries and checks if current request should be allowed.
+
+    Parameters
+    ----------
+    client_id : str
+        Client identifier.
+    request_counts : Dict[str, List[float]]
+        Storage for request timestamps per client.
+    rate_limit : int
+        Maximum requests allowed per minute.
+
+    Returns
+    -------
+    Tuple[bool, int]
+        Tuple of (is_allowed, retry_after_seconds).
+        If is_allowed is True, retry_after is 0.
+        If is_allowed is False, retry_after indicates seconds until a slot opens.
+    """
+    now = time.time()
+    window_start = now - RATE_LIMIT_WINDOW_SECONDS
+
+    # Clean old entries (older than window)
+    request_counts[client_id] = [
+        ts for ts in request_counts[client_id]
+        if ts > window_start
+    ]
+
+    # Check if limit exceeded
+    if len(request_counts[client_id]) >= rate_limit:
+        # Find when the oldest request in window will expire
+        oldest = min(request_counts[client_id])
+        retry_after = int(oldest + RATE_LIMIT_WINDOW_SECONDS - now) + 1
+        return False, max(1, retry_after)
+
+    # Add current request timestamp
+    request_counts[client_id].append(now)
+    return True, 0
 
 
 @router.get(
@@ -311,6 +407,87 @@ async def get_video_entities(
     data = [VideoEntitySummary(**s) for s in summaries]
 
     return VideoEntitiesResponse(data=data)
+
+
+@router.get(
+    "/entities/check-duplicate",
+    response_model=DuplicateCheckResponse,
+    status_code=200,
+    summary="Check for duplicate entity by normalized name and type",
+)
+async def check_duplicate_entity(
+    request: Request,
+    name: str = Query(..., description="Entity name to check"),
+    type: str = Query(..., description="Entity type (person, organization, place, etc.)"),
+    session: AsyncSession = Depends(get_db),
+) -> DuplicateCheckResponse | JSONResponse:
+    """Check whether an entity with the same normalized name and type already exists.
+
+    Normalizes the provided name using ``TagNormalizationService`` and queries
+    the ``named_entities`` table for an active entity with the same normalized
+    canonical name and entity type.
+
+    Rate-limited to 50 requests per minute per client IP.
+
+    Parameters
+    ----------
+    request : Request
+        FastAPI request object (used for rate limiting).
+    name : str
+        Entity name to check for duplicates.
+    type : str
+        Entity type to filter by (person, organization, place, etc.).
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    DuplicateCheckResponse
+        Contains ``is_duplicate`` flag and optional ``existing_entity`` details.
+    JSONResponse (429)
+        If rate limit is exceeded.
+    """
+    # Rate limiting
+    client_id = _get_client_id(request)
+    is_allowed, retry_after = _check_rate_limit(
+        client_id, _duplicate_check_counts, RATE_LIMIT_DUPLICATE_CHECK
+    )
+    if not is_allowed:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "detail": "Rate limit exceeded. Maximum 50 duplicate-check requests per minute.",
+                "retry_after": retry_after,
+            },
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    # Normalize the input name
+    normalized_name = _normalizer.normalize(name)
+    if not normalized_name:
+        return DuplicateCheckResponse(is_duplicate=False, existing_entity=None)
+
+    # Query for an active entity with the same normalized name and type
+    query = select(NamedEntityDB).where(
+        NamedEntityDB.canonical_name_normalized == normalized_name,
+        NamedEntityDB.entity_type == type,
+        NamedEntityDB.status == "active",
+    )
+    result = await session.execute(query)
+    entity = result.scalar_one_or_none()
+
+    if entity is not None:
+        return DuplicateCheckResponse(
+            is_duplicate=True,
+            existing_entity=ExistingEntityInfo(
+                entity_id=str(entity.id),
+                canonical_name=entity.canonical_name,
+                entity_type=entity.entity_type,
+                description=entity.description,
+            ),
+        )
+
+    return DuplicateCheckResponse(is_duplicate=False, existing_entity=None)
 
 
 @router.get(
@@ -927,3 +1104,270 @@ async def delete_manual_association(
     )
     await session.commit()
     return Response(status_code=204)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# POST /entities/classify — Tag-Backed Entity Creation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+    "/entities/classify",
+    status_code=201,
+    summary="Classify a canonical tag as a named entity",
+)
+async def classify_tag(
+    body: ClassifyTagRequest = Body(...),
+    session: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Classify an existing canonical tag to create or link a named entity.
+
+    Delegates to ``TagManagementService.classify()`` which handles entity
+    creation/linking and alias management. Maps service-layer ``ValueError``
+    exceptions to appropriate HTTP status codes.
+
+    Parameters
+    ----------
+    body : ClassifyTagRequest
+        Request body with normalized_form, entity_type, and optional description.
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    dict
+        Created/linked entity details with alias count and operation ID.
+
+    Raises
+    ------
+    NotFoundError
+        If the canonical tag is not found or inactive (404).
+    ConflictError
+        If the tag is already classified as an entity (409).
+    APIValidationError
+        If the request is otherwise invalid (400).
+    """
+    try:
+        entity_type_enum = EntityType(body.entity_type)
+    except ValueError:
+        raise BadRequestError(
+            message=f"Invalid entity_type: {body.entity_type}",
+            details={"entity_type": body.entity_type},
+        )
+
+    try:
+        result = await _tag_mgmt_service.classify(
+            session,
+            body.normalized_form,
+            entity_type_enum,
+            description=body.description,
+            auto_case=True,
+        )
+    except ValueError as exc:
+        error_msg = str(exc)
+
+        if "not found" in error_msg.lower() or "status" in error_msg.lower():
+            raise NotFoundError(
+                resource_type="CanonicalTag",
+                identifier=body.normalized_form,
+            )
+
+        if "already classified" in error_msg.lower():
+            # Look up the canonical tag to get existing entity details
+            tag_query = select(CanonicalTagDB).where(
+                CanonicalTagDB.normalized_form == body.normalized_form,
+            )
+            tag_result = await session.execute(tag_query)
+            tag = tag_result.scalar_one_or_none()
+
+            existing_entity_data: dict[str, Any] | None = None
+            if tag is not None and tag.entity_id is not None:
+                entity = await session.get(NamedEntityDB, tag.entity_id)
+                if entity is not None:
+                    existing_entity_data = {
+                        "entity_id": str(entity.id),
+                        "canonical_name": entity.canonical_name,
+                        "entity_type": entity.entity_type,
+                        "description": entity.description,
+                    }
+
+            raise ConflictError(
+                message=error_msg,
+                details={"existing_entity": existing_entity_data}
+                if existing_entity_data
+                else None,
+            )
+
+        # Other ValueError → 400 Bad Request
+        raise BadRequestError(
+            message=error_msg,
+            details={"normalized_form": body.normalized_form},
+        )
+
+    # After successful classification, look up the canonical tag to get entity_id
+    tag_query = select(CanonicalTagDB).where(
+        CanonicalTagDB.normalized_form == body.normalized_form,
+    )
+    tag_result = await session.execute(tag_query)
+    tag = tag_result.scalar_one_or_none()
+
+    entity_id_str: str | None = None
+    canonical_name = result.canonical_form
+    description: str | None = body.description
+
+    if tag is not None and tag.entity_id is not None:
+        entity = await session.get(NamedEntityDB, tag.entity_id)
+        if entity is not None:
+            entity_id_str = str(entity.id)
+            canonical_name = entity.canonical_name
+            description = entity.description
+
+    await session.commit()
+
+    return {
+        "entity_id": entity_id_str,
+        "canonical_name": canonical_name,
+        "entity_type": result.entity_type,
+        "description": description,
+        "alias_count": result.entity_alias_count,
+        "entity_created": result.entity_created,
+        "operation_id": str(result.operation_id),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# POST /entities — Standalone Entity Creation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.post(
+    "/entities",
+    status_code=201,
+    summary="Create a new named entity",
+)
+async def create_entity(
+    body: CreateEntityRequest = Body(...),
+    session: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Create a standalone named entity with optional aliases.
+
+    Normalizes the entity name, checks for duplicates by normalized name
+    and type, creates the entity, and registers aliases (including the
+    canonical name as the first alias).
+
+    Parameters
+    ----------
+    body : CreateEntityRequest
+        Request body with name, entity_type, optional description and aliases.
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    dict
+        Created entity summary with entity_id, canonical_name, entity_type,
+        description, and alias_count.
+
+    Raises
+    ------
+    BadRequestError
+        If entity_type is not a valid EntityType enum value (400).
+    APIValidationError
+        If the name normalizes to an empty string (422).
+    ConflictError
+        If an active entity with the same normalized name and type already
+        exists (409).
+    """
+    # 1. Convert entity_type string to enum
+    try:
+        entity_type_enum = EntityType(body.entity_type)
+    except ValueError:
+        raise BadRequestError(
+            message=f"Invalid entity_type: {body.entity_type}",
+            details={"entity_type": body.entity_type},
+        )
+
+    # 2. Normalize the name
+    normalized_name = _normalizer.normalize(body.name)
+    if not normalized_name:
+        raise APIValidationError(
+            message="Entity name normalizes to an empty string",
+            details={"name": body.name},
+        )
+
+    # 3. Auto-title-case
+    canonical_name = body.name.strip().title()
+
+    # 4. Check for duplicate (same normalized name + type + active status)
+    dup_query = select(NamedEntityDB).where(
+        NamedEntityDB.canonical_name_normalized == normalized_name,
+        NamedEntityDB.entity_type == entity_type_enum.value,
+        NamedEntityDB.status == "active",
+    )
+    dup_result = await session.execute(dup_query)
+    existing = dup_result.scalar_one_or_none()
+    if existing is not None:
+        raise ConflictError(
+            message=(
+                f"An active entity with normalized name '{normalized_name}' "
+                f"and type '{entity_type_enum.value}' already exists"
+            ),
+            details={
+                "existing_entity": {
+                    "entity_id": str(existing.id),
+                    "canonical_name": existing.canonical_name,
+                    "entity_type": existing.entity_type,
+                    "description": existing.description,
+                }
+            },
+        )
+
+    # 5. Create entity via repository
+    entity_create = NamedEntityCreate(
+        canonical_name=canonical_name,
+        canonical_name_normalized=normalized_name,
+        entity_type=entity_type_enum,
+        description=body.description,
+        status=TagStatus.ACTIVE,
+        discovery_method=DiscoveryMethod.USER_CREATED,
+        confidence=1.0,
+    )
+    db_entity = await _entity_repo.create(session, obj_in=entity_create)
+
+    # 6. Create canonical name as first alias
+    canonical_alias = EntityAliasCreate(
+        entity_id=db_entity.id,
+        alias_name=canonical_name,
+        alias_name_normalized=normalized_name,
+        alias_type=EntityAliasType.NAME_VARIANT,
+        occurrence_count=0,
+    )
+    await _alias_repo.create(session, obj_in=canonical_alias)
+
+    # 7. Create additional aliases, skipping normalized duplicates
+    seen_normalized: set[str] = {normalized_name}
+    for alias_text in body.aliases:
+        alias_normalized = _normalizer.normalize(alias_text)
+        if not alias_normalized or alias_normalized in seen_normalized:
+            continue
+        seen_normalized.add(alias_normalized)
+        alias_create = EntityAliasCreate(
+            entity_id=db_entity.id,
+            alias_name=alias_text.strip(),
+            alias_name_normalized=alias_normalized,
+            alias_type=EntityAliasType.NAME_VARIANT,
+            occurrence_count=0,
+        )
+        await _alias_repo.create(session, obj_in=alias_create)
+
+    # 8. Commit and return 201
+    await session.commit()
+    await session.refresh(db_entity)
+
+    return {
+        "entity_id": str(db_entity.id),
+        "canonical_name": db_entity.canonical_name,
+        "entity_type": db_entity.entity_type,
+        "description": db_entity.description,
+        "alias_count": len(seen_normalized),
+    }

--- a/src/chronovista/api/schemas/entity_mentions.py
+++ b/src/chronovista/api/schemas/entity_mentions.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from chronovista.api.schemas.responses import PaginationMeta
 
@@ -353,3 +353,157 @@ class ExclusionPatternRequest(BaseModel):
         max_length=500,
         description="Exclusion pattern to add or remove",
     )
+
+
+# ---------------------------------------------------------------------------
+# Entity creation & duplicate-check schemas (Feature 051)
+# ---------------------------------------------------------------------------
+
+_ENTITY_PRODUCING_TYPES = {
+    "person",
+    "organization",
+    "place",
+    "event",
+    "work",
+    "technical_term",
+    "concept",
+    "other",
+}
+
+
+class ExistingEntityInfo(BaseModel):
+    """Summary of an existing entity for duplicate detection.
+
+    Attributes
+    ----------
+    entity_id : str
+        Named entity UUID.
+    canonical_name : str
+        Display name of the entity.
+    entity_type : str
+        Entity type.
+    description : str | None
+        Entity description.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    entity_id: str = Field(..., description="Named entity UUID")
+    canonical_name: str = Field(..., description="Display name of the entity")
+    entity_type: str = Field(..., description="Entity type")
+    description: str | None = Field(None, description="Entity description")
+
+
+class DuplicateCheckResponse(BaseModel):
+    """Response for duplicate entity check.
+
+    Attributes
+    ----------
+    is_duplicate : bool
+        Whether a duplicate entity was found.
+    existing_entity : ExistingEntityInfo | None
+        Details of the existing entity, if found.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    is_duplicate: bool = Field(
+        ..., description="Whether a duplicate entity was found"
+    )
+    existing_entity: ExistingEntityInfo | None = Field(
+        default=None, description="Details of the existing entity, if found"
+    )
+
+
+class CreateEntityRequest(BaseModel):
+    """Request body for standalone entity creation.
+
+    Attributes
+    ----------
+    name : str
+        Entity display name (1-500 chars).
+    entity_type : str
+        Must be one of the entity-producing types.
+    description : str | None
+        Optional entity description (max 5000 chars).
+    aliases : list[str]
+        Optional list of alias strings (max 20).
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    name: str = Field(
+        ..., min_length=1, max_length=500, description="Entity display name"
+    )
+    entity_type: str = Field(
+        ..., min_length=1, description="Entity type"
+    )
+    description: str | None = Field(
+        default=None,
+        max_length=5000,
+        description="Optional entity description",
+    )
+    aliases: list[str] = Field(
+        default_factory=list,
+        max_length=20,
+        description="Optional alias strings",
+    )
+
+    @field_validator("entity_type")
+    @classmethod
+    def validate_entity_type(cls, v: str) -> str:
+        """Ensure entity_type is a valid entity-producing type."""
+        if v not in _ENTITY_PRODUCING_TYPES:
+            raise ValueError(
+                f"entity_type must be one of: "
+                f"{', '.join(sorted(_ENTITY_PRODUCING_TYPES))}"
+            )
+        return v
+
+    @field_validator("aliases")
+    @classmethod
+    def validate_aliases(cls, v: list[str]) -> list[str]:
+        """Strip whitespace from aliases and filter out empty strings."""
+        return [a.strip() for a in v if a.strip()]
+
+
+class ClassifyTagRequest(BaseModel):
+    """Request body for tag-backed entity creation.
+
+    Attributes
+    ----------
+    normalized_form : str
+        Normalized form of the canonical tag (1-500 chars).
+    entity_type : str
+        Must be one of the entity-producing types.
+    description : str | None
+        Optional entity description (max 5000 chars).
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    normalized_form: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Normalized form of the canonical tag",
+    )
+    entity_type: str = Field(
+        ..., min_length=1, description="Entity type"
+    )
+    description: str | None = Field(
+        default=None,
+        max_length=5000,
+        description="Optional entity description",
+    )
+
+    @field_validator("entity_type")
+    @classmethod
+    def validate_entity_type(cls, v: str) -> str:
+        """Ensure entity_type is a valid entity-producing type."""
+        if v not in _ENTITY_PRODUCING_TYPES:
+            raise ValueError(
+                f"entity_type must be one of: "
+                f"{', '.join(sorted(_ENTITY_PRODUCING_TYPES))}"
+            )
+        return v

--- a/src/chronovista/cli/entity_commands.py
+++ b/src/chronovista/cli/entity_commands.py
@@ -58,6 +58,8 @@ _ENTITY_PRODUCING_TYPES = {
     "event",
     "work",
     "technical_term",
+    "concept",
+    "other",
 }
 
 
@@ -71,7 +73,7 @@ def create_entity(
         "--type",
         help=(
             "Entity type. Valid values: person, organization, place, "
-            "event, work, technical_term."
+            "event, work, technical_term, concept, other."
         ),
     ),
     description: Optional[str] = typer.Option(
@@ -94,7 +96,7 @@ def create_entity(
                 Panel(
                     f"[red]Entity type '{type_str}' is not valid for entities.[/red]\n"
                     "Only entity-producing types are allowed: "
-                    "person, organization, place, event, work, technical_term",
+                    "person, organization, place, event, work, technical_term, concept, other",
                     title="Invalid Type",
                     border_style="red",
                 )

--- a/src/chronovista/cli/tag_commands.py
+++ b/src/chronovista/cli/tag_commands.py
@@ -1079,7 +1079,8 @@ def classify_tag(
         "--type",
         help=(
             "Entity type to assign. Valid values: person, organization, "
-            "place, event, work, technical_term, topic, descriptor."
+            "place, event, work, technical_term, concept, other, "
+            "topic, descriptor."
         ),
     ),
     top: Optional[int] = typer.Option(
@@ -1142,7 +1143,7 @@ def classify_tag(
             Panel(
                 "[red]--type is required when classifying a tag. "
                 "Valid values: person, organization, place, event, work, "
-                "technical_term, topic, descriptor.[/red]",
+                "technical_term, concept, other, topic, descriptor.[/red]",
                 title="Missing --type",
                 border_style="red",
             )

--- a/src/chronovista/db/migrations/versions/051_add_concept_other_entity_types.py
+++ b/src/chronovista/db/migrations/versions/051_add_concept_other_entity_types.py
@@ -1,0 +1,189 @@
+"""add_concept_other_entity_types — extend entity_type CHECK constraints
+
+Revision ID: a1b3c5d7e9f2
+Revises: f6a8c0b2d4e9
+Create Date: 2026-03-23 12:00:00.000000
+
+This is a schema-only migration — no data migration is required.
+
+The goal is to widen the allowed values for the ``entity_type`` column on two
+tables so that new entity classifications ('concept' and 'other') are accepted
+by the database.
+
+Changes to named_entities:
+- DROP   chk_entity_type_valid (old — 6 values)
+- ADD    chk_entity_type_valid (new — 8 values, adds 'concept' and 'other')
+
+Changes to canonical_tags:
+- DROP   chk_canonical_tag_entity_type_valid (old — 8 values + IS NULL)
+- ADD    chk_canonical_tag_entity_type_valid (new — 10 values + IS NULL,
+         adds 'concept' and 'other')
+
+Constraint expressions (kept as module-level constants so upgrade/downgrade
+stay in sync with each other and with db/models.py):
+
+named_entities — old:
+    entity_type IN ('person', 'organization', 'place', 'event', 'work',
+                    'technical_term')
+
+named_entities — new:
+    entity_type IN ('person', 'organization', 'place', 'event', 'work',
+                    'technical_term', 'concept', 'other')
+
+canonical_tags — old:
+    entity_type IN ('person', 'organization', 'place', 'event', 'work',
+                    'technical_term', 'topic', 'descriptor')
+    OR entity_type IS NULL
+
+canonical_tags — new:
+    entity_type IN ('person', 'organization', 'place', 'event', 'work',
+                    'technical_term', 'concept', 'other', 'topic',
+                    'descriptor')
+    OR entity_type IS NULL
+
+All operations are fully reversible via downgrade().
+
+Related: Feature 051 (Concept/Other Entity Types), ADR-006
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b3c5d7e9f2"
+down_revision = "f6a8c0b2d4e9"
+branch_labels = None
+depends_on = None
+
+# ---------------------------------------------------------------------------
+# named_entities — chk_entity_type_valid
+# ---------------------------------------------------------------------------
+_NAMED_ENTITY_TYPE_CHECK_OLD = (
+    "entity_type IN ("
+    "'person', 'organization', 'place', 'event', 'work', 'technical_term'"
+    ")"
+)
+_NAMED_ENTITY_TYPE_CHECK_NEW = (
+    "entity_type IN ("
+    "'person', 'organization', 'place', 'event', 'work', 'technical_term', "
+    "'concept', 'other'"
+    ")"
+)
+
+# ---------------------------------------------------------------------------
+# canonical_tags — chk_canonical_tag_entity_type_valid
+# ---------------------------------------------------------------------------
+_CANONICAL_TAG_ENTITY_TYPE_CHECK_OLD = (
+    "entity_type IN ("
+    "'person', 'organization', 'place', 'event', 'work', 'technical_term', "
+    "'topic', 'descriptor'"
+    ") OR entity_type IS NULL"
+)
+_CANONICAL_TAG_ENTITY_TYPE_CHECK_NEW = (
+    "entity_type IN ("
+    "'person', 'organization', 'place', 'event', 'work', 'technical_term', "
+    "'concept', 'other', 'topic', 'descriptor'"
+    ") OR entity_type IS NULL"
+)
+
+
+def upgrade() -> None:
+    """
+    Widen the entity_type CHECK constraints on named_entities and canonical_tags
+    to include 'concept' and 'other'.
+
+    Operations performed (in dependency order):
+    1. DROP chk_entity_type_valid on named_entities (old — 6 values)
+    2. ADD  chk_entity_type_valid on named_entities (new — 8 values)
+    3. DROP chk_canonical_tag_entity_type_valid on canonical_tags (old — 8 values)
+    4. ADD  chk_canonical_tag_entity_type_valid on canonical_tags (new — 10 values)
+    """
+
+    # =========================================================================
+    # 1. DROP old named_entities CHECK constraint
+    # =========================================================================
+    op.drop_constraint(
+        "chk_entity_type_valid",
+        "named_entities",
+        type_="check",
+    )
+
+    # =========================================================================
+    # 2. ADD new named_entities CHECK constraint (includes 'concept', 'other')
+    # =========================================================================
+    op.create_check_constraint(
+        "chk_entity_type_valid",
+        "named_entities",
+        _NAMED_ENTITY_TYPE_CHECK_NEW,
+    )
+
+    # =========================================================================
+    # 3. DROP old canonical_tags CHECK constraint
+    # =========================================================================
+    op.drop_constraint(
+        "chk_canonical_tag_entity_type_valid",
+        "canonical_tags",
+        type_="check",
+    )
+
+    # =========================================================================
+    # 4. ADD new canonical_tags CHECK constraint (includes 'concept', 'other')
+    # =========================================================================
+    op.create_check_constraint(
+        "chk_canonical_tag_entity_type_valid",
+        "canonical_tags",
+        _CANONICAL_TAG_ENTITY_TYPE_CHECK_NEW,
+    )
+
+
+def downgrade() -> None:
+    """
+    Restore the original (narrower) entity_type CHECK constraints on both tables.
+
+    Operations performed in reverse dependency order:
+    1. DROP new chk_canonical_tag_entity_type_valid on canonical_tags
+    2. ADD  old chk_canonical_tag_entity_type_valid on canonical_tags
+    3. DROP new chk_entity_type_valid on named_entities
+    4. ADD  old chk_entity_type_valid on named_entities
+
+    WARNING: Any rows that have entity_type = 'concept' or entity_type = 'other'
+    will violate the restored CHECK constraints.  Delete or reclassify those rows
+    before running this downgrade in production environments.
+    """
+
+    # =========================================================================
+    # 1. DROP new canonical_tags CHECK constraint
+    # =========================================================================
+    op.drop_constraint(
+        "chk_canonical_tag_entity_type_valid",
+        "canonical_tags",
+        type_="check",
+    )
+
+    # =========================================================================
+    # 2. ADD old canonical_tags CHECK constraint (without 'concept', 'other')
+    # =========================================================================
+    op.create_check_constraint(
+        "chk_canonical_tag_entity_type_valid",
+        "canonical_tags",
+        _CANONICAL_TAG_ENTITY_TYPE_CHECK_OLD,
+    )
+
+    # =========================================================================
+    # 3. DROP new named_entities CHECK constraint
+    # =========================================================================
+    op.drop_constraint(
+        "chk_entity_type_valid",
+        "named_entities",
+        type_="check",
+    )
+
+    # =========================================================================
+    # 4. ADD old named_entities CHECK constraint (without 'concept', 'other')
+    # =========================================================================
+    op.create_check_constraint(
+        "chk_entity_type_valid",
+        "named_entities",
+        _NAMED_ENTITY_TYPE_CHECK_OLD,
+    )

--- a/src/chronovista/db/models.py
+++ b/src/chronovista/db/models.py
@@ -792,7 +792,7 @@ class NamedEntity(Base):
     __table_args__ = (
         UniqueConstraint("canonical_name_normalized", "entity_type", name="uq_named_entity_canonical"),
         CheckConstraint(
-            "entity_type IN ('person', 'organization', 'place', 'event', 'work', 'technical_term')",
+            "entity_type IN ('person', 'organization', 'place', 'event', 'work', 'technical_term', 'concept', 'other')",
             name="chk_entity_type_valid"
         ),
         CheckConstraint(
@@ -905,7 +905,7 @@ class CanonicalTag(Base):
     # Table constraints
     __table_args__ = (
         CheckConstraint(
-            "entity_type IN ('person', 'organization', 'place', 'event', 'work', 'technical_term', 'topic', 'descriptor') OR entity_type IS NULL",
+            "entity_type IN ('person', 'organization', 'place', 'event', 'work', 'technical_term', 'concept', 'other', 'topic', 'descriptor') OR entity_type IS NULL",
             name="chk_canonical_tag_entity_type_valid"
         ),
         CheckConstraint(

--- a/src/chronovista/models/enums.py
+++ b/src/chronovista/models/enums.py
@@ -245,6 +245,8 @@ class EntityType(str, Enum):
     TECHNICAL_TERM = "technical_term"
     TOPIC = "topic"
     DESCRIPTOR = "descriptor"
+    CONCEPT = "concept"
+    OTHER = "other"
 
 
 class EntityAliasType(str, Enum):

--- a/src/chronovista/services/tag_management.py
+++ b/src/chronovista/services/tag_management.py
@@ -921,6 +921,8 @@ class TagManagementService:
             EntityType.EVENT,
             EntityType.WORK,
             EntityType.TECHNICAL_TERM,
+            EntityType.CONCEPT,
+            EntityType.OTHER,
         }
         tag_only_types = {EntityType.TOPIC, EntityType.DESCRIPTOR}
 

--- a/src/chronovista/services/tag_normalization.py
+++ b/src/chronovista/services/tag_normalization.py
@@ -164,6 +164,17 @@ class TagNormalizationService:
         parts = text.split()
         text = " ".join(parts)
 
+        # FR-007 Idempotency: Strip any leading '#' characters exposed by
+        # diacritic removal (e.g. '´#' → after diacritic strip → '#').
+        # Without this second pass, normalize(normalize('´#')) would differ
+        # from normalize('´#') because the first call returns '#' while the
+        # second call would return None.
+        text = text.lstrip("#")
+
+        # Collapse whitespace again in case lstrip revealed new leading spaces
+        parts = text.split()
+        text = " ".join(parts)
+
         # FR-002: Return None for empty results
         return text if text else None
 

--- a/tests/integration/api/test_entity_creation_integration.py
+++ b/tests/integration/api/test_entity_creation_integration.py
@@ -1,0 +1,878 @@
+"""Integration tests for entity creation API endpoints (Feature 051).
+
+Covers the three entity-creation and duplicate-detection endpoints:
+  - POST /api/v1/entities/classify
+  - POST /api/v1/entities
+  - GET /api/v1/entities/check-duplicate
+
+All tests require the integration database (chronovista_integration_test).
+Each test class seeds its own data and cleans up after itself in FK-reverse
+order to preserve isolation from other integration test files.
+
+Auth: ``require_auth`` is bypassed by patching
+``chronovista.api.deps.youtube_oauth`` so tests do not require real OAuth
+credentials, following the pattern established in
+``test_entity_mentions_api.py``.
+
+Notes
+-----
+- Stable ID prefixes use ``ect_`` (Entity Creation Test) to avoid collisions.
+- channel_id max 24 chars, video_id max 20 chars (PostgreSQL column limits).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, AsyncGenerator
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete, select
+from uuid_utils import uuid7
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import (
+    CanonicalTag as CanonicalTagDB,
+    Channel as ChannelDB,
+    EntityAlias as EntityAliasDB,
+    NamedEntity as NamedEntityDB,
+    TagAlias as TagAliasDB,
+    Video as VideoDB,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+# CRITICAL: Ensures all async tests in this module run with pytest-asyncio
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# Stable test IDs — chosen to avoid collisions with all other test files.
+# ---------------------------------------------------------------------------
+_CHANNEL_ID = "UCect_creation_test01"  # 21 chars — within 24-char limit
+
+
+# ---------------------------------------------------------------------------
+# URL helpers
+# ---------------------------------------------------------------------------
+
+
+def _classify_url() -> str:
+    """Return the classify tag endpoint URL."""
+    return "/api/v1/entities/classify"
+
+
+def _create_entity_url() -> str:
+    """Return the standalone entity creation endpoint URL."""
+    return "/api/v1/entities"
+
+
+def _check_duplicate_url(name: str, entity_type: str) -> str:
+    """Return the duplicate check endpoint URL with query params."""
+    return f"/api/v1/entities/check-duplicate?name={name}&type={entity_type}"
+
+
+def _entity_detail_url(entity_id: str) -> str:
+    """Return the entity detail endpoint URL."""
+    return f"/api/v1/entities/{entity_id}"
+
+
+# ---------------------------------------------------------------------------
+# Shared helper: authenticated request context manager
+# ---------------------------------------------------------------------------
+
+
+def _authenticated():
+    """Context manager that patches oauth to return is_authenticated=True."""
+    mock = patch("chronovista.api.deps.youtube_oauth")
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# TestClassifyFlowEndToEnd
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyFlowEndToEnd:
+    """Integration tests for POST /api/v1/entities/classify."""
+
+    @pytest.fixture
+    async def seed_canonical_tag(
+        self,
+        integration_session_factory: "async_sessionmaker[AsyncSession]",
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Seed a canonical tag with a tag alias for classify tests.
+
+        Yields a dict with:
+        - ``tag_id``: CanonicalTag UUID
+        - ``canonical_form``: display form
+        - ``normalized_form``: normalized form used in classify requests
+        - ``tag_alias_raw``: raw form of the seeded TagAlias
+
+        Cleanup removes all seeded rows in FK-reverse order.
+        """
+        tag_id = uuid.UUID(bytes=uuid7().bytes)
+        canonical_form = "Ect Classify Person"
+        normalized_form = "ect classify person"
+        tag_alias_raw = "ECT Classify Person"
+
+        async with integration_session_factory() as session:
+            # Remove any leftover rows from previous runs
+            await session.execute(
+                delete(TagAliasDB).where(
+                    TagAliasDB.normalized_form == normalized_form
+                )
+            )
+            await session.execute(
+                delete(CanonicalTagDB).where(
+                    CanonicalTagDB.normalized_form == normalized_form
+                )
+            )
+            await session.execute(
+                delete(NamedEntityDB).where(
+                    NamedEntityDB.canonical_name_normalized == normalized_form,
+                    NamedEntityDB.entity_type == "person",
+                )
+            )
+            await session.commit()
+
+            # Seed the canonical tag
+            tag = CanonicalTagDB(
+                id=tag_id,
+                canonical_form=canonical_form,
+                normalized_form=normalized_form,
+                alias_count=1,
+                video_count=0,
+                status="active",
+            )
+            session.add(tag)
+            await session.commit()
+
+            # Seed one tag alias linked to the canonical tag
+            tag_alias = TagAliasDB(
+                id=uuid.UUID(bytes=uuid7().bytes),
+                raw_form=tag_alias_raw,
+                normalized_form=normalized_form,
+                canonical_tag_id=tag_id,
+                creation_method="auto_normalize",
+                occurrence_count=1,
+            )
+            session.add(tag_alias)
+            await session.commit()
+
+        yield {
+            "tag_id": tag_id,
+            "canonical_form": canonical_form,
+            "normalized_form": normalized_form,
+            "tag_alias_raw": tag_alias_raw,
+        }
+
+        # Cleanup — FK reverse: entity_aliases before named_entities, tag_aliases before canonical_tags
+        async with integration_session_factory() as session:
+            # Fetch entity linked to the tag (if any) and delete its aliases
+            tag_row = (
+                await session.execute(
+                    select(CanonicalTagDB).where(
+                        CanonicalTagDB.normalized_form == normalized_form
+                    )
+                )
+            ).scalar_one_or_none()
+            if tag_row is not None and tag_row.entity_id is not None:
+                await session.execute(
+                    delete(EntityAliasDB).where(
+                        EntityAliasDB.entity_id == tag_row.entity_id
+                    )
+                )
+            await session.execute(
+                delete(NamedEntityDB).where(
+                    NamedEntityDB.canonical_name_normalized == normalized_form,
+                    NamedEntityDB.entity_type == "person",
+                )
+            )
+            await session.execute(
+                delete(TagAliasDB).where(
+                    TagAliasDB.normalized_form == normalized_form
+                )
+            )
+            await session.execute(
+                delete(CanonicalTagDB).where(
+                    CanonicalTagDB.normalized_form == normalized_form
+                )
+            )
+            await session.commit()
+
+    async def test_classify_flow_end_to_end(
+        self,
+        async_client: AsyncClient,
+        seed_canonical_tag: dict[str, Any],
+        integration_session_factory: "async_sessionmaker[AsyncSession]",
+    ) -> None:
+        """POST /entities/classify returns 201 and correctly links entity to tag.
+
+        Verifies:
+        - 201 response with entity_id, canonical_name, entity_type.
+        - NamedEntity row exists in DB with correct canonical_name and entity_type.
+        - CanonicalTag.entity_id is set to the newly created entity.
+        - At least one EntityAlias (the self-alias) is created for the entity.
+        """
+        normalized_form = seed_canonical_tag["normalized_form"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.post(
+                _classify_url(),
+                json={
+                    "normalized_form": normalized_form,
+                    "entity_type": "person",
+                },
+            )
+
+        assert response.status_code == 201, (
+            f"Expected 201 but got {response.status_code}: {response.text}"
+        )
+        body = response.json()
+
+        # Response must contain required fields
+        assert "entity_id" in body, f"Missing entity_id in response: {body}"
+        assert "canonical_name" in body, f"Missing canonical_name in response: {body}"
+        assert "entity_type" in body, f"Missing entity_type in response: {body}"
+        assert body["entity_type"] == "person", (
+            f"Expected entity_type 'person', got: {body['entity_type']}"
+        )
+        assert body["entity_created"] is True, (
+            f"Expected entity_created=True, got: {body.get('entity_created')}"
+        )
+
+        entity_id_str = body["entity_id"]
+        assert entity_id_str is not None, "entity_id must not be None after classify"
+
+        # Verify DB state: NamedEntity row must exist
+        async with integration_session_factory() as session:
+            entity_uuid = uuid.UUID(entity_id_str)
+            db_entity = await session.get(NamedEntityDB, entity_uuid)
+            assert db_entity is not None, (
+                f"NamedEntity {entity_id_str} not found in DB after classify"
+            )
+            assert db_entity.entity_type == "person", (
+                f"NamedEntity.entity_type mismatch: {db_entity.entity_type}"
+            )
+            # canonical_name should be title-cased (auto_case=True in endpoint)
+            assert db_entity.canonical_name is not None
+            assert db_entity.canonical_name_normalized == normalized_form, (
+                f"Normalized name mismatch: {db_entity.canonical_name_normalized}"
+            )
+
+            # Verify CanonicalTag.entity_id is linked
+            db_tag = await session.get(CanonicalTagDB, seed_canonical_tag["tag_id"])
+            assert db_tag is not None, "CanonicalTag must still exist after classify"
+            assert db_tag.entity_id == entity_uuid, (
+                f"CanonicalTag.entity_id not linked: expected {entity_uuid}, "
+                f"got {db_tag.entity_id}"
+            )
+            assert db_tag.entity_type == "person", (
+                f"CanonicalTag.entity_type not set: {db_tag.entity_type}"
+            )
+
+            # Verify EntityAlias (self-alias) was created
+            aliases_result = await session.execute(
+                select(EntityAliasDB).where(
+                    EntityAliasDB.entity_id == entity_uuid
+                )
+            )
+            aliases = aliases_result.scalars().all()
+            assert len(aliases) >= 1, (
+                f"Expected at least 1 EntityAlias (self-alias), found {len(aliases)}"
+            )
+            alias_names_normalized = [a.alias_name_normalized for a in aliases]
+            assert normalized_form in alias_names_normalized, (
+                f"Self-alias with normalized_form='{normalized_form}' not found "
+                f"in entity aliases: {alias_names_normalized}"
+            )
+
+    async def test_classify_returns_409_when_tag_already_classified(
+        self,
+        async_client: AsyncClient,
+        seed_canonical_tag: dict[str, Any],
+    ) -> None:
+        """POST /entities/classify returns 409 on a second classify call for the same tag.
+
+        The first call succeeds (201); the second call must return 409 because
+        the tag is already classified and force is not set.
+        """
+        normalized_form = seed_canonical_tag["normalized_form"]
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+
+            # First classify — should succeed
+            first_response = await async_client.post(
+                _classify_url(),
+                json={
+                    "normalized_form": normalized_form,
+                    "entity_type": "person",
+                },
+            )
+            assert first_response.status_code == 201, (
+                f"First classify failed unexpectedly: {first_response.text}"
+            )
+
+            # Second classify — should conflict
+            second_response = await async_client.post(
+                _classify_url(),
+                json={
+                    "normalized_form": normalized_form,
+                    "entity_type": "person",
+                },
+            )
+
+        assert second_response.status_code == 409, (
+            f"Expected 409 on duplicate classify but got "
+            f"{second_response.status_code}: {second_response.text}"
+        )
+
+    async def test_classify_returns_404_for_unknown_tag(
+        self,
+        async_client: AsyncClient,
+    ) -> None:
+        """POST /entities/classify returns 404 when normalized_form does not exist."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.post(
+                _classify_url(),
+                json={
+                    "normalized_form": "ect nonexistent tag zzzz",
+                    "entity_type": "person",
+                },
+            )
+
+        assert response.status_code == 404, (
+            f"Expected 404 for unknown tag, got {response.status_code}: {response.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestStandaloneCreationEndToEnd
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneCreationEndToEnd:
+    """Integration tests for POST /api/v1/entities."""
+
+    # Stable normalized forms used across fixtures/tests in this class
+    _SNOWDEN_NORMALIZED = "edward snowden"
+
+    @pytest.fixture(autouse=True)
+    async def cleanup_snowden(
+        self,
+        integration_session_factory: "async_sessionmaker[AsyncSession]",
+    ) -> AsyncGenerator[None, None]:
+        """Remove any leftover Edward Snowden entity rows before and after each test."""
+        normalized = self._SNOWDEN_NORMALIZED
+
+        async def _wipe(session: AsyncSession) -> None:
+            rows = (
+                await session.execute(
+                    select(NamedEntityDB).where(
+                        NamedEntityDB.canonical_name_normalized == normalized,
+                        NamedEntityDB.entity_type == "person",
+                    )
+                )
+            ).scalars().all()
+            for row in rows:
+                await session.execute(
+                    delete(EntityAliasDB).where(EntityAliasDB.entity_id == row.id)
+                )
+            await session.execute(
+                delete(NamedEntityDB).where(
+                    NamedEntityDB.canonical_name_normalized == normalized,
+                    NamedEntityDB.entity_type == "person",
+                )
+            )
+            await session.commit()
+
+        async with integration_session_factory() as session:
+            await _wipe(session)
+
+        yield
+
+        async with integration_session_factory() as session:
+            await _wipe(session)
+
+    async def test_standalone_creation_end_to_end(
+        self,
+        async_client: AsyncClient,
+        integration_session_factory: "async_sessionmaker[AsyncSession]",
+    ) -> None:
+        """POST /entities creates an entity with title-cased name and aliases.
+
+        Verifies:
+        - 201 response.
+        - canonical_name is title-cased ("Edward Snowden").
+        - NamedEntity exists in DB with correct canonical_name and entity_type.
+        - 3 EntityAlias rows exist: canonical name + 2 user-supplied aliases.
+        """
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.post(
+                _create_entity_url(),
+                json={
+                    "name": "edward snowden",
+                    "entity_type": "person",
+                    "aliases": ["Ed Snowden", "Snowden"],
+                },
+            )
+
+        assert response.status_code == 201, (
+            f"Expected 201 but got {response.status_code}: {response.text}"
+        )
+        body = response.json()
+
+        # Verify response shape
+        assert "entity_id" in body, f"Missing entity_id in response: {body}"
+        assert "canonical_name" in body, f"Missing canonical_name in response: {body}"
+        assert "entity_type" in body, f"Missing entity_type in response: {body}"
+        assert "alias_count" in body, f"Missing alias_count in response: {body}"
+
+        # canonical_name must be title-cased
+        assert body["canonical_name"] == "Edward Snowden", (
+            f"Expected title-cased 'Edward Snowden', got: {body['canonical_name']}"
+        )
+        assert body["entity_type"] == "person", (
+            f"Expected entity_type 'person', got: {body['entity_type']}"
+        )
+
+        entity_id_str = body["entity_id"]
+        entity_uuid = uuid.UUID(entity_id_str)
+
+        # Verify DB state
+        async with integration_session_factory() as session:
+            db_entity = await session.get(NamedEntityDB, entity_uuid)
+            assert db_entity is not None, (
+                f"NamedEntity {entity_id_str} not found in DB"
+            )
+            assert db_entity.canonical_name == "Edward Snowden", (
+                f"DB canonical_name mismatch: {db_entity.canonical_name}"
+            )
+            assert db_entity.canonical_name_normalized == self._SNOWDEN_NORMALIZED, (
+                f"DB canonical_name_normalized mismatch: "
+                f"{db_entity.canonical_name_normalized}"
+            )
+            assert db_entity.entity_type == "person", (
+                f"DB entity_type mismatch: {db_entity.entity_type}"
+            )
+            assert db_entity.status == "active", (
+                f"DB status mismatch: {db_entity.status}"
+            )
+
+            # Verify alias count — canonical name + 2 user aliases = 3 aliases
+            aliases_result = await session.execute(
+                select(EntityAliasDB).where(
+                    EntityAliasDB.entity_id == entity_uuid
+                )
+            )
+            aliases = aliases_result.scalars().all()
+            assert len(aliases) == 3, (
+                f"Expected 3 aliases (canonical + 2 user), found {len(aliases)}: "
+                f"{[a.alias_name for a in aliases]}"
+            )
+
+            alias_names = {a.alias_name for a in aliases}
+            assert "Edward Snowden" in alias_names, (
+                f"Canonical alias 'Edward Snowden' missing: {alias_names}"
+            )
+            assert "Ed Snowden" in alias_names, (
+                f"User alias 'Ed Snowden' missing: {alias_names}"
+            )
+            assert "Snowden" in alias_names, (
+                f"User alias 'Snowden' missing: {alias_names}"
+            )
+
+    async def test_standalone_creation_deduplicates_identical_aliases(
+        self,
+        async_client: AsyncClient,
+        integration_session_factory: "async_sessionmaker[AsyncSession]",
+    ) -> None:
+        """POST /entities de-duplicates aliases that normalize to the same form.
+
+        When the aliases list contains a value whose normalized form equals
+        the entity's own normalized form, it should be silently skipped so
+        no unique-constraint error occurs.
+        """
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.post(
+                _create_entity_url(),
+                json={
+                    "name": "edward snowden",
+                    "entity_type": "person",
+                    # "Edward Snowden" normalizes the same as the entity name
+                    "aliases": ["Edward Snowden", "Ed Snowden"],
+                },
+            )
+
+        assert response.status_code == 201, (
+            f"Expected 201 but got {response.status_code}: {response.text}"
+        )
+        body = response.json()
+        entity_uuid = uuid.UUID(body["entity_id"])
+
+        async with integration_session_factory() as session:
+            aliases_result = await session.execute(
+                select(EntityAliasDB).where(
+                    EntityAliasDB.entity_id == entity_uuid
+                )
+            )
+            aliases = aliases_result.scalars().all()
+            # canonical + "Ed Snowden" only — "Edward Snowden" duplicate skipped
+            assert len(aliases) == 2, (
+                f"Expected 2 aliases after dedup, found {len(aliases)}: "
+                f"{[a.alias_name for a in aliases]}"
+            )
+
+    async def test_standalone_creation_rejects_invalid_entity_type(
+        self,
+        async_client: AsyncClient,
+    ) -> None:
+        """POST /entities returns 422 when entity_type is not a valid value."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.post(
+                _create_entity_url(),
+                json={
+                    "name": "Test Entity",
+                    "entity_type": "invalid_type_xyz",
+                },
+            )
+
+        # Pydantic validation rejects invalid entity_type with 422
+        assert response.status_code == 422, (
+            f"Expected 422 for invalid entity_type, got "
+            f"{response.status_code}: {response.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestDuplicateDetection
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateDetection:
+    """Integration tests for GET /api/v1/entities/check-duplicate."""
+
+    _GARLAND_CANONICAL = "Garland Nixon"
+    _GARLAND_NORMALIZED = "garland nixon"
+
+    @pytest.fixture
+    async def seed_garland_entity(
+        self,
+        integration_session_factory: "async_sessionmaker[AsyncSession]",
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Seed a 'Garland Nixon' named entity for duplicate detection tests.
+
+        Yields a dict with:
+        - ``entity_id``: UUID of the seeded entity
+        - ``canonical_name``: "Garland Nixon"
+        - ``normalized_name``: "garland nixon"
+
+        Cleanup removes the entity and its aliases.
+        """
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        canonical = self._GARLAND_CANONICAL
+        normalized = self._GARLAND_NORMALIZED
+
+        async with integration_session_factory() as session:
+            # Remove any leftover from prior runs
+            existing = (
+                await session.execute(
+                    select(NamedEntityDB).where(
+                        NamedEntityDB.canonical_name_normalized == normalized,
+                        NamedEntityDB.entity_type == "person",
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing is not None:
+                await session.execute(
+                    delete(EntityAliasDB).where(
+                        EntityAliasDB.entity_id == existing.id
+                    )
+                )
+                await session.execute(
+                    delete(NamedEntityDB).where(NamedEntityDB.id == existing.id)
+                )
+                await session.commit()
+
+            # Seed the entity
+            entity = NamedEntityDB(
+                id=entity_id,
+                canonical_name=canonical,
+                canonical_name_normalized=normalized,
+                entity_type="person",
+                status="active",
+                discovery_method="user_created",
+                confidence=1.0,
+            )
+            session.add(entity)
+            await session.commit()
+
+        yield {
+            "entity_id": entity_id,
+            "entity_id_str": str(entity_id),
+            "canonical_name": canonical,
+            "normalized_name": normalized,
+        }
+
+        # Cleanup
+        async with integration_session_factory() as session:
+            await session.execute(
+                delete(EntityAliasDB).where(
+                    EntityAliasDB.entity_id == entity_id
+                )
+            )
+            await session.execute(
+                delete(NamedEntityDB).where(NamedEntityDB.id == entity_id)
+            )
+            await session.commit()
+
+    async def test_duplicate_detection_returns_correct_entity(
+        self,
+        async_client: AsyncClient,
+        seed_garland_entity: dict[str, Any],
+    ) -> None:
+        """GET /entities/check-duplicate returns is_duplicate=True for existing entity.
+
+        Sends the query with lower-case input ("garland nixon") to verify the
+        endpoint normalizes before comparison.  Verifies:
+        - is_duplicate: True
+        - existing_entity has correct entity_id, canonical_name, and entity_type.
+        """
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                _check_duplicate_url(
+                    name="garland+nixon",
+                    entity_type="person",
+                )
+            )
+
+        assert response.status_code == 200, (
+            f"Expected 200 but got {response.status_code}: {response.text}"
+        )
+        body = response.json()
+
+        assert body["is_duplicate"] is True, (
+            f"Expected is_duplicate=True, got: {body.get('is_duplicate')}"
+        )
+        existing = body.get("existing_entity")
+        assert existing is not None, (
+            f"Expected existing_entity to be populated, got None. Body: {body}"
+        )
+        assert existing["entity_id"] == seed_garland_entity["entity_id_str"], (
+            f"entity_id mismatch: expected {seed_garland_entity['entity_id_str']}, "
+            f"got {existing['entity_id']}"
+        )
+        assert existing["canonical_name"] == self._GARLAND_CANONICAL, (
+            f"canonical_name mismatch: {existing['canonical_name']}"
+        )
+        assert existing["entity_type"] == "person", (
+            f"entity_type mismatch: {existing['entity_type']}"
+        )
+
+    async def test_duplicate_check_returns_false_for_unknown_entity(
+        self,
+        async_client: AsyncClient,
+    ) -> None:
+        """GET /entities/check-duplicate returns is_duplicate=False for unknown name."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                _check_duplicate_url(
+                    name="zzz+nobody+ect+xyz",
+                    entity_type="person",
+                )
+            )
+
+        assert response.status_code == 200, (
+            f"Expected 200 but got {response.status_code}: {response.text}"
+        )
+        body = response.json()
+        assert body["is_duplicate"] is False, (
+            f"Expected is_duplicate=False, got: {body.get('is_duplicate')}"
+        )
+        assert body.get("existing_entity") is None, (
+            f"Expected existing_entity=None, got: {body.get('existing_entity')}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test409OnDuplicateCreation
+# ---------------------------------------------------------------------------
+
+
+class TestConflictOnDuplicateCreation:
+    """Integration tests for 409 conflict behaviour on POST /api/v1/entities."""
+
+    _GARLAND_CANONICAL = "Garland Nixon"
+    _GARLAND_NORMALIZED = "garland nixon"
+
+    @pytest.fixture
+    async def seed_garland_for_conflict(
+        self,
+        integration_session_factory: "async_sessionmaker[AsyncSession]",
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Seed a 'Garland Nixon' named entity for the 409 conflict test.
+
+        Separate fixture (vs TestDuplicateDetection) to avoid cross-test
+        state dependency.
+        """
+        entity_id = uuid.UUID(bytes=uuid7().bytes)
+        canonical = self._GARLAND_CANONICAL
+        normalized = self._GARLAND_NORMALIZED
+
+        async with integration_session_factory() as session:
+            # Remove any leftover from prior runs
+            existing = (
+                await session.execute(
+                    select(NamedEntityDB).where(
+                        NamedEntityDB.canonical_name_normalized == normalized,
+                        NamedEntityDB.entity_type == "person",
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing is not None:
+                await session.execute(
+                    delete(EntityAliasDB).where(
+                        EntityAliasDB.entity_id == existing.id
+                    )
+                )
+                await session.execute(
+                    delete(NamedEntityDB).where(NamedEntityDB.id == existing.id)
+                )
+                await session.commit()
+
+            entity = NamedEntityDB(
+                id=entity_id,
+                canonical_name=canonical,
+                canonical_name_normalized=normalized,
+                entity_type="person",
+                status="active",
+                discovery_method="user_created",
+                confidence=1.0,
+            )
+            session.add(entity)
+            await session.commit()
+
+        yield {
+            "entity_id": entity_id,
+            "entity_id_str": str(entity_id),
+        }
+
+        # Cleanup
+        async with integration_session_factory() as session:
+            await session.execute(
+                delete(EntityAliasDB).where(
+                    EntityAliasDB.entity_id == entity_id
+                )
+            )
+            await session.execute(
+                delete(NamedEntityDB).where(NamedEntityDB.id == entity_id)
+            )
+            await session.commit()
+
+    async def test_409_on_duplicate_creation(
+        self,
+        async_client: AsyncClient,
+        seed_garland_for_conflict: dict[str, Any],
+    ) -> None:
+        """POST /entities returns 409 when entity with same name+type already exists.
+
+        Attempts to create another "Garland Nixon" (person) while one is
+        already active in the DB; expects the endpoint to detect the
+        duplicate and return 409 Conflict.
+        """
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.post(
+                _create_entity_url(),
+                json={
+                    "name": "Garland Nixon",
+                    "entity_type": "person",
+                },
+            )
+
+        assert response.status_code == 409, (
+            f"Expected 409 Conflict on duplicate entity creation, "
+            f"got {response.status_code}: {response.text}"
+        )
+
+    async def test_same_name_different_type_is_allowed(
+        self,
+        async_client: AsyncClient,
+        seed_garland_for_conflict: dict[str, Any],
+        integration_session_factory: "async_sessionmaker[AsyncSession]",
+    ) -> None:
+        """POST /entities allows same name when entity_type differs.
+
+        'Garland Nixon' as 'organization' should not conflict with the
+        seeded 'Garland Nixon' of type 'person'.
+        """
+        async with integration_session_factory() as session:
+            # Pre-clean any existing 'garland nixon' of type 'organization'
+            existing = (
+                await session.execute(
+                    select(NamedEntityDB).where(
+                        NamedEntityDB.canonical_name_normalized
+                        == self._GARLAND_NORMALIZED,
+                        NamedEntityDB.entity_type == "organization",
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing is not None:
+                await session.execute(
+                    delete(EntityAliasDB).where(
+                        EntityAliasDB.entity_id == existing.id
+                    )
+                )
+                await session.execute(
+                    delete(NamedEntityDB).where(NamedEntityDB.id == existing.id)
+                )
+                await session.commit()
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.post(
+                _create_entity_url(),
+                json={
+                    "name": "Garland Nixon",
+                    "entity_type": "organization",
+                },
+            )
+
+        try:
+            assert response.status_code == 201, (
+                f"Expected 201 for different entity_type, "
+                f"got {response.status_code}: {response.text}"
+            )
+        finally:
+            # Cleanup the newly created organization entity
+            async with integration_session_factory() as session:
+                created = (
+                    await session.execute(
+                        select(NamedEntityDB).where(
+                            NamedEntityDB.canonical_name_normalized
+                            == self._GARLAND_NORMALIZED,
+                            NamedEntityDB.entity_type == "organization",
+                        )
+                    )
+                ).scalar_one_or_none()
+                if created is not None:
+                    await session.execute(
+                        delete(EntityAliasDB).where(
+                            EntityAliasDB.entity_id == created.id
+                        )
+                    )
+                    await session.execute(
+                        delete(NamedEntityDB).where(NamedEntityDB.id == created.id)
+                    )
+                    await session.commit()

--- a/tests/unit/api/test_entity_creation_endpoints.py
+++ b/tests/unit/api/test_entity_creation_endpoints.py
@@ -1,0 +1,1963 @@
+"""Unit tests for POST /api/v1/entities/classify endpoint.
+
+Tests the classify_tag endpoint in isolation by mocking the database session and
+the module-level ``_tag_mgmt_service`` singleton.  No live database is required.
+
+Coverage targets
+----------------
+- 201 happy path: valid request creates entity, returns entity_id, canonical_name,
+  entity_type, alias_count, entity_created, operation_id
+- 201 with optional description field
+- 201 with entity_created=False (existing entity linked, not created)
+- 404 Not Found: service raises ValueError containing "not found"
+- 404 Not Found: service raises ValueError containing "status"
+- 409 Conflict: service raises ValueError containing "already classified"
+  (with existing entity details in response)
+- 409 Conflict: service raises ValueError "already classified" but tag lookup
+  returns None (no existing entity data available)
+- 400 Bad Request: service raises other ValueError
+- 422 Unprocessable Entity: entity_type not in allowed set (Pydantic validates)
+- 422 Unprocessable Entity: empty normalized_form (min_length=1 fails)
+- 422 Unprocessable Entity: normalized_form too long (max_length=500 fails)
+- 422 Unprocessable Entity: description too long (max_length=5000 fails)
+- 422 Unprocessable Entity: missing normalized_form field
+- 422 Unprocessable Entity: missing entity_type field
+- Auth: unauthenticated request returns 401
+
+Architecture
+------------
+The endpoint (``classify_tag``) lives at
+``chronovista.api.routers.entity_mentions`` and delegates to a module-level
+``_tag_mgmt_service`` singleton (``TagManagementService``).  After a successful
+``classify()`` call it makes two additional DB calls:
+
+1. SELECT CanonicalTagDB WHERE normalized_form == body.normalized_form
+2. session.get(NamedEntityDB, tag.entity_id)
+
+These are mocked via the session's ``execute`` / ``get`` side-effects.
+
+Mocking strategy
+----------------
+- ``_tag_mgmt_service.classify`` is patched at the module level using
+  ``unittest.mock.patch`` on the full dotted path.
+- The ``get_db`` FastAPI dependency is overridden to inject a mock
+  ``AsyncSession`` whose ``execute`` and ``get`` attributes are
+  ``AsyncMock`` instances returning controlled MagicMock DB rows.
+- The ``require_auth`` dependency is overridden to a no-op to avoid
+  needing real OAuth credentials.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.main import app
+from chronovista.services.tag_management import ClassifyResult
+
+# CRITICAL: ensures all async tests in this module are picked up by pytest-asyncio
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CLASSIFY_ENDPOINT = "/api/v1/entities/classify"
+
+_VALID_NORMALIZED_FORM = "elon musk"
+_VALID_ENTITY_TYPE = "person"
+
+# All entity types accepted by ClassifyTagRequest.validate_entity_type
+_VALID_ENTITY_TYPES = [
+    "person",
+    "organization",
+    "place",
+    "event",
+    "work",
+    "technical_term",
+    "concept",
+    "other",
+]
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_classify_result(
+    *,
+    normalized_form: str = _VALID_NORMALIZED_FORM,
+    canonical_form: str = "Elon Musk",
+    entity_type: str = "person",
+    entity_created: bool = True,
+    entity_alias_count: int = 2,
+    operation_id: uuid.UUID | None = None,
+) -> ClassifyResult:
+    """Build a ``ClassifyResult`` dataclass for use as the mock return value.
+
+    Parameters
+    ----------
+    normalized_form : str
+        Normalized tag form.
+    canonical_form : str
+        Display form of the canonical tag.
+    entity_type : str
+        Entity type string value.
+    entity_created : bool
+        Whether a new entity was created (vs. linked to existing).
+    entity_alias_count : int
+        Number of aliases copied to the entity.
+    operation_id : uuid.UUID | None
+        Operation log UUID.  Auto-generated when None.
+
+    Returns
+    -------
+    ClassifyResult
+        A fully-populated ClassifyResult dataclass instance.
+    """
+    return ClassifyResult(
+        normalized_form=normalized_form,
+        canonical_form=canonical_form,
+        entity_type=entity_type,
+        entity_created=entity_created,
+        entity_alias_count=entity_alias_count,
+        operation_id=operation_id or uuid.uuid4(),
+    )
+
+
+def _make_canonical_tag_row(
+    *,
+    normalized_form: str = _VALID_NORMALIZED_FORM,
+    entity_id: uuid.UUID | None = None,
+) -> MagicMock:
+    """Create a minimal mock CanonicalTagDB row.
+
+    Parameters
+    ----------
+    normalized_form : str
+        The normalized form stored on the tag.
+    entity_id : uuid.UUID | None
+        The linked entity UUID, or None if not yet linked.
+
+    Returns
+    -------
+    MagicMock
+        A mock with the minimum attributes read by the endpoint.
+    """
+    row = MagicMock()
+    row.normalized_form = normalized_form
+    row.entity_id = entity_id or uuid.uuid4()
+    return row
+
+
+def _make_named_entity_row(
+    *,
+    entity_id: uuid.UUID | None = None,
+    canonical_name: str = "Elon Musk",
+    entity_type: str = "person",
+    description: str | None = None,
+) -> MagicMock:
+    """Create a minimal mock NamedEntityDB row.
+
+    Parameters
+    ----------
+    entity_id : uuid.UUID | None
+        Entity primary key UUID.  Auto-generated when None.
+    canonical_name : str
+        Display name.
+    entity_type : str
+        Entity type string.
+    description : str | None
+        Optional description.
+
+    Returns
+    -------
+    MagicMock
+        A mock with the minimum attributes serialized by the endpoint.
+    """
+    row = MagicMock()
+    row.id = entity_id or uuid.uuid4()
+    row.canonical_name = canonical_name
+    row.entity_type = entity_type
+    row.description = description
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Session helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session_success(
+    tag_row: MagicMock, entity_row: MagicMock
+) -> AsyncMock:
+    """Build a mock AsyncSession for the happy path.
+
+    The endpoint makes these DB calls after a successful classify():
+    1. session.execute(SELECT CanonicalTagDB WHERE normalized_form == ...)
+       → tag_row
+    2. session.get(NamedEntityDB, tag.entity_id) → entity_row
+    3. session.commit()
+
+    Parameters
+    ----------
+    tag_row : MagicMock
+        The CanonicalTagDB mock row returned by execute.
+    entity_row : MagicMock
+        The NamedEntityDB mock row returned by session.get.
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    # execute() → scalar_one_or_none() → tag_row
+    tag_result = MagicMock()
+    tag_result.scalar_one_or_none.return_value = tag_row
+    mock_session.execute = AsyncMock(return_value=tag_result)
+
+    # session.get() → entity_row
+    mock_session.get = AsyncMock(return_value=entity_row)
+
+    mock_session.commit = AsyncMock()
+    return mock_session
+
+
+def _make_session_tag_not_found() -> AsyncMock:
+    """Build a mock session where the post-classify tag lookup returns None.
+
+    Used for the conflict branch where tag is already classified but the
+    subsequent SELECT cannot locate the tag row.
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    tag_result = MagicMock()
+    tag_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=tag_result)
+    mock_session.get = AsyncMock(return_value=None)
+    mock_session.commit = AsyncMock()
+    return mock_session
+
+
+def _make_session_conflict_with_existing_entity(
+    tag_row: MagicMock, entity_row: MagicMock
+) -> AsyncMock:
+    """Build a mock session for the 'already classified' conflict branch.
+
+    When the service raises ValueError("already classified ...") the endpoint
+    performs two extra DB queries to fetch existing entity details:
+    1. SELECT CanonicalTagDB WHERE normalized_form == ...
+    2. session.get(NamedEntityDB, tag.entity_id)
+
+    Parameters
+    ----------
+    tag_row : MagicMock
+        The CanonicalTagDB mock row returned by execute.
+    entity_row : MagicMock
+        The NamedEntityDB mock row returned by session.get.
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    tag_result = MagicMock()
+    tag_result.scalar_one_or_none.return_value = tag_row
+    mock_session.execute = AsyncMock(return_value=tag_result)
+    mock_session.get = AsyncMock(return_value=entity_row)
+    mock_session.commit = AsyncMock()
+    return mock_session
+
+
+# ---------------------------------------------------------------------------
+# Shared client fixture builder
+# ---------------------------------------------------------------------------
+
+
+async def _build_client(mock_session: AsyncMock) -> AsyncGenerator[AsyncClient, None]:
+    """Yield an AsyncClient with get_db and require_auth overridden.
+
+    Parameters
+    ----------
+    mock_session : AsyncMock
+        The mock database session to inject via the get_db override.
+
+    Yields
+    ------
+    AsyncClient
+        A configured HTTP test client with overridden dependencies.
+    """
+
+    async def mock_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    async def mock_require_auth() -> None:
+        return None
+
+    app.dependency_overrides[get_db] = mock_get_db
+    app.dependency_overrides[require_auth] = mock_require_auth
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# T_CLASSIFY_201 — Happy-path tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTagHappyPath:
+    """Tests that verify 201 responses for valid classify requests."""
+
+    async def test_valid_request_returns_201(self) -> None:
+        """Valid normalized_form and entity_type → 201 Created.
+
+        Verifies the most basic happy path: the service classifies successfully
+        and the endpoint returns a 201 status code.
+        """
+        entity_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(entity_id=entity_id)
+        mock_session = _make_session_success(tag_row, entity_row)
+        classify_result = _make_classify_result()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(return_value=classify_result)
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": _VALID_ENTITY_TYPE,
+                    },
+                )
+
+        assert response.status_code == 201, response.text
+
+    async def test_response_body_contains_required_fields(self) -> None:
+        """201 response body contains entity_id, canonical_name, entity_type,
+        alias_count, entity_created, and operation_id.
+
+        Validates the full response schema returned by the classify endpoint.
+        """
+        entity_id = uuid.uuid4()
+        operation_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(
+            entity_id=entity_id,
+            canonical_name="Elon Musk",
+            entity_type="person",
+        )
+        mock_session = _make_session_success(tag_row, entity_row)
+        classify_result = _make_classify_result(
+            entity_alias_count=3,
+            entity_created=True,
+            operation_id=operation_id,
+        )
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(return_value=classify_result)
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+
+        assert "entity_id" in body, f"Missing 'entity_id' in: {body}"
+        assert "canonical_name" in body, f"Missing 'canonical_name' in: {body}"
+        assert "entity_type" in body, f"Missing 'entity_type' in: {body}"
+        assert "alias_count" in body, f"Missing 'alias_count' in: {body}"
+        assert "entity_created" in body, f"Missing 'entity_created' in: {body}"
+        assert "operation_id" in body, f"Missing 'operation_id' in: {body}"
+
+    async def test_response_body_values_match_service_and_db(self) -> None:
+        """Response field values are pulled from the entity row and classify result.
+
+        entity_id and canonical_name come from the NamedEntityDB lookup;
+        entity_type, alias_count, entity_created, and operation_id come from
+        ClassifyResult.
+        """
+        entity_id = uuid.uuid4()
+        operation_id = uuid.uuid4()
+
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(
+            entity_id=entity_id,
+            canonical_name="Elon Musk",
+            entity_type="person",
+            description="South African-born entrepreneur",
+        )
+        mock_session = _make_session_success(tag_row, entity_row)
+        classify_result = _make_classify_result(
+            entity_alias_count=5,
+            entity_created=True,
+            entity_type="person",
+            operation_id=operation_id,
+        )
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(return_value=classify_result)
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        body = response.json()
+        assert body["entity_id"] == str(entity_id)
+        assert body["canonical_name"] == "Elon Musk"
+        assert body["entity_type"] == "person"
+        assert body["alias_count"] == 5
+        assert body["entity_created"] is True
+        assert body["operation_id"] == str(operation_id)
+
+    async def test_optional_description_is_included_in_response(self) -> None:
+        """When description is passed in the request, it is reflected in the response.
+
+        The endpoint sets ``description`` from the entity row's description field
+        after the tag lookup.
+        """
+        entity_id = uuid.uuid4()
+        description_text = "Tesla and SpaceX CEO"
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(
+            entity_id=entity_id,
+            description=description_text,
+        )
+        mock_session = _make_session_success(tag_row, entity_row)
+        classify_result = _make_classify_result()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(return_value=classify_result)
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                        "description": description_text,
+                    },
+                )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["description"] == description_text
+
+    async def test_entity_created_false_when_existing_entity_linked(self) -> None:
+        """When an existing entity is linked (not created), entity_created is False.
+
+        ClassifyResult.entity_created=False occurs when classify() finds an
+        existing NamedEntity and links the canonical tag to it instead of
+        creating a new one.
+        """
+        entity_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(entity_id=entity_id)
+        mock_session = _make_session_success(tag_row, entity_row)
+        classify_result = _make_classify_result(entity_created=False)
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(return_value=classify_result)
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["entity_created"] is False
+
+    async def test_service_called_with_correct_arguments(self) -> None:
+        """The endpoint passes normalized_form, entity_type enum, description,
+        and auto_case=True to the service classify() method.
+
+        Guards against a regression where arguments are shuffled or the enum
+        conversion is skipped.
+        """
+        from chronovista.models.enums import EntityType
+
+        entity_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(entity_id=entity_id)
+        mock_session = _make_session_success(tag_row, entity_row)
+        classify_result = _make_classify_result()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(return_value=classify_result)
+
+                await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": "tesla motors",
+                        "entity_type": "organization",
+                        "description": "Electric vehicle manufacturer",
+                    },
+                )
+
+                mock_svc.classify.assert_called_once()
+                call_args: Any = mock_svc.classify.call_args
+                # Verify positional args: session, normalized_form, entity_type_enum
+                assert call_args.args[1] == "tesla motors"
+                assert call_args.args[2] == EntityType.ORGANIZATION
+                # Verify keyword args
+                assert call_args.kwargs.get("description") == "Electric vehicle manufacturer"
+                assert call_args.kwargs.get("auto_case") is True
+
+    async def test_alias_count_is_zero_when_no_aliases_created(self) -> None:
+        """alias_count == 0 in the response when entity_alias_count is 0.
+
+        A new entity with no tag aliases produces alias_count=0 in the
+        ClassifyResult and this must be faithfully serialized.
+        """
+        entity_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(entity_id=entity_id)
+        mock_session = _make_session_success(tag_row, entity_row)
+        classify_result = _make_classify_result(entity_alias_count=0)
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(return_value=classify_result)
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        body = response.json()
+        assert body["alias_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# T_CLASSIFY_404 — Tag not found / inactive
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTagNotFound:
+    """Tests for 404 responses when the canonical tag does not exist or is inactive."""
+
+    async def test_tag_not_found_returns_404(self) -> None:
+        """Service raises ValueError with 'not found' → endpoint returns 404.
+
+        The ``classify()`` method raises ValueError when the normalized_form
+        does not match any active canonical tag.  The endpoint inspects the
+        error message and maps it to NotFoundError (404).
+        """
+        mock_session = _make_session_tag_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(
+                    side_effect=ValueError("Tag 'unknown-tag' not found")
+                )
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": "unknown-tag",
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 404, response.text
+
+    async def test_tag_not_found_has_rfc7807_error_body(self) -> None:
+        """404 response body follows RFC-7807 Problem Details structure."""
+        mock_session = _make_session_tag_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(
+                    side_effect=ValueError("Tag 'x' not found in database")
+                )
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": "x",
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 404
+        body = response.json()
+        assert "status" in body or "type" in body, (
+            f"Expected RFC-7807 error body, got: {body}"
+        )
+
+    async def test_inactive_tag_returns_404(self) -> None:
+        """Service raises ValueError mentioning 'status' → endpoint returns 404.
+
+        When a canonical tag exists but is deprecated/inactive, the service
+        raises a ValueError containing 'status'.  The endpoint maps this to
+        a 404 response.
+        """
+        mock_session = _make_session_tag_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(
+                    side_effect=ValueError(
+                        "Tag 'deprecated-tag' has status 'deprecated' and cannot be classified"
+                    )
+                )
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": "deprecated-tag",
+                        "entity_type": "organization",
+                    },
+                )
+
+        assert response.status_code == 404, response.text
+
+
+# ---------------------------------------------------------------------------
+# T_CLASSIFY_409 — Already classified (conflict)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTagConflict:
+    """Tests for 409 Conflict when a tag is already classified as an entity."""
+
+    async def test_already_classified_returns_409(self) -> None:
+        """Service raises ValueError 'already classified' → 409 Conflict.
+
+        The ``classify()`` method raises ValueError when the canonical tag
+        already has an entity_type set and force=False (the default).
+        """
+        entity_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(entity_id=entity_id)
+        mock_session = _make_session_conflict_with_existing_entity(
+            tag_row, entity_row
+        )
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(
+                    side_effect=ValueError(
+                        "Tag 'elon musk' is already classified as person"
+                    )
+                )
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 409, response.text
+
+    async def test_already_classified_response_has_rfc7807_body(self) -> None:
+        """409 Conflict response body follows RFC-7807 Problem Details structure."""
+        entity_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(entity_id=entity_id)
+        mock_session = _make_session_conflict_with_existing_entity(
+            tag_row, entity_row
+        )
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(
+                    side_effect=ValueError("Tag is already classified as an entity")
+                )
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 409
+        body = response.json()
+        assert "status" in body or "type" in body, (
+            f"Expected RFC-7807 error body, got: {body}"
+        )
+
+    async def test_already_classified_includes_existing_entity_in_details(
+        self,
+    ) -> None:
+        """409 Conflict response body includes existing entity details in 'details'.
+
+        When the tag lookup succeeds after the conflict, the endpoint fetches
+        the existing entity and includes it in the ConflictError details dict.
+        The RFC-7807 response should therefore contain the existing entity info.
+        """
+        entity_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(
+            entity_id=entity_id,
+            canonical_name="Elon Musk",
+            entity_type="person",
+            description="CEO of Tesla and SpaceX",
+        )
+        mock_session = _make_session_conflict_with_existing_entity(
+            tag_row, entity_row
+        )
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(
+                    side_effect=ValueError(
+                        "Tag 'elon musk' is already classified as person"
+                    )
+                )
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 409
+        body = response.json()
+        # The ConflictError details should carry existing entity information.
+        # RFC-7807 responses in this project include an "errors" or "details" key.
+        assert "status" in body or "type" in body
+
+    async def test_already_classified_no_tag_row_still_returns_409(self) -> None:
+        """409 returned even when the post-conflict tag lookup returns None.
+
+        Edge case: the service reports "already classified" but the subsequent
+        SELECT for existing entity details finds no matching tag row.  The
+        endpoint still raises ConflictError with no ``details`` payload.
+        """
+        mock_session = _make_session_tag_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(
+                    side_effect=ValueError(
+                        "Tag is already classified — use force=True to override"
+                    )
+                )
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 409, response.text
+
+
+# ---------------------------------------------------------------------------
+# T_CLASSIFY_400 — Other ValueError from service → 400 Bad Request
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTagBadRequest:
+    """Tests for 400 Bad Request when the service raises a generic ValueError."""
+
+    async def test_generic_value_error_returns_400(self) -> None:
+        """Service raises ValueError that is neither 'not found' nor 'already classified'
+        → endpoint returns 400 Bad Request.
+
+        The endpoint has a catch-all branch that maps unrecognized ValueError
+        messages to BadRequestError (400).
+        """
+        mock_session = _make_session_tag_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(
+                    side_effect=ValueError(
+                        "Some unexpected validation error from the service layer"
+                    )
+                )
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 400, response.text
+
+    async def test_generic_value_error_has_rfc7807_body(self) -> None:
+        """400 Bad Request response body follows RFC-7807 Problem Details structure."""
+        mock_session = _make_session_tag_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(
+                    side_effect=ValueError("Cannot process this request")
+                )
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert "status" in body or "type" in body, (
+            f"Expected RFC-7807 error body, got: {body}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T_CLASSIFY_422 — Pydantic validation errors (no DB required)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTagValidation:
+    """Tests for 422 Unprocessable Entity responses driven by Pydantic / FastAPI.
+
+    These tests do NOT reach the handler because FastAPI validates the request
+    body before invoking the endpoint function.  No mock session is needed.
+    """
+
+    async def test_invalid_entity_type_returns_422(self) -> None:
+        """entity_type not in the allowed set → 422 Unprocessable Entity.
+
+        ClassifyTagRequest uses a Pydantic field_validator that raises ValueError
+        for any entity_type not in ``_ENTITY_PRODUCING_TYPES``.  FastAPI converts
+        this to a 422 response before the handler runs.
+        """
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                _CLASSIFY_ENDPOINT,
+                json={
+                    "normalized_form": _VALID_NORMALIZED_FORM,
+                    "entity_type": "robot",  # Not a valid entity type
+                },
+            )
+
+        assert response.status_code == 422, response.text
+
+    async def test_entity_type_topic_is_valid_per_schema(self) -> None:
+        """entity_type='topic' is in the schema's allowed set but NOT in EntityType enum.
+
+        The Pydantic schema (ClassifyTagRequest) uses a set-based validator that
+        accepts 'concept' and 'other' (Feature 051 additions). The router then does
+        ``EntityType(body.entity_type)`` which will raise ValueError for any value
+        not in the enum. This produces a 400 from the BadRequestError branch.
+
+        Note: 'topic' and 'descriptor' are in EntityType enum but NOT in
+        _ENTITY_PRODUCING_TYPES used by the schema validator, so they fail at 422.
+        """
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                _CLASSIFY_ENDPOINT,
+                json={
+                    "normalized_form": _VALID_NORMALIZED_FORM,
+                    "entity_type": "topic",  # Not in _ENTITY_PRODUCING_TYPES → 422
+                },
+            )
+
+        # "topic" is not in the Pydantic validator's allowed set so it fails at 422
+        assert response.status_code == 422, response.text
+
+    async def test_empty_normalized_form_returns_422(self) -> None:
+        """normalized_form="" is rejected by Pydantic min_length=1 → 422.
+
+        ClassifyTagRequest.normalized_form has ``min_length=1`` so an empty
+        string fails at schema validation before the handler is called.
+        """
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                _CLASSIFY_ENDPOINT,
+                json={
+                    "normalized_form": "",
+                    "entity_type": _VALID_ENTITY_TYPE,
+                },
+            )
+
+        assert response.status_code == 422, response.text
+
+    async def test_normalized_form_too_long_returns_422(self) -> None:
+        """normalized_form with 501 characters exceeds max_length=500 → 422.
+
+        ClassifyTagRequest.normalized_form has ``max_length=500``.  Any string
+        longer than 500 characters is rejected by Pydantic.
+        """
+        too_long = "x" * 501
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                _CLASSIFY_ENDPOINT,
+                json={
+                    "normalized_form": too_long,
+                    "entity_type": _VALID_ENTITY_TYPE,
+                },
+            )
+
+        assert response.status_code == 422, response.text
+
+    async def test_normalized_form_exactly_500_chars_passes_validation(self) -> None:
+        """normalized_form with exactly 500 characters is at the boundary → valid.
+
+        Pydantic's max_length=500 is inclusive, so a 500-character string should
+        pass validation and reach the handler (which is mocked to succeed).
+        """
+        boundary_form = "a" * 500
+        entity_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(entity_id=entity_id)
+        mock_session = _make_session_success(tag_row, entity_row)
+        classify_result = _make_classify_result(normalized_form=boundary_form)
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(return_value=classify_result)
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": boundary_form,
+                        "entity_type": _VALID_ENTITY_TYPE,
+                    },
+                )
+
+        assert response.status_code == 201, response.text
+
+    async def test_description_too_long_returns_422(self) -> None:
+        """description with 5001 characters exceeds max_length=5000 → 422.
+
+        ClassifyTagRequest.description has ``max_length=5000``.  Any description
+        longer than 5000 characters is rejected by Pydantic before the handler runs.
+        """
+        too_long_desc = "d" * 5001
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                _CLASSIFY_ENDPOINT,
+                json={
+                    "normalized_form": _VALID_NORMALIZED_FORM,
+                    "entity_type": _VALID_ENTITY_TYPE,
+                    "description": too_long_desc,
+                },
+            )
+
+        assert response.status_code == 422, response.text
+
+    async def test_missing_normalized_form_returns_422(self) -> None:
+        """Request body without normalized_form → 422 (required field missing)."""
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                _CLASSIFY_ENDPOINT,
+                json={"entity_type": _VALID_ENTITY_TYPE},
+            )
+
+        assert response.status_code == 422, response.text
+
+    async def test_missing_entity_type_returns_422(self) -> None:
+        """Request body without entity_type → 422 (required field missing)."""
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                _CLASSIFY_ENDPOINT,
+                json={"normalized_form": _VALID_NORMALIZED_FORM},
+            )
+
+        assert response.status_code == 422, response.text
+
+    async def test_empty_request_body_returns_422(self) -> None:
+        """Empty JSON object {} missing both required fields → 422."""
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(_CLASSIFY_ENDPOINT, json={})
+
+        assert response.status_code == 422, response.text
+
+
+# ---------------------------------------------------------------------------
+# T_CLASSIFY_VALID_TYPES — All allowed entity types produce 201
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTagAllowedEntityTypes:
+    """Tests that each entity-producing type accepted by the schema yields 201.
+
+    Validates that the Pydantic validator and the EntityType enum conversion
+    in the handler both accept each of the schema's allowed entity types.
+    """
+
+    async def _post_with_entity_type(self, entity_type: str) -> int:
+        """Helper: post a classify request with the given entity_type and return status.
+
+        Parameters
+        ----------
+        entity_type : str
+            The entity type string to include in the request body.
+
+        Returns
+        -------
+        int
+            HTTP status code of the response.
+        """
+        entity_id = uuid.uuid4()
+        tag_row = _make_canonical_tag_row(entity_id=entity_id)
+        entity_row = _make_named_entity_row(
+            entity_id=entity_id, entity_type=entity_type
+        )
+        mock_session = _make_session_success(tag_row, entity_row)
+        classify_result = _make_classify_result(entity_type=entity_type)
+        status_code: int = 0
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._tag_mgmt_service"
+            ) as mock_svc:
+                mock_svc.classify = AsyncMock(return_value=classify_result)
+
+                response = await client.post(
+                    _CLASSIFY_ENDPOINT,
+                    json={
+                        "normalized_form": _VALID_NORMALIZED_FORM,
+                        "entity_type": entity_type,
+                    },
+                )
+                status_code = response.status_code
+
+        return status_code
+
+    async def test_person_returns_201(self) -> None:
+        """entity_type='person' is valid → 201."""
+        assert await self._post_with_entity_type("person") == 201
+
+    async def test_organization_returns_201(self) -> None:
+        """entity_type='organization' is valid → 201."""
+        assert await self._post_with_entity_type("organization") == 201
+
+    async def test_place_returns_201(self) -> None:
+        """entity_type='place' is valid → 201."""
+        assert await self._post_with_entity_type("place") == 201
+
+    async def test_event_returns_201(self) -> None:
+        """entity_type='event' is valid → 201."""
+        assert await self._post_with_entity_type("event") == 201
+
+    async def test_work_returns_201(self) -> None:
+        """entity_type='work' is valid → 201."""
+        assert await self._post_with_entity_type("work") == 201
+
+    async def test_technical_term_returns_201(self) -> None:
+        """entity_type='technical_term' is valid → 201."""
+        assert await self._post_with_entity_type("technical_term") == 201
+
+    async def test_concept_returns_201(self) -> None:
+        """entity_type='concept' is valid per schema and enum → 201."""
+        assert await self._post_with_entity_type("concept") == 201
+
+    async def test_other_returns_201(self) -> None:
+        """entity_type='other' is valid per schema and enum → 201."""
+        assert await self._post_with_entity_type("other") == 201
+
+    async def test_valid_types_count_guard(self) -> None:
+        """Guard test: the module-level allowed-type list contains exactly 8 entries.
+
+        If a new valid entity type is added to the schema, this test will fail,
+        prompting the addition of a corresponding individual test above.
+        """
+        assert len(_VALID_ENTITY_TYPES) == 8
+        assert set(_VALID_ENTITY_TYPES) == {
+            "person",
+            "organization",
+            "place",
+            "event",
+            "work",
+            "technical_term",
+            "concept",
+            "other",
+        }
+
+
+# ---------------------------------------------------------------------------
+# T_CLASSIFY_AUTH — Authentication
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTagAuthentication:
+    """Tests for authentication behavior on the classify endpoint."""
+
+    async def test_unauthenticated_request_returns_401(self) -> None:
+        """No valid auth token → 401 Unauthorized.
+
+        The entity_mentions router declares
+        ``dependencies=[Depends(require_auth)]``.  When require_auth is NOT
+        overridden and the OAuth service reports unauthenticated, the endpoint
+        must return 401 before any DB or service interaction.
+        """
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async def mock_get_db() -> AsyncGenerator[AsyncSession, None]:
+            yield mock_session
+
+        app.dependency_overrides[get_db] = mock_get_db
+        # Intentionally do NOT override require_auth here
+
+        try:
+            with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+                mock_oauth.is_authenticated.return_value = False
+
+                transport = ASGITransport(app=app)
+                async with AsyncClient(
+                    transport=transport, base_url="http://test"
+                ) as client:
+                    response = await client.post(
+                        _CLASSIFY_ENDPOINT,
+                        json={
+                            "normalized_form": _VALID_NORMALIZED_FORM,
+                            "entity_type": _VALID_ENTITY_TYPE,
+                        },
+                    )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 401, response.text
+
+
+# ---------------------------------------------------------------------------
+# T_CHECK_DUPLICATE — GET /api/v1/entities/check-duplicate
+# ---------------------------------------------------------------------------
+#
+# The endpoint normalizes the ``name`` query param, then queries
+# ``named_entities`` for an active row with the same canonical_name_normalized
+# and entity_type.
+#
+# Mocking strategy
+# ----------------
+# - ``_normalizer.normalize`` is patched at the module level to control the
+#   exact normalized form returned without exercising the full NLP pipeline.
+# - The DB query is mocked via ``session.execute`` returning a mock result
+#   whose ``scalar_one_or_none()`` returns either a NamedEntityDB mock or None.
+# - Rate limiting is tested by patching ``_check_rate_limit`` in the module
+#   to return (False, 30), bypassing the real time-window logic.
+# ---------------------------------------------------------------------------
+
+_CHECK_DUPLICATE_ENDPOINT = "/api/v1/entities/check-duplicate"
+
+_DUPLICATE_NAME = "Garland Nixon"
+_DUPLICATE_TYPE = "person"
+_DUPLICATE_NORMALIZED = "garland nixon"
+
+
+def _make_named_entity_for_duplicate(
+    *,
+    entity_id: uuid.UUID | None = None,
+    canonical_name: str = "Garland Nixon",
+    entity_type: str = "person",
+    description: str | None = "Political commentator",
+) -> MagicMock:
+    """Build a minimal mock NamedEntityDB row for duplicate-check tests.
+
+    Parameters
+    ----------
+    entity_id : uuid.UUID | None
+        Entity primary key UUID.  Auto-generated when None.
+    canonical_name : str
+        Display name stored on the entity row.
+    entity_type : str
+        Entity type string.
+    description : str | None
+        Optional description string.
+
+    Returns
+    -------
+    MagicMock
+        Mock with the attributes read by the check_duplicate_entity endpoint.
+    """
+    row = MagicMock()
+    row.id = entity_id or uuid.uuid4()
+    row.canonical_name = canonical_name
+    row.entity_type = entity_type
+    row.description = description
+    return row
+
+
+def _make_session_duplicate_found(entity_row: MagicMock) -> AsyncMock:
+    """Build a mock AsyncSession where the entity query returns a matching row.
+
+    Parameters
+    ----------
+    entity_row : MagicMock
+        The NamedEntityDB mock row to return from execute().scalar_one_or_none().
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = entity_row
+    mock_session.execute = AsyncMock(return_value=result_mock)
+    mock_session.commit = AsyncMock()
+    return mock_session
+
+
+def _make_session_duplicate_not_found() -> AsyncMock:
+    """Build a mock AsyncSession where the entity query returns no matching row.
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session where execute().scalar_one_or_none() returns None.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=result_mock)
+    mock_session.commit = AsyncMock()
+    return mock_session
+
+
+class TestCheckDuplicateEndpoint:
+    """Tests for GET /api/v1/entities/check-duplicate.
+
+    Coverage targets
+    ----------------
+    - 200 duplicate found: is_duplicate=True with existing_entity populated
+    - 200 no duplicate: is_duplicate=False with existing_entity=null
+    - normalization-aware matching: lowercase input matches mixed-case entity
+    - name normalizes to empty: returns is_duplicate=False without error
+    - 429 rate limit exceeded: returns 429 with Retry-After header
+    - different type not duplicate: same name but different entity_type → no match
+    """
+
+    async def test_200_duplicate_found(self) -> None:
+        """When an active entity with the same normalized name and type exists,
+        returns 200 with is_duplicate=True and populated existing_entity.
+
+        The existing_entity object must contain entity_id (UUID string),
+        canonical_name, entity_type, and description.
+        """
+        entity_id = uuid.uuid4()
+        entity_row = _make_named_entity_for_duplicate(entity_id=entity_id)
+        mock_session = _make_session_duplicate_found(entity_row)
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._normalizer"
+            ) as mock_normalizer:
+                mock_normalizer.normalize.return_value = _DUPLICATE_NORMALIZED
+
+                response = await client.get(
+                    _CHECK_DUPLICATE_ENDPOINT,
+                    params={"name": _DUPLICATE_NAME, "type": _DUPLICATE_TYPE},
+                )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["is_duplicate"] is True, f"Expected is_duplicate=True in: {body}"
+        assert body["existing_entity"] is not None, (
+            f"Expected existing_entity to be populated in: {body}"
+        )
+        existing = body["existing_entity"]
+        assert existing["entity_id"] == str(entity_id), (
+            f"entity_id mismatch: {existing['entity_id']} != {entity_id}"
+        )
+        assert existing["canonical_name"] == "Garland Nixon"
+        assert existing["entity_type"] == "person"
+        assert existing["description"] == "Political commentator"
+
+    async def test_200_no_duplicate(self) -> None:
+        """When no active entity with the same normalized name and type exists,
+        returns 200 with is_duplicate=False and existing_entity=null.
+        """
+        mock_session = _make_session_duplicate_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._normalizer"
+            ) as mock_normalizer:
+                mock_normalizer.normalize.return_value = _DUPLICATE_NORMALIZED
+
+                response = await client.get(
+                    _CHECK_DUPLICATE_ENDPOINT,
+                    params={"name": "Unknown Person", "type": "person"},
+                )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["is_duplicate"] is False, (
+            f"Expected is_duplicate=False in: {body}"
+        )
+        assert body["existing_entity"] is None, (
+            f"Expected existing_entity=null in: {body}"
+        )
+
+    async def test_normalization_aware_matching(self) -> None:
+        """Lowercase input "garland nixon" matches entity "Garland Nixon".
+
+        The normalization step strips case differences, so a query with a
+        lowercase name must detect the duplicate against the stored
+        mixed-case canonical_name via the canonical_name_normalized column.
+        """
+        entity_id = uuid.uuid4()
+        entity_row = _make_named_entity_for_duplicate(
+            entity_id=entity_id,
+            canonical_name="Garland Nixon",
+        )
+        mock_session = _make_session_duplicate_found(entity_row)
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._normalizer"
+            ) as mock_normalizer:
+                # Simulates normalization stripping case: "garland nixon" → "garland nixon"
+                mock_normalizer.normalize.return_value = "garland nixon"
+
+                response = await client.get(
+                    _CHECK_DUPLICATE_ENDPOINT,
+                    params={"name": "garland nixon", "type": "person"},
+                )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["is_duplicate"] is True, (
+            f"Lowercase query should detect mixed-case duplicate, got: {body}"
+        )
+        assert body["existing_entity"]["canonical_name"] == "Garland Nixon", (
+            f"Expected canonical_name='Garland Nixon' in: {body['existing_entity']}"
+        )
+
+    async def test_name_normalizes_to_empty(self) -> None:
+        """A name that normalizes to empty/None returns is_duplicate=False.
+
+        When ``TagNormalizationService.normalize()`` returns None (or empty),
+        the endpoint short-circuits and returns is_duplicate=False without
+        querying the database.  This is not an error condition.
+        """
+        mock_session = _make_session_duplicate_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._normalizer"
+            ) as mock_normalizer:
+                # normalize() returns None → endpoint treats as empty
+                mock_normalizer.normalize.return_value = None
+
+                response = await client.get(
+                    _CHECK_DUPLICATE_ENDPOINT,
+                    params={"name": "   ", "type": "person"},
+                )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["is_duplicate"] is False, (
+            f"Empty-normalizing name should yield is_duplicate=False, got: {body}"
+        )
+        assert body["existing_entity"] is None, (
+            f"Expected existing_entity=null when name normalizes empty, got: {body}"
+        )
+        # Database must NOT be queried when the normalized name is empty
+        mock_session.execute.assert_not_called()
+
+    async def test_rate_limit_429(self) -> None:
+        """When the rate limit is exceeded, returns 429 with Retry-After header.
+
+        The endpoint calls ``_check_rate_limit`` and, when it returns
+        (False, retry_after), responds with a 429 JSONResponse that includes
+        the ``Retry-After`` header.
+        """
+        mock_session = _make_session_duplicate_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._check_rate_limit"
+            ) as mock_rate_limit:
+                # Simulate 50 req/min limit already exceeded; retry after 30s
+                mock_rate_limit.return_value = (False, 30)
+
+                response = await client.get(
+                    _CHECK_DUPLICATE_ENDPOINT,
+                    params={"name": _DUPLICATE_NAME, "type": _DUPLICATE_TYPE},
+                )
+
+        assert response.status_code == 429, (
+            f"Expected 429 when rate limit exceeded, got {response.status_code}: "
+            f"{response.text}"
+        )
+        assert "Retry-After" in response.headers, (
+            f"Missing Retry-After header in 429 response. Headers: {dict(response.headers)}"
+        )
+        assert response.headers["Retry-After"] == "30", (
+            f"Expected Retry-After: 30, got: {response.headers['Retry-After']}"
+        )
+
+    async def test_rate_limit_429_response_body(self) -> None:
+        """The 429 response body includes a detail message and retry_after field.
+
+        Validates the exact shape of the JSON response body returned when the
+        rate limit is exceeded: ``detail`` and ``retry_after`` keys must be present.
+        """
+        mock_session = _make_session_duplicate_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._check_rate_limit"
+            ) as mock_rate_limit:
+                mock_rate_limit.return_value = (False, 15)
+
+                response = await client.get(
+                    _CHECK_DUPLICATE_ENDPOINT,
+                    params={"name": _DUPLICATE_NAME, "type": _DUPLICATE_TYPE},
+                )
+
+        assert response.status_code == 429, response.text
+        body = response.json()
+        assert "detail" in body, f"Missing 'detail' key in 429 body: {body}"
+        assert "retry_after" in body, f"Missing 'retry_after' key in 429 body: {body}"
+        assert body["retry_after"] == 15, (
+            f"Expected retry_after=15, got: {body['retry_after']}"
+        )
+
+    async def test_different_type_not_duplicate(self) -> None:
+        """Entity "Garland Nixon" as "person" exists, but checking with type
+        "organization" must return is_duplicate=False.
+
+        The query filters on BOTH canonical_name_normalized AND entity_type.
+        A person and an organization with the same normalized name are
+        distinct entities.
+        """
+        mock_session = _make_session_duplicate_not_found()
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._normalizer"
+            ) as mock_normalizer:
+                mock_normalizer.normalize.return_value = _DUPLICATE_NORMALIZED
+
+                response = await client.get(
+                    _CHECK_DUPLICATE_ENDPOINT,
+                    params={"name": _DUPLICATE_NAME, "type": "organization"},
+                )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["is_duplicate"] is False, (
+            f"Different entity_type should not be flagged as duplicate, got: {body}"
+        )
+        assert body["existing_entity"] is None, (
+            f"Expected existing_entity=null for type mismatch, got: {body}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T_CREATE_ENTITY — POST /api/v1/entities
+# ---------------------------------------------------------------------------
+#
+# The endpoint (``create_entity``) lives at
+# ``chronovista.api.routers.entity_mentions`` and uses three module-level
+# singletons: ``_entity_repo``, ``_alias_repo``, and ``_normalizer``.
+#
+# Endpoint flow:
+# 1. Convert entity_type string → EntityType enum (400 if invalid)
+# 2. Normalize the name via _normalizer.normalize() (422 if empty result)
+# 3. Auto-title-case: body.name.strip().title()
+# 4. Duplicate check: session.execute(SELECT ...).scalar_one_or_none() (409 if found)
+# 5. _entity_repo.create() → db_entity row
+# 6. _alias_repo.create() for canonical name alias (alias_count starts at 1)
+# 7. _alias_repo.create() for each unique user alias (skips normalized duplicates)
+# 8. session.commit() + session.refresh(db_entity)
+# 9. Return 201 with entity_id, canonical_name, entity_type, description, alias_count
+#
+# alias_count = len(seen_normalized) — starts with the canonical normalized name
+# and grows by 1 for each user alias whose normalized form is not already seen.
+#
+# Mocking strategy
+# ----------------
+# - ``_entity_repo.create`` is patched at the module level via ``unittest.mock.patch``
+#   on ``chronovista.api.routers.entity_mentions._entity_repo``.
+# - ``_alias_repo.create`` is similarly patched.
+# - ``_normalizer.normalize`` is patched for tests that require controlled
+#   normalization output; for 422 tests it returns None/empty.
+# - The DB session's ``execute`` is an AsyncMock that returns a MagicMock with
+#   ``scalar_one_or_none()`` returning either a NamedEntityDB mock (409) or None (pass).
+# - session.commit and session.refresh are AsyncMock no-ops.
+# ---------------------------------------------------------------------------
+
+_CREATE_ENTITY_ENDPOINT = "/api/v1/entities"
+
+_VALID_CREATE_NAME = "edward snowden"
+_VALID_CREATE_TYPE = "person"
+
+
+def _make_create_entity_db_row(
+    *,
+    entity_id: uuid.UUID | None = None,
+    canonical_name: str = "Edward Snowden",
+    entity_type: str = "person",
+    description: str | None = None,
+) -> MagicMock:
+    """Build a minimal mock NamedEntityDB row returned by _entity_repo.create().
+
+    Parameters
+    ----------
+    entity_id : uuid.UUID | None
+        Entity primary key UUID.  Auto-generated when None.
+    canonical_name : str
+        Display name stored on the entity row.
+    entity_type : str
+        Entity type string (as stored in the DB column).
+    description : str | None
+        Optional entity description.
+
+    Returns
+    -------
+    MagicMock
+        Mock with the attributes read by the create_entity endpoint after
+        session.refresh().
+    """
+    row = MagicMock()
+    row.id = entity_id or uuid.uuid4()
+    row.canonical_name = canonical_name
+    row.entity_type = entity_type
+    row.description = description
+    return row
+
+
+def _make_session_no_duplicate(db_entity_row: MagicMock) -> AsyncMock:
+    """Build a mock AsyncSession for the create_entity happy path.
+
+    The endpoint makes these DB calls in order:
+    1. session.execute(dup check query) → scalar_one_or_none() returns None
+    2. _entity_repo.create() — mocked at module level, not via session
+    3. _alias_repo.create() — mocked at module level, not via session
+    4. session.commit()
+    5. session.refresh(db_entity_row)
+
+    Parameters
+    ----------
+    db_entity_row : MagicMock
+        The entity row; passed so session.refresh can be configured as a
+        no-op AsyncMock (the row attributes are already set).
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    # Duplicate check → not found
+    dup_result = MagicMock()
+    dup_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=dup_result)
+
+    mock_session.commit = AsyncMock()
+    mock_session.refresh = AsyncMock()
+    return mock_session
+
+
+def _make_session_with_existing_entity(existing_row: MagicMock) -> AsyncMock:
+    """Build a mock AsyncSession where the dup-check finds an existing entity.
+
+    Parameters
+    ----------
+    existing_row : MagicMock
+        The NamedEntityDB mock row to return from execute().scalar_one_or_none(),
+        triggering the 409 ConflictError branch.
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    dup_result = MagicMock()
+    dup_result.scalar_one_or_none.return_value = existing_row
+    mock_session.execute = AsyncMock(return_value=dup_result)
+
+    mock_session.commit = AsyncMock()
+    mock_session.refresh = AsyncMock()
+    return mock_session
+
+
+class TestCreateEntityEndpoint:
+    """Tests for POST /api/v1/entities (standalone entity creation).
+
+    Coverage targets
+    ----------------
+    - 201 happy path: alias_count reflects canonical alias + user aliases
+    - 201 auto-title-casing: lowercase input -> Title Cased canonical_name
+    - 409 Conflict: duplicate entity detected by normalized name + type
+    - 422 Unprocessable Entity: name that normalizes to empty string
+    - 201 with normalized alias duplicates skipped (only unique aliases stored)
+    - 422 Unprocessable Entity: more than 20 aliases (Pydantic max_length=20)
+    """
+
+    async def test_201_success_with_correct_alias_count(self) -> None:
+        """Create "edward snowden" with type "person" and two user aliases.
+
+        The endpoint creates:
+        - 1 canonical alias (the title-cased name itself)
+        - 1 alias for "Ed Snowden"
+        - 1 alias for "Snowden"
+
+        So alias_count must be 3, and canonical_name must be "Edward Snowden".
+        """
+        entity_id = uuid.uuid4()
+        db_entity = _make_create_entity_db_row(
+            entity_id=entity_id,
+            canonical_name="Edward Snowden",
+            entity_type="person",
+        )
+        mock_session = _make_session_no_duplicate(db_entity)
+
+        async for client in _build_client(mock_session):
+            with (
+                patch(
+                    "chronovista.api.routers.entity_mentions._entity_repo"
+                ) as mock_entity_repo,
+                patch(
+                    "chronovista.api.routers.entity_mentions._alias_repo"
+                ) as mock_alias_repo,
+                patch(
+                    "chronovista.api.routers.entity_mentions._normalizer"
+                ) as mock_normalizer,
+            ):
+                # normalize() maps every alias to a distinct lowercase form
+                mock_normalizer.normalize.side_effect = lambda text: text.strip().lower()
+
+                mock_entity_repo.create = AsyncMock(return_value=db_entity)
+                mock_alias_repo.create = AsyncMock(return_value=MagicMock())
+
+                response = await client.post(
+                    _CREATE_ENTITY_ENDPOINT,
+                    json={
+                        "name": _VALID_CREATE_NAME,
+                        "entity_type": _VALID_CREATE_TYPE,
+                        "aliases": ["Ed Snowden", "Snowden"],
+                    },
+                )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["canonical_name"] == "Edward Snowden", (
+            f"Expected 'Edward Snowden', got: {body['canonical_name']}"
+        )
+        assert body["alias_count"] == 3, (
+            f"Expected alias_count=3 (canonical + 2 user aliases), got: {body['alias_count']}"
+        )
+        assert body["entity_type"] == "person", (
+            f"Expected entity_type='person', got: {body['entity_type']}"
+        )
+
+    async def test_auto_title_casing(self) -> None:
+        """Lowercase input "garland nixon" produces canonical_name="Garland Nixon".
+
+        The endpoint performs ``body.name.strip().title()`` before storing;
+        the DB row's canonical_name must reflect the Title-Cased form.
+        """
+        entity_id = uuid.uuid4()
+        db_entity = _make_create_entity_db_row(
+            entity_id=entity_id,
+            canonical_name="Garland Nixon",
+            entity_type="person",
+        )
+        mock_session = _make_session_no_duplicate(db_entity)
+
+        async for client in _build_client(mock_session):
+            with (
+                patch(
+                    "chronovista.api.routers.entity_mentions._entity_repo"
+                ) as mock_entity_repo,
+                patch(
+                    "chronovista.api.routers.entity_mentions._alias_repo"
+                ) as mock_alias_repo,
+                patch(
+                    "chronovista.api.routers.entity_mentions._normalizer"
+                ) as mock_normalizer,
+            ):
+                mock_normalizer.normalize.return_value = "garland nixon"
+                mock_entity_repo.create = AsyncMock(return_value=db_entity)
+                mock_alias_repo.create = AsyncMock(return_value=MagicMock())
+
+                response = await client.post(
+                    _CREATE_ENTITY_ENDPOINT,
+                    json={
+                        "name": "garland nixon",
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["canonical_name"] == "Garland Nixon", (
+            f"Expected auto-title-cased 'Garland Nixon', got: {body['canonical_name']}"
+        )
+
+    async def test_409_duplicate(self) -> None:
+        """When an active entity with the same normalized name + type exists, returns 409.
+
+        The duplicate-check query returns an existing NamedEntityDB row, so the
+        endpoint raises ConflictError.  The 409 response body must include
+        existing_entity details nested inside the ``details`` field.
+        """
+        existing_id = uuid.uuid4()
+        existing_row = MagicMock()
+        existing_row.id = existing_id
+        existing_row.canonical_name = "Edward Snowden"
+        existing_row.entity_type = "person"
+        existing_row.description = "NSA whistleblower"
+
+        mock_session = _make_session_with_existing_entity(existing_row)
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._normalizer"
+            ) as mock_normalizer:
+                mock_normalizer.normalize.return_value = "edward snowden"
+
+                response = await client.post(
+                    _CREATE_ENTITY_ENDPOINT,
+                    json={
+                        "name": "edward snowden",
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 409, response.text
+
+    async def test_409_duplicate_response_body_shape(self) -> None:
+        """The 409 response body follows the RFC 7807 Problem Detail format.
+
+        The exception handler converts ConflictError to an RFC 7807 response
+        using only ``exc.message`` — the ``details`` dict is not serialized
+        into the response body (see exception_handlers.py:api_error_handler).
+        The body must contain: type, title, status, detail, instance, code.
+        The ``detail`` field must reference the normalized name to help callers
+        identify which entity caused the conflict.
+        """
+        existing_id = uuid.uuid4()
+        existing_row = MagicMock()
+        existing_row.id = existing_id
+        existing_row.canonical_name = "Edward Snowden"
+        existing_row.entity_type = "person"
+        existing_row.description = "NSA whistleblower"
+
+        mock_session = _make_session_with_existing_entity(existing_row)
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._normalizer"
+            ) as mock_normalizer:
+                mock_normalizer.normalize.return_value = "edward snowden"
+
+                response = await client.post(
+                    _CREATE_ENTITY_ENDPOINT,
+                    json={
+                        "name": "edward snowden",
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 409, response.text
+        body = response.json()
+        # RFC 7807 required fields must be present
+        assert "status" in body, f"Missing 'status' in 409 body: {body}"
+        assert "detail" in body, f"Missing 'detail' in 409 body: {body}"
+        assert body["status"] == 409, (
+            f"Expected status=409 in body, got: {body['status']}"
+        )
+        # The detail message must reference the normalized name so callers
+        # know which entity caused the conflict
+        assert "edward snowden" in body["detail"], (
+            f"Expected normalized name in detail, got: {body['detail']}"
+        )
+
+    async def test_422_name_normalizes_to_empty(self) -> None:
+        """A name whose normalized form is empty triggers a 422 APIValidationError.
+
+        When ``_normalizer.normalize()`` returns None (or empty string), the
+        endpoint raises APIValidationError before touching the database.
+        """
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._normalizer"
+            ) as mock_normalizer:
+                mock_normalizer.normalize.return_value = None
+
+                response = await client.post(
+                    _CREATE_ENTITY_ENDPOINT,
+                    json={
+                        "name": "   ",
+                        "entity_type": "person",
+                    },
+                )
+
+        assert response.status_code == 422, response.text
+        # Database must NOT be queried when the name normalizes to empty
+        mock_session.execute.assert_not_called()
+
+    async def test_aliases_with_normalized_duplicates_skipped(self) -> None:
+        """Aliases ["Ed Snowden", "ed snowden"] produce only 1 additional alias.
+
+        When two user-supplied aliases normalize to the same string, the second
+        is silently skipped.  alias_count = 1 (canonical) + 1 (unique alias) = 2.
+        """
+        entity_id = uuid.uuid4()
+        db_entity = _make_create_entity_db_row(
+            entity_id=entity_id,
+            canonical_name="Edward Snowden",
+            entity_type="person",
+        )
+        mock_session = _make_session_no_duplicate(db_entity)
+
+        async for client in _build_client(mock_session):
+            with (
+                patch(
+                    "chronovista.api.routers.entity_mentions._entity_repo"
+                ) as mock_entity_repo,
+                patch(
+                    "chronovista.api.routers.entity_mentions._alias_repo"
+                ) as mock_alias_repo,
+                patch(
+                    "chronovista.api.routers.entity_mentions._normalizer"
+                ) as mock_normalizer,
+            ):
+                # "edward snowden" -> "edward snowden" (canonical)
+                # "Ed Snowden"     -> "ed snowden" (unique alias)
+                # "ed snowden"     -> "ed snowden" (DUPLICATE -> skipped)
+                mock_normalizer.normalize.side_effect = lambda text: text.strip().lower()
+                mock_entity_repo.create = AsyncMock(return_value=db_entity)
+                mock_alias_repo.create = AsyncMock(return_value=MagicMock())
+
+                response = await client.post(
+                    _CREATE_ENTITY_ENDPOINT,
+                    json={
+                        "name": "edward snowden",
+                        "entity_type": "person",
+                        "aliases": ["Ed Snowden", "ed snowden"],
+                    },
+                )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["alias_count"] == 2, (
+            f"Expected alias_count=2 (canonical + 1 unique alias, 1 duplicate skipped), "
+            f"got: {body['alias_count']}"
+        )
+
+    async def test_max_20_aliases_validation(self) -> None:
+        """Submitting 21 aliases is rejected by Pydantic max_length=20 -> 422.
+
+        CreateEntityRequest.aliases has ``max_length=20``; any list with more
+        than 20 items fails Pydantic schema validation before the handler runs.
+        """
+        too_many_aliases = [f"Alias {i}" for i in range(21)]
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                _CREATE_ENTITY_ENDPOINT,
+                json={
+                    "name": "edward snowden",
+                    "entity_type": "person",
+                    "aliases": too_many_aliases,
+                },
+            )
+
+        assert response.status_code == 422, response.text


### PR DESCRIPTION
## Summary

- **Tag-backed entity creation**: Modal form with canonical tag autocomplete, entity type selector (8 types), optional description; calls `POST /api/v1/entities/classify` via TagManagementService
- **Standalone entity creation**: Freeform name entry with repeatable alias field (max 20); calls `POST /api/v1/entities` with auto-title-casing and normalization
- **Duplicate detection**: Real-time debounced check via `GET /api/v1/entities/check-duplicate` with rate limiting (50 req/min); blocks submission with warning showing existing entity details and link
- **EntityType expansion**: Added `concept` and `other` types across enums, DB constraints (migration 051), frontend constants, and entity type tabs
- **Bug fix**: Tag normalization idempotency for diacritic+hash edge case (`'´#'`)
- **Test fix**: EntitiesPage.test.tsx missing mock stubs for new hooks (93 failures resolved)

## Technical Details

- 3 new API endpoints, 1 new React component (`CreateEntityModal`), 3 new hooks, 1 constants module
- 158 new tests (49 BE unit + 70 FE component + 10 BE integration + 29 FE hook)
- 7,403 total backend tests, 3,519 total frontend tests — all passing
- WCAG 2.1 AA: ARIA dialog, combobox, focus trap, keyboard nav, aria-live announcements
- TypeScript strict (0 errors), mypy strict (0 errors)
- No new dependencies

## Test plan

- [x] Backend unit tests: 49/49 pass (`test_entity_creation_endpoints.py`)
- [x] Backend integration tests: 10/10 pass (`test_entity_creation_integration.py`)
- [x] Frontend component tests: 70/70 pass (`CreateEntityModal.test.tsx`)
- [x] Frontend hook tests: 29/29 pass (`useEntityCreation.test.tsx`)
- [x] Full backend suite: 7,403 passed, 0 failed
- [x] Full frontend suite: 3,519 passed, 0 failed (147 test files)
- [x] TypeScript compilation: 0 errors
- [x] mypy strict: 0 errors
- [x] Manual testing: tag-backed creation (Henry Whitfield, BJR, Nils Bergström), standalone creation, duplicate blocking