### PR TITLE
refactor: fix 2,542 ruff violations in tests + revert unsafe asyncio.gather

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run ruff
-        run: poetry run ruff check src/chronovista/
+        run: poetry run ruff check src/chronovista/ tests/
 
       - name: Run mypy
         run: poetry run mypy src/chronovista/ --strict --no-error-summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,7 +299,22 @@ ignore = [
 unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101", "S105", "S106", "S107", "S108"]
+"tests/*" = [
+    "S101",   # assert — expected in tests
+    "S105", "S106", "S107", "S108",  # hardcoded passwords — test credentials
+    "S311",   # random — non-crypto random is fine for test data
+    "N802",   # invalid function name — test naming conventions
+    "N806",   # non-lowercase variable — PascalCase mock classes/factories
+    "N811",   # constant imported as non-constant — test aliasing
+    "N814",   # camelcase imported as constant — test aliasing
+    "E741",   # ambiguous variable name — single-letter vars in tests
+    "B017",   # assertRaises(Exception) — intentionally broad in tests
+    "F402",   # import shadowed by loop var — parametrize patterns
+    "SIM115", # open without context manager — test file handling
+    "SIM117", # multiple with statements — readability in test setup
+    "LOG015", # root logger call — test logging setup
+    "T201",   # print — debug output in tests
+]
 "*/migrations/*" = ["N806", "N815"]
 "*/cli/*" = ["T201"]  # CLI commands use print() for user-facing output
 

--- a/src/chronovista/api/routers/settings.py
+++ b/src/chronovista/api/routers/settings.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import uuid
@@ -247,21 +246,25 @@ async def get_app_info(
     ApiResponse[AppInfoResponse]
         Application info including versions, database stats, and sync timestamps.
     """
-    # Query all counts concurrently (6 independent queries)
-    (
-        video_count,
-        channel_count,
-        playlist_count,
-        transcript_count,
-        correction_count,
-        canonical_tag_count,
-    ) = await asyncio.gather(
-        session.scalar(select(func.count()).select_from(Video)),
-        session.scalar(select(func.count()).select_from(Channel)),
-        session.scalar(select(func.count()).select_from(Playlist)),
-        session.scalar(select(func.count()).select_from(VideoTranscript)),
-        session.scalar(select(func.count()).select_from(TranscriptCorrection)),
-        session.scalar(select(func.count()).select_from(CanonicalTag)),
+    # Sequential queries — AsyncSession is not safe for concurrent use
+    # via asyncio.gather() (causes IllegalStateChangeError).
+    video_count = await session.scalar(
+        select(func.count()).select_from(Video)
+    )
+    channel_count = await session.scalar(
+        select(func.count()).select_from(Channel)
+    )
+    playlist_count = await session.scalar(
+        select(func.count()).select_from(Playlist)
+    )
+    transcript_count = await session.scalar(
+        select(func.count()).select_from(VideoTranscript)
+    )
+    correction_count = await session.scalar(
+        select(func.count()).select_from(TranscriptCorrection)
+    )
+    canonical_tag_count = await session.scalar(
+        select(func.count()).select_from(CanonicalTag)
     )
 
     database_stats = DatabaseStats(

--- a/src/chronovista/services/onboarding_service.py
+++ b/src/chronovista/services/onboarding_service.py
@@ -7,7 +7,6 @@ operations to existing services via the TaskManager.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 from collections.abc import Callable, Coroutine
@@ -272,29 +271,22 @@ class OnboardingService:
             recently created video (or ``None``).
         """
         async with self._session_factory() as session:
-            # Run all count queries concurrently (9 independent queries).
-            # asyncio.gather returns tuple[object, ...] for mixed types,
-            # so we cast the result to the expected shape.
-            results: Any = await asyncio.gather(
-                self._count(session, Channel),
-                self._count(session, Video),
-                self._count_available_videos(session),
-                self._count_enriched_videos(session),
-                self._count(session, Playlist),
-                self._count(session, VideoTranscript),
-                self._count(session, VideoCategory),
-                self._count(session, CanonicalTag),
-                session.execute(select(func.max(Video.created_at))),
+            # Sequential queries — AsyncSession is not safe for concurrent
+            # use via asyncio.gather() (causes IllegalStateChangeError).
+            channels = await self._count(session, Channel)
+            videos = await self._count(session, Video)
+            available_videos = await self._count_available_videos(session)
+            enriched_videos = await self._count_enriched_videos(session)
+            playlists = await self._count(session, Playlist)
+            transcripts = await self._count(session, VideoTranscript)
+            categories = await self._count(session, VideoCategory)
+            canonical_tags = await self._count(session, CanonicalTag)
+
+            # Also fetch last-loaded timestamp in the same session
+            result = await session.execute(
+                select(func.max(Video.created_at))
             )
-            channels: int = results[0]
-            videos: int = results[1]
-            available_videos: int = results[2]
-            enriched_videos: int = results[3]
-            playlists: int = results[4]
-            transcripts: int = results[5]
-            categories: int = results[6]
-            canonical_tags: int = results[7]
-            latest = results[8].scalar_one_or_none()
+            latest = result.scalar_one_or_none()
             last_loaded_at = latest.timestamp() if latest is not None else None
 
         counts = OnboardingCounts(

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -7,6 +7,22 @@ and easy customization using keyword arguments.
 
 from __future__ import annotations
 
+from .batch_correction_factory import (
+    BatchListItemFactory,
+    BatchListItemTestData,
+    create_batch_list_item,
+)
+from .canonical_tag_factory import (
+    CanonicalTagBaseFactory,
+    CanonicalTagCreateFactory,
+    CanonicalTagFactory,
+    CanonicalTagTestData,
+    CanonicalTagUpdateFactory,
+    create_canonical_tag,
+    create_canonical_tag_base,
+    create_canonical_tag_create,
+    create_canonical_tag_update,
+)
 from .channel_keyword_factory import (
     ChannelKeywordAnalyticsFactory,
     ChannelKeywordBaseFactory,
@@ -37,6 +53,28 @@ from .channel_topic_factory import (
     create_channel_topic_statistics,
     create_channel_topic_update,
 )
+from .entity_alias_factory import (
+    EntityAliasBaseFactory,
+    EntityAliasCreateFactory,
+    EntityAliasFactory,
+    EntityAliasTestData,
+    EntityAliasUpdateFactory,
+    create_entity_alias,
+    create_entity_alias_base,
+    create_entity_alias_create,
+    create_entity_alias_update,
+)
+from .entity_mention_factory import (
+    EntityMentionBaseFactory,
+    EntityMentionCreateFactory,
+    EntityMentionFactory,
+    EntityMentionTestData,
+    ManualEntityMentionFactory,
+    create_entity_mention,
+    create_entity_mention_base,
+    create_entity_mention_create,
+    create_manual_entity_mention,
+)
 from .id_factory import (
     TestIds,
     YouTubeIdFactory,
@@ -45,6 +83,17 @@ from .id_factory import (
     topic_id,
     user_id,
     video_id,
+)
+from .named_entity_factory import (
+    NamedEntityBaseFactory,
+    NamedEntityCreateFactory,
+    NamedEntityFactory,
+    NamedEntityTestData,
+    NamedEntityUpdateFactory,
+    create_named_entity,
+    create_named_entity_base,
+    create_named_entity_create,
+    create_named_entity_update,
 )
 from .playlist_factory import (
     PlaylistBaseFactory,
@@ -59,6 +108,24 @@ from .playlist_factory import (
     create_playlist_filters,
     create_playlist_statistics,
     create_playlist_update,
+)
+from .tag_alias_factory import (
+    TagAliasBaseFactory,
+    TagAliasCreateFactory,
+    TagAliasFactory,
+    TagAliasTestData,
+    TagAliasUpdateFactory,
+    create_tag_alias,
+    create_tag_alias_base,
+    create_tag_alias_create,
+    create_tag_alias_update,
+)
+from .tag_operation_log_factory import (
+    TagOperationLogFactory,
+    TagOperationLogTestData,
+    create_merge_operation_log,
+    create_split_operation_log,
+    create_tag_operation_log,
 )
 from .takeout_watch_entry_factory import (
     TakeoutWatchEntryFactory,
@@ -89,6 +156,19 @@ from .topic_category_factory import (
     create_topic_category_hierarchy,
     create_topic_category_statistics,
     create_topic_category_update,
+)
+from .transcript_segment_factory import (
+    TranscriptSegmentBaseFactory,
+    TranscriptSegmentCreateFactory,
+    TranscriptSegmentFactory,
+    TranscriptSegmentResponseFactory,
+    TranscriptSegmentTestData,
+    create_batch_transcript_segments,
+    create_corrected_transcript_segment,
+    create_transcript_segment,
+    create_transcript_segment_base,
+    create_transcript_segment_create,
+    create_transcript_segment_response,
 )
 from .video_localization_factory import (
     VideoLocalizationBaseFactory,
@@ -131,86 +211,6 @@ from .video_topic_factory import (
     create_video_topic_filters,
     create_video_topic_statistics,
     create_video_topic_update,
-)
-from .transcript_segment_factory import (
-    TranscriptSegmentBaseFactory,
-    TranscriptSegmentCreateFactory,
-    TranscriptSegmentFactory,
-    TranscriptSegmentResponseFactory,
-    TranscriptSegmentTestData,
-    create_batch_transcript_segments,
-    create_corrected_transcript_segment,
-    create_transcript_segment,
-    create_transcript_segment_base,
-    create_transcript_segment_create,
-    create_transcript_segment_response,
-)
-from .canonical_tag_factory import (
-    CanonicalTagBaseFactory,
-    CanonicalTagCreateFactory,
-    CanonicalTagFactory,
-    CanonicalTagTestData,
-    CanonicalTagUpdateFactory,
-    create_canonical_tag,
-    create_canonical_tag_base,
-    create_canonical_tag_create,
-    create_canonical_tag_update,
-)
-from .tag_alias_factory import (
-    TagAliasBaseFactory,
-    TagAliasCreateFactory,
-    TagAliasFactory,
-    TagAliasTestData,
-    TagAliasUpdateFactory,
-    create_tag_alias,
-    create_tag_alias_base,
-    create_tag_alias_create,
-    create_tag_alias_update,
-)
-from .named_entity_factory import (
-    NamedEntityBaseFactory,
-    NamedEntityCreateFactory,
-    NamedEntityFactory,
-    NamedEntityTestData,
-    NamedEntityUpdateFactory,
-    create_named_entity,
-    create_named_entity_base,
-    create_named_entity_create,
-    create_named_entity_update,
-)
-from .entity_alias_factory import (
-    EntityAliasBaseFactory,
-    EntityAliasCreateFactory,
-    EntityAliasFactory,
-    EntityAliasTestData,
-    EntityAliasUpdateFactory,
-    create_entity_alias,
-    create_entity_alias_base,
-    create_entity_alias_create,
-    create_entity_alias_update,
-)
-from .tag_operation_log_factory import (
-    TagOperationLogFactory,
-    TagOperationLogTestData,
-    create_merge_operation_log,
-    create_split_operation_log,
-    create_tag_operation_log,
-)
-from .entity_mention_factory import (
-    EntityMentionBaseFactory,
-    EntityMentionCreateFactory,
-    EntityMentionFactory,
-    EntityMentionTestData,
-    ManualEntityMentionFactory,
-    create_entity_mention,
-    create_entity_mention_base,
-    create_entity_mention_create,
-    create_manual_entity_mention,
-)
-from .batch_correction_factory import (
-    BatchListItemFactory,
-    BatchListItemTestData,
-    create_batch_list_item,
 )
 
 __all__ = [

--- a/tests/factories/batch_correction_factory.py
+++ b/tests/factories/batch_correction_factory.py
@@ -12,7 +12,7 @@ summarizes a batch of corrections sharing the same batch_id.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import factory
@@ -47,7 +47,7 @@ class BatchListItemFactory(factory.Factory[BatchListItem]):
     pattern: Any = Sequence(lambda n: f"original text {n}")
     replacement: Any = Sequence(lambda n: f"corrected text {n}")
     batch_timestamp: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
 
 
@@ -125,7 +125,7 @@ class BatchListItemTestData:
             "corrected_by_user_id": cls.VALID_USER_IDS[0],
             "pattern": cls.VALID_PATTERNS[0],
             "replacement": cls.VALID_REPLACEMENTS[0],
-            "batch_timestamp": datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+            "batch_timestamp": datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
         }
 
     @classmethod

--- a/tests/factories/canonical_tag_factory.py
+++ b/tests/factories/canonical_tag_factory.py
@@ -8,7 +8,7 @@ with sensible defaults and easy customization.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import factory
@@ -87,10 +87,10 @@ class CanonicalTagFactory(factory.Factory[CanonicalTag]):
     entity_id: Any = LazyFunction(lambda: None)
     merged_into_id: Any = LazyFunction(lambda: None)
     created_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
     updated_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
 
 

--- a/tests/factories/channel_factory.py
+++ b/tests/factories/channel_factory.py
@@ -7,11 +7,10 @@ with realistic and consistent test data.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, List, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
-from factory import LazyFunction
 
 from chronovista.models.channel import (
     Channel,
@@ -101,10 +100,10 @@ class ChannelFactory(factory.Factory[Channel]):
         lambda: "https://yt3.ggpht.com/ytc/AKedOLStephenColbert=s240-c-k-c0x00ffffff-no-rj"
     )
     created_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 10, 15, 9, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 10, 15, 9, 30, 0, tzinfo=UTC)
     )
     updated_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 1, 14, 45, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 1, 14, 45, 0, tzinfo=UTC)
     )
 
 
@@ -245,7 +244,7 @@ def create_channel_statistics(**kwargs: Any) -> ChannelStatistics:
     return result
 
 
-def create_batch_channels(count: int = 5) -> List[Channel]:
+def create_batch_channels(count: int = 5) -> list[Channel]:
     """Create a batch of Channel instances for testing."""
     channels = []
     base_channel_ids = [

--- a/tests/factories/channel_keyword_factory.py
+++ b/tests/factories/channel_keyword_factory.py
@@ -7,8 +7,8 @@ with sensible defaults and easy customization.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 from factory import Faker, LazyAttribute
@@ -65,7 +65,7 @@ class ChannelKeywordFactory(ChannelKeywordBaseFactory):
     class Meta:
         model = ChannelKeyword
 
-    created_at: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_at: Any = Faker("date_time", tzinfo=UTC)
 
 
 class ChannelKeywordSearchFiltersFactory(factory.Factory[ChannelKeywordSearchFilters]):
@@ -82,8 +82,8 @@ class ChannelKeywordSearchFiltersFactory(factory.Factory[ChannelKeywordSearchFil
     min_keyword_order: Any = Faker("random_int", min=0, max=5)
     max_keyword_order: Any = Faker("random_int", min=6, max=20)
     has_order: Any = Faker("boolean")
-    created_after: Any = Faker("date_time", tzinfo=timezone.utc)
-    created_before: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_after: Any = Faker("date_time", tzinfo=UTC)
+    created_before: Any = Faker("date_time", tzinfo=UTC)
 
 
 class ChannelKeywordStatisticsFactory(factory.Factory[ChannelKeywordStatistics]):
@@ -286,6 +286,6 @@ class ChannelKeywordTestData:
             "min_keyword_order": 1,
             "max_keyword_order": 10,
             "has_order": True,
-            "created_after": datetime(2023, 1, 1, tzinfo=timezone.utc),
-            "created_before": datetime(2023, 12, 31, tzinfo=timezone.utc),
+            "created_after": datetime(2023, 1, 1, tzinfo=UTC),
+            "created_before": datetime(2023, 12, 31, tzinfo=UTC),
         }

--- a/tests/factories/channel_topic_factory.py
+++ b/tests/factories/channel_topic_factory.py
@@ -7,8 +7,8 @@ with sensible defaults and easy customization.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 from factory import Faker, LazyAttribute
@@ -57,7 +57,7 @@ class ChannelTopicFactory(ChannelTopicBaseFactory):
     class Meta:
         model = ChannelTopic
 
-    created_at: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_at: Any = Faker("date_time", tzinfo=UTC)
 
 
 class ChannelTopicSearchFiltersFactory(factory.Factory[ChannelTopicSearchFilters]):
@@ -72,8 +72,8 @@ class ChannelTopicSearchFiltersFactory(factory.Factory[ChannelTopicSearchFilters
     topic_ids: Any = factory.LazyFunction(
         lambda: ["topic_music", "topic_gaming", "topic_education"]
     )
-    created_after: Any = Faker("date_time", tzinfo=timezone.utc)
-    created_before: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_after: Any = Faker("date_time", tzinfo=UTC)
+    created_before: Any = Faker("date_time", tzinfo=UTC)
 
 
 class ChannelTopicStatisticsFactory(factory.Factory[ChannelTopicStatistics]):
@@ -207,6 +207,6 @@ class ChannelTopicTestData:
         return {
             "channel_ids": cls.VALID_CHANNEL_IDS[:2],
             "topic_ids": cls.VALID_TOPIC_IDS[:3],
-            "created_after": datetime(2023, 1, 1, tzinfo=timezone.utc),
-            "created_before": datetime(2023, 12, 31, tzinfo=timezone.utc),
+            "created_after": datetime(2023, 1, 1, tzinfo=UTC),
+            "created_before": datetime(2023, 12, 31, tzinfo=UTC),
         }

--- a/tests/factories/entity_alias_factory.py
+++ b/tests/factories/entity_alias_factory.py
@@ -8,7 +8,7 @@ with sensible defaults and easy customization.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import factory
@@ -80,10 +80,10 @@ class EntityAliasFactory(factory.Factory[EntityAlias]):
     entity_id: Any = LazyFunction(_uuid7)
     occurrence_count: Any = LazyFunction(lambda: 0)
     first_seen_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
     last_seen_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
 
 

--- a/tests/factories/entity_mention_factory.py
+++ b/tests/factories/entity_mention_factory.py
@@ -8,7 +8,7 @@ with sensible defaults and easy customization.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import factory
@@ -82,7 +82,7 @@ class EntityMentionFactory(factory.Factory[EntityMention]):
     match_end: Any = None
     correction_id: Any = None
     created_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
 
 
@@ -104,7 +104,7 @@ class ManualEntityMentionFactory(factory.Factory[EntityMention]):
     match_end: Any = None
     correction_id: Any = None
     created_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
 
 
@@ -283,7 +283,7 @@ class EntityMentionTestData:
         data.update(
             {
                 "id": _uuid7(),
-                "created_at": datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+                "created_at": datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
             }
         )
         return data

--- a/tests/factories/id_factory.py
+++ b/tests/factories/id_factory.py
@@ -8,14 +8,13 @@ playlist IDs, and user IDs that meet all validation requirements.
 import hashlib
 import random
 import string
-from typing import Optional
 
 
 class YouTubeIdFactory:
     """Factory for generating valid YouTube IDs."""
 
     @staticmethod
-    def create_channel_id(seed: Optional[str] = None) -> str:
+    def create_channel_id(seed: str | None = None) -> str:
         """
         Create a valid 24-character YouTube channel ID starting with 'UC'.
 
@@ -41,7 +40,7 @@ class YouTubeIdFactory:
         return f"UC{hash_value}"
 
     @staticmethod
-    def create_video_id(seed: Optional[str] = None) -> str:
+    def create_video_id(seed: str | None = None) -> str:
         """
         Create a valid 11-character YouTube video ID.
 
@@ -66,7 +65,7 @@ class YouTubeIdFactory:
         return hash_value
 
     @staticmethod
-    def create_playlist_id(seed: Optional[str] = None) -> str:
+    def create_playlist_id(seed: str | None = None) -> str:
         """
         Create a valid 30-34 character YouTube playlist ID starting with 'PL'.
 
@@ -91,7 +90,7 @@ class YouTubeIdFactory:
         return f"PL{hash_value}"
 
     @staticmethod
-    def create_user_id(seed: Optional[str] = None) -> str:
+    def create_user_id(seed: str | None = None) -> str:
         """
         Create a valid user ID.
 
@@ -111,7 +110,7 @@ class YouTubeIdFactory:
             return f"user_{''.join(random.choices(string.ascii_lowercase + string.digits, k=16))}"
 
     @staticmethod
-    def create_topic_id(seed: Optional[str] = None) -> str:
+    def create_topic_id(seed: str | None = None) -> str:
         """
         Create a valid topic ID.
 
@@ -138,27 +137,27 @@ class YouTubeIdFactory:
 
 
 # Convenience functions for easy access
-def channel_id(seed: Optional[str] = None) -> str:
+def channel_id(seed: str | None = None) -> str:
     """Generate a valid channel ID."""
     return YouTubeIdFactory.create_channel_id(seed)
 
 
-def video_id(seed: Optional[str] = None) -> str:
+def video_id(seed: str | None = None) -> str:
     """Generate a valid video ID."""
     return YouTubeIdFactory.create_video_id(seed)
 
 
-def playlist_id(seed: Optional[str] = None) -> str:
+def playlist_id(seed: str | None = None) -> str:
     """Generate a valid playlist ID."""
     return YouTubeIdFactory.create_playlist_id(seed)
 
 
-def user_id(seed: Optional[str] = None) -> str:
+def user_id(seed: str | None = None) -> str:
     """Generate a valid user ID."""
     return YouTubeIdFactory.create_user_id(seed)
 
 
-def topic_id(seed: Optional[str] = None) -> str:
+def topic_id(seed: str | None = None) -> str:
     """Generate a valid topic ID."""
     return YouTubeIdFactory.create_topic_id(seed)
 

--- a/tests/factories/named_entity_factory.py
+++ b/tests/factories/named_entity_factory.py
@@ -8,7 +8,7 @@ with sensible defaults and easy customization.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import factory
@@ -95,10 +95,10 @@ class NamedEntityFactory(factory.Factory[NamedEntity]):
     confidence: Any = LazyFunction(lambda: 1.0)
     merged_into_id: Any = LazyFunction(lambda: None)
     created_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
     updated_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
 
 

--- a/tests/factories/playlist_factory.py
+++ b/tests/factories/playlist_factory.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import hashlib
 import uuid
-from datetime import datetime, timezone
-from typing import Any, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 from factory import Faker, LazyAttribute
@@ -73,8 +73,8 @@ class PlaylistFactory(PlaylistBaseFactory):
     class Meta:
         model = Playlist
 
-    created_at: Any = Faker("date_time", tzinfo=timezone.utc)
-    updated_at: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_at: Any = Faker("date_time", tzinfo=UTC)
+    updated_at: Any = Faker("date_time", tzinfo=UTC)
 
     @classmethod
     def with_youtube_id(cls, youtube_id: str | None = None, **kwargs: Any) -> Playlist:
@@ -124,10 +124,10 @@ class PlaylistSearchFiltersFactory(factory.Factory[PlaylistSearchFilters]):
     min_video_count: Any = Faker("random_int", min=1, max=10)
     max_video_count: Any = Faker("random_int", min=11, max=100)
     has_description: Any = Faker("boolean")
-    created_after: Any = Faker("date_time", tzinfo=timezone.utc)
-    created_before: Any = Faker("date_time", tzinfo=timezone.utc)
-    updated_after: Any = Faker("date_time", tzinfo=timezone.utc)
-    updated_before: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_after: Any = Faker("date_time", tzinfo=UTC)
+    created_before: Any = Faker("date_time", tzinfo=UTC)
+    updated_after: Any = Faker("date_time", tzinfo=UTC)
+    updated_before: Any = Faker("date_time", tzinfo=UTC)
 
 
 class PlaylistStatisticsFactory(factory.Factory[PlaylistStatistics]):
@@ -410,10 +410,10 @@ class PlaylistTestData:
             "min_video_count": 5,
             "max_video_count": 100,
             "has_description": True,
-            "created_after": datetime(2023, 1, 1, tzinfo=timezone.utc),
-            "created_before": datetime(2023, 12, 31, tzinfo=timezone.utc),
-            "updated_after": datetime(2023, 6, 1, tzinfo=timezone.utc),
-            "updated_before": datetime(2023, 12, 31, tzinfo=timezone.utc),
+            "created_after": datetime(2023, 1, 1, tzinfo=UTC),
+            "created_before": datetime(2023, 12, 31, tzinfo=UTC),
+            "updated_after": datetime(2023, 6, 1, tzinfo=UTC),
+            "updated_before": datetime(2023, 12, 31, tzinfo=UTC),
         }
 
     @classmethod

--- a/tests/factories/tag_alias_factory.py
+++ b/tests/factories/tag_alias_factory.py
@@ -8,7 +8,7 @@ with sensible defaults and easy customization.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import factory
@@ -82,13 +82,13 @@ class TagAliasFactory(factory.Factory[TagAlias]):
     normalization_version: Any = LazyFunction(lambda: 1)
     occurrence_count: Any = LazyFunction(lambda: 1)
     first_seen_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
     last_seen_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
     created_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
 
 

--- a/tests/factories/tag_operation_log_factory.py
+++ b/tests/factories/tag_operation_log_factory.py
@@ -10,8 +10,8 @@ factory targets the SQLAlchemy ORM model directly.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 from factory import LazyFunction
@@ -38,7 +38,7 @@ class TagOperationLogFactory(factory.Factory[TagOperationLog]):
     reason: Any = LazyFunction(lambda: None)
     performed_by: Any = LazyFunction(lambda: "system")
     performed_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
     rollback_data: Any = LazyFunction(dict)
     rolled_back: Any = LazyFunction(lambda: False)
@@ -69,7 +69,7 @@ def create_merge_operation_log(**kwargs: Any) -> TagOperationLog:
     source_id = uuid7()
     target_id = uuid7()
     alias_id = uuid7()
-    defaults: Dict[str, Any] = {
+    defaults: dict[str, Any] = {
         "operation_type": "merge",
         "source_canonical_ids": [str(source_id)],
         "target_canonical_id": target_id,
@@ -97,7 +97,7 @@ def create_split_operation_log(**kwargs: Any) -> TagOperationLog:
         A TagOperationLog instance configured for a split operation.
     """
     source_id = uuid7()
-    defaults: Dict[str, Any] = {
+    defaults: dict[str, Any] = {
         "operation_type": "split",
         "source_canonical_ids": [str(source_id)],
         "reason": "Tag split into more specific variants",
@@ -129,7 +129,7 @@ class TagOperationLogTestData:
     ]
 
     @classmethod
-    def valid_operation_log_data(cls) -> Dict[str, Any]:
+    def valid_operation_log_data(cls) -> dict[str, Any]:
         """Get valid tag operation log data."""
         return {
             "operation_type": "create",
@@ -144,7 +144,7 @@ class TagOperationLogTestData:
         }
 
     @classmethod
-    def merge_operation_data(cls) -> Dict[str, Any]:
+    def merge_operation_data(cls) -> dict[str, Any]:
         """Get data for a merge operation."""
         source_id = uuid7()
         target_id = uuid7()

--- a/tests/factories/takeout_data_factory.py
+++ b/tests/factories/takeout_data_factory.py
@@ -7,9 +7,9 @@ with realistic and consistent test data.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Any, List, Optional, Tuple, cast
+from typing import Any
 
 import factory
 
@@ -37,7 +37,7 @@ class TakeoutDataFactory(factory.Factory[TakeoutData]):
     playlists: Any = factory.LazyFunction(lambda: create_batch_takeout_playlists(3))
     subscriptions: Any = factory.LazyFunction(lambda: create_batch_takeout_subscriptions(5))
     parsed_at: Any = factory.LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
     )
 
     # These will be calculated automatically from the data
@@ -60,7 +60,7 @@ class TakeoutDataMinimalFactory(factory.Factory[TakeoutData]):
     watch_history: Any = factory.LazyFunction(list)  # Empty list
     playlists: Any = factory.LazyFunction(list)  # Empty list
     subscriptions: Any = factory.LazyFunction(list)  # Empty list
-    parsed_at: Any = factory.LazyFunction(lambda: datetime.now(timezone.utc))
+    parsed_at: Any = factory.LazyFunction(lambda: datetime.now(UTC))
     total_videos_watched = 0
     total_playlists = 0
     total_subscriptions = 0
@@ -80,7 +80,7 @@ class TakeoutDataLargeFactory(factory.Factory[TakeoutData]):
     playlists: Any = factory.LazyFunction(lambda: create_batch_takeout_playlists(15))
     subscriptions: Any = factory.LazyFunction(lambda: create_batch_takeout_subscriptions(50))
     parsed_at: Any = factory.LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
     )
     total_videos_watched = 0
     total_playlists = 0
@@ -99,7 +99,7 @@ class TakeoutDataHistoricalFactory(factory.Factory[TakeoutData]):
     playlists: Any = factory.LazyFunction(lambda: create_batch_takeout_playlists(5))
     subscriptions: Any = factory.LazyFunction(lambda: create_batch_takeout_subscriptions(10))
     parsed_at: Any = factory.LazyFunction(
-        lambda: datetime(2020, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2020, 6, 1, 12, 0, 0, tzinfo=UTC)
     )
     total_videos_watched = 0
     total_playlists = 0
@@ -118,7 +118,7 @@ class TakeoutDataWithExplicitTotalsFactory(factory.Factory[TakeoutData]):
     playlists: Any = factory.LazyFunction(lambda: create_batch_takeout_playlists(2))
     subscriptions: Any = factory.LazyFunction(lambda: create_batch_takeout_subscriptions(3))
     parsed_at: Any = factory.LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
     )
 
     # Explicitly set totals (won't be auto-calculated)
@@ -127,8 +127,8 @@ class TakeoutDataWithExplicitTotalsFactory(factory.Factory[TakeoutData]):
     total_subscriptions = 50
     date_range: Any = factory.LazyFunction(
         lambda: (
-            datetime(2020, 1, 1, tzinfo=timezone.utc),
-            datetime(2024, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, tzinfo=UTC),
+            datetime(2024, 1, 1, tzinfo=UTC),
         )
     )
 
@@ -149,20 +149,20 @@ class TakeoutDataTestData:
     ]
 
     VALID_PARSED_AT_TIMESTAMPS = [
-        datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
-        datetime(2020, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
-        datetime(2023, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
-        datetime.now(timezone.utc),
+        datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
+        datetime(2020, 6, 1, 12, 0, 0, tzinfo=UTC),
+        datetime(2023, 12, 31, 23, 59, 59, tzinfo=UTC),
+        datetime.now(UTC),
     ]
 
     VALID_DATE_RANGES = [
         (
-            datetime(2020, 1, 1, tzinfo=timezone.utc),
-            datetime(2024, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, tzinfo=UTC),
+            datetime(2024, 1, 1, tzinfo=UTC),
         ),
         (
-            datetime(2023, 1, 1, tzinfo=timezone.utc),
-            datetime(2023, 12, 31, tzinfo=timezone.utc),
+            datetime(2023, 1, 1, tzinfo=UTC),
+            datetime(2023, 12, 31, tzinfo=UTC),
         ),
         None,  # Can be None
     ]
@@ -207,7 +207,7 @@ def create_takeout_data_with_explicit_totals(**kwargs: Any) -> TakeoutData:
     return result
 
 
-def create_empty_takeout_data(takeout_path: Optional[Path] = None) -> TakeoutData:
+def create_empty_takeout_data(takeout_path: Path | None = None) -> TakeoutData:
     """Create a TakeoutData with no watch history, playlists, or subscriptions."""
     if takeout_path is None:
         takeout_path = Path("/tmp/empty-takeout")
@@ -238,7 +238,7 @@ def create_takeout_data_with_counts(
     return result
 
 
-def create_batch_takeout_data(count: int = 3) -> List[TakeoutData]:
+def create_batch_takeout_data(count: int = 3) -> list[TakeoutData]:
     """Create a batch of TakeoutData instances for testing."""
     takeout_data_list = []
 
@@ -248,7 +248,7 @@ def create_batch_takeout_data(count: int = 3) -> List[TakeoutData]:
         playlist_count = i + 1  # 1, 2, 3, etc.
         subscription_count = (i + 1) * 2  # 2, 4, 6, etc.
 
-        parsed_at = datetime(2024, 1, 1 + i, 10, 0, 0, tzinfo=timezone.utc)
+        parsed_at = datetime(2024, 1, 1 + i, 10, 0, 0, tzinfo=UTC)
 
         takeout_data = create_takeout_data_with_counts(
             video_count=video_count,

--- a/tests/factories/takeout_playlist_factory.py
+++ b/tests/factories/takeout_playlist_factory.py
@@ -8,7 +8,7 @@ with realistic and consistent test data.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Any, List, cast
+from typing import Any
 
 import factory
 
@@ -178,7 +178,7 @@ def create_tech_takeout_playlist(**kwargs: Any) -> TakeoutPlaylist:
     return result
 
 
-def create_batch_takeout_playlists(count: int = 3) -> List[TakeoutPlaylist]:
+def create_batch_takeout_playlists(count: int = 3) -> list[TakeoutPlaylist]:
     """Create a batch of TakeoutPlaylist instances for testing."""
     playlists = []
     base_names = [

--- a/tests/factories/takeout_playlist_item_factory.py
+++ b/tests/factories/takeout_playlist_item_factory.py
@@ -7,8 +7,8 @@ with realistic and consistent test data.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Any, List, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 
@@ -26,7 +26,7 @@ class TakeoutPlaylistItemFactory(factory.Factory[TakeoutPlaylistItem]):
 
     # Optional fields with realistic defaults
     creation_timestamp: Any = factory.LazyFunction(
-        lambda: datetime(2023, 6, 15, 14, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 6, 15, 14, 30, 0, tzinfo=UTC)
     )
     raw_timestamp: Any = factory.LazyFunction(lambda: "2023-06-15T14:30:00+00:00")
 
@@ -53,7 +53,7 @@ class TakeoutPlaylistItemRecentFactory(factory.Factory[TakeoutPlaylistItem]):
 
     video_id: Any = factory.LazyFunction(lambda: "3tmd-ClpJxA")
     creation_timestamp: Any = factory.LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
     )
     raw_timestamp: Any = factory.LazyFunction(lambda: "2024-01-15T10:00:00+00:00")
 
@@ -66,7 +66,7 @@ class TakeoutPlaylistItemOldFactory(factory.Factory[TakeoutPlaylistItem]):
 
     video_id: Any = factory.LazyFunction(lambda: "jNQXAC9IVRw")
     creation_timestamp: Any = factory.LazyFunction(
-        lambda: datetime(2020, 5, 10, 16, 45, 0, tzinfo=timezone.utc)
+        lambda: datetime(2020, 5, 10, 16, 45, 0, tzinfo=UTC)
     )
     raw_timestamp: Any = factory.LazyFunction(lambda: "2020-05-10T16:45:00+00:00")
 
@@ -141,7 +141,7 @@ def create_old_takeout_playlist_item(**kwargs: Any) -> TakeoutPlaylistItem:
     return result
 
 
-def create_batch_takeout_playlist_items(count: int = 5) -> List[TakeoutPlaylistItem]:
+def create_batch_takeout_playlist_items(count: int = 5) -> list[TakeoutPlaylistItem]:
     """Create a batch of TakeoutPlaylistItem instances for testing."""
     items = []
     base_video_ids = [
@@ -156,7 +156,7 @@ def create_batch_takeout_playlist_items(count: int = 5) -> List[TakeoutPlaylistI
         video_id = base_video_ids[i % len(base_video_ids)]
 
         # Create progressive timestamps
-        timestamp = datetime(2023, 1, 1, tzinfo=timezone.utc)
+        timestamp = datetime(2023, 1, 1, tzinfo=UTC)
         timestamp = timestamp.replace(day=1 + (i % 28), hour=10 + (i % 12))
 
         item = TakeoutPlaylistItemFactory.build(

--- a/tests/factories/takeout_subscription_factory.py
+++ b/tests/factories/takeout_subscription_factory.py
@@ -7,7 +7,7 @@ with realistic and consistent test data.
 
 from __future__ import annotations
 
-from typing import Any, Any, List, cast
+from typing import Any
 
 import factory
 
@@ -193,7 +193,7 @@ def create_handle_takeout_subscription(**kwargs: Any) -> TakeoutSubscription:
     return result
 
 
-def create_batch_takeout_subscriptions(count: int = 5) -> List[TakeoutSubscription]:
+def create_batch_takeout_subscriptions(count: int = 5) -> list[TakeoutSubscription]:
     """Create a batch of TakeoutSubscription instances for testing."""
     subscriptions = []
     base_channels = [

--- a/tests/factories/takeout_watch_entry_factory.py
+++ b/tests/factories/takeout_watch_entry_factory.py
@@ -7,11 +7,10 @@ with realistic and consistent test data.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Any, Dict, List, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
-from factory import LazyFunction
 
 from chronovista.models.takeout.takeout_data import TakeoutWatchEntry
 
@@ -38,7 +37,7 @@ class TakeoutWatchEntryFactory(factory.Factory[TakeoutWatchEntry]):
     )
     channel_id: Any = factory.LazyFunction(lambda: "UCuAXFkgsw1L7xaCfnd5JJOw")
     watched_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 6, 15, 14, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 6, 15, 14, 30, 0, tzinfo=UTC)
     )
     raw_time: Any = factory.LazyFunction(lambda: "2023-06-15T14:30:00Z")
 
@@ -83,7 +82,7 @@ class TakeoutWatchEntryWithTimeFactory(factory.Factory[TakeoutWatchEntry]):
     )
     channel_id: Any = factory.LazyFunction(lambda: "UCMtFAi84ehTSYSE9XoHefig")
     watched_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 15, 23, 35, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 15, 23, 35, 0, tzinfo=UTC)
     )
     raw_time: Any = factory.LazyFunction(lambda: "2023-12-15T23:35:00Z")
 
@@ -107,7 +106,7 @@ class TakeoutWatchEntryTechFactory(factory.Factory[TakeoutWatchEntry]):
     )
     channel_id: Any = factory.LazyFunction(lambda: "UC_x5XG1OV2P6uZZ5FSM9Ttw")
     watched_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 5, 10, 17, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 5, 10, 17, 0, 0, tzinfo=UTC)
     )
     raw_time: Any = factory.LazyFunction(lambda: "2023-05-10T17:00:00Z")
 
@@ -240,7 +239,7 @@ def create_tech_takeout_watch_entry(**kwargs: Any) -> TakeoutWatchEntry:
     return result
 
 
-def create_batch_takeout_watch_entries(count: int = 5) -> List[TakeoutWatchEntry]:
+def create_batch_takeout_watch_entries(count: int = 5) -> list[TakeoutWatchEntry]:
     """Create a batch of TakeoutWatchEntry instances for testing."""
     entries = []
     base_video_ids = [
@@ -271,7 +270,7 @@ def create_batch_takeout_watch_entries(count: int = 5) -> List[TakeoutWatchEntry
         channel_name, channel_id = base_channels[i % len(base_channels)]
 
         # Create progressive timestamps
-        timestamp = datetime(2023, 1, 1, tzinfo=timezone.utc)
+        timestamp = datetime(2023, 1, 1, tzinfo=UTC)
         timestamp = timestamp.replace(day=1 + (i % 28), hour=10 + (i % 12))
 
         entry = TakeoutWatchEntryFactory.build(

--- a/tests/factories/topic_category_factory.py
+++ b/tests/factories/topic_category_factory.py
@@ -7,8 +7,8 @@ with sensible defaults and easy customization.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 from factory import Faker, LazyAttribute
@@ -61,7 +61,7 @@ class TopicCategoryFactory(TopicCategoryBaseFactory):
     class Meta:
         model = TopicCategory
 
-    created_at: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_at: Any = Faker("date_time", tzinfo=UTC)
 
 
 class TopicCategorySearchFiltersFactory(factory.Factory[TopicCategorySearchFilters]):
@@ -77,8 +77,8 @@ class TopicCategorySearchFiltersFactory(factory.Factory[TopicCategorySearchFilte
     is_root_topic: Any = Faker("boolean")
     has_children: Any = Faker("boolean")
     max_depth: Any = Faker("random_int", min=1, max=5)
-    created_after: Any = Faker("date_time", tzinfo=timezone.utc)
-    created_before: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_after: Any = Faker("date_time", tzinfo=UTC)
+    created_before: Any = Faker("date_time", tzinfo=UTC)
 
 
 class TopicCategoryStatisticsFactory(factory.Factory[TopicCategoryStatistics]):
@@ -357,8 +357,8 @@ class TopicCategoryTestData:
             "is_root_topic": False,
             "has_children": True,
             "max_depth": 3,
-            "created_after": datetime(2023, 1, 1, tzinfo=timezone.utc),
-            "created_before": datetime(2023, 12, 31, tzinfo=timezone.utc),
+            "created_after": datetime(2023, 1, 1, tzinfo=UTC),
+            "created_before": datetime(2023, 12, 31, tzinfo=UTC),
         }
 
     @classmethod

--- a/tests/factories/transcript_correction_factory.py
+++ b/tests/factories/transcript_correction_factory.py
@@ -9,7 +9,7 @@ with sensible defaults and easy customization.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import factory
@@ -46,7 +46,7 @@ class TranscriptCorrectionFactory(factory.Factory[TranscriptCorrectionDB]):
     corrected_text: Any = Sequence(lambda n: f"corrected text {n}")
     correction_note: Any = LazyFunction(lambda: None)
     corrected_by_user_id: Any = LazyFunction(lambda: "cli")
-    corrected_at: Any = LazyFunction(lambda: datetime.now(tz=timezone.utc))
+    corrected_at: Any = LazyFunction(lambda: datetime.now(tz=UTC))
     version_number: Any = LazyFunction(lambda: 1)
 
 
@@ -90,7 +90,7 @@ class TranscriptCorrectionTestData:
         "corrected_text": "the quick brown fox",
         "correction_note": None,
         "corrected_by_user_id": "cli",
-        "corrected_at": datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+        "corrected_at": datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
         "version_number": 1,
     }
 

--- a/tests/factories/transcript_segment_factory.py
+++ b/tests/factories/transcript_segment_factory.py
@@ -7,8 +7,8 @@ with sensible defaults and easy customization.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, List
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 from factory import LazyAttribute, LazyFunction, Sequence
@@ -53,7 +53,7 @@ class TranscriptSegmentFactory(TranscriptSegmentBaseFactory):
     has_correction: Any = LazyFunction(lambda: False)
     corrected_text: Any = LazyFunction(lambda: None)
     created_at: Any = LazyFunction(
-        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
     )
 
 
@@ -121,7 +121,7 @@ def create_batch_transcript_segments(
     video_id: str = "dQw4w9WgXcQ",
     language_code: str = "en",
     count: int = 5,
-) -> List[TranscriptSegment]:
+) -> list[TranscriptSegment]:
     """Create a batch of sequential TranscriptSegment instances.
 
     Parameters
@@ -138,7 +138,7 @@ def create_batch_transcript_segments(
     List[TranscriptSegment]
         List of sequential transcript segments.
     """
-    segments: List[TranscriptSegment] = []
+    segments: list[TranscriptSegment] = []
     base_texts = [
         "Hello and welcome to this video.",
         "Today we'll be discussing important topics.",
@@ -267,7 +267,7 @@ class TranscriptSegmentTestData:
                 "id": 1,
                 "has_correction": False,
                 "corrected_text": None,
-                "created_at": datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+                "created_at": datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
             }
         )
         return data

--- a/tests/factories/user_language_preference_factory.py
+++ b/tests/factories/user_language_preference_factory.py
@@ -7,8 +7,8 @@ with realistic and consistent test data.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, List, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 
@@ -82,7 +82,7 @@ class UserLanguagePreferenceFactory(factory.Factory[UserLanguagePreference]):
         lambda: "Cultural interest in French media and cinema"
     )
     created_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 10, 15, 14, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 10, 15, 14, 30, 0, tzinfo=UTC)
     )
 
 
@@ -177,7 +177,7 @@ def create_user_language_preference(**kwargs: Any) -> UserLanguagePreference:
 
 def create_batch_user_language_preferences(
     count: int = 5,
-) -> List[UserLanguagePreference]:
+) -> list[UserLanguagePreference]:
     """Create a batch of UserLanguagePreference instances for testing."""
     preferences = []
     base_user_ids = ["user_001", "user_002", "user_003", "user_004", "user_005"]

--- a/tests/factories/user_video_factory.py
+++ b/tests/factories/user_video_factory.py
@@ -7,11 +7,10 @@ with realistic and consistent test data.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, List, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
-from factory import LazyFunction
 
 from chronovista.models.user_video import (
     GoogleTakeoutWatchHistoryItem,
@@ -33,7 +32,7 @@ class UserVideoBaseFactory(factory.Factory[UserVideoBase]):
     user_id: Any = factory.LazyFunction(lambda: "test_user_123")
     video_id: Any = factory.LazyFunction(lambda: "dQw4w9WgXcQ")
     watched_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 1, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 1, 10, 30, 0, tzinfo=UTC)
     )
     rewatch_count: Any = factory.LazyFunction(lambda: 1)
     liked: Any = factory.LazyFunction(lambda: True)
@@ -49,7 +48,7 @@ class UserVideoCreateFactory(factory.Factory[UserVideoCreate]):
     user_id: Any = factory.LazyFunction(lambda: "test_user_456")
     video_id: Any = factory.LazyFunction(lambda: "9bZkp7q19f0")
     watched_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 11, 15, 14, 20, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 11, 15, 14, 20, 0, tzinfo=UTC)
     )
     rewatch_count: Any = factory.LazyFunction(lambda: 0)
     liked: Any = factory.LazyFunction(lambda: False)
@@ -80,16 +79,16 @@ class UserVideoFactory(factory.Factory[UserVideo]):
     user_id: Any = factory.LazyFunction(lambda: "test_user_789")
     video_id: Any = factory.LazyFunction(lambda: "3tmd-ClpJxA")
     watched_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 10, 20, 9, 15, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 10, 20, 9, 15, 0, tzinfo=UTC)
     )
     rewatch_count: Any = factory.LazyFunction(lambda: 3)
     liked: Any = factory.LazyFunction(lambda: True)
     saved_to_playlist: Any = factory.LazyFunction(lambda: True)
     created_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 10, 20, 9, 15, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 10, 20, 9, 15, 0, tzinfo=UTC)
     )
     updated_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 1, 10, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 1, 10, 30, 0, tzinfo=UTC)
     )
 
 
@@ -130,19 +129,19 @@ class UserVideoSearchFiltersFactory(factory.Factory[UserVideoSearchFilters]):
         lambda: ["dQw4w9WgXcQ", "9bZkp7q19f0", "3tmd-ClpJxA"]
     )
     watched_after: Any = factory.LazyFunction(
-        lambda: datetime(2023, 1, 1, tzinfo=timezone.utc)
+        lambda: datetime(2023, 1, 1, tzinfo=UTC)
     )
     watched_before: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 31, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 31, tzinfo=UTC)
     )
     liked_only: Any = factory.LazyFunction(lambda: True)
     playlist_saved_only: Any = factory.LazyFunction(lambda: True)
     min_rewatch_count: Any = factory.LazyFunction(lambda: 1)
     created_after: Any = factory.LazyFunction(
-        lambda: datetime(2023, 6, 1, tzinfo=timezone.utc)
+        lambda: datetime(2023, 6, 1, tzinfo=UTC)
     )
     created_before: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 1, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 1, tzinfo=UTC)
     )
 
 
@@ -158,7 +157,7 @@ class UserVideoStatisticsFactory(factory.Factory[UserVideoStatistics]):
     rewatch_count: Any = factory.LazyFunction(lambda: 25)
     unique_videos: Any = factory.LazyFunction(lambda: 125)
     most_watched_date: Any = factory.LazyFunction(
-        lambda: datetime(2023, 11, 15, tzinfo=timezone.utc)
+        lambda: datetime(2023, 11, 15, tzinfo=UTC)
     )
     watch_streak_days: Any = factory.LazyFunction(lambda: 14)
 
@@ -261,7 +260,7 @@ def create_user_video_statistics(**kwargs: Any) -> UserVideoStatistics:
     return result
 
 
-def create_batch_user_videos(count: int = 5) -> List[UserVideo]:
+def create_batch_user_videos(count: int = 5) -> list[UserVideo]:
     """Create a batch of UserVideo instances for testing."""
     videos = []
     base_user_ids = ["user1", "user2", "user3"]

--- a/tests/factories/video_factory.py
+++ b/tests/factories/video_factory.py
@@ -7,11 +7,10 @@ with realistic and consistent test data.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
-from factory import LazyFunction
 
 from chronovista.models.enums import AvailabilityStatus, LanguageCode
 from chronovista.models.video import (
@@ -46,7 +45,7 @@ class VideoBaseFactory(factory.Factory[VideoBase]):
         lambda: "The official video for 'Never Gonna Give You Up' by Rick Astley. A timeless classic that has become an internet phenomenon."
     )
     upload_date: Any = factory.LazyFunction(
-        lambda: datetime(2009, 10, 25, 8, 15, 0, tzinfo=timezone.utc)
+        lambda: datetime(2009, 10, 25, 8, 15, 0, tzinfo=UTC)
     )
     duration: Any = factory.LazyFunction(lambda: 213)  # 3:33 in seconds
     made_for_kids: Any = factory.LazyFunction(lambda: False)
@@ -89,7 +88,7 @@ class VideoCreateFactory(factory.Factory[VideoCreate]):
         lambda: "Join us for an overview of the latest ML developments from Google, including new tools, frameworks, and research breakthroughs."
     )
     upload_date: Any = factory.LazyFunction(
-        lambda: datetime(2023, 5, 10, 17, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 5, 10, 17, 0, 0, tzinfo=UTC)
     )
     duration: Any = factory.LazyFunction(lambda: 2760)  # 46 minutes
     made_for_kids: Any = factory.LazyFunction(lambda: False)
@@ -158,7 +157,7 @@ class VideoFactory(factory.Factory[Video]):
         lambda: "A compilation of the funniest and most memorable moments from The Late Show with Stephen Colbert in 2023."
     )
     upload_date: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 15, 23, 35, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 15, 23, 35, 0, tzinfo=UTC)
     )
     duration: Any = factory.LazyFunction(lambda: 1440)  # 24 minutes
     made_for_kids: Any = factory.LazyFunction(lambda: False)
@@ -175,10 +174,10 @@ class VideoFactory(factory.Factory[Video]):
     comment_count: Any = factory.LazyFunction(lambda: 8500)
     availability_status: Any = factory.LazyFunction(lambda: AvailabilityStatus.AVAILABLE)
     created_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 15, 23, 35, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 15, 23, 35, 0, tzinfo=UTC)
     )
     updated_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 16, 10, 20, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 16, 10, 20, 0, tzinfo=UTC)
     )
 
 
@@ -197,10 +196,10 @@ class VideoSearchFiltersFactory(factory.Factory[VideoSearchFilters]):
         lambda: [LanguageCode.ENGLISH, LanguageCode.ENGLISH_US, LanguageCode.SPANISH]
     )
     upload_after: Any = factory.LazyFunction(
-        lambda: datetime(2023, 1, 1, tzinfo=timezone.utc)
+        lambda: datetime(2023, 1, 1, tzinfo=UTC)
     )
     upload_before: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 31, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 31, tzinfo=UTC)
     )
     min_duration: Any = factory.LazyFunction(lambda: 300)  # 5 minutes
     max_duration: Any = factory.LazyFunction(lambda: 3600)  # 1 hour
@@ -257,7 +256,7 @@ class VideoWithChannelFactory(factory.Factory[VideoWithChannel]):
         lambda: "The most comprehensive review of Apple's latest flagship iPhone with detailed testing and comparisons."
     )
     upload_date: Any = factory.LazyFunction(
-        lambda: datetime(2023, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 9, 22, 12, 0, 0, tzinfo=UTC)
     )
     duration: Any = factory.LazyFunction(lambda: 1260)  # 21 minutes
     made_for_kids: Any = factory.LazyFunction(lambda: False)
@@ -272,10 +271,10 @@ class VideoWithChannelFactory(factory.Factory[VideoWithChannel]):
     comment_count: Any = factory.LazyFunction(lambda: 35000)
     availability_status: Any = factory.LazyFunction(lambda: AvailabilityStatus.AVAILABLE)
     created_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 9, 22, 12, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 9, 22, 12, 0, 0, tzinfo=UTC)
     )
     updated_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 9, 22, 15, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 9, 22, 15, 30, 0, tzinfo=UTC)
     )
     channel_title: Any = factory.LazyFunction(lambda: "Marques Brownlee")
     channel_subscriber_count: Any = factory.LazyFunction(lambda: 17800000)
@@ -428,7 +427,7 @@ def create_video_with_channel(**kwargs: Any) -> VideoWithChannel:
     return result
 
 
-def create_batch_videos(count: int = 5) -> List[Video]:
+def create_batch_videos(count: int = 5) -> list[Video]:
     """Create a batch of Video instances for testing."""
     videos = []
     base_video_ids = [

--- a/tests/factories/video_localization_factory.py
+++ b/tests/factories/video_localization_factory.py
@@ -7,8 +7,8 @@ with sensible defaults and easy customization.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 from factory import Faker, LazyAttribute
@@ -71,7 +71,7 @@ class VideoLocalizationFactory(VideoLocalizationBaseFactory):
     class Meta:
         model = VideoLocalization
 
-    created_at: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_at: Any = Faker("date_time", tzinfo=UTC)
 
 
 class VideoLocalizationSearchFiltersFactory(factory.Factory[VideoLocalizationSearchFilters]):
@@ -87,8 +87,8 @@ class VideoLocalizationSearchFiltersFactory(factory.Factory[VideoLocalizationSea
     title_query: Any = Faker("word")
     description_query: Any = Faker("word")
     has_description: Any = Faker("boolean")
-    created_after: Any = Faker("date_time", tzinfo=timezone.utc)
-    created_before: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_after: Any = Faker("date_time", tzinfo=UTC)
+    created_before: Any = Faker("date_time", tzinfo=UTC)
 
 
 class VideoLocalizationStatisticsFactory(factory.Factory[VideoLocalizationStatistics]):
@@ -243,6 +243,6 @@ class VideoLocalizationTestData:
             "title_query": "tutorial",
             "description_query": "how to",
             "has_description": True,
-            "created_after": datetime(2023, 1, 1, tzinfo=timezone.utc),
-            "created_before": datetime(2023, 12, 31, tzinfo=timezone.utc),
+            "created_after": datetime(2023, 1, 1, tzinfo=UTC),
+            "created_before": datetime(2023, 12, 31, tzinfo=UTC),
         }

--- a/tests/factories/video_tag_factory.py
+++ b/tests/factories/video_tag_factory.py
@@ -7,7 +7,7 @@ with sensible defaults and easy customization.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import factory
@@ -62,7 +62,7 @@ class VideoTagFactory(VideoTagBaseFactory):
     class Meta:
         model = VideoTag
 
-    created_at: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_at: Any = Faker("date_time", tzinfo=UTC)
 
 
 class VideoTagSearchFiltersFactory(factory.Factory[VideoTagSearchFilters]):
@@ -76,8 +76,8 @@ class VideoTagSearchFiltersFactory(factory.Factory[VideoTagSearchFilters]):
     tag_pattern: Any = Faker("word")
     min_tag_order: Any = Faker("random_int", min=0, max=5)
     max_tag_order: Any = Faker("random_int", min=6, max=20)
-    created_after: Any = Faker("date_time", tzinfo=timezone.utc)
-    created_before: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_after: Any = Faker("date_time", tzinfo=UTC)
+    created_before: Any = Faker("date_time", tzinfo=UTC)
 
 
 class VideoTagStatisticsFactory(factory.Factory[VideoTagStatistics]):
@@ -194,6 +194,6 @@ class VideoTagTestData:
             "tag_pattern": "tutorial",
             "min_tag_order": 1,
             "max_tag_order": 10,
-            "created_after": datetime(2023, 1, 1, tzinfo=timezone.utc),
-            "created_before": datetime(2023, 12, 31, tzinfo=timezone.utc),
+            "created_after": datetime(2023, 1, 1, tzinfo=UTC),
+            "created_before": datetime(2023, 12, 31, tzinfo=UTC),
         }

--- a/tests/factories/video_topic_factory.py
+++ b/tests/factories/video_topic_factory.py
@@ -7,12 +7,11 @@ with sensible defaults and easy customization.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
 from factory import Faker, LazyAttribute
-from factory.faker import Faker as FakerType
 
 from chronovista.models.video_topic import (
     VideoTopic,
@@ -61,7 +60,7 @@ class VideoTopicFactory(VideoTopicBaseFactory):
     class Meta:
         model = VideoTopic
 
-    created_at: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_at: Any = Faker("date_time", tzinfo=UTC)
 
 
 class VideoTopicSearchFiltersFactory(factory.Factory[VideoTopicSearchFilters]):
@@ -75,8 +74,8 @@ class VideoTopicSearchFiltersFactory(factory.Factory[VideoTopicSearchFilters]):
         lambda: ["topic_music", "topic_gaming", "topic_education"]
     )
     relevance_types: Any = factory.LazyFunction(lambda: ["primary", "relevant"])
-    created_after: Any = Faker("date_time", tzinfo=timezone.utc)
-    created_before: Any = Faker("date_time", tzinfo=timezone.utc)
+    created_after: Any = Faker("date_time", tzinfo=UTC)
+    created_before: Any = Faker("date_time", tzinfo=UTC)
 
 
 class VideoTopicStatisticsFactory(factory.Factory[VideoTopicStatistics]):
@@ -207,6 +206,6 @@ class VideoTopicTestData:
             "video_ids": cls.VALID_VIDEO_IDS[:2],
             "topic_ids": cls.VALID_TOPIC_IDS[:3],
             "relevance_types": cls.VALID_RELEVANCE_TYPES[:2],
-            "created_after": datetime(2023, 1, 1, tzinfo=timezone.utc),
-            "created_before": datetime(2023, 12, 31, tzinfo=timezone.utc),
+            "created_after": datetime(2023, 1, 1, tzinfo=UTC),
+            "created_before": datetime(2023, 12, 31, tzinfo=UTC),
         }

--- a/tests/factories/video_transcript_factory.py
+++ b/tests/factories/video_transcript_factory.py
@@ -7,11 +7,10 @@ with realistic and consistent test data.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, List, cast
+from datetime import UTC, datetime
+from typing import Any
 
 import factory
-from factory import LazyFunction
 
 from chronovista.models.enums import (
     DownloadReason,
@@ -106,7 +105,7 @@ class VideoTranscriptFactory(factory.Factory[VideoTranscript]):
     track_kind: Any = factory.LazyFunction(lambda: TrackKind.STANDARD)
     caption_name: Any = factory.LazyFunction(lambda: "Español (manual)")
     downloaded_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 15, 16, 30, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 15, 16, 30, 0, tzinfo=UTC)
     )
     # Feature 007: Raw transcript data with timestamps
     raw_transcript_data: Any = factory.LazyFunction(
@@ -150,7 +149,7 @@ class VideoTranscriptWithQualityFactory(factory.Factory[VideoTranscriptWithQuali
     track_kind: Any = factory.LazyFunction(lambda: TrackKind.STANDARD)
     caption_name: Any = factory.LazyFunction(lambda: "English (Professional)")
     downloaded_at: Any = factory.LazyFunction(
-        lambda: datetime(2023, 9, 22, 14, 0, 0, tzinfo=timezone.utc)
+        lambda: datetime(2023, 9, 22, 14, 0, 0, tzinfo=UTC)
     )
     quality_score: Any = factory.LazyFunction(lambda: 0.94)
     is_high_quality: Any = factory.LazyFunction(lambda: True)
@@ -178,10 +177,10 @@ class TranscriptSearchFiltersFactory(factory.Factory[TranscriptSearchFilters]):
     is_cc_only: Any = factory.LazyFunction(lambda: True)
     is_manual_only: Any = factory.LazyFunction(lambda: False)
     downloaded_after: Any = factory.LazyFunction(
-        lambda: datetime(2023, 1, 1, tzinfo=timezone.utc)
+        lambda: datetime(2023, 1, 1, tzinfo=UTC)
     )
     downloaded_before: Any = factory.LazyFunction(
-        lambda: datetime(2023, 12, 31, tzinfo=timezone.utc)
+        lambda: datetime(2023, 12, 31, tzinfo=UTC)
     )
 
 
@@ -317,7 +316,7 @@ def create_transcript_search_filters(**kwargs: Any) -> TranscriptSearchFilters:
     return result
 
 
-def create_batch_video_transcripts(count: int = 5) -> List[VideoTranscript]:
+def create_batch_video_transcripts(count: int = 5) -> list[VideoTranscript]:
     """Create a batch of VideoTranscript instances for testing."""
     transcripts = []
     base_video_ids = [

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -7,14 +7,19 @@ fixtures for systematic integration testing across model tiers.
 
 from __future__ import annotations
 
-import os
 import asyncio
-from collections.abc import AsyncGenerator
-from typing import Any, Awaitable, Callable, Dict, Generator
+import os
+from collections.abc import AsyncGenerator, Awaitable
+from typing import Any
 
 import pytest
+
+# FastAPI test client imports
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from chronovista.api.deps import get_db
+from chronovista.api.main import app
 from chronovista.auth.oauth_service import YouTubeOAuthService
 from chronovista.config.settings import get_settings
 from chronovista.db.models import Base
@@ -28,12 +33,6 @@ from chronovista.repositories.video_transcript_repository import (
     VideoTranscriptRepository,
 )
 from chronovista.services.youtube_service import YouTubeService
-
-# FastAPI test client imports
-from httpx import ASGITransport, AsyncClient
-
-from chronovista.api.main import app
-from chronovista.api.deps import get_db
 
 
 async def check_database_availability(engine) -> bool:
@@ -88,7 +87,6 @@ def integration_db_schema_setup(integration_test_db_url):
 
     Uses autouse=True so it runs automatically for all integration tests.
     """
-    import asyncio
 
     engine = create_async_engine(
         integration_test_db_url,
@@ -177,7 +175,7 @@ class SessionWithCheck:
     def __init__(
         self,
         factory: async_sessionmaker[AsyncSession],
-        checker: "DatabaseAvailabilityChecker",
+        checker: DatabaseAvailabilityChecker,
     ) -> None:
         self._factory = factory
         self._checker = checker
@@ -388,7 +386,7 @@ async def established_channel(
     authenticated_youtube_service,
     integration_db_session,
     sample_youtube_channel_ids,
-) -> Dict[str, Any] | None:
+) -> dict[str, Any] | None:
     """
     Provide an established channel in the database for dependent model testing.
 
@@ -479,9 +477,9 @@ async def established_channel(
 async def established_videos(
     authenticated_youtube_service,
     integration_db_session,
-    established_channel: Awaitable[Dict[str, Any] | None],
+    established_channel: Awaitable[dict[str, Any] | None],
     sample_youtube_video_ids,
-) -> list[Dict[str, Any]] | None:
+) -> list[dict[str, Any]] | None:
     """
     Provide established videos in the database for dependent model testing.
 
@@ -585,9 +583,6 @@ async def established_videos(
                 )
 
             await session.commit()
-            print(
-                f"DEBUG: Returning {len(videos)} videos from established_videos fixture"
-            )
             return videos
     except Exception as e:
         pytest.skip(f"Could not establish test videos: {e}")

--- a/tests/integration/api/test_canonical_tags_router.py
+++ b/tests/integration/api/test_canonical_tags_router.py
@@ -8,8 +8,9 @@ suggestions, and rate limiting.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, AsyncGenerator, List
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -31,8 +32,6 @@ from tests.factories.id_factory import YouTubeIdFactory
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
 
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Test IDs generated via factory to avoid collisions and ensure validity
 # ---------------------------------------------------------------------------
@@ -51,7 +50,7 @@ _TAG_PREFIX = "ctag_test_"
 
 @pytest.fixture
 async def test_data_session(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[AsyncSession, None]:
     """Provide a session for test data setup and cleanup."""
     async with integration_session_factory() as session:
@@ -88,7 +87,7 @@ async def sample_data(
     Returns a dict with keys: canonical_tags, aliases, videos, video_tags
     so individual tests can reference specific records.
     """
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     # ---- Canonical Tags ----
     ct_music_id = uuid.UUID(bytes=uuid7().bytes)
@@ -175,7 +174,7 @@ async def sample_data(
         video_id=_VIDEO_ID_001,
         channel_id=_CHANNEL_ID,
         title="Music Video One",
-        upload_date=datetime(2024, 6, 15, tzinfo=timezone.utc),
+        upload_date=datetime(2024, 6, 15, tzinfo=UTC),
         duration=300,
         availability_status="available",
     )
@@ -183,7 +182,7 @@ async def sample_data(
         video_id=_VIDEO_ID_002,
         channel_id=_CHANNEL_ID,
         title="Music and New York Video",
-        upload_date=datetime(2024, 7, 20, tzinfo=timezone.utc),
+        upload_date=datetime(2024, 7, 20, tzinfo=UTC),
         duration=420,
         availability_status="available",
     )
@@ -191,7 +190,7 @@ async def sample_data(
         video_id=_VIDEO_ID_003,
         channel_id=_CHANNEL_ID,
         title="Python Tutorial",
-        upload_date=datetime(2024, 5, 10, tzinfo=timezone.utc),
+        upload_date=datetime(2024, 5, 10, tzinfo=UTC),
         duration=600,
         availability_status="available",
     )
@@ -199,7 +198,7 @@ async def sample_data(
         video_id=_VIDEO_ID_004,
         channel_id=_CHANNEL_ID,
         title="Deleted Music Video",
-        upload_date=datetime(2024, 8, 1, tzinfo=timezone.utc),
+        upload_date=datetime(2024, 8, 1, tzinfo=UTC),
         duration=180,
         availability_status="deleted",
     )
@@ -504,7 +503,7 @@ class TestSearchResolvesMergedAliases:
         CanonicalTag
             The flushed ORM instance.
         """
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         tag = CanonicalTag(
             id=uuid.UUID(bytes=uuid7().bytes),
             canonical_form=canonical_form,
@@ -548,7 +547,7 @@ class TestSearchResolvesMergedAliases:
         TagAlias
             The flushed ORM instance.
         """
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         alias = TagAlias(
             id=uuid.UUID(bytes=uuid7().bytes),
             raw_form=raw_form,
@@ -1192,7 +1191,7 @@ class TestFuzzySuggestions:
         alias_count defaults to 1 to satisfy the database check constraint
         ``chk_canonical_tag_alias_count_positive`` (alias_count >= 1).
         """
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         tag = CanonicalTag(
             id=uuid.UUID(bytes=uuid7().bytes),
             canonical_form=canonical_form,

--- a/tests/integration/api/test_category_endpoints.py
+++ b/tests/integration/api/test_category_endpoints.py
@@ -6,13 +6,11 @@ GET /api/v1/categories/{category_id}/videos endpoints.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
-import pytest
 from httpx import AsyncClient
-from sqlalchemy import delete, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import delete
 
 from chronovista.db.models import (
     Channel,
@@ -21,9 +19,6 @@ from chronovista.db.models import (
     VideoTag,
     VideoTopic,
 )
-
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestListCategories:
@@ -100,7 +95,7 @@ class TestListCategories:
                     video_id=f"vid_{i:03d}",
                     channel_id=channel.channel_id,
                     title=f"Video {i}",
-                    upload_date=datetime.now(timezone.utc),
+                    upload_date=datetime.now(UTC),
                     duration=300,
                     category_id="2" if i < 3 else ("1" if i < 5 else "3"),
                 )
@@ -333,7 +328,7 @@ class TestGetCategoryVideos:
                 video_id="vid_test_00",
                 channel_id=channel.channel_id,
                 title="Test Video",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
                 category_id=category.category_id,
             )
@@ -410,7 +405,7 @@ class TestGetCategoryVideos:
                 video_id="vid_active",
                 channel_id=channel.channel_id,
                 title="Active Video",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
                 category_id=category.category_id,
                 availability_status="available",
@@ -419,7 +414,7 @@ class TestGetCategoryVideos:
                 video_id="vid_deleted",
                 channel_id=channel.channel_id,
                 title="Deleted Video",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
                 category_id=category.category_id,
                 availability_status="unavailable",
@@ -488,7 +483,7 @@ class TestGetCategoryVideos:
 
             # Create videos with different upload dates
             from datetime import timedelta
-            base_date = datetime.now(timezone.utc)
+            base_date = datetime.now(UTC)
             videos = [
                 Video(
                     video_id=f"vid_sort_{i}",

--- a/tests/integration/api/test_channel_endpoints.py
+++ b/tests/integration/api/test_channel_endpoints.py
@@ -13,20 +13,16 @@ Tests cover:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel as ChannelDB
 from chronovista.db.models import Video as VideoDB
-
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # Test Fixtures
@@ -36,7 +32,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def sample_channel(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a sample channel in the database for testing.
 
@@ -88,8 +84,8 @@ async def sample_channel(
 @pytest.fixture
 async def sample_channel_with_videos(
     integration_session_factory,
-    sample_channel: Dict[str, Any],
-) -> Dict[str, Any]:
+    sample_channel: dict[str, Any],
+) -> dict[str, Any]:
     """
     Create a sample channel with associated videos.
 
@@ -107,7 +103,7 @@ async def sample_channel_with_videos(
                 channel_id=channel_id,
                 title=f"Test Video {i + 1}",
                 description=f"Description for test video {i + 1}",
-                upload_date=datetime(2024, 1, 15 + i, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 1, 15 + i, tzinfo=UTC),
                 duration=300 + (i * 60),
                 view_count=1000 * (i + 1),
                 made_for_kids=False,
@@ -136,7 +132,7 @@ async def sample_channel_with_videos(
 @pytest.fixture
 async def channel_without_videos(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a channel with no videos for testing has_videos filter.
 
@@ -228,7 +224,7 @@ class TestListChannels:
     async def test_list_channels_returns_paginated_response(
         self,
         async_client: AsyncClient,
-        sample_channel: Dict[str, Any],
+        sample_channel: dict[str, Any],
     ) -> None:
         """Test channel list returns paginated response structure."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -243,7 +239,7 @@ class TestListChannels:
     async def test_list_channels_pagination_metadata(
         self,
         async_client: AsyncClient,
-        sample_channel: Dict[str, Any],
+        sample_channel: dict[str, Any],
     ) -> None:
         """Test pagination metadata contains required fields."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -263,7 +259,7 @@ class TestListChannels:
     async def test_list_channels_default_pagination(
         self,
         async_client: AsyncClient,
-        sample_channel: Dict[str, Any],
+        sample_channel: dict[str, Any],
     ) -> None:
         """Test default pagination values (limit=20, offset=0)."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -305,7 +301,7 @@ class TestListChannels:
     async def test_list_channels_item_structure(
         self,
         async_client: AsyncClient,
-        sample_channel: Dict[str, Any],
+        sample_channel: dict[str, Any],
     ) -> None:
         """Test channel list items have correct structure."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -327,8 +323,8 @@ class TestListChannels:
     async def test_list_channels_has_videos_filter_true(
         self,
         async_client: AsyncClient,
-        sample_channel: Dict[str, Any],
-        channel_without_videos: Dict[str, Any],
+        sample_channel: dict[str, Any],
+        channel_without_videos: dict[str, Any],
     ) -> None:
         """Test has_videos=true filter returns only channels with videos."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -345,7 +341,7 @@ class TestListChannels:
     async def test_list_channels_has_videos_filter_false(
         self,
         async_client: AsyncClient,
-        channel_without_videos: Dict[str, Any],
+        channel_without_videos: dict[str, Any],
     ) -> None:
         """Test has_videos=false filter returns only channels without videos."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -361,8 +357,8 @@ class TestListChannels:
     async def test_list_channels_ordered_by_video_count(
         self,
         async_client: AsyncClient,
-        sample_channel: Dict[str, Any],
-        channel_without_videos: Dict[str, Any],
+        sample_channel: dict[str, Any],
+        channel_without_videos: dict[str, Any],
     ) -> None:
         """Test channels are ordered by video_count descending."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -391,7 +387,7 @@ class TestChannelDetail:
     async def test_get_channel_detail(
         self,
         async_client: AsyncClient,
-        sample_channel: Dict[str, Any],
+        sample_channel: dict[str, Any],
     ) -> None:
         """Test getting channel details by ID."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -407,7 +403,7 @@ class TestChannelDetail:
     async def test_get_channel_detail_structure(
         self,
         async_client: AsyncClient,
-        sample_channel: Dict[str, Any],
+        sample_channel: dict[str, Any],
     ) -> None:
         """Test channel detail response has all expected fields."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -494,7 +490,7 @@ class TestChannelVideos:
     async def test_get_channel_videos_returns_videos(
         self,
         async_client: AsyncClient,
-        sample_channel_with_videos: Dict[str, Any],
+        sample_channel_with_videos: dict[str, Any],
     ) -> None:
         """Test getting videos for a channel returns video list."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -511,7 +507,7 @@ class TestChannelVideos:
     async def test_get_channel_videos_empty_channel(
         self,
         async_client: AsyncClient,
-        channel_without_videos: Dict[str, Any],
+        channel_without_videos: dict[str, Any],
     ) -> None:
         """Test getting videos for channel with no videos returns empty list."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -541,7 +537,7 @@ class TestChannelVideos:
     async def test_get_channel_videos_pagination(
         self,
         async_client: AsyncClient,
-        sample_channel_with_videos: Dict[str, Any],
+        sample_channel_with_videos: dict[str, Any],
     ) -> None:
         """Test pagination works for channel videos."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -558,7 +554,7 @@ class TestChannelVideos:
     async def test_get_channel_videos_item_structure(
         self,
         async_client: AsyncClient,
-        sample_channel_with_videos: Dict[str, Any],
+        sample_channel_with_videos: dict[str, Any],
     ) -> None:
         """Test video list items have correct structure."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -581,7 +577,7 @@ class TestChannelVideos:
     async def test_get_channel_videos_ordered_by_upload_date(
         self,
         async_client: AsyncClient,
-        sample_channel_with_videos: Dict[str, Any],
+        sample_channel_with_videos: dict[str, Any],
     ) -> None:
         """Test videos are ordered by upload_date descending."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:

--- a/tests/integration/api/test_channel_recovery.py
+++ b/tests/integration/api/test_channel_recovery.py
@@ -14,22 +14,17 @@ Tests cover:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel as ChannelDB
 from chronovista.exceptions import CDXError
 from chronovista.models.enums import AvailabilityStatus
 from chronovista.services.recovery.models import ChannelRecoveryResult
-
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # Test Fixtures
@@ -39,7 +34,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def unavailable_channel(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a channel with availability_status = 'deleted'.
 
@@ -87,7 +82,7 @@ async def unavailable_channel(
 @pytest.fixture
 async def available_channel(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a channel with availability_status = 'available'.
 
@@ -141,7 +136,7 @@ class TestChannelRecoverySuccess:
     async def test_recover_channel_success_with_metadata(
         self,
         async_client: AsyncClient,
-        unavailable_channel: Dict[str, Any],
+        unavailable_channel: dict[str, Any],
     ) -> None:
         """Test successful channel recovery with populated ChannelRecoveryResult."""
         channel_id = unavailable_channel["channel_id"]
@@ -195,7 +190,7 @@ class TestChannelRecoverySuccess:
     async def test_recover_channel_zero_new_fields(
         self,
         async_client: AsyncClient,
-        unavailable_channel: Dict[str, Any],
+        unavailable_channel: dict[str, Any],
     ) -> None:
         """Test successful recovery with empty fields_recovered list."""
         channel_id = unavailable_channel["channel_id"]
@@ -271,7 +266,7 @@ class TestChannelRecoveryErrors:
     async def test_recover_available_channel_409(
         self,
         async_client: AsyncClient,
-        available_channel: Dict[str, Any],
+        available_channel: dict[str, Any],
     ) -> None:
         """Test 409 conflict when channel is available."""
         channel_id = available_channel["channel_id"]
@@ -293,7 +288,7 @@ class TestChannelRecoveryErrors:
     async def test_recover_invalid_year_range_422(
         self,
         async_client: AsyncClient,
-        unavailable_channel: Dict[str, Any],
+        unavailable_channel: dict[str, Any],
     ) -> None:
         """Test 422 validation error when end_year < start_year."""
         channel_id = unavailable_channel["channel_id"]
@@ -317,7 +312,7 @@ class TestChannelRecoveryErrors:
     async def test_recover_year_out_of_range_422(
         self,
         async_client: AsyncClient,
-        unavailable_channel: Dict[str, Any],
+        unavailable_channel: dict[str, Any],
     ) -> None:
         """Test 422 validation error when year is out of range."""
         channel_id = unavailable_channel["channel_id"]
@@ -340,7 +335,7 @@ class TestChannelRecoveryErrors:
     async def test_recover_cdx_error_503(
         self,
         async_client: AsyncClient,
-        unavailable_channel: Dict[str, Any],
+        unavailable_channel: dict[str, Any],
     ) -> None:
         """Test 503 error when CDX API is unavailable."""
         channel_id = unavailable_channel["channel_id"]
@@ -386,7 +381,7 @@ class TestChannelRecoveryQueryParameters:
     async def test_recover_with_start_year(
         self,
         async_client: AsyncClient,
-        unavailable_channel: Dict[str, Any],
+        unavailable_channel: dict[str, Any],
     ) -> None:
         """Test recovery with start_year parameter."""
         channel_id = unavailable_channel["channel_id"]
@@ -424,7 +419,7 @@ class TestChannelRecoveryQueryParameters:
     async def test_recover_with_end_year(
         self,
         async_client: AsyncClient,
-        unavailable_channel: Dict[str, Any],
+        unavailable_channel: dict[str, Any],
     ) -> None:
         """Test recovery with end_year parameter."""
         channel_id = unavailable_channel["channel_id"]
@@ -462,7 +457,7 @@ class TestChannelRecoveryQueryParameters:
     async def test_recover_with_year_range(
         self,
         async_client: AsyncClient,
-        unavailable_channel: Dict[str, Any],
+        unavailable_channel: dict[str, Any],
     ) -> None:
         """Test recovery with both start_year and end_year parameters."""
         channel_id = unavailable_channel["channel_id"]

--- a/tests/integration/api/test_channels_integration.py
+++ b/tests/integration/api/test_channels_integration.py
@@ -7,8 +7,9 @@ Also tests channel video sort and liked filter (US-5).
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, List
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -18,8 +19,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel, UserVideo, Video
 from chronovista.models.enums import AvailabilityStatus
-
-pytestmark = pytest.mark.asyncio
 
 # Test channel IDs (all exactly 24 characters)
 CH_SUB_A = "UCsort_sub_a_1234567890"  # subscribed, video_count=500, title="Alpha"
@@ -560,9 +559,9 @@ async def channel_video_data(
 
     # Create videos
     video_specs = [
-        (VID_ALPHA, "Alpha Video", datetime(2024, 1, 10, tzinfo=timezone.utc)),
-        (VID_BRAVO, "Bravo Video", datetime(2024, 3, 15, tzinfo=timezone.utc)),
-        (VID_CHARLIE, "Charlie Video", datetime(2024, 2, 20, tzinfo=timezone.utc)),
+        (VID_ALPHA, "Alpha Video", datetime(2024, 1, 10, tzinfo=UTC)),
+        (VID_BRAVO, "Bravo Video", datetime(2024, 3, 15, tzinfo=UTC)),
+        (VID_CHARLIE, "Charlie Video", datetime(2024, 2, 20, tzinfo=UTC)),
     ]
     for vid_id, title, upload_date in video_specs:
         video = Video(

--- a/tests/integration/api/test_channels_unavailable.py
+++ b/tests/integration/api/test_channels_unavailable.py
@@ -7,8 +7,7 @@ return 200 with full metadata, and only truly non-existent channel IDs return 40
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
 from unittest.mock import patch
 
 import pytest
@@ -18,8 +17,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel
 from chronovista.models.enums import AvailabilityStatus
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture

--- a/tests/integration/api/test_entity_creation_integration.py
+++ b/tests/integration/api/test_entity_creation_integration.py
@@ -23,31 +23,33 @@ Notes
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import delete, select
-from uuid_utils import uuid7
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
 
 from chronovista.db.models import (
     CanonicalTag as CanonicalTagDB,
-    Channel as ChannelDB,
+)
+from chronovista.db.models import (
     EntityAlias as EntityAliasDB,
+)
+from chronovista.db.models import (
     NamedEntity as NamedEntityDB,
+)
+from chronovista.db.models import (
     TagAlias as TagAliasDB,
-    Video as VideoDB,
 )
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
 
 # CRITICAL: Ensures all async tests in this module run with pytest-asyncio
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Stable test IDs — chosen to avoid collisions with all other test files.
 # ---------------------------------------------------------------------------
@@ -101,7 +103,7 @@ class TestClassifyFlowEndToEnd:
     @pytest.fixture
     async def seed_canonical_tag(
         self,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Seed a canonical tag with a tag alias for classify tests.
 
@@ -207,7 +209,7 @@ class TestClassifyFlowEndToEnd:
         self,
         async_client: AsyncClient,
         seed_canonical_tag: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """POST /entities/classify returns 201 and correctly links entity to tag.
 
@@ -366,7 +368,7 @@ class TestStandaloneCreationEndToEnd:
     @pytest.fixture(autouse=True)
     async def cleanup_snowden(
         self,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> AsyncGenerator[None, None]:
         """Remove any leftover Edward Snowden entity rows before and after each test."""
         normalized = self._SNOWDEN_NORMALIZED
@@ -403,7 +405,7 @@ class TestStandaloneCreationEndToEnd:
     async def test_standalone_creation_end_to_end(
         self,
         async_client: AsyncClient,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """POST /entities creates an entity with title-cased name and aliases.
 
@@ -492,7 +494,7 @@ class TestStandaloneCreationEndToEnd:
     async def test_standalone_creation_deduplicates_identical_aliases(
         self,
         async_client: AsyncClient,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """POST /entities de-duplicates aliases that normalize to the same form.
 
@@ -567,7 +569,7 @@ class TestDuplicateDetection:
     @pytest.fixture
     async def seed_garland_entity(
         self,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Seed a 'Garland Nixon' named entity for duplicate detection tests.
 
@@ -719,7 +721,7 @@ class TestConflictOnDuplicateCreation:
     @pytest.fixture
     async def seed_garland_for_conflict(
         self,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Seed a 'Garland Nixon' named entity for the 409 conflict test.
 
@@ -810,7 +812,7 @@ class TestConflictOnDuplicateCreation:
         self,
         async_client: AsyncClient,
         seed_garland_for_conflict: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """POST /entities allows same name when entity_type differs.
 

--- a/tests/integration/api/test_entity_mentions_api.py
+++ b/tests/integration/api/test_entity_mentions_api.py
@@ -20,22 +20,33 @@ from __future__ import annotations
 
 import time
 import uuid
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import delete, select
-from uuid_utils import uuid7
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
 
 from chronovista.db.models import (
     Channel as ChannelDB,
+)
+from chronovista.db.models import (
     EntityMention as EntityMentionDB,
+)
+from chronovista.db.models import (
     NamedEntity as NamedEntityDB,
+)
+from chronovista.db.models import (
     TranscriptSegment as TranscriptSegmentDB,
+)
+from chronovista.db.models import (
     Video as VideoDB,
+)
+from chronovista.db.models import (
     VideoTranscript as VideoTranscriptDB,
 )
 
@@ -43,8 +54,6 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
 
 # CRITICAL: Ensures all async tests in this module run with pytest-asyncio
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Unique stable IDs — chosen to avoid collisions with other test files.
 # All IDs must respect column length constraints.
@@ -90,7 +99,7 @@ def _entity_detail_url(entity_id: str) -> str:
 
 @pytest.fixture
 async def seed_entity_data(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Seed the integration DB with channel, videos, transcripts, segments, entity, and mentions.
 
@@ -141,7 +150,7 @@ async def seed_entity_data(
                 channel_id=_CHANNEL_ID,
                 title="Entity API Test Video 1",
                 description="Integration test video for Feature 038",
-                upload_date=datetime(2024, 3, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 3, 1, tzinfo=UTC),
                 duration=600,
             )
             session.add(video1)
@@ -158,7 +167,7 @@ async def seed_entity_data(
                 channel_id=_CHANNEL_ID,
                 title="Entity API Test Video 2",
                 description="Second integration test video for Feature 038",
-                upload_date=datetime(2024, 3, 2, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 3, 2, tzinfo=UTC),
                 duration=300,
             )
             session.add(video2)
@@ -620,7 +629,7 @@ class TestGetEntityVideos:
     async def test_get_entity_videos_200_empty_data(
         self,
         async_client: AsyncClient,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
         seed_entity_data: dict[str, Any],
     ) -> None:
         """200 response with empty data list when entity exists but has no mentions.
@@ -1062,7 +1071,7 @@ class TestListEntities:
     async def test_list_entities_filter_has_mentions_true(
         self,
         async_client: AsyncClient,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
         seed_entity_data: dict[str, Any],
     ) -> None:
         """``has_mentions=true`` returns only entities with mention_count > 0.
@@ -1203,7 +1212,7 @@ class TestListEntities:
     async def test_list_entities_sort_by_name_default(
         self,
         async_client: AsyncClient,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
         seed_entity_data: dict[str, Any],
     ) -> None:
         """Default sort (no ``sort`` param) returns entities in alphabetical name order.
@@ -1253,7 +1262,7 @@ class TestListEntities:
     async def test_list_entities_sort_by_mentions_desc(
         self,
         async_client: AsyncClient,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
         seed_entity_data: dict[str, Any],
     ) -> None:
         """``sort=mentions`` returns entities ordered by mention_count descending.
@@ -1359,7 +1368,7 @@ class TestListEntities:
     async def test_list_entities_pagination_has_more_true(
         self,
         async_client: AsyncClient,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
         seed_entity_data: dict[str, Any],
     ) -> None:
         """``has_more`` is True when the total exceeds ``offset + limit``.
@@ -1529,7 +1538,7 @@ class TestGetEntityDetail:
     async def test_get_entity_detail_description_may_be_null(
         self,
         async_client: AsyncClient,
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
         seed_entity_data: dict[str, Any],
     ) -> None:
         """``description`` field is null when the entity has no description set.
@@ -1666,7 +1675,7 @@ def _manual_association_url(video_id: str, entity_id: str) -> str:
 
 @pytest.fixture
 async def seed_search_data(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Seed the integration DB for Feature 050 search and manual association tests.
 
@@ -1715,7 +1724,7 @@ async def seed_search_data(
                     channel_id=_SEARCH_CHANNEL_ID,
                     title="Search Manual Test Video",
                     description="Feature 050 test video",
-                    upload_date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+                    upload_date=datetime(2024, 6, 1, tzinfo=UTC),
                     duration=300,
                 )
             )
@@ -2205,7 +2214,7 @@ class TestCreateManualAssociationEndpoint:
         self,
         async_client: AsyncClient,
         seed_search_data: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """POST manual association returns 409 when the link already exists.
 
@@ -2271,7 +2280,7 @@ class TestCreateManualAssociationEndpoint:
         self,
         async_client: AsyncClient,
         seed_search_data: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """POST manual association updates mention_count/video_count on named_entities.
 
@@ -2501,7 +2510,7 @@ def _delete_manual_url(video_id: str, entity_id: str) -> str:
 
 @pytest.fixture
 async def seed_delete_data(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Seed the integration DB for Feature 050 T037 DELETE endpoint tests.
 
@@ -2545,7 +2554,7 @@ async def seed_delete_data(
                     channel_id=_DELETE_CHANNEL_ID,
                     title="Delete Manual Test Video 1",
                     description="Feature 050 T037 test video",
-                    upload_date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+                    upload_date=datetime(2024, 6, 1, tzinfo=UTC),
                     duration=300,
                 )
             )
@@ -2563,7 +2572,7 @@ async def seed_delete_data(
                     channel_id=_DELETE_CHANNEL_ID,
                     title="Delete Manual Test Video 2",
                     description="Feature 050 T037 test video 2",
-                    upload_date=datetime(2024, 7, 1, tzinfo=timezone.utc),
+                    upload_date=datetime(2024, 7, 1, tzinfo=UTC),
                     duration=200,
                 )
             )
@@ -2648,7 +2657,7 @@ class TestDeleteManualAssociation:
         self,
         async_client: AsyncClient,
         seed_delete_data: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """DELETE manual association returns 204 No Content on success.
 
@@ -2742,7 +2751,7 @@ class TestDeleteManualAssociation:
         self,
         async_client: AsyncClient,
         seed_delete_data: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """DELETE manual association triggers update_entity_counters.
 
@@ -2814,7 +2823,7 @@ class TestDeleteManualAssociation:
         self,
         async_client: AsyncClient,
         seed_delete_data: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """DELETE manual association leaves transcript-derived mentions intact.
 
@@ -2925,7 +2934,7 @@ class TestDeleteManualAssociation:
         self,
         async_client: AsyncClient,
         seed_delete_data: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """DELETE returns 404 when only transcript mentions exist (no manual row).
 
@@ -3080,7 +3089,7 @@ class TestPerformanceAssertions:
         self,
         async_client: AsyncClient,
         seed_search_data: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """POST /api/v1/videos/{video_id}/entities/{entity_id}/manual must complete within 1 000 ms (NFR-003).
 

--- a/tests/integration/api/test_health_api.py
+++ b/tests/integration/api/test_health_api.py
@@ -1,13 +1,10 @@
 """Integration tests for health endpoint."""
 from datetime import datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
-import pytest
 from httpx import AsyncClient
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 class TestHealthEndpoint:
     """Tests for GET /api/v1/health endpoint."""

--- a/tests/integration/api/test_images_integration.py
+++ b/tests/integration/api/test_images_integration.py
@@ -16,16 +16,14 @@ from httpx import ASGITransport, AsyncClient
 
 from chronovista.api.main import app
 from chronovista.services.image_cache import (
+    _CACHE_CONTROL_HIT,
     ImageCacheConfig,
     ImageCacheService,
-    _CACHE_CONTROL_HIT,
 )
 from tests.factories.channel_factory import ChannelTestData
 from tests.factories.video_factory import VideoTestData
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Fixtures
@@ -35,8 +33,8 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def async_client() -> AsyncGenerator[AsyncClient, None]:
     """Create async test client for FastAPI testing."""
-    from collections.abc import AsyncGenerator
     from sqlalchemy.ext.asyncio import AsyncSession
+
     from chronovista.api.deps import get_db
 
     # Mock database dependency

--- a/tests/integration/api/test_include_unavailable.py
+++ b/tests/integration/api/test_include_unavailable.py
@@ -10,8 +10,8 @@ endpoints per FR-010 and FR-011. Verifies that:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -21,8 +21,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel, Video, VideoTag, VideoTranscript
 from chronovista.models.enums import AvailabilityStatus
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
@@ -159,7 +157,7 @@ async def create_test_video(
         channel_id=channel_id,
         title=title or f"Test Video - {availability_status.value}",
         description=description or f"Test video with status: {availability_status.value}",
-        upload_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+        upload_date=datetime(2024, 1, 15, tzinfo=UTC),
         duration=300,
         availability_status=availability_status.value,
     )

--- a/tests/integration/api/test_onboarding_endpoints.py
+++ b/tests/integration/api/test_onboarding_endpoints.py
@@ -39,10 +39,8 @@ Usage
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Iterator
 from datetime import UTC, datetime
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -50,14 +48,15 @@ from httpx import AsyncClient
 
 from chronovista.api.routers import onboarding as onboarding_router
 from chronovista.api.routers import tasks as tasks_router
-from chronovista.api.schemas.onboarding import OnboardingCounts, OnboardingStatus, PipelineStep
+from chronovista.api.schemas.onboarding import (
+    OnboardingCounts,
+    OnboardingStatus,
+    PipelineStep,
+)
 from chronovista.api.schemas.tasks import BackgroundTask
-from chronovista.api.services.task_manager import TaskManager
 from chronovista.models.enums import OperationType, PipelineStepStatus, TaskStatus
 
 # CRITICAL: This line ensures async tests work with coverage tools
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Module-level wiring
 # ---------------------------------------------------------------------------
@@ -1099,7 +1098,7 @@ class TestListTasks:
             OperationType.NORMALIZE_TAGS,
         ]
 
-        for task_id, op_type in zip(task_ids, operation_types):
+        for task_id, op_type in zip(task_ids, operation_types, strict=False):
             onboarding_router._task_manager._tasks[task_id] = _make_background_task(
                 task_id=task_id,
                 operation_type=op_type,

--- a/tests/integration/api/test_performance.py
+++ b/tests/integration/api/test_performance.py
@@ -18,8 +18,6 @@ import pytest
 from httpx import AsyncClient
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 class TestConcurrentRequestsCore:
     """Test SC-008: Core concurrent request handling (stateless endpoints)."""
@@ -267,7 +265,7 @@ class TestConcurrentRequestsWithAuth:
             # All should complete without 5xx errors (server errors)
             server_errors = [
                 (ep, status)
-                for ep, status in zip(endpoints_hit, status_codes)
+                for ep, status in zip(endpoints_hit, status_codes, strict=False)
                 if status >= 500
             ]
             assert len(server_errors) == 0, f"Found server errors: {server_errors}"
@@ -313,7 +311,7 @@ class TestConcurrentWriteRequests:
                         },
                     )
                     return lang_code, response.status_code
-                except Exception as e:
+                except Exception:
                     # Return exception as status 0 for analysis
                     return lang_code, 0
 
@@ -390,11 +388,7 @@ class TestFilterApiPerformance:
             )
 
             # Log results for debugging
-            avg = sum(times) / len(times)
-            print(f"\nAutocomplete performance (NFR-003):")
-            print(f"  Average: {avg:.1f}ms")
-            print(f"  p95: {p95:.1f}ms")
-            print(f"  Max: {max(times):.1f}ms")
+            sum(times) / len(times)
 
     async def test_sidebar_categories_load_under_300ms_p95(
         self, async_client: AsyncClient
@@ -433,11 +427,7 @@ class TestFilterApiPerformance:
             )
 
             # Log results for debugging
-            avg = sum(times) / len(times)
-            print(f"\nSidebar categories performance (NFR-004):")
-            print(f"  Average: {avg:.1f}ms")
-            print(f"  p95: {p95:.1f}ms")
-            print(f"  Max: {max(times):.1f}ms")
+            sum(times) / len(times)
 
     async def test_topic_hierarchy_api_under_500ms_p95(
         self, async_client: AsyncClient
@@ -476,11 +466,7 @@ class TestFilterApiPerformance:
             )
 
             # Log results for debugging
-            avg = sum(times) / len(times)
-            print(f"\nTopic hierarchy performance (NFR-002):")
-            print(f"  Average: {avg:.1f}ms")
-            print(f"  p95: {p95:.1f}ms")
-            print(f"  Max: {max(times):.1f}ms")
+            sum(times) / len(times)
 
 
 class TestRateLimitingBehavior:

--- a/tests/integration/api/test_playlist_endpoints.py
+++ b/tests/integration/api/test_playlist_endpoints.py
@@ -8,13 +8,9 @@ Tests cover:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from unittest.mock import patch
 
-import pytest
 from httpx import AsyncClient
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestListPlaylists:

--- a/tests/integration/api/test_playlists_integration.py
+++ b/tests/integration/api/test_playlists_integration.py
@@ -13,21 +13,24 @@ Uses the integration test database with real data insertion.
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import delete, select, text
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import delete
 
 from chronovista.db.models import (
     Channel,
-    Playlist as PlaylistDB,
     PlaylistMembership,
     UserVideo,
-    Video as VideoDB,
     VideoTranscript,
+)
+from chronovista.db.models import (
+    Playlist as PlaylistDB,
+)
+from chronovista.db.models import (
+    Video as VideoDB,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
@@ -117,7 +120,7 @@ async def seed_playlist_data(
                 video_id="vid_test_0001",
                 channel_id=CHANNEL_ID,
                 title="Alpha Video",
-                upload_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 1, 15, tzinfo=UTC),
                 duration=300,
                 availability_status="available",
             ),
@@ -125,7 +128,7 @@ async def seed_playlist_data(
                 video_id="vid_test_0002",
                 channel_id=CHANNEL_ID,
                 title="Beta Video",
-                upload_date=datetime(2024, 3, 20, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 3, 20, tzinfo=UTC),
                 duration=450,
                 availability_status="available",
             ),
@@ -133,7 +136,7 @@ async def seed_playlist_data(
                 video_id="vid_test_0003",
                 channel_id=CHANNEL_ID,
                 title="Charlie Video",
-                upload_date=datetime(2024, 2, 10, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 2, 10, tzinfo=UTC),
                 duration=600,
                 availability_status="deleted",  # unavailable
             ),
@@ -141,7 +144,7 @@ async def seed_playlist_data(
                 video_id="vid_test_0004",
                 channel_id=CHANNEL_ID,
                 title="Delta Video",
-                upload_date=datetime(2024, 5, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 5, 1, tzinfo=UTC),
                 duration=180,
                 availability_status="available",
             ),
@@ -149,7 +152,7 @@ async def seed_playlist_data(
                 video_id="vid_test_0005",
                 channel_id=CHANNEL_ID,
                 title="Echo Video",
-                upload_date=datetime(2024, 4, 10, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 4, 10, tzinfo=UTC),
                 duration=240,
                 availability_status="available",
             ),

--- a/tests/integration/api/test_preferences_api.py
+++ b/tests/integration/api/test_preferences_api.py
@@ -1,14 +1,11 @@
 """Integration tests for language preferences endpoints (US4)."""
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from httpx import AsyncClient
 
-from chronovista.api.main import app
 from chronovista.api.deps import get_db
-
-pytestmark = pytest.mark.asyncio
+from chronovista.api.main import app
 
 
 async def get_mock_db() -> AsyncGenerator[AsyncMock, None]:
@@ -112,7 +109,10 @@ class TestGetLanguagePreferences:
                 mock_oauth.is_authenticated.return_value = True
 
                 # Create a mock preference object
-                from chronovista.models.enums import LanguageCode, LanguagePreferenceType
+                from chronovista.models.enums import (
+                    LanguageCode,
+                    LanguagePreferenceType,
+                )
 
                 mock_pref = AsyncMock()
                 mock_pref.language_code = LanguageCode.ENGLISH

--- a/tests/integration/api/test_recovery_fields.py
+++ b/tests/integration/api/test_recovery_fields.py
@@ -12,20 +12,16 @@ Tests cover:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel as ChannelDB
 from chronovista.db.models import Video as VideoDB
-
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # Test Fixtures
@@ -35,7 +31,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def video_not_recovered(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a video with recovered_at=NULL and recovery_source=NULL.
 
@@ -69,7 +65,7 @@ async def video_not_recovered(
             channel_id="UCrec123456789012345678",
             title="Not Recovered Video",
             description="A video that was never recovered",
-            upload_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2024, 1, 15, tzinfo=UTC),
             duration=300,
             made_for_kids=False,
             availability_status="available",
@@ -110,7 +106,7 @@ async def video_not_recovered(
 @pytest.fixture
 async def video_recovered(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a video with recovered_at and recovery_source populated.
 
@@ -139,13 +135,13 @@ async def video_recovered(
             await session.refresh(channel)
 
         # Create video with recovery fields populated
-        recovery_timestamp = datetime(2024, 2, 10, 14, 30, 0, tzinfo=timezone.utc)
+        recovery_timestamp = datetime(2024, 2, 10, 14, 30, 0, tzinfo=UTC)
         video = VideoDB(
             video_id="yesrecovr01",  # 11 chars
             channel_id="UCrec123456789012345678",
             title="Recovered Video",
             description="A video that was recovered from Wayback Machine",
-            upload_date=datetime(2023, 5, 20, tzinfo=timezone.utc),
+            upload_date=datetime(2023, 5, 20, tzinfo=UTC),
             duration=420,
             made_for_kids=False,
             availability_status="deleted",
@@ -186,7 +182,7 @@ async def video_recovered(
 @pytest.fixture
 async def channel_not_recovered(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a channel with recovered_at=NULL and recovery_source=NULL.
 
@@ -237,14 +233,14 @@ async def channel_not_recovered(
 @pytest.fixture
 async def channel_recovered(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a channel with recovered_at and recovery_source populated.
 
     Returns channel data dict for use in tests.
     """
     async with integration_session_factory() as session:
-        recovery_timestamp = datetime(2024, 3, 5, 10, 15, 0, tzinfo=timezone.utc)
+        recovery_timestamp = datetime(2024, 3, 5, 10, 15, 0, tzinfo=UTC)
         channel = ChannelDB(
             channel_id="UCyesrec1234567890123456",
             title="Recovered Channel",
@@ -297,7 +293,7 @@ class TestVideoRecoveryFields:
     async def test_video_detail_fields_null_when_not_recovered(
         self,
         async_client: AsyncClient,
-        video_not_recovered: Dict[str, Any],
+        video_not_recovered: dict[str, Any],
     ) -> None:
         """Test that recovered_at and recovery_source are null for non-recovered video."""
         video_id = video_not_recovered["video_id"]
@@ -327,7 +323,7 @@ class TestVideoRecoveryFields:
     async def test_video_detail_fields_populated_when_recovered(
         self,
         async_client: AsyncClient,
-        video_recovered: Dict[str, Any],
+        video_recovered: dict[str, Any],
     ) -> None:
         """Test that recovered_at and recovery_source are populated for recovered video."""
         video_id = video_recovered["video_id"]
@@ -374,7 +370,7 @@ class TestChannelRecoveryFields:
     async def test_channel_detail_fields_null_when_not_recovered(
         self,
         async_client: AsyncClient,
-        channel_not_recovered: Dict[str, Any],
+        channel_not_recovered: dict[str, Any],
     ) -> None:
         """Test that recovered_at and recovery_source are null for non-recovered channel."""
         channel_id = channel_not_recovered["channel_id"]
@@ -404,7 +400,7 @@ class TestChannelRecoveryFields:
     async def test_channel_detail_fields_populated_when_recovered(
         self,
         async_client: AsyncClient,
-        channel_recovered: Dict[str, Any],
+        channel_recovered: dict[str, Any],
     ) -> None:
         """Test that recovered_at and recovery_source are populated for recovered channel."""
         channel_id = channel_recovered["channel_id"]

--- a/tests/integration/api/test_recovery_idempotency.py
+++ b/tests/integration/api/test_recovery_idempotency.py
@@ -14,22 +14,18 @@ Tests cover:
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
-from typing import Any, Dict
+from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel as ChannelDB
 from chronovista.db.models import Video as VideoDB
 from chronovista.models.enums import AvailabilityStatus
 from chronovista.services.recovery.models import ChannelRecoveryResult, RecoveryResult
-
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # Video Recovery Idempotency Fixtures
@@ -39,7 +35,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def idempotency_channel(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a test channel for FK constraints in idempotency tests.
 
@@ -76,22 +72,22 @@ async def idempotency_channel(
 @pytest.fixture
 async def recently_recovered_video(
     integration_session_factory,
-    idempotency_channel: Dict[str, Any],
-) -> Dict[str, Any]:
+    idempotency_channel: dict[str, Any],
+) -> dict[str, Any]:
     """
     Create a deleted video that was recovered 2 minutes ago.
 
     This should trigger the idempotency guard (< 5 min).
     """
     async with integration_session_factory() as session:
-        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=2)
+        recovered_time = datetime.now(UTC) - timedelta(minutes=2)
 
         video = VideoDB(
             video_id="recvid00001",  # 11 chars
             channel_id=idempotency_channel["channel_id"],
             title="Recently Recovered Video",
             description="Recovered 2 minutes ago",
-            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2023, 1, 15, tzinfo=UTC),
             duration=300,
             made_for_kids=False,
             availability_status=AvailabilityStatus.DELETED.value,
@@ -127,22 +123,22 @@ async def recently_recovered_video(
 @pytest.fixture
 async def stale_recovered_video(
     integration_session_factory,
-    idempotency_channel: Dict[str, Any],
-) -> Dict[str, Any]:
+    idempotency_channel: dict[str, Any],
+) -> dict[str, Any]:
     """
     Create a deleted video that was recovered 10 minutes ago.
 
     This should NOT trigger the idempotency guard (> 5 min).
     """
     async with integration_session_factory() as session:
-        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        recovered_time = datetime.now(UTC) - timedelta(minutes=10)
 
         video = VideoDB(
             video_id="oldvid00001",  # 11 chars
             channel_id=idempotency_channel["channel_id"],
             title="Stale Recovered Video",
             description="Recovered 10 minutes ago",
-            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2023, 1, 15, tzinfo=UTC),
             duration=300,
             made_for_kids=False,
             availability_status=AvailabilityStatus.DELETED.value,
@@ -178,8 +174,8 @@ async def stale_recovered_video(
 @pytest.fixture
 async def never_recovered_video(
     integration_session_factory,
-    idempotency_channel: Dict[str, Any],
-) -> Dict[str, Any]:
+    idempotency_channel: dict[str, Any],
+) -> dict[str, Any]:
     """
     Create a deleted video that has never been recovered (recovered_at is None).
 
@@ -191,7 +187,7 @@ async def never_recovered_video(
             channel_id=idempotency_channel["channel_id"],
             title="Never Recovered Video",
             description="Has never been recovered",
-            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2023, 1, 15, tzinfo=UTC),
             duration=300,
             made_for_kids=False,
             availability_status=AvailabilityStatus.DELETED.value,
@@ -221,8 +217,8 @@ async def never_recovered_video(
 @pytest.fixture
 async def edge_case_video(
     integration_session_factory,
-    idempotency_channel: Dict[str, Any],
-) -> Dict[str, Any]:
+    idempotency_channel: dict[str, Any],
+) -> dict[str, Any]:
     """
     Create a deleted video recovered exactly 5 minutes ago.
 
@@ -230,14 +226,14 @@ async def edge_case_video(
     timedelta(minutes=5), so the guard should NOT trigger.
     """
     async with integration_session_factory() as session:
-        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+        recovered_time = datetime.now(UTC) - timedelta(minutes=5)
 
         video = VideoDB(
             video_id="edgvid00001",  # 11 chars
             channel_id=idempotency_channel["channel_id"],
             title="Edge Case Video",
             description="Recovered exactly 5 minutes ago",
-            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2023, 1, 15, tzinfo=UTC),
             duration=300,
             made_for_kids=False,
             availability_status=AvailabilityStatus.DELETED.value,
@@ -278,14 +274,14 @@ async def edge_case_video(
 @pytest.fixture
 async def recently_recovered_channel(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a deleted channel that was recovered 2 minutes ago.
 
     This should trigger the idempotency guard (< 5 min).
     """
     async with integration_session_factory() as session:
-        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=2)
+        recovered_time = datetime.now(UTC) - timedelta(minutes=2)
 
         channel = ChannelDB(
             channel_id="UCrecent_recovery_test01",
@@ -326,14 +322,14 @@ async def recently_recovered_channel(
 @pytest.fixture
 async def stale_recovered_channel(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a deleted channel that was recovered 10 minutes ago.
 
     This should NOT trigger the idempotency guard (> 5 min).
     """
     async with integration_session_factory() as session:
-        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        recovered_time = datetime.now(UTC) - timedelta(minutes=10)
 
         channel = ChannelDB(
             channel_id="UCstale_recovery_test001",
@@ -374,7 +370,7 @@ async def stale_recovered_channel(
 @pytest.fixture
 async def never_recovered_channel(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a deleted channel that has never been recovered.
 
@@ -414,14 +410,14 @@ async def never_recovered_channel(
 @pytest.fixture
 async def edge_case_channel(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a deleted channel recovered exactly 5 minutes ago.
 
     At exactly 5 minutes, the guard should NOT trigger.
     """
     async with integration_session_factory() as session:
-        recovered_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+        recovered_time = datetime.now(UTC) - timedelta(minutes=5)
 
         channel = ChannelDB(
             channel_id="UCedge_recovery_test0001",
@@ -470,7 +466,7 @@ class TestVideoRecoveryIdempotency:
     async def test_recently_recovered_video_returns_cached(
         self,
         async_client: AsyncClient,
-        recently_recovered_video: Dict[str, Any],
+        recently_recovered_video: dict[str, Any],
     ) -> None:
         """
         Video recovered < 5 min ago should return 200 with empty fields_recovered.
@@ -511,7 +507,7 @@ class TestVideoRecoveryIdempotency:
     async def test_stale_recovered_video_proceeds_to_orchestrator(
         self,
         async_client: AsyncClient,
-        stale_recovered_video: Dict[str, Any],
+        stale_recovered_video: dict[str, Any],
     ) -> None:
         """
         Video recovered > 5 min ago should proceed normally to orchestrator.
@@ -555,7 +551,7 @@ class TestVideoRecoveryIdempotency:
     async def test_never_recovered_video_proceeds_to_orchestrator(
         self,
         async_client: AsyncClient,
-        never_recovered_video: Dict[str, Any],
+        never_recovered_video: dict[str, Any],
     ) -> None:
         """
         Video with recovered_at=None should proceed normally to orchestrator.
@@ -598,7 +594,7 @@ class TestVideoRecoveryIdempotency:
     async def test_edge_case_exactly_5_min_proceeds(
         self,
         async_client: AsyncClient,
-        edge_case_video: Dict[str, Any],
+        edge_case_video: dict[str, Any],
     ) -> None:
         """
         Video recovered exactly 5 min ago should proceed to orchestrator.
@@ -648,7 +644,7 @@ class TestChannelRecoveryIdempotency:
     async def test_recently_recovered_channel_returns_cached(
         self,
         async_client: AsyncClient,
-        recently_recovered_channel: Dict[str, Any],
+        recently_recovered_channel: dict[str, Any],
     ) -> None:
         """
         Channel recovered < 5 min ago should return 200 with empty fields_recovered.
@@ -689,7 +685,7 @@ class TestChannelRecoveryIdempotency:
     async def test_stale_recovered_channel_proceeds_to_orchestrator(
         self,
         async_client: AsyncClient,
-        stale_recovered_channel: Dict[str, Any],
+        stale_recovered_channel: dict[str, Any],
     ) -> None:
         """
         Channel recovered > 5 min ago should proceed normally to orchestrator.
@@ -733,7 +729,7 @@ class TestChannelRecoveryIdempotency:
     async def test_never_recovered_channel_proceeds_to_orchestrator(
         self,
         async_client: AsyncClient,
-        never_recovered_channel: Dict[str, Any],
+        never_recovered_channel: dict[str, Any],
     ) -> None:
         """
         Channel with recovered_at=None should proceed normally to orchestrator.
@@ -776,7 +772,7 @@ class TestChannelRecoveryIdempotency:
     async def test_edge_case_exactly_5_min_proceeds(
         self,
         async_client: AsyncClient,
-        edge_case_channel: Dict[str, Any],
+        edge_case_channel: dict[str, Any],
     ) -> None:
         """
         Channel recovered exactly 5 min ago should proceed to orchestrator.

--- a/tests/integration/api/test_request_id.py
+++ b/tests/integration/api/test_request_id.py
@@ -46,8 +46,6 @@ if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 # UUID regex pattern for validation
 UUID_PATTERN = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
@@ -388,7 +386,7 @@ class TestRequestIdLogging:
                 exc_info=None
             )
             filter_instance.filter(test_record_2)
-            assert getattr(test_record_2, "request_id") == test_request_id
+            assert test_record_2.request_id == test_request_id  # type: ignore[attr-defined]
         finally:
             request_id_var.reset(token)
 
@@ -573,7 +571,6 @@ class TestContentTypeCompliance:
         from unittest.mock import MagicMock
 
         from fastapi.exceptions import RequestValidationError
-        from pydantic_core import InitErrorDetails, ValidationError
 
         from chronovista.api.exception_handlers import validation_error_handler
         from chronovista.api.middleware.request_id import request_id_var
@@ -639,7 +636,6 @@ class TestContentTypeCompliance:
         from unittest.mock import MagicMock
 
         from fastapi import Request
-        from starlette.datastructures import URL
 
         from chronovista.api.exception_handlers import generic_error_handler
         from chronovista.api.middleware.request_id import request_id_var

--- a/tests/integration/api/test_search_api.py
+++ b/tests/integration/api/test_search_api.py
@@ -2,10 +2,7 @@
 
 from unittest.mock import patch
 
-import pytest
 from httpx import AsyncClient
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestSearchSegments:
@@ -189,8 +186,8 @@ class TestSearchSegments:
                 assert isinstance(result["video_id"], str)
                 assert isinstance(result["video_title"], str)
                 assert isinstance(result["text"], str)
-                assert isinstance(result["start_time"], (int, float))
-                assert isinstance(result["end_time"], (int, float))
+                assert isinstance(result["start_time"], int | float)
+                assert isinstance(result["end_time"], int | float)
                 assert isinstance(result["match_count"], int)
                 assert isinstance(result["language_code"], str)
 

--- a/tests/integration/api/test_sync_api.py
+++ b/tests/integration/api/test_sync_api.py
@@ -5,15 +5,11 @@ status monitoring, and request validation for sync operations.
 """
 
 from unittest.mock import patch
-from datetime import datetime, timezone
 
 import pytest
 from httpx import AsyncClient
 
-pytestmark = pytest.mark.asyncio
-
-from chronovista.api.services.sync_manager import sync_manager, SyncManager
-from chronovista.api.schemas.sync import SyncOperationType
+from chronovista.api.services.sync_manager import sync_manager
 
 
 class TestSyncAuthentication:
@@ -314,7 +310,7 @@ class TestConflictHandling:
             # Start first sync
             response1 = await async_client.post("/api/v1/sync/transcripts")
             assert response1.status_code == 202
-            first_operation_id = response1.json()["data"]["operation_id"]
+            response1.json()["data"]["operation_id"]
 
             # Try to start second sync
             response2 = await async_client.post("/api/v1/sync/playlists")

--- a/tests/integration/api/test_tag_endpoints.py
+++ b/tests/integration/api/test_tag_endpoints.py
@@ -10,8 +10,9 @@ were added.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -24,8 +25,6 @@ from tests.factories.id_factory import YouTubeIdFactory
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
-
-pytestmark = pytest.mark.asyncio
 
 # ---------------------------------------------------------------------------
 # Namespace constants for TestTagEndpointRegression fixtures
@@ -190,7 +189,7 @@ class TestListTagsWithCounts:
                     video_id=f"tag_sort_{i:02d}",
                     channel_id=channel.channel_id,
                     title=f"Test Video {i}",
-                    upload_date=datetime.now(timezone.utc),
+                    upload_date=datetime.now(UTC),
                     duration=300,
                 )
                 videos.append(video)
@@ -282,7 +281,7 @@ class TestTagDetail:
                 video_id="tag_detail_vid",
                 channel_id=channel.channel_id,
                 title="Tag Detail Video",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
             )
             session.add(video)
@@ -359,7 +358,7 @@ class TestTagDetail:
                 video_id="tag_encode_vid",
                 channel_id=channel.channel_id,
                 title="Encoding Test Video",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
             )
             session.add(video)
@@ -440,7 +439,7 @@ class TestTagVideos:
                 video_id="tag_vid_test_00",
                 channel_id=channel.channel_id,
                 title="Test Video",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
             )
             session.add(video)
@@ -501,7 +500,7 @@ class TestTagVideos:
                 video_id="tag_active_vid",
                 channel_id=channel.channel_id,
                 title="Active Video",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
                 availability_status="available",
             )
@@ -512,7 +511,7 @@ class TestTagVideos:
                 video_id="tag_deleted_vid",
                 channel_id=channel.channel_id,
                 title="Deleted Video",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
                 availability_status="unavailable",
             )
@@ -569,21 +568,21 @@ class TestTagVideos:
                 video_id="tag_sort_vid_1",
                 channel_id=channel.channel_id,
                 title="Oldest Video",
-                upload_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2023, 1, 1, tzinfo=UTC),
                 duration=300,
             )
             video2 = Video(
                 video_id="tag_sort_vid_2",
                 channel_id=channel.channel_id,
                 title="Middle Video",
-                upload_date=datetime(2023, 6, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2023, 6, 1, tzinfo=UTC),
                 duration=300,
             )
             video3 = Video(
                 video_id="tag_sort_vid_3",
                 channel_id=channel.channel_id,
                 title="Newest Video",
-                upload_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 1, 1, tzinfo=UTC),
                 duration=300,
             )
             session.add_all([video1, video2, video3])
@@ -642,7 +641,7 @@ class TestTagVideos:
                     video_id=f"tag_pag_test_{i:02d}",
                     channel_id=channel.channel_id,
                     title=f"Pagination Test Video {i}",
-                    upload_date=datetime.now(timezone.utc),
+                    upload_date=datetime.now(UTC),
                     duration=300 + i * 10,
                 )
                 videos.append(video)
@@ -693,7 +692,7 @@ class TestTagVideos:
 
 @pytest.fixture
 async def _reg_test_session(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[AsyncSession, None]:
     """Bare session for regression test data setup and cleanup.
 
@@ -749,7 +748,7 @@ async def _reg_sample_data(
         video_id=_REG_VID1_ID,
         channel_id=_REG_CHANNEL_ID,
         title="Python Basics",
-        upload_date=datetime(2024, 3, 10, tzinfo=timezone.utc),
+        upload_date=datetime(2024, 3, 10, tzinfo=UTC),
         duration=600,
         availability_status="available",
     )
@@ -757,7 +756,7 @@ async def _reg_sample_data(
         video_id=_REG_VID2_ID,
         channel_id=_REG_CHANNEL_ID,
         title="Python and Testing",
-        upload_date=datetime(2024, 5, 20, tzinfo=timezone.utc),
+        upload_date=datetime(2024, 5, 20, tzinfo=UTC),
         duration=900,
         availability_status="available",
     )
@@ -765,7 +764,7 @@ async def _reg_sample_data(
         video_id=_REG_VID3_ID,
         channel_id=_REG_CHANNEL_ID,
         title="Deleted Python Video",
-        upload_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        upload_date=datetime(2024, 1, 1, tzinfo=UTC),
         duration=300,
         availability_status="deleted",
     )

--- a/tests/integration/api/test_targeted_scan_endpoints.py
+++ b/tests/integration/api/test_targeted_scan_endpoints.py
@@ -19,8 +19,9 @@ Feature 052 — Targeted Entity & Video-Level Mention Scanning
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -29,17 +30,19 @@ from sqlalchemy import delete, select
 
 from chronovista.db.models import (
     Channel as ChannelDB,
+)
+from chronovista.db.models import (
     NamedEntity as NamedEntityDB,
+)
+from chronovista.db.models import (
     Video as VideoDB,
 )
 from chronovista.services.entity_mention_scan_service import ScanResult
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 # CRITICAL: Module-level asyncio marker ensures async tests run with coverage.
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Stable IDs — must not collide with other integration test files.
 # channel_id max 24 chars, video_id max 20 chars.
@@ -97,7 +100,7 @@ def _make_scan_result(
 
 @pytest.fixture
 async def seed_scan_data(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Seed a channel, video, and named entity for scan endpoint tests.
 
@@ -139,7 +142,7 @@ async def seed_scan_data(
                 channel_id=_CHANNEL_ID,
                 title="Scan 052 Test Video",
                 description="Integration test video for Feature 052",
-                upload_date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 6, 1, tzinfo=UTC),
                 duration=300,
             )
             session.add(video)
@@ -411,7 +414,7 @@ class TestEntityScanEndpoint:
             )
 
         assert response.status_code == 400, response.text
-        body = response.json()
+        response.json()
         # Error detail must mention the status
         detail = response.text.lower()
         assert "active" in detail or "status" in detail

--- a/tests/integration/api/test_tier1_independent.py
+++ b/tests/integration/api/test_tier1_independent.py
@@ -34,8 +34,6 @@ from chronovista.models.user_language_preference import UserLanguagePreferenceCr
 from chronovista.repositories.base import BaseSQLAlchemyRepository
 from tests.integration.api.quota_utils import skip_if_quota_exceeded
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.mark.integration
 @pytest.mark.api
@@ -75,10 +73,9 @@ class TestChannelFromYouTubeAPI:
                     await session.execute(delete(DBChannel))
 
                     await session.commit()
-                except Exception as e:
+                except Exception:
                     # If cleanup fails, rollback and continue
                     # Tests should be isolated and not depend on existing data
-                    print(f"Cleanup warning: {e}")
                     await session.rollback()
 
                 # Returns a list of YouTubeChannelResponse Pydantic models
@@ -416,7 +413,6 @@ class TestChannelFromYouTubeAPI:
                             raise
 
                         if not api_data_list:
-                            print(f"No data returned for channel {channel_id}")
                             continue
 
                         api_data = api_data_list[0]  # Get first channel from list
@@ -465,9 +461,9 @@ class TestChannelFromYouTubeAPI:
                         )
                         created_channels.append(db_channel)
 
-                    except Exception as e:
+                    except Exception:
                         # Log but don't fail test for individual channel issues
-                        print(f"Failed to create channel {channel_id}: {e}")
+                        pass
 
                 await session.commit()
 
@@ -635,10 +631,10 @@ class TestUserLanguagePreferenceIndependent:
                 )
 
                 # Create in reverse order to test sorting
-                low_pref_db = await user_language_preference_repository.create(
+                await user_language_preference_repository.create(
                     session, obj_in=low_priority
                 )
-                high_pref_db = await user_language_preference_repository.create(
+                await user_language_preference_repository.create(
                     session, obj_in=high_priority
                 )
                 await session.commit()

--- a/tests/integration/api/test_tier2_channel_deps.py
+++ b/tests/integration/api/test_tier2_channel_deps.py
@@ -11,7 +11,8 @@ and verify the channel → dependent model data flow.
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Dict
+from collections.abc import Awaitable
+from typing import Any
 
 import pytest
 from sqlalchemy import delete
@@ -26,8 +27,6 @@ from chronovista.models.enums import PrivacyStatus
 from chronovista.models.playlist import PlaylistCreate, PlaylistUpdate
 from chronovista.repositories.base import BaseSQLAlchemyRepository
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.mark.integration
 @pytest.mark.api
@@ -38,7 +37,7 @@ class TestChannelKeywordFromAPI:
     async def test_channel_keyword_extraction(
         self,
         authenticated_youtube_service,
-        established_channel: Awaitable[Dict[str, Any] | None],
+        established_channel: Awaitable[dict[str, Any] | None],
         integration_db_session,
     ):
         """Test extracting and storing channel keywords from real channel data."""
@@ -122,7 +121,7 @@ class TestChannelKeywordFromAPI:
 
     async def test_channel_keyword_uniqueness(
         self,
-        established_channel: Awaitable[Dict[str, Any] | None],
+        established_channel: Awaitable[dict[str, Any] | None],
         integration_db_session,
     ):
         """Test that duplicate keywords for same channel are handled properly."""
@@ -202,7 +201,7 @@ class TestPlaylistFromAPI:
     async def test_playlist_creation_from_api(
         self,
         authenticated_youtube_service,
-        established_channel: Awaitable[Dict[str, Any] | None],
+        established_channel: Awaitable[dict[str, Any] | None],
         integration_db_session,
     ):
         """Test creating playlists from YouTube API data."""
@@ -301,7 +300,7 @@ class TestPlaylistFromAPI:
     async def test_playlist_statistics_update(
         self,
         authenticated_youtube_service,
-        established_channel: Awaitable[Dict[str, Any] | None],
+        established_channel: Awaitable[dict[str, Any] | None],
         integration_db_session,
     ):
         """Test updating playlist statistics from API."""
@@ -383,7 +382,7 @@ class TestPlaylistFromAPI:
 
     async def test_playlist_video_relationship_preparation(
         self,
-        established_channel: Awaitable[Dict[str, Any] | None],
+        established_channel: Awaitable[dict[str, Any] | None],
         integration_db_session,
     ):
         """Test playlist creation in preparation for video relationships (Tier 3)."""
@@ -400,7 +399,6 @@ class TestPlaylistFromAPI:
                     DBPlaylist, PlaylistCreate, PlaylistUpdate
                 ] = BaseSQLAlchemyRepository(DBPlaylist)
 
-                import time
 
                 # test_suffix = f"prep_test_{int(time.time())}"
                 # Create multiple playlists that will be used in Tier 3 video tests

--- a/tests/integration/api/test_tier3_video_core.py
+++ b/tests/integration/api/test_tier3_video_core.py
@@ -13,8 +13,9 @@ and form the foundation for video-dependent models in Tier 4.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Awaitable, Dict, List
+from collections.abc import Awaitable
+from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 from sqlalchemy import delete, select
@@ -22,8 +23,6 @@ from sqlalchemy import delete, select
 from chronovista.db.models import Video as DBVideo
 from chronovista.models.video import Video, VideoCreate, VideoStatistics, VideoUpdate
 from chronovista.repositories.base import BaseSQLAlchemyRepository
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.integration
@@ -36,7 +35,7 @@ class TestVideoFromYouTubeAPI:
         self,
         authenticated_youtube_service,
         integration_db_session,
-        established_channel: Awaitable[Dict[str, Any] | None],
+        established_channel: Awaitable[dict[str, Any] | None],
         sample_youtube_video_ids,
     ):
         """Test creating videos from real YouTube API data."""
@@ -46,7 +45,7 @@ class TestVideoFromYouTubeAPI:
         if not authenticated_youtube_service or not established_channel_data:
             pytest.skip("Prerequisites not available")
 
-        channel_id = established_channel_data["channel_id"]
+        established_channel_data["channel_id"]
         video_id = sample_youtube_video_ids[0]  # Rick Astley - Never Gonna Give You Up
 
         async with integration_db_session() as session:
@@ -222,8 +221,7 @@ class TestVideoFromYouTubeAPI:
                                 stat_value = int(stats[stat_name])
                                 assert stat_value >= 0
 
-                    except Exception as e:
-                        print(f"Warning: Could not test video {video_id}: {e}")
+                    except Exception:
                         continue
             except Exception:
                 await session.rollback()
@@ -264,26 +262,22 @@ class TestVideoFromYouTubeAPI:
                 # Test available languages structure
                 available_languages = api_data["snippet"].get("availableLanguages")
                 if available_languages:
-                    assert isinstance(available_languages, (dict, list))
+                    assert isinstance(available_languages, dict | list)
 
-            except Exception as e:
-                print(f"Warning: Could not test language detection for {video_id}: {e}")
+            except Exception:
                 continue
 
     async def test_video_update_from_fresh_api_data(
         self,
         authenticated_youtube_service,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
     ):
         """Test updating video with fresh data from API."""
         # Await the fixture since it's async
         established_videos_data = await established_videos
 
         if not authenticated_youtube_service or not established_videos_data:
-            print(
-                f"DEBUG: Test prerequisites - auth_service: {bool(authenticated_youtube_service)}, videos_data: {bool(established_videos_data)}, videos_count: {len(established_videos_data) if established_videos_data else 0}"
-            )
             pytest.skip("Prerequisites not available")
 
         test_video = established_videos_data[0]
@@ -388,7 +382,7 @@ class TestVideoSearchAndFiltering:
     async def test_video_search_filters_with_real_data(
         self,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
     ):
         """Test video search filters with established video data."""
         # Await the fixture since it's async
@@ -403,13 +397,11 @@ class TestVideoSearchAndFiltering:
         async with integration_db_session() as session:
             try:
                 # Use repository pattern
-                video_repo: BaseSQLAlchemyRepository[
-                    DBVideo, VideoCreate, VideoUpdate
-                ] = BaseSQLAlchemyRepository(DBVideo)
+                BaseSQLAlchemyRepository(DBVideo)
                 # Test channel-based filtering
                 from tests.factories.video_factory import create_video_search_filters
 
-                channel_filter = create_video_search_filters(
+                create_video_search_filters(
                     channel_ids=[channel_id],
                     exclude_deleted=True,
                 )
@@ -453,7 +445,7 @@ class TestVideoSearchAndFiltering:
     async def test_video_date_range_filtering(
         self,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
     ):
         """Test video filtering by upload date ranges."""
         # Await the fixture since it's async
@@ -465,11 +457,9 @@ class TestVideoSearchAndFiltering:
         async with integration_db_session() as session:
             try:
                 # Use repository pattern
-                video_repo: BaseSQLAlchemyRepository[
-                    DBVideo, VideoCreate, VideoUpdate
-                ] = BaseSQLAlchemyRepository(DBVideo)
+                BaseSQLAlchemyRepository(DBVideo)
                 # Test recent videos (last year)
-                recent_date = datetime.now(timezone.utc).replace(
+                recent_date = datetime.now(UTC).replace(
                     year=datetime.now().year - 1
                 )
 
@@ -481,7 +471,7 @@ class TestVideoSearchAndFiltering:
                     assert video.upload_date >= recent_date
 
                 # Test older videos (before specific date)
-                cutoff_date = datetime(2020, 1, 1, tzinfo=timezone.utc)
+                cutoff_date = datetime(2020, 1, 1, tzinfo=UTC)
 
                 older_result = await session.execute(
                     select(DBVideo).where(DBVideo.upload_date <= cutoff_date)
@@ -503,7 +493,7 @@ class TestVideoStatisticsAggregation:
     async def test_channel_video_statistics(
         self,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
     ):
         """Test aggregating video statistics for a channel."""
         # Await the fixture since it's async
@@ -518,9 +508,7 @@ class TestVideoStatisticsAggregation:
         async with integration_db_session() as session:
             try:
                 # Use repository pattern to get channel videos
-                video_repo: BaseSQLAlchemyRepository[
-                    DBVideo, VideoCreate, VideoUpdate
-                ] = BaseSQLAlchemyRepository(DBVideo)
+                BaseSQLAlchemyRepository(DBVideo)
                 # Get all videos for the channel
                 result = await session.execute(
                     select(DBVideo).where(DBVideo.channel_id == channel_id)
@@ -577,7 +565,7 @@ class TestVideoStatisticsAggregation:
 
     def _extract_top_languages(self, videos: list[Video]) -> list[tuple[str, int]]:
         """Extract top languages from video collection."""
-        language_counts: Dict[str, int] = {}
+        language_counts: dict[str, int] = {}
 
         for video in videos:
             lang = video.default_language or "unknown"
@@ -591,7 +579,7 @@ class TestVideoStatisticsAggregation:
 
     def _calculate_upload_trend(self, videos: list[Video]) -> dict[str, int]:
         """Calculate upload trend by month."""
-        trend: Dict[str, int] = {}
+        trend: dict[str, int] = {}
 
         for video in videos:
             month_key = video.upload_date.strftime("%Y-%m")

--- a/tests/integration/api/test_tier4_video_deps.py
+++ b/tests/integration/api/test_tier4_video_deps.py
@@ -22,8 +22,9 @@ Defensive Implementation Notes:
 from __future__ import annotations
 
 import time
-from datetime import datetime, timezone
-from typing import Any, Awaitable, Dict, List
+from collections.abc import Awaitable
+from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 from sqlalchemy import delete, select
@@ -40,14 +41,11 @@ from chronovista.models.enums import (
 from chronovista.models.user_video import UserVideoCreate, UserVideoUpdate
 from chronovista.models.video_tag import VideoTagCreate, VideoTagUpdate
 from chronovista.models.video_transcript import (
-    VideoTranscript,
     VideoTranscriptCreate,
     VideoTranscriptUpdate,
 )
 from chronovista.repositories.base import BaseSQLAlchemyRepository
 from tests.factories.user_video_factory import create_user_video_update
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.integration
@@ -60,7 +58,7 @@ class TestVideoTranscriptFromAPI:
         self,
         authenticated_youtube_service,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
     ):
         """Test creating video transcripts from real YouTube API data."""
         # Await the fixture once - defensive pattern from Tier 3 lessons
@@ -107,7 +105,7 @@ class TestVideoTranscriptFromAPI:
                     transcript_content = f"Real caption track: {caption_name}"
 
                 # Create unique transcript ID using timestamp - defensive pattern
-                unique_suffix = f"test_{int(time.time())}"
+                f"test_{int(time.time())}"
 
                 transcript_create = VideoTranscriptCreate(
                     video_id=video_id,
@@ -185,7 +183,7 @@ class TestVideoTranscriptFromAPI:
     async def test_video_transcript_multi_language_support(
         self,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
     ):
         """Test video transcript multi-language capabilities."""
         established_videos_data = await established_videos
@@ -293,7 +291,7 @@ class TestVideoTagFromAPI:
         self,
         authenticated_youtube_service,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
     ):
         """Test creating video tags from real YouTube API data."""
         established_videos_data = await established_videos
@@ -325,7 +323,7 @@ class TestVideoTagFromAPI:
 
                 # Extract tags from video title and description for realistic testing
                 title = api_video_data["snippet"]["title"]
-                description = api_video_data["snippet"].get("description", "")
+                api_video_data["snippet"].get("description", "")
 
                 # Generate test tags based on content - more realistic than arbitrary tags
                 content_tags = []
@@ -404,7 +402,7 @@ class TestVideoTagFromAPI:
     async def test_video_tag_deduplication(
         self,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
     ):
         """Test that duplicate video tags are handled properly."""
         established_videos_data = await established_videos
@@ -445,7 +443,7 @@ class TestVideoTagFromAPI:
                     )
 
                     # This should fail due to unique constraint (video_id + tag_name)
-                    second_tag = await tag_repo.create(session, obj_in=duplicate_tag)
+                    await tag_repo.create(session, obj_in=duplicate_tag)
                     await session.commit()
 
                     # If we get here, duplicate was somehow allowed
@@ -468,7 +466,7 @@ class TestVideoTagFromAPI:
                 # If duplicate was created, that's actually fine for some designs
                 # but we should be aware of the behavior
                 if duplicate_created:
-                    print(f"Note: Duplicate tags were allowed for video {video_id}")
+                    pass
 
             except Exception:
                 await session.rollback()
@@ -483,7 +481,7 @@ class TestUserVideoFromAPI:
     async def test_user_video_interaction_tracking(
         self,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
         test_user_id,
     ):
         """Test tracking user-video interactions."""
@@ -514,7 +512,7 @@ class TestUserVideoFromAPI:
                 user_video_create = UserVideoCreate(
                     user_id=test_user_id,
                     video_id=video_id,
-                    watched_at=datetime.now(timezone.utc),  # Correct field name
+                    watched_at=datetime.now(UTC),  # Correct field name
                     liked=True,
                     rewatch_count=1,  # Correct field name
                     saved_to_playlist=False,  # Correct field name
@@ -553,7 +551,7 @@ class TestUserVideoFromAPI:
 
                 interaction_update = create_user_video_update(
                     rewatch_count=2,  # Correct field name
-                    watched_at=datetime.now(timezone.utc),  # Correct field name
+                    watched_at=datetime.now(UTC),  # Correct field name
                 )
 
                 updated_interaction = await user_video_repo.update(
@@ -580,7 +578,7 @@ class TestUserVideoFromAPI:
     async def test_user_video_analytics_aggregation(
         self,
         integration_db_session,
-        established_videos: Awaitable[List[Dict[str, Any]] | None],
+        established_videos: Awaitable[list[dict[str, Any]] | None],
         test_user_id,
     ):
         """Test aggregating user video analytics."""
@@ -613,7 +611,7 @@ class TestUserVideoFromAPI:
                     interaction_create = UserVideoCreate(
                         user_id=test_user_id,
                         video_id=video_id,
-                        watched_at=datetime.now(timezone.utc),  # Correct field name
+                        watched_at=datetime.now(UTC),  # Correct field name
                         liked=i % 2 == 0,  # Alternate liked status
                         rewatch_count=i + 1,  # Correct field name
                         saved_to_playlist=i
@@ -657,10 +655,6 @@ class TestUserVideoFromAPI:
                 assert total_likes >= 0
                 assert total_bookmarks >= 0
 
-                print(f"User {test_user_id} analytics:")
-                print(f"  Videos watched: {total_videos_watched}")
-                print(f"  Videos liked: {total_likes}")
-                print(f"  Videos bookmarked: {total_bookmarks}")
 
                 # Clean up all test data - proper cleanup from lessons learned
                 await session.execute(

--- a/tests/integration/api/test_topic_endpoints.py
+++ b/tests/integration/api/test_topic_endpoints.py
@@ -6,13 +6,11 @@ GET /api/v1/topics/{topic_id}/videos endpoints.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
-import pytest
 from httpx import AsyncClient
-from sqlalchemy import delete, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import delete
 
 from chronovista.db.models import (
     Channel,
@@ -21,9 +19,6 @@ from chronovista.db.models import (
     Video,
     VideoTopic,
 )
-
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestListTopics:
@@ -178,14 +173,14 @@ class TestListTopicsWithCounts:
                 video_id="test_vid_001",
                 channel_id=channel.channel_id,
                 title="Test Video 1",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
             )
             video2 = Video(
                 video_id="test_vid_002",
                 channel_id=channel.channel_id,
                 title="Test Video 2",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=400,
             )
             session.add_all([video1, video2])
@@ -483,7 +478,7 @@ class TestTopicVideos:
                 video_id="vid_test_00",
                 channel_id=channel.channel_id,
                 title="Test Video",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=300,
             )
             session.add(video)
@@ -565,7 +560,7 @@ class TestTopicVideos:
                     video_id=f"pag_test_{i:02d}",
                     channel_id=channel.channel_id,
                     title=f"Pagination Test Video {i}",
-                    upload_date=datetime.now(timezone.utc),
+                    upload_date=datetime.now(UTC),
                     duration=300 + i * 10,
                 )
                 videos.append(video)

--- a/tests/integration/api/test_transcript_corrections_api.py
+++ b/tests/integration/api/test_transcript_corrections_api.py
@@ -12,8 +12,9 @@ isolation from other integration test files.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -23,9 +24,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import (
     Channel as ChannelDB,
+)
+from chronovista.db.models import (
     TranscriptCorrection as TranscriptCorrectionDB,
+)
+from chronovista.db.models import (
     TranscriptSegment as TranscriptSegmentDB,
+)
+from chronovista.db.models import (
     Video as VideoDB,
+)
+from chronovista.db.models import (
     VideoTranscript as VideoTranscriptDB,
 )
 
@@ -33,8 +42,6 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
 
 # CRITICAL: Ensures all async tests in this module run with pytest-asyncio
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Unique stable IDs — chosen to avoid collisions with other test files
 # ---------------------------------------------------------------------------
@@ -63,7 +70,7 @@ def _revert_url(video_id: str, segment_id: int | str) -> str:
 
 @pytest.fixture
 async def seed_test_data(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Seed database with a channel, video, transcript, and segment for correction tests.
 
@@ -98,7 +105,7 @@ async def seed_test_data(
                 channel_id=_CHANNEL_ID,
                 title="Transcript Correction Test Video",
                 description="Integration test video for Feature 034",
-                upload_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 1, 1, tzinfo=UTC),
                 duration=300,
             )
             session.add(video)
@@ -919,7 +926,7 @@ def _segments_url(video_id: str) -> str:
 
 @pytest.fixture
 async def seed_enrichment_data(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Seed database with a channel, video, transcript, and 2 segments for enrichment tests.
 
@@ -956,7 +963,7 @@ async def seed_enrichment_data(
                 channel_id=_ENR_CHANNEL_ID,
                 title="Enrichment Test Video",
                 description="Integration test video for T013 segment enrichment",
-                upload_date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 6, 1, tzinfo=UTC),
                 duration=120,
             )
             session.add(video)

--- a/tests/integration/api/test_transcript_download.py
+++ b/tests/integration/api/test_transcript_download.py
@@ -20,8 +20,9 @@ Pattern mirrors test_transcript_corrections_api.py:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -31,8 +32,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import (
     Channel as ChannelDB,
+)
+from chronovista.db.models import (
     TranscriptSegment as TranscriptSegmentDB,
+)
+from chronovista.db.models import (
     Video as VideoDB,
+)
+from chronovista.db.models import (
     VideoTranscript as VideoTranscriptDB,
 )
 from chronovista.models.enums import DownloadReason
@@ -48,8 +55,6 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
 
 # CRITICAL: Ensures all async tests in this module run with pytest-asyncio
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Stable IDs — generated via YouTubeIdFactory with deterministic seeds
 # ---------------------------------------------------------------------------
@@ -146,7 +151,7 @@ def _make_enhanced_transcript(
 
 @pytest.fixture
 async def seed_video_without_transcript(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Seed a channel and video record with NO pre-existing transcript.
 
@@ -179,7 +184,7 @@ async def seed_video_without_transcript(
                 channel_id=_CHANNEL_ID,
                 title="Transcript Download Test Video",
                 description="Integration test video for transcript download endpoint",
-                upload_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 1, 1, tzinfo=UTC),
                 duration=300,
             )
             session.add(video)
@@ -216,7 +221,7 @@ async def seed_video_without_transcript(
 
 @pytest.fixture
 async def seed_video_with_existing_transcript(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Seed a channel, video, and an existing transcript to test 409 conflict.
 
@@ -249,7 +254,7 @@ async def seed_video_with_existing_transcript(
                 channel_id=_CHANNEL_ID,
                 title="Video With Pre-existing Transcript",
                 description="Already has a transcript — triggers 409",
-                upload_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2024, 1, 1, tzinfo=UTC),
                 duration=180,
             )
             session.add(video)
@@ -396,7 +401,7 @@ class TestDownloadHappyPath:
         self,
         async_client: AsyncClient,
         seed_video_without_transcript: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """Successful download returns 200 with TranscriptDownloadResponse payload."""
         video_id = seed_video_without_transcript["video_id"]
@@ -428,7 +433,7 @@ class TestDownloadHappyPath:
         self,
         async_client: AsyncClient,
         seed_video_without_transcript: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """After a successful download the transcript row is saved in the database."""
         video_id = seed_video_without_transcript["video_id"]
@@ -465,7 +470,7 @@ class TestDownloadHappyPath:
         self,
         async_client: AsyncClient,
         seed_video_without_transcript: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """After download the TranscriptSegment rows are created from raw data snippets."""
         video_id = seed_video_without_transcript["video_id"]
@@ -911,7 +916,7 @@ class TestDownloadDatabaseState:
         self,
         async_client: AsyncClient,
         seed_video_without_transcript: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """The persisted VideoTranscript row has the language code from the service response."""
         video_id = seed_video_without_transcript["video_id"]
@@ -946,7 +951,7 @@ class TestDownloadDatabaseState:
         self,
         async_client: AsyncClient,
         seed_video_without_transcript: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """Each saved TranscriptSegment has start_time, end_time, and duration set."""
         video_id = seed_video_without_transcript["video_id"]
@@ -984,7 +989,7 @@ class TestDownloadDatabaseState:
         self,
         async_client: AsyncClient,
         seed_video_without_transcript: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """Segments are stored with ascending sequence_number matching snippet order."""
         video_id = seed_video_without_transcript["video_id"]
@@ -1019,7 +1024,7 @@ class TestDownloadDatabaseState:
         self,
         async_client: AsyncClient,
         seed_video_without_transcript: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """All persisted TranscriptSegment rows carry the correct video_id FK."""
         video_id = seed_video_without_transcript["video_id"]
@@ -1053,7 +1058,7 @@ class TestDownloadDatabaseState:
         self,
         async_client: AsyncClient,
         seed_video_without_transcript: dict[str, Any],
-        integration_session_factory: "async_sessionmaker[AsyncSession]",
+        integration_session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         """No transcript or segment rows are persisted when the service raises an error.
 

--- a/tests/integration/api/test_transcripts_api.py
+++ b/tests/integration/api/test_transcripts_api.py
@@ -2,10 +2,7 @@
 
 from unittest.mock import patch
 
-import pytest
 from httpx import AsyncClient
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestTranscriptLanguages:
@@ -319,8 +316,8 @@ class TestTranscriptSegments:
                 assert "start_time" in segment
                 assert "end_time" in segment
                 assert "duration" in segment
-                assert isinstance(segment["start_time"], (int, float))
-                assert isinstance(segment["end_time"], (int, float))
+                assert isinstance(segment["start_time"], int | float)
+                assert isinstance(segment["end_time"], int | float)
 
     async def test_get_segments_pagination_has_more(
         self, async_client: AsyncClient

--- a/tests/integration/api/test_video_recovery.py
+++ b/tests/integration/api/test_video_recovery.py
@@ -14,23 +14,19 @@ Tests cover:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel as ChannelDB
 from chronovista.db.models import Video as VideoDB
 from chronovista.exceptions import CDXError
 from chronovista.models.enums import AvailabilityStatus
 from chronovista.services.recovery.models import RecoveryResult
-
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # Test Fixtures
@@ -40,7 +36,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def test_channel(
     integration_session_factory,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a test channel for FK constraints.
 
@@ -78,8 +74,8 @@ async def test_channel(
 @pytest.fixture
 async def deleted_video(
     integration_session_factory,
-    test_channel: Dict[str, Any],
-) -> Dict[str, Any]:
+    test_channel: dict[str, Any],
+) -> dict[str, Any]:
     """
     Create a video with availability_status = 'deleted'.
 
@@ -91,7 +87,7 @@ async def deleted_video(
             channel_id=test_channel["channel_id"],
             title="Deleted Video for Recovery",
             description="A deleted video that needs recovery",
-            upload_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2023, 1, 15, tzinfo=UTC),
             duration=420,
             made_for_kids=False,
             availability_status=AvailabilityStatus.DELETED.value,
@@ -129,8 +125,8 @@ async def deleted_video(
 @pytest.fixture
 async def available_video(
     integration_session_factory,
-    test_channel: Dict[str, Any],
-) -> Dict[str, Any]:
+    test_channel: dict[str, Any],
+) -> dict[str, Any]:
     """
     Create a video with availability_status = 'available'.
 
@@ -142,7 +138,7 @@ async def available_video(
             channel_id=test_channel["channel_id"],
             title="Available Video",
             description="An available video that should not be recovered",
-            upload_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2024, 1, 15, tzinfo=UTC),
             duration=300,
             made_for_kids=False,
             availability_status=AvailabilityStatus.AVAILABLE.value,
@@ -186,7 +182,7 @@ class TestVideoRecoverySuccess:
     async def test_recover_video_success_with_metadata(
         self,
         async_client: AsyncClient,
-        deleted_video: Dict[str, Any],
+        deleted_video: dict[str, Any],
     ) -> None:
         """Test successful video recovery with populated RecoveryResult."""
         video_id = deleted_video["video_id"]
@@ -243,7 +239,7 @@ class TestVideoRecoverySuccess:
     async def test_recover_video_zero_new_fields(
         self,
         async_client: AsyncClient,
-        deleted_video: Dict[str, Any],
+        deleted_video: dict[str, Any],
     ) -> None:
         """Test successful recovery with empty fields_recovered list."""
         video_id = deleted_video["video_id"]
@@ -315,7 +311,7 @@ class TestVideoRecoveryErrors:
     async def test_recover_available_video_409(
         self,
         async_client: AsyncClient,
-        available_video: Dict[str, Any],
+        available_video: dict[str, Any],
     ) -> None:
         """Test 409 conflict when video is available."""
         video_id = available_video["video_id"]
@@ -335,7 +331,7 @@ class TestVideoRecoveryErrors:
     async def test_recover_invalid_year_range_422(
         self,
         async_client: AsyncClient,
-        deleted_video: Dict[str, Any],
+        deleted_video: dict[str, Any],
     ) -> None:
         """Test 422 validation error when end_year < start_year."""
         video_id = deleted_video["video_id"]
@@ -359,7 +355,7 @@ class TestVideoRecoveryErrors:
     async def test_recover_year_out_of_range_422(
         self,
         async_client: AsyncClient,
-        deleted_video: Dict[str, Any],
+        deleted_video: dict[str, Any],
     ) -> None:
         """Test 422 validation error when year is out of range."""
         video_id = deleted_video["video_id"]
@@ -382,7 +378,7 @@ class TestVideoRecoveryErrors:
     async def test_recover_cdx_error_503(
         self,
         async_client: AsyncClient,
-        deleted_video: Dict[str, Any],
+        deleted_video: dict[str, Any],
     ) -> None:
         """Test 503 error when CDX API is unavailable."""
         video_id = deleted_video["video_id"]
@@ -426,7 +422,7 @@ class TestVideoRecoveryQueryParameters:
     async def test_recover_with_start_year(
         self,
         async_client: AsyncClient,
-        deleted_video: Dict[str, Any],
+        deleted_video: dict[str, Any],
     ) -> None:
         """Test recovery with start_year parameter."""
         video_id = deleted_video["video_id"]
@@ -464,7 +460,7 @@ class TestVideoRecoveryQueryParameters:
     async def test_recover_with_end_year(
         self,
         async_client: AsyncClient,
-        deleted_video: Dict[str, Any],
+        deleted_video: dict[str, Any],
     ) -> None:
         """Test recovery with end_year parameter."""
         video_id = deleted_video["video_id"]
@@ -502,7 +498,7 @@ class TestVideoRecoveryQueryParameters:
     async def test_recover_with_year_range(
         self,
         async_client: AsyncClient,
-        deleted_video: Dict[str, Any],
+        deleted_video: dict[str, Any],
     ) -> None:
         """Test recovery with both start_year and end_year parameters."""
         video_id = deleted_video["video_id"]

--- a/tests/integration/api/test_videos_api.py
+++ b/tests/integration/api/test_videos_api.py
@@ -1,14 +1,10 @@
 """Integration tests for video list endpoint (US1)."""
 
-from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 from urllib.parse import quote
 
-import pytest
 from httpx import AsyncClient
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestListVideos:
@@ -166,7 +162,7 @@ class TestVideoFilters:
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
             mock_oauth.is_authenticated.return_value = True
             # Use URL-encoded ISO format with timezone
-            date = (datetime.now(timezone.utc) - timedelta(days=30)).strftime(
+            date = (datetime.now(UTC) - timedelta(days=30)).strftime(
                 "%Y-%m-%dT%H:%M:%S+00:00"
             )
             encoded_date = quote(date)
@@ -180,7 +176,7 @@ class TestVideoFilters:
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
             mock_oauth.is_authenticated.return_value = True
             # Use URL-encoded ISO format with timezone
-            date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+            date = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S+00:00")
             encoded_date = quote(date)
             response = await async_client.get(
                 f"/api/v1/videos?uploaded_before={encoded_date}"

--- a/tests/integration/api/test_videos_filters.py
+++ b/tests/integration/api/test_videos_filters.py
@@ -6,16 +6,16 @@ Tests filter logic for tags, categories, and topics per FR-019 through FR-053.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, AsyncGenerator, List
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
-
-from uuid_utils import uuid7
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
 
 from chronovista.db.models import (
     CanonicalTag,
@@ -32,12 +32,10 @@ from tests.factories.id_factory import YouTubeIdFactory
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture
 async def test_data_session(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[AsyncSession, None]:
     """Provide a session for test data setup and cleanup."""
     async with integration_session_factory() as session:
@@ -117,7 +115,7 @@ async def sample_videos_with_filters(
     sample_channel: Channel,
     sample_category: VideoCategory,
     sample_topic: TopicCategory,
-) -> List[Video]:
+) -> list[Video]:
     """Create sample videos with tags, categories, and topics for filter testing."""
     videos = []
 
@@ -148,7 +146,7 @@ async def sample_videos_with_filters(
             channel_id=sample_channel.channel_id,
             title="Music Video Test",
             description="A test video with music content",
-            upload_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2024, 1, 15, tzinfo=UTC),
             duration=300,
             category_id=sample_category.category_id,
         )
@@ -180,7 +178,7 @@ async def sample_videos_with_filters(
             channel_id=sample_channel.channel_id,
             title="Rock Music Test",
             description="A test video with rock music",
-            upload_date=datetime(2024, 1, 16, tzinfo=timezone.utc),
+            upload_date=datetime(2024, 1, 16, tzinfo=UTC),
             duration=240,
             category_id=sample_category.category_id,
         )
@@ -203,7 +201,7 @@ async def sample_videos_with_filters(
             channel_id=sample_channel.channel_id,
             title="Unclassified Video",
             description="A video with no classification",
-            upload_date=datetime(2024, 1, 17, tzinfo=timezone.utc),
+            upload_date=datetime(2024, 1, 17, tzinfo=UTC),
             duration=180,
         )
         test_data_session.add(video3)
@@ -251,7 +249,7 @@ class TestTagFilter:
     async def test_single_tag_filter_returns_matching_videos(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that single tag filter returns only videos with that tag."""
@@ -268,7 +266,7 @@ class TestTagFilter:
     async def test_multiple_tags_or_logic(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that multiple tags use OR logic (T023)."""
@@ -285,7 +283,7 @@ class TestTagFilter:
     async def test_invalid_tag_is_ignored_with_warning(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that non-existent tag is ignored with warning (FR-042, FR-045)."""
@@ -319,14 +317,14 @@ class TestCategoryFilter:
     async def test_category_filter_returns_matching_videos(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         sample_category: VideoCategory,
         cleanup_test_data: None,
     ) -> None:
         """Test that category filter returns only videos in that category."""
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
             mock_oauth.is_authenticated.return_value = True
-            response = await async_client.get(f"/api/v1/videos?category=10")
+            response = await async_client.get("/api/v1/videos?category=10")
             assert response.status_code == 200
             data = response.json()
             video_ids = [v["video_id"] for v in data["data"]]
@@ -339,7 +337,7 @@ class TestCategoryFilter:
     async def test_invalid_category_is_ignored_with_warning(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that non-existent category is ignored with warning (FR-042, FR-045)."""
@@ -362,7 +360,7 @@ class TestTopicFilter:
     async def test_single_topic_filter_returns_matching_videos(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         sample_topic: TopicCategory,
         cleanup_test_data: None,
     ) -> None:
@@ -380,7 +378,7 @@ class TestTopicFilter:
     async def test_invalid_topic_is_ignored_with_warning(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that non-existent topic is ignored with warning (FR-043, FR-045)."""
@@ -412,7 +410,7 @@ class TestCombinedFilters:
     async def test_tag_and_category_combined(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that tag AND category filters use AND logic (FR-020)."""
@@ -430,7 +428,7 @@ class TestCombinedFilters:
     async def test_all_three_filters_combined(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         sample_topic: TopicCategory,
         cleanup_test_data: None,
     ) -> None:
@@ -465,7 +463,7 @@ class TestPaginationWithFilters:
     async def test_pagination_with_tag_filter(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that pagination works correctly with tag filter."""
@@ -483,7 +481,7 @@ class TestPaginationWithFilters:
     async def test_pagination_total_reflects_filtered_results(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that pagination total reflects filtered count, not all videos."""
@@ -507,7 +505,7 @@ class TestPartialSuccessResponse:
     async def test_partial_success_with_invalid_tag(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test partial success when one tag is invalid (FR-049)."""
@@ -531,7 +529,7 @@ class TestPartialSuccessResponse:
     async def test_response_without_warnings_when_all_valid(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test response has no warnings when all filters are valid."""
@@ -551,7 +549,7 @@ class TestEmptyResults:
     async def test_filters_with_no_matches_returns_empty_list(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that filters with no matches return empty list with valid pagination."""
@@ -569,7 +567,7 @@ class TestEmptyResults:
     async def test_all_filters_invalid_returns_all_videos(
         self,
         async_client: AsyncClient,
-        sample_videos_with_filters: List[Video],
+        sample_videos_with_filters: list[Video],
         cleanup_test_data: None,
     ) -> None:
         """Test that when all filter values are invalid, all videos are returned."""
@@ -753,7 +751,7 @@ class TestCanonicalTagFilter:
                     channel_id=_CT_CHANNEL_ID,
                     title=f"Canonical Tag Test Video {idx}",
                     description=f"Test video {idx} for canonical tag filter",
-                    upload_date=datetime(2024, 3, idx, tzinfo=timezone.utc),
+                    upload_date=datetime(2024, 3, idx, tzinfo=UTC),
                     duration=200 + idx * 10,
                 )
                 session.add(v)

--- a/tests/integration/api/test_videos_integration.py
+++ b/tests/integration/api/test_videos_integration.py
@@ -6,12 +6,13 @@ pagination with sort, and empty liked results against the integration database.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, AsyncGenerator, List
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import (
@@ -25,8 +26,6 @@ from chronovista.db.models import (
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import async_sessionmaker
 
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Fixtures
@@ -35,7 +34,7 @@ pytestmark = pytest.mark.asyncio
 
 @pytest.fixture
 async def sort_test_session(
-    integration_session_factory: "async_sessionmaker[AsyncSession]",
+    integration_session_factory: async_sessionmaker[AsyncSession],
 ) -> AsyncGenerator[AsyncSession, None]:
     """Provide a session for test data setup and cleanup."""
     async with integration_session_factory() as session:
@@ -67,7 +66,7 @@ async def sort_test_channel(sort_test_session: AsyncSession) -> Channel:
 async def sort_test_videos(
     sort_test_session: AsyncSession,
     sort_test_channel: Channel,
-) -> List[Video]:
+) -> list[Video]:
     """Create videos with distinct titles and upload dates for sort testing.
 
     Creates 3 videos:
@@ -76,12 +75,12 @@ async def sort_test_videos(
     - sort_vid_c: title="Charlie Video",  upload_date=2024-02-20
     """
     video_specs = [
-        ("sort_vid__a", "Alpha Video", datetime(2024, 1, 10, tzinfo=timezone.utc)),
-        ("sort_vid__b", "Bravo Video", datetime(2024, 3, 15, tzinfo=timezone.utc)),
-        ("sort_vid__c", "Charlie Video", datetime(2024, 2, 20, tzinfo=timezone.utc)),
+        ("sort_vid__a", "Alpha Video", datetime(2024, 1, 10, tzinfo=UTC)),
+        ("sort_vid__b", "Bravo Video", datetime(2024, 3, 15, tzinfo=UTC)),
+        ("sort_vid__c", "Charlie Video", datetime(2024, 2, 20, tzinfo=UTC)),
     ]
 
-    videos: List[Video] = []
+    videos: list[Video] = []
     for vid_id, title, upload_date in video_specs:
         result = await sort_test_session.execute(
             select(Video).where(Video.video_id == vid_id)
@@ -111,7 +110,7 @@ async def sort_test_videos(
 @pytest.fixture
 async def liked_video_data(
     sort_test_session: AsyncSession,
-    sort_test_videos: List[Video],
+    sort_test_videos: list[Video],
 ) -> None:
     """Mark sort_vid__a as liked via user_videos table."""
     result = await sort_test_session.execute(
@@ -134,7 +133,7 @@ async def liked_video_data(
 @pytest.fixture
 async def transcript_video_data(
     sort_test_session: AsyncSession,
-    sort_test_videos: List[Video],
+    sort_test_videos: list[Video],
 ) -> None:
     """Add a transcript to sort_vid__b."""
     result = await sort_test_session.execute(
@@ -159,7 +158,7 @@ async def transcript_video_data(
 @pytest.fixture
 async def tagged_video_data(
     sort_test_session: AsyncSession,
-    sort_test_videos: List[Video],
+    sort_test_videos: list[Video],
 ) -> None:
     """Add tag 'sort_test_tag' to sort_vid__a and sort_vid__c."""
     for vid_id in ["sort_vid__a", "sort_vid__c"]:
@@ -189,7 +188,7 @@ class TestSortOrdering:
     async def test_sort_by_upload_date_desc(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
     ) -> None:
         """upload_date desc should return newest first."""
         response = await async_client.get(
@@ -210,7 +209,7 @@ class TestSortOrdering:
     async def test_sort_by_upload_date_asc(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
     ) -> None:
         """upload_date asc should return oldest first."""
         response = await async_client.get(
@@ -229,7 +228,7 @@ class TestSortOrdering:
     async def test_sort_by_title_asc(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
     ) -> None:
         """title asc should return alphabetically A-Z."""
         response = await async_client.get(
@@ -248,7 +247,7 @@ class TestSortOrdering:
     async def test_sort_by_title_desc(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
     ) -> None:
         """title desc should return alphabetically Z-A."""
         response = await async_client.get(
@@ -277,7 +276,7 @@ class TestLikedFilter:
     async def test_liked_only_returns_liked_video(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
         liked_video_data: None,
     ) -> None:
         """liked_only=true should include the liked video."""
@@ -293,7 +292,7 @@ class TestLikedFilter:
     async def test_liked_only_excludes_non_liked_videos(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
         liked_video_data: None,
     ) -> None:
         """liked_only=true should exclude non-liked videos."""
@@ -311,7 +310,7 @@ class TestLikedFilter:
     async def test_empty_liked_results(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
     ) -> None:
         """liked_only=true with no liked videos should return empty data."""
         # We don't set up liked_video_data here, so no videos are liked
@@ -335,7 +334,7 @@ class TestCombinedFilterIntersection:
     async def test_liked_and_has_transcript(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
         liked_video_data: None,
         transcript_video_data: None,
     ) -> None:
@@ -355,7 +354,7 @@ class TestCombinedFilterIntersection:
     async def test_liked_and_tag(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
         liked_video_data: None,
         tagged_video_data: None,
     ) -> None:
@@ -385,7 +384,7 @@ class TestPaginationWithSort:
     async def test_pagination_with_sort_returns_200(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
     ) -> None:
         """Pagination + sort params should return 200."""
         response = await async_client.get(
@@ -400,7 +399,7 @@ class TestPaginationWithSort:
     async def test_pagination_offset_with_sort(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
     ) -> None:
         """Second page with sort should skip first page items."""
         response = await async_client.get(
@@ -413,7 +412,7 @@ class TestPaginationWithSort:
     async def test_pagination_has_more_flag(
         self,
         async_client: AsyncClient,
-        sort_test_videos: List[Video],
+        sort_test_videos: list[Video],
     ) -> None:
         """has_more should be true when more results exist beyond the page."""
         response = await async_client.get(

--- a/tests/integration/api/test_videos_unavailable.py
+++ b/tests/integration/api/test_videos_unavailable.py
@@ -7,8 +7,8 @@ return 200 with full metadata, and only truly non-existent video IDs return 404.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -18,8 +18,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel, Video, VideoTranscript
 from chronovista.models.enums import AvailabilityStatus
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
@@ -118,7 +116,7 @@ async def create_test_video(
         channel_id=channel_id,
         title=f"Test Video - {availability_status.value}",
         description=f"Test video for availability status: {availability_status.value}",
-        upload_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+        upload_date=datetime(2024, 1, 15, tzinfo=UTC),
         duration=300,
         availability_status=availability_status.value,
         alternative_url=alternative_url,

--- a/tests/integration/cli/test_entity_commands.py
+++ b/tests/integration/cli/test_entity_commands.py
@@ -20,11 +20,10 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from typer.testing import CliRunner
 
@@ -63,7 +62,7 @@ def _make_mock_entity(
     entity.canonical_name = name
     entity.entity_type = entity_type
     entity.description = description
-    entity.created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    entity.created_at = datetime(2024, 1, 1, tzinfo=UTC)
     entity.status = "active"
     entity.mention_count = 0
     return entity

--- a/tests/integration/cli/test_tag_management_commands.py
+++ b/tests/integration/cli/test_tag_management_commands.py
@@ -20,14 +20,13 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from chronovista.services.tag_management import CollisionGroup
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from typer.testing import CliRunner
 
@@ -705,7 +704,7 @@ def _make_operation_log_mock(
     log = MagicMock()
     log.id = op_id
     log.operation_type = op_type
-    log.performed_at = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    log.performed_at = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
     log.rolled_back = rolled_back
     log.reason = reason
     return log
@@ -1281,7 +1280,7 @@ def _make_collision_group(
     normalized_form: str = "cafe",
     aliases: list[dict[str, Any]] | None = None,
     total_occurrences: int = 10,
-) -> "CollisionGroup":
+) -> CollisionGroup:
     """Build a CollisionGroup-like mock."""
     from chronovista.services.tag_management import CollisionGroup
 

--- a/tests/integration/cli/test_tag_normalize_commands.py
+++ b/tests/integration/cli/test_tag_normalize_commands.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import AsyncGenerator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/tests/integration/cli/test_transcript_commands.py
+++ b/tests/integration/cli/test_transcript_commands.py
@@ -12,7 +12,7 @@ internally via run_sync_operation().
 from __future__ import annotations
 
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,9 +21,15 @@ from typer.testing import CliRunner
 from chronovista.cli.main import app
 from chronovista.db.models import (
     Channel as ChannelDB,
+)
+from chronovista.db.models import (
     TranscriptSegment as TranscriptSegmentDB,
-    VideoTranscript as VideoTranscriptDB,
+)
+from chronovista.db.models import (
     Video as VideoDB,
+)
+from chronovista.db.models import (
+    VideoTranscript as VideoTranscriptDB,
 )
 from chronovista.models.enums import DownloadReason, TranscriptType
 
@@ -44,8 +50,8 @@ def patch_settings_for_integration(monkeypatch: pytest.MonkeyPatch) -> None:
     This fixture patches the effective_database_url property to return the
     integration test database URL.
     """
-    from chronovista.config import settings as settings_module
     from chronovista.config import database as database_module
+    from chronovista.config import settings as settings_module
 
     # Patch the settings object to return the test database URL
     monkeypatch.setattr(
@@ -92,7 +98,7 @@ async def db_with_segments(db_session: AsyncSession) -> AsyncSession:
         channel_id="test_channel",
         title="Test Video",
         description="Test Description",
-        upload_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        upload_date=datetime(2023, 1, 1, tzinfo=UTC),
         duration=300,  # 5 minutes
         made_for_kids=False,
         self_declared_made_for_kids=False,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ Provides database session fixtures for migration and integration testing.
 from __future__ import annotations
 
 import os
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine

--- a/tests/integration/db/test_gin_trigram_indexes.py
+++ b/tests/integration/db/test_gin_trigram_indexes.py
@@ -50,8 +50,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 # ---------------------------------------------------------------------------
 # Module-level marker: ensures all async tests work correctly with coverage.
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------

--- a/tests/integration/db/test_migration_availability_status.py
+++ b/tests/integration/db/test_migration_availability_status.py
@@ -18,18 +18,15 @@ Related: Feature 023 (Deleted Content Visibility), Task T013
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
-import pytest
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from chronovista.db.models import Base, Channel, Playlist, Video
+from chronovista.db.models import Channel, Playlist, Video
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 def get_column_names(model: type[Any]) -> list[str]:
     """
@@ -165,7 +162,7 @@ class TestSchemaIntegration:
             channel_id="UC_test_channel_001",
             title="Test Video",
             description="Test",
-            upload_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2024, 1, 1, tzinfo=UTC),
             duration=300,
             availability_status="available",
         )
@@ -196,7 +193,7 @@ class TestSchemaIntegration:
             channel_id="UC_test_channel_002",
             title="Unavailable Video",
             description="Test",
-            upload_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2024, 1, 1, tzinfo=UTC),
             duration=300,
             availability_status="unavailable",
         )

--- a/tests/integration/db/test_tag_normalization_schema.py
+++ b/tests/integration/db/test_tag_normalization_schema.py
@@ -22,7 +22,6 @@ Migration: 028a_add_tag_normalization_tables (f9b5c8d6e3a1)
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, cast
 
 import pytest
@@ -37,15 +36,11 @@ from chronovista.db.models import (
     NamedEntity,
     TagAlias,
     TagOperationLog,
-    Video,
-    VideoTag,
 )
 
 # CRITICAL: This line ensures async tests work with coverage
 # Note: This applies to ALL tests in the module, including sync tests
 # For sync tests, we explicitly mark them with @pytest.mark.asyncio(False)
-pytestmark = pytest.mark.asyncio
-
 
 def get_table_names_sync(connection: Any) -> list[str]:
     """

--- a/tests/integration/enrichment/test_enrichment_validation.py
+++ b/tests/integration/enrichment/test_enrichment_validation.py
@@ -16,7 +16,7 @@ all documented success criteria are met.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -49,12 +49,10 @@ from chronovista.services.enrichment.enrichment_service import (
 )
 from chronovista.services.enrichment.seeders import (
     CategorySeeder,
+    CategorySeedResult,
     TopicSeeder,
     TopicSeedResult,
-    CategorySeedResult,
 )
-
-pytestmark = pytest.mark.asyncio
 
 runner = CliRunner()
 
@@ -171,9 +169,9 @@ class TestT100EndToEndWorkflowValidation:
         # call the service with actual operations when dry_run=True
 
         mock_repo = AsyncMock()
-        mock_session = AsyncMock()
+        AsyncMock()
 
-        seeder = TopicSeeder(topic_repository=mock_repo)
+        TopicSeeder(topic_repository=mock_repo)
 
         # In dry-run mode, the CLI shows preview without calling seed
         # This test verifies TopicSeeder dry-run class methods work
@@ -473,7 +471,7 @@ class TestT102SuccessCriteriaSC013TopicSeeding:
 
     def test_child_topics_have_valid_parents(self) -> None:
         """Test that all child topics reference valid parent IDs."""
-        for topic_id, (name, parent_id, _) in TopicSeeder.YOUTUBE_TOPICS.items():
+        for _topic_id, (_name, parent_id, _) in TopicSeeder.YOUTUBE_TOPICS.items():
             if parent_id is not None:
                 # Parent must exist in the topics dict
                 assert parent_id in TopicSeeder.YOUTUBE_TOPICS
@@ -540,7 +538,7 @@ class TestT105FinalIntegrationFlow:
 
     def test_enrichment_report_model_validation(self) -> None:
         """Test that EnrichmentReport model validates correctly."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
 
         summary = EnrichmentSummary(
             videos_processed=100,
@@ -593,7 +591,7 @@ class TestT105FinalIntegrationFlow:
 
     def test_enrichment_report_json_serialization(self, tmp_path: Path) -> None:
         """Test that EnrichmentReport serializes to JSON correctly."""
-        timestamp = datetime(2025, 1, 15, 10, 30, 45, tzinfo=timezone.utc)
+        timestamp = datetime(2025, 1, 15, 10, 30, 45, tzinfo=UTC)
 
         summary = EnrichmentSummary(
             videos_processed=50,

--- a/tests/integration/services/test_batch_correction_integration.py
+++ b/tests/integration/services/test_batch_correction_integration.py
@@ -23,11 +23,9 @@ Feature 045 — Correction Intelligence Pipeline
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta, timezone
-from typing import Any
+from datetime import UTC, datetime, timedelta
 
-import pytest
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
@@ -37,6 +35,8 @@ from chronovista.models.enums import CorrectionType
 from scripts.utilities.backfill_batch_ids import (
     assign_batch_id,
     fetch_unassigned_corrections,
+)
+from scripts.utilities.backfill_batch_ids import (
     identify_batches_by_text as identify_batches,
 )
 
@@ -44,8 +44,6 @@ from scripts.utilities.backfill_batch_ids import (
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
 # with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # DB seed helpers
@@ -73,7 +71,7 @@ async def _seed_video(
     video = VideoDB(
         video_id=video_id,
         title="Backfill Integration Test Video",
-        upload_date=datetime(2020, 6, 1, tzinfo=timezone.utc),
+        upload_date=datetime(2020, 6, 1, tzinfo=UTC),
         duration=600,
     )
     session.add(video)
@@ -162,7 +160,7 @@ async def _seed_correction(
         The persisted TranscriptCorrection ORM instance.
     """
     if corrected_at is None:
-        corrected_at = datetime(2024, 3, 1, 12, 0, 0, tzinfo=timezone.utc)
+        corrected_at = datetime(2024, 3, 1, 12, 0, 0, tzinfo=UTC)
 
     correction = TranscriptCorrectionDB(
         video_id=video_id,
@@ -193,7 +191,7 @@ def _ts(seconds_offset: float) -> datetime:
     datetime
         Anchor time plus the given offset.
     """
-    base = datetime(2024, 3, 1, 12, 0, 0, tzinfo=timezone.utc)
+    base = datetime(2024, 3, 1, 12, 0, 0, tzinfo=UTC)
     return base + timedelta(seconds=seconds_offset)
 
 

--- a/tests/integration/services/test_cross_segment_corrections.py
+++ b/tests/integration/services/test_cross_segment_corrections.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import (
@@ -68,8 +67,6 @@ DEFAULT_CHANNEL_ID: str = channel_id(seed="cross_seg_test")
 
 # CRITICAL: This line ensures async tests work with coverage tools,
 # avoiding silent test-skipping when pytest-cov is used (see CLAUDE.md).
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Seed helpers

--- a/tests/integration/services/test_entity_mention_scan_integration.py
+++ b/tests/integration/services/test_entity_mention_scan_integration.py
@@ -28,17 +28,28 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import (
     Channel as ChannelDB,
+)
+from chronovista.db.models import (
     EntityAlias as EntityAliasDB,
+)
+from chronovista.db.models import (
     EntityMention as EntityMentionDB,
+)
+from chronovista.db.models import (
     NamedEntity as NamedEntityDB,
+)
+from chronovista.db.models import (
     TranscriptSegment as TranscriptSegmentDB,
+)
+from chronovista.db.models import (
     Video as VideoDB,
+)
+from chronovista.db.models import (
     VideoTranscript as VideoTranscriptDB,
 )
 from chronovista.models.enums import DetectionMethod
@@ -53,8 +64,6 @@ DEFAULT_CHANNEL_ID = channel_id(seed="scan_test")
 
 # CRITICAL: This line ensures async tests work with coverage tools,
 # avoiding silent test-skipping (see CLAUDE.md).
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers for test data construction
@@ -376,7 +385,7 @@ class TestIdempotentRerun:
         factory = _make_session_factory_from_session(db_session)
         service = EntityMentionScanService(session_factory=factory)
         # First scan
-        result1 = await service.scan()
+        await service.scan()
         count_after_first = len(
             (await db_session.execute(select(EntityMentionDB))).scalars().all()
         )
@@ -754,7 +763,7 @@ class TestIncrementalScan:
         await db_session.commit()
 
         # Incremental scan — only JavaScript (zero mentions) should be processed
-        result2 = await service.scan(new_entities_only=True)
+        await service.scan(new_entities_only=True)
 
         js_rows = (
             await db_session.execute(

--- a/tests/integration/services/test_tag_backfill_integration.py
+++ b/tests/integration/services/test_tag_backfill_integration.py
@@ -21,28 +21,34 @@ from __future__ import annotations
 
 import io
 from datetime import UTC, datetime
-from typing import cast
 
 import pytest
 from rich.console import Console
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
-from uuid_utils import uuid7
 
 from chronovista.db.models import (
     CanonicalTag as CanonicalTagDB,
+)
+from chronovista.db.models import (
     Channel as ChannelDB,
+)
+from chronovista.db.models import (
     TagAlias as TagAliasDB,
+)
+from chronovista.db.models import (
     TagOperationLog as TagOperationLogDB,
+)
+from chronovista.db.models import (
     Video as VideoDB,
+)
+from chronovista.db.models import (
     VideoTag as VideoTagDB,
 )
 from chronovista.services.tag_backfill import TagBackfillService
 from chronovista.services.tag_normalization import TagNormalizationService
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # Test Fixtures and Helpers

--- a/tests/integration/test_batch_corrections.py
+++ b/tests/integration/test_batch_corrections.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import csv
 import io
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import select
@@ -57,8 +57,6 @@ from chronovista.services.transcript_correction_service import (
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
 # with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # DB seed helpers
@@ -70,7 +68,7 @@ async def _seed_video(session: AsyncSession, video_id: str = "dQw4w9WgXcQ") -> V
     video = VideoDB(
         video_id=video_id,
         title="Integration Test Video",
-        upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        upload_date=datetime(2020, 1, 1, tzinfo=UTC),
         duration=300,
     )
     session.add(video)
@@ -799,7 +797,7 @@ class TestBatchCorrectionIntegration:
             sequence_number=0,
             start_time=0.0,
         )
-        seg_b = await _seed_segment(
+        await _seed_segment(
             db_session,
             video_id=video_id,
             language_code=language_code,

--- a/tests/integration/test_language_download_integration.py
+++ b/tests/integration/test_language_download_integration.py
@@ -15,16 +15,13 @@ Test Coverage:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List, Tuple
-from unittest.mock import MagicMock
+from datetime import UTC, datetime
 
 import pytest
 
 from chronovista.models.enums import LanguageCode, LanguagePreferenceType
 from chronovista.models.user_language_preference import UserLanguagePreference
 from chronovista.services.preference_aware_transcript_filter import (
-    DownloadPlan,
     PreferenceAwareTranscriptFilter,
 )
 
@@ -87,7 +84,7 @@ def create_preference(
         priority=priority,
         auto_download_transcripts=auto_download,
         learning_goal=learning_goal if learning_goal else None,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
 
@@ -235,7 +232,7 @@ class TestPreferenceAwareDownloadFlow:
         the system should provide an empty download list, allowing
         the caller to implement locale-based fallback.
         """
-        prefs: List[UserLanguagePreference] = []  # No preferences
+        prefs: list[UserLanguagePreference] = []  # No preferences
         available = ["en", "es", "fr"]
 
         filter_service = PreferenceAwareTranscriptFilter()
@@ -527,7 +524,7 @@ class TestEdgeCases:
             create_preference("es", "fluent", priority=2),
         ]
 
-        available: List[str] = []
+        available: list[str] = []
 
         filter_service = PreferenceAwareTranscriptFilter()
         plan = filter_service.create_download_plan(available, prefs)

--- a/tests/integration/test_playlist_integration.py
+++ b/tests/integration/test_playlist_integration.py
@@ -16,33 +16,26 @@ database setup, following the project's established testing patterns.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from chronovista.config.database import DatabaseManager
-from chronovista.db.models import Channel as ChannelDB
 from chronovista.db.models import Playlist as PlaylistDB
-from chronovista.models.channel import ChannelCreate
 from chronovista.models.enums import LanguageCode, PrivacyStatus
 from chronovista.models.playlist import PlaylistCreate
-from chronovista.models.takeout.takeout_data import TakeoutData, TakeoutPlaylist
+from chronovista.models.takeout.takeout_data import TakeoutData
 from chronovista.models.youtube_types import (
     create_test_channel_id,
-    create_test_playlist_id,
     is_internal_playlist_id,
     is_youtube_playlist_id,
     validate_playlist_id,
 )
-from chronovista.repositories.channel_repository import ChannelRepository
 from chronovista.repositories.playlist_repository import PlaylistRepository
 from chronovista.services.seeding.playlist_seeder import (
-    PlaylistSeeder,
     generate_internal_playlist_id,
 )
 from tests.factories.takeout_playlist_factory import (
@@ -54,11 +47,9 @@ from tests.factories.takeout_playlist_item_factory import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    pass
 
 # CRITICAL: Module-level marker ensures ALL async tests run with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ============================================================================
 # FIXTURES
@@ -247,16 +238,6 @@ class TestT041CoverageValidation:
         # Verify we can execute a simple query
         result = await mock_session.execute(text("SELECT 1"))
         assert result.scalar() == 1
-
-    async def test_module_level_pytestmark_present(self) -> None:
-        """
-        Verify module has pytestmark = pytest.mark.asyncio.
-
-        This ensures all async tests in the module run with Mode.AUTO,
-        preventing the coverage skipping issue documented in CLAUDE.md.
-        """
-        assert pytestmark is not None
-        assert pytestmark.name == "asyncio"
 
     async def test_integration_test_performance_acceptable(
         self,

--- a/tests/integration/test_segment_migration.py
+++ b/tests/integration/test_segment_migration.py
@@ -7,19 +7,15 @@ These tests validate FR-MIG-01 through FR-MIG-19 requirements for data migration
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict
+from datetime import UTC, datetime
+from typing import Any
 
-import pytest
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
 from chronovista.db.models import Video as VideoDB
 from chronovista.db.models import VideoTranscript as VideoTranscriptDB
-from chronovista.models.youtube_types import VideoId
-
-pytestmark = pytest.mark.asyncio
 
 
 async def create_test_video(
@@ -30,7 +26,7 @@ async def create_test_video(
     video = VideoDB(
         video_id=video_id,
         title="Test Video",
-        upload_date=datetime.now(timezone.utc),
+        upload_date=datetime.now(UTC),
         duration=300,
     )
     session.add(video)
@@ -165,7 +161,7 @@ class TestSegmentMigration:
         await create_test_video(db_session, video_id)
 
         # Create transcript with valid raw_transcript_data
-        raw_data: Dict[str, Any] = {
+        raw_data: dict[str, Any] = {
             "snippets": [
                 {"text": "Hello world", "start": 0.0, "duration": 2.5},
                 {"text": "This is a test", "start": 2.5, "duration": 3.0},
@@ -289,7 +285,7 @@ class TestSegmentMigration:
         await create_test_video(db_session, video_id)
 
         # Create transcript with raw_transcript_data = {"snippets": []}
-        raw_data: Dict[str, Any] = {"snippets": []}
+        raw_data: dict[str, Any] = {"snippets": []}
 
         transcript = VideoTranscriptDB(
             video_id=video_id,
@@ -337,7 +333,7 @@ class TestSegmentMigration:
         await create_test_video(db_session, video_id)
 
         # Create transcript with one valid and one invalid snippet
-        raw_data: Dict[str, Any] = {
+        raw_data: dict[str, Any] = {
             "snippets": [
                 {"text": "Valid segment", "start": 0.0, "duration": 2.0},
                 {"text": "Missing start"},  # Missing start and duration
@@ -397,7 +393,7 @@ class TestSegmentMigration:
         await create_test_video(db_session, video_id)
 
         # Create transcript
-        raw_data: Dict[str, Any] = {
+        raw_data: dict[str, Any] = {
             "snippets": [
                 {"text": "Segment 1", "start": 0.0, "duration": 2.0},
                 {"text": "Segment 2", "start": 2.0, "duration": 2.0},
@@ -464,7 +460,7 @@ class TestSegmentMigration:
         await create_test_video(db_session, video_id)
 
         # Create transcript with raw_transcript_data containing 5 snippets
-        raw_data: Dict[str, Any] = {
+        raw_data: dict[str, Any] = {
             "snippets": [
                 {"text": f"Segment {i}", "start": float(i * 2), "duration": 2.0}
                 for i in range(5)
@@ -515,7 +511,7 @@ class TestSegmentMigration:
         await create_test_video(db_session, video_id)
 
         # Create transcript with snippets as a dict instead of list
-        raw_data: Dict[str, Any] = {"snippets": {"invalid": "not a list"}}
+        raw_data: dict[str, Any] = {"snippets": {"invalid": "not a list"}}
 
         transcript = VideoTranscriptDB(
             video_id=video_id,
@@ -561,7 +557,7 @@ class TestSegmentMigration:
         await create_test_video(db_session, video_id)
 
         # Create transcript with invalid numeric values
-        raw_data: Dict[str, Any] = {
+        raw_data: dict[str, Any] = {
             "snippets": [
                 {"text": "Valid", "start": 0.0, "duration": 2.0},
                 {"text": "Invalid start", "start": "not a number", "duration": 2.0},

--- a/tests/integration/test_transcript_corrections.py
+++ b/tests/integration/test_transcript_corrections.py
@@ -27,7 +27,7 @@ Feature 033 — Transcript Corrections Audit
 from __future__ import annotations
 
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import or_, select
@@ -53,8 +53,6 @@ from chronovista.repositories.video_transcript_repository import (
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
 # with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # DB seed helpers
@@ -66,7 +64,7 @@ async def _seed_video(session: AsyncSession, video_id: str = "dQw4w9WgXcQ") -> V
     video = VideoDB(
         video_id=video_id,
         title="Integration Test Video",
-        upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        upload_date=datetime(2020, 1, 1, tzinfo=UTC),
         duration=300,
     )
     session.add(video)

--- a/tests/integration/test_transcript_sync_preferences.py
+++ b/tests/integration/test_transcript_sync_preferences.py
@@ -18,8 +18,7 @@ Test Coverage:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -97,7 +96,7 @@ def create_preference(
         priority=priority,
         auto_download_transcripts=auto_download,
         learning_goal=learning_goal if learning_goal else None,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
 
@@ -454,7 +453,7 @@ class TestSyncTranscriptsLearningPreferences:
 
         # Execute command
         runner = CliRunner()
-        result = runner.invoke(app, ["sync", "transcripts", "--limit", "1"])
+        runner.invoke(app, ["sync", "transcripts", "--limit", "1"])
 
         # Verify only Italian was downloaded
         assert mock_transcript_service.get_transcript.call_count == 1

--- a/tests/performance/test_topic_hierarchy.py
+++ b/tests/performance/test_topic_hierarchy.py
@@ -10,17 +10,14 @@ from __future__ import annotations
 
 import time
 from collections.abc import AsyncGenerator
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import TopicCategory
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 class TestTopicHierarchyPerformance:
     """Test NFR-002: Topic hierarchy load performance."""
@@ -29,7 +26,7 @@ class TestTopicHierarchyPerformance:
     async def seed_topics(
         self,
         integration_db_session: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Seed database with test topics for performance testing.
 
@@ -45,11 +42,11 @@ class TestTopicHierarchyPerformance:
         List[str]
             List of created topic IDs.
         """
-        topic_ids: List[str] = []
+        topic_ids: list[str] = []
 
         async with integration_db_session() as session:
             # Create root topics (10 categories)
-            root_topics: List[TopicCategory] = []
+            root_topics: list[TopicCategory] = []
             for i in range(10):
                 topic = TopicCategory(
                     topic_id=f"/perf/root_{i}",
@@ -63,7 +60,7 @@ class TestTopicHierarchyPerformance:
                 topic_ids.append(topic.topic_id)
 
             # Create first-level children (10 per root = 100 total)
-            first_level: List[TopicCategory] = []
+            first_level: list[TopicCategory] = []
             for root in root_topics:
                 for j in range(10):
                     topic = TopicCategory(
@@ -99,7 +96,7 @@ class TestTopicHierarchyPerformance:
     async def cleanup_topics(
         self,
         integration_db_session: Any,
-        seed_topics: List[str],
+        seed_topics: list[str],
     ) -> AsyncGenerator[None, None]:
         """
         Clean up seeded topics after test.
@@ -128,7 +125,7 @@ class TestTopicHierarchyPerformance:
     async def test_topic_hierarchy_load_under_500ms(
         self,
         integration_db_session: Any,
-        seed_topics: List[str],
+        seed_topics: list[str],
         cleanup_topics: None,
     ) -> None:
         """
@@ -156,7 +153,7 @@ class TestTopicHierarchyPerformance:
             await session.execute(select(TopicCategory).limit(1))
 
             # Measure query time for full hierarchy load
-            times: List[float] = []
+            times: list[float] = []
             for _ in range(5):  # Run 5 iterations for stability
                 start = time.perf_counter()
 
@@ -189,12 +186,7 @@ class TestTopicHierarchyPerformance:
             )
 
             # Log results for debugging
-            avg = sum(times) / len(times)
-            print(f"\nTopic hierarchy load performance:")
-            print(f"  Topics loaded: {len(rows)}")
-            print(f"  Average: {avg:.1f}ms")
-            print(f"  p95: {p95:.1f}ms")
-            print(f"  Max: {max(times):.1f}ms")
+            sum(times) / len(times)
 
     @pytest.mark.performance
     async def test_topic_hierarchy_query_execution_time(
@@ -228,9 +220,6 @@ class TestTopicHierarchyPerformance:
             elapsed_ms = (time.perf_counter() - start) * 1000
 
             # Log results
-            print(f"\nTopic hierarchy query (existing data):")
-            print(f"  Topics loaded: {len(rows)}")
-            print(f"  Execution time: {elapsed_ms:.1f}ms")
 
             # If we have topics, assert reasonable performance
             if len(rows) > 0:

--- a/tests/performance/test_transcript_query_performance.py
+++ b/tests/performance/test_transcript_query_performance.py
@@ -23,19 +23,17 @@ from __future__ import annotations
 
 import random
 import time
-from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 import pytest_asyncio
 from sqlalchemy import delete, select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Video as VideoDB
 from chronovista.db.models import VideoTranscript as VideoTranscriptDB
 from chronovista.models.enums import (
     DownloadReason,
-    LanguageCode,
     TrackKind,
     TranscriptType,
 )
@@ -85,7 +83,7 @@ class TestTranscriptQueryPerformance:
     @pytest_asyncio.fixture
     async def performance_videos(
         self, integration_db_session
-    ) -> List[VideoDB]:
+    ) -> list[VideoDB]:
         """
         Create parent video records for transcript performance testing.
 
@@ -105,21 +103,19 @@ class TestTranscriptQueryPerformance:
                     select(VideoDB).where(VideoDB.video_id.like("perf_test_%"))
                 )
                 videos = list(result.scalars().all())
-                print(f"\n[SETUP] Using {len(videos)} existing performance test videos")
                 return videos
 
             # Create new videos
             videos = []
             video_count = 1000  # Create 1000 videos
 
-            print(f"\n[SETUP] Creating {video_count} video records for performance testing...")
 
             for i in range(video_count):
                 video = VideoDB(
                     video_id=f"perf_test_{i:05d}",
                     title=f"Performance Test Video {i}",
                     description=f"Test video {i} for performance testing",
-                    upload_date=datetime.now(timezone.utc) - timedelta(days=random.randint(1, 365)),
+                    upload_date=datetime.now(UTC) - timedelta(days=random.randint(1, 365)),
                     duration=random.randint(60, 3600),
                     made_for_kids=False,
                     view_count=random.randint(100, 1000000),
@@ -130,15 +126,13 @@ class TestTranscriptQueryPerformance:
                 # Commit in batches to avoid memory issues
                 if (i + 1) % 100 == 0:
                     await session.commit()
-                    print(f"[SETUP] Created {i + 1}/{video_count} videos...")
 
             await session.commit()
-            print(f"[SETUP] Completed creating {video_count} videos")
             return videos
 
     @pytest_asyncio.fixture
     async def performance_transcripts(
-        self, integration_db_session, performance_videos: List[VideoDB]
+        self, integration_db_session, performance_videos: list[VideoDB]
     ) -> int:
         """
         T042: Create performance test fixtures - generate 10,000 transcript records.
@@ -172,11 +166,9 @@ class TestTranscriptQueryPerformance:
                     .where(VideoDB.video_id.like("perf_test_%"))
                 )
                 count = len(list(count_result.scalars().all()))
-                print(f"\n[T042] Using {count} existing performance test transcripts")
                 return count
 
             # Create new transcripts
-            print(f"\n[T042] Generating {self.TARGET_RECORD_COUNT} transcript records with varied metadata...")
 
             transcripts_created = 0
             batch_size = 500
@@ -203,7 +195,7 @@ class TestTranscriptQueryPerformance:
                     language = self.LANGUAGES[lang_idx]
 
                     # Generate realistic raw_transcript_data for those with timestamps
-                    raw_data: Dict[str, Any] | None = None
+                    raw_data: dict[str, Any] | None = None
                     if has_timestamps and segment_count:
                         snippets = []
                         current_time = 0.0
@@ -224,7 +216,7 @@ class TestTranscriptQueryPerformance:
                             "is_generated": random.choice([True, False]),
                             "is_translatable": True,
                             "source": source,
-                            "retrieved_at": datetime.now(timezone.utc).isoformat(),
+                            "retrieved_at": datetime.now(UTC).isoformat(),
                         }
 
                     transcript = VideoTranscriptDB(
@@ -238,7 +230,7 @@ class TestTranscriptQueryPerformance:
                         is_auto_synced=random.choice([True, False]),
                         track_kind=TrackKind.STANDARD.value,
                         caption_name=f"Caption {language}",
-                        downloaded_at=datetime.now(timezone.utc) - timedelta(days=random.randint(1, 30)),
+                        downloaded_at=datetime.now(UTC) - timedelta(days=random.randint(1, 30)),
                         raw_transcript_data=raw_data,
                         has_timestamps=has_timestamps,
                         segment_count=segment_count,
@@ -254,7 +246,6 @@ class TestTranscriptQueryPerformance:
                         session.add_all(transcripts_batch)
                         await session.commit()
                         transcripts_batch = []
-                        print(f"[T042] Created {transcripts_created}/{self.TARGET_RECORD_COUNT} transcripts...")
 
                 # Break if we've created enough
                 if transcripts_created >= self.TARGET_RECORD_COUNT:
@@ -265,13 +256,6 @@ class TestTranscriptQueryPerformance:
                 session.add_all(transcripts_batch)
                 await session.commit()
 
-            print(f"[T042] Completed creating {transcripts_created} transcripts")
-            print(f"[T042] Performance test data ready:")
-            print(f"  - Sources: {', '.join(self.SOURCES)}")
-            print(f"  - Languages: {', '.join(self.LANGUAGES)}")
-            print(f"  - ~75% with timestamps, ~25% without")
-            print(f"  - Segment counts: 5-500")
-            print(f"  - Durations: 30-7200 seconds")
 
             return transcripts_created
 
@@ -292,7 +276,6 @@ class TestTranscriptQueryPerformance:
         Validates SC-005: Query by timestamp availability <2s for 10,000 transcripts.
         """
         async with integration_db_session() as session:
-            print(f"\n[T043] Testing has_timestamps query with {performance_transcripts} records...")
 
             start_time = time.perf_counter()
 
@@ -304,7 +287,6 @@ class TestTranscriptQueryPerformance:
 
             elapsed = time.perf_counter() - start_time
 
-            print(f"[SC-005] ✓ has_timestamps=True query: {elapsed:.3f}s, {len(results)} results")
 
             assert elapsed < self.PERFORMANCE_THRESHOLD_SECONDS, (
                 f"Query took {elapsed:.3f}s, exceeds {self.PERFORMANCE_THRESHOLD_SECONDS}s threshold (SC-005)"
@@ -323,7 +305,6 @@ class TestTranscriptQueryPerformance:
         Validates SC-003: Query by segment count <2s for 10,000 transcripts.
         """
         async with integration_db_session() as session:
-            print(f"\n[T044] Testing min_segment_count query with {performance_transcripts} records...")
 
             start_time = time.perf_counter()
 
@@ -335,7 +316,6 @@ class TestTranscriptQueryPerformance:
 
             elapsed = time.perf_counter() - start_time
 
-            print(f"[SC-003] ✓ min_segment_count>=100 query: {elapsed:.3f}s, {len(results)} results")
 
             assert elapsed < self.PERFORMANCE_THRESHOLD_SECONDS, (
                 f"Query took {elapsed:.3f}s, exceeds {self.PERFORMANCE_THRESHOLD_SECONDS}s threshold (SC-003)"
@@ -358,7 +338,6 @@ class TestTranscriptQueryPerformance:
         Validates SC-004: Query by duration <2s for 10,000 transcripts.
         """
         async with integration_db_session() as session:
-            print(f"\n[T045] Testing min_duration query with {performance_transcripts} records...")
 
             start_time = time.perf_counter()
 
@@ -370,7 +349,6 @@ class TestTranscriptQueryPerformance:
 
             elapsed = time.perf_counter() - start_time
 
-            print(f"[SC-004] ✓ min_duration>=1800s query: {elapsed:.3f}s, {len(results)} results")
 
             assert elapsed < self.PERFORMANCE_THRESHOLD_SECONDS, (
                 f"Query took {elapsed:.3f}s, exceeds {self.PERFORMANCE_THRESHOLD_SECONDS}s threshold (SC-004)"
@@ -393,7 +371,6 @@ class TestTranscriptQueryPerformance:
         Validates SC-006: Query by source <2s for 10,000 transcripts.
         """
         async with integration_db_session() as session:
-            print(f"\n[T046] Testing source query with {performance_transcripts} records...")
 
             start_time = time.perf_counter()
 
@@ -405,7 +382,6 @@ class TestTranscriptQueryPerformance:
 
             elapsed = time.perf_counter() - start_time
 
-            print(f"[SC-006] ✓ source='youtube_transcript_api' query: {elapsed:.3f}s, {len(results)} results")
 
             assert elapsed < self.PERFORMANCE_THRESHOLD_SECONDS, (
                 f"Query took {elapsed:.3f}s, exceeds {self.PERFORMANCE_THRESHOLD_SECONDS}s threshold (SC-006)"
@@ -428,7 +404,6 @@ class TestTranscriptQueryPerformance:
         This is important for real-world usage where users may combine filters.
         """
         async with integration_db_session() as session:
-            print(f"\n[T047] Testing combined filters query with {performance_transcripts} records...")
 
             start_time = time.perf_counter()
 
@@ -443,8 +418,6 @@ class TestTranscriptQueryPerformance:
 
             elapsed = time.perf_counter() - start_time
 
-            print(f"[T047] ✓ Combined filters query: {elapsed:.3f}s, {len(results)} results")
-            print(f"  Filters: has_timestamps=True AND min_segment_count>=50 AND min_duration>=300s AND source='youtube_transcript_api'")
 
             assert elapsed < self.PERFORMANCE_THRESHOLD_SECONDS, (
                 f"Combined query took {elapsed:.3f}s, exceeds {self.PERFORMANCE_THRESHOLD_SECONDS}s threshold"
@@ -472,12 +445,6 @@ class TestTranscriptQueryPerformance:
         This serves as documentation and allows tracking performance over time.
         """
         async with integration_db_session() as session:
-            print(f"\n{'='*80}")
-            print(f"PERFORMANCE BASELINE RESULTS - Feature 007")
-            print(f"{'='*80}")
-            print(f"Test Dataset: {performance_transcripts} transcripts")
-            print(f"Performance Threshold: {self.PERFORMANCE_THRESHOLD_SECONDS}s")
-            print(f"{'='*80}\n")
 
             baseline_results = []
 
@@ -538,25 +505,12 @@ class TestTranscriptQueryPerformance:
             baseline_results.append(("Combined (4 filters)", elapsed, len(results), "Combined"))
 
             # Print results table
-            print(f"{'Query Filter':<40} {'Time (s)':<12} {'Results':<10} {'SC':<10} {'Status'}")
-            print(f"{'-'*80}")
 
             all_passed = True
-            for query, elapsed, count, sc in baseline_results:
-                status = "✓ PASS" if elapsed < self.PERFORMANCE_THRESHOLD_SECONDS else "✗ FAIL"
+            for _query, elapsed, _count, _sc in baseline_results:
                 if elapsed >= self.PERFORMANCE_THRESHOLD_SECONDS:
                     all_passed = False
-                print(f"{query:<40} {elapsed:>8.3f}s    {count:>6}     {sc:<10} {status}")
 
-            print(f"\n{'='*80}")
-            print(f"SUMMARY")
-            print(f"{'='*80}")
-            print(f"All queries: {'✓ PASSED' if all_passed else '✗ FAILED'}")
-            print(f"Threshold: {self.PERFORMANCE_THRESHOLD_SECONDS}s")
-            print(f"Average time: {sum(r[1] for r in baseline_results) / len(baseline_results):.3f}s")
-            print(f"Fastest query: {min(r[1] for r in baseline_results):.3f}s ({min(baseline_results, key=lambda r: r[1])[0]})")
-            print(f"Slowest query: {max(r[1] for r in baseline_results):.3f}s ({max(baseline_results, key=lambda r: r[1])[0]})")
-            print(f"{'='*80}\n")
 
             # Assert all passed
             assert all_passed, (
@@ -581,7 +535,6 @@ async def cleanup_performance_data(integration_db_session):
 
     # Cleanup after all tests in module complete
     async with integration_db_session() as session:
-        print("\n[CLEANUP] Removing performance test data...")
 
         # Delete all performance test transcripts
         await session.execute(
@@ -596,4 +549,3 @@ async def cleanup_performance_data(integration_db_session):
         )
 
         await session.commit()
-        print("[CLEANUP] Performance test data removed")

--- a/tests/unit/api/routers/test_batch_corrections.py
+++ b/tests/unit/api/routers/test_batch_corrections.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,12 +27,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.api.deps import get_db, require_auth
 from chronovista.api.main import app
-from chronovista.models.batch_correction_models import BatchCorrectionResult, BatchListItem
+from chronovista.models.batch_correction_models import (
+    BatchCorrectionResult,
+    BatchListItem,
+)
 from tests.factories.batch_correction_factory import BatchListItemFactory
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Helpers
@@ -358,11 +359,11 @@ class TestListBatches:
         """Items are returned in the order provided by get_batch_list (most recent first)."""
         older = _make_batch_list_item(
             pattern="old",
-            batch_timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            batch_timestamp=datetime(2024, 1, 1, tzinfo=UTC),
         )
         newer = _make_batch_list_item(
             pattern="new",
-            batch_timestamp=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            batch_timestamp=datetime(2024, 6, 1, tzinfo=UTC),
         )
         # Simulate repository returning newest first
         mock_repo.get_batch_list = AsyncMock(return_value=[newer, older])

--- a/tests/unit/api/routers/test_channels.py
+++ b/tests/unit/api/routers/test_channels.py
@@ -14,19 +14,17 @@ Tests:
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from chronovista.api.main import app
 from chronovista.api.deps import get_db
+from chronovista.api.main import app
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Fixtures
@@ -455,7 +453,7 @@ def _make_video_row(
     row.video_id = video_id
     row.title = title
     row.channel_id = channel_id
-    row.upload_date = upload_date or datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    row.upload_date = upload_date or datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
     row.duration = duration
     row.view_count = view_count
     row.category_id = category_id

--- a/tests/unit/api/routers/test_entity_aliases.py
+++ b/tests/unit/api/routers/test_entity_aliases.py
@@ -21,11 +21,10 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -33,8 +32,6 @@ from chronovista.api.deps import get_db, require_auth
 from chronovista.api.main import app
 
 # CRITICAL: ensures all async tests in this module are picked up by pytest-asyncio
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -111,8 +108,8 @@ def _make_alias_db_row(
     row.alias_name = alias_name
     row.alias_type = alias_type
     row.occurrence_count = occurrence_count
-    row.first_seen_at = datetime(2024, 1, 15, tzinfo=timezone.utc)
-    row.last_seen_at = datetime(2024, 1, 15, tzinfo=timezone.utc)
+    row.first_seen_at = datetime(2024, 1, 15, tzinfo=UTC)
+    row.last_seen_at = datetime(2024, 1, 15, tzinfo=UTC)
     return row
 
 

--- a/tests/unit/api/routers/test_images.py
+++ b/tests/unit/api/routers/test_images.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -23,8 +23,6 @@ from chronovista.services.image_cache import (
 from tests.factories.channel_factory import ChannelTestData
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Fixtures
@@ -34,8 +32,8 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def async_client() -> AsyncGenerator[AsyncClient, None]:
     """Create async test client for FastAPI testing."""
-    from collections.abc import AsyncGenerator
     from sqlalchemy.ext.asyncio import AsyncSession
+
     from chronovista.api.deps import get_db
 
     # Mock database dependency

--- a/tests/unit/api/routers/test_playlists.py
+++ b/tests/unit/api/routers/test_playlists.py
@@ -13,19 +13,16 @@ Tests cover:
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from chronovista.api.main import app
 from chronovista.api.deps import get_db
+from chronovista.api.main import app
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Fixtures
@@ -329,6 +326,6 @@ class TestPlaylistVideoNotFound:
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
             mock_oauth.is_authenticated.return_value = True
             response = await async_client_no_playlist.get(
-                f"/api/v1/playlists/PLnonexistent12345678901/videos"
+                "/api/v1/playlists/PLnonexistent12345678901/videos"
             )
             assert response.status_code == 404

--- a/tests/unit/api/routers/test_settings.py
+++ b/tests/unit/api/routers/test_settings.py
@@ -21,8 +21,6 @@ from chronovista.api.schemas.sync import SyncOperationType
 from chronovista.models.enums import LanguageCode
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Fixtures

--- a/tests/unit/api/routers/test_videos.py
+++ b/tests/unit/api/routers/test_videos.py
@@ -9,8 +9,8 @@ include_unavailable, tag, category, topic_id).
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -21,8 +21,6 @@ from chronovista.api.main import app
 from chronovista.api.routers.videos import VideoSortField
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Fixtures
@@ -40,7 +38,7 @@ def _make_video_row(
     video.video_id = video_id
     video.title = title
     video.channel_id = channel_id
-    video.upload_date = upload_date or datetime(2024, 1, 15, tzinfo=timezone.utc)
+    video.upload_date = upload_date or datetime(2024, 1, 15, tzinfo=UTC)
     video.duration = 300
     video.view_count = 1000
     video.category_id = None

--- a/tests/unit/api/services/test_task_manager.py
+++ b/tests/unit/api/services/test_task_manager.py
@@ -8,7 +8,8 @@ semantics, and query methods (get_task, list_tasks, get_running_task_for_operati
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Callable, Coroutine
+from collections.abc import Callable, Coroutine
+from typing import Any
 
 import pytest
 
@@ -17,8 +18,6 @@ from chronovista.api.services.task_manager import TaskManager
 from chronovista.models.enums import OperationType, TaskStatus
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Helper coroutine factories
 # ---------------------------------------------------------------------------
@@ -520,7 +519,6 @@ class TestProgressCallback:
         self, manager: TaskManager
     ) -> None:
         """Progress values above 100 are clamped to 100.0 by update_progress."""
-        received: list[float] = []
 
         async def _coro(progress_cb: Callable[[float], None]) -> dict[str, Any]:
             progress_cb(150.0)
@@ -545,7 +543,6 @@ class TestProgressCallback:
         """An intermediate progress value is visible on the task between steps."""
         gate_mid = asyncio.Event()
         gate_end = asyncio.Event()
-        saw_progress: list[float] = []
 
         async def _coro(progress_cb: Callable[[float], None]) -> dict[str, Any]:
             progress_cb(42.0)
@@ -790,7 +787,7 @@ class TestListTasks:
         self, manager: TaskManager
     ) -> None:
         """list_tasks returns empty list when the filter matches no tasks."""
-        id_ok = await manager.submit(OperationType.LOAD_DATA, make_noop_coro())
+        await manager.submit(OperationType.LOAD_DATA, make_noop_coro())
         await asyncio.sleep(0)
         await asyncio.sleep(0)
 
@@ -919,7 +916,7 @@ class TestGetRunningTaskForOperation:
         as active.
         """
         gate = asyncio.Event()
-        task_id = await manager.submit(
+        await manager.submit(
             OperationType.LOAD_DATA, make_slow_coro(gate)
         )
         # Do NOT yield — the asyncio.Task hasn't started yet

--- a/tests/unit/api/test_cross_segment_endpoint.py
+++ b/tests/unit/api/test_cross_segment_endpoint.py
@@ -27,8 +27,6 @@ from chronovista.api.main import app
 from chronovista.services.cross_segment_discovery import CrossSegmentCandidate
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Helpers

--- a/tests/unit/api/test_deps.py
+++ b/tests/unit/api/test_deps.py
@@ -1,13 +1,11 @@
 """Unit tests for API dependencies."""
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 class TestGetDb:
     """Tests for get_db dependency."""
@@ -61,7 +59,7 @@ class TestGetDb:
             mock_db.get_session = mock_get_session
 
             with pytest.raises(ConnectionError, match="Database unavailable"):
-                async for session in get_db():
+                async for _session in get_db():
                     pass
 
 

--- a/tests/unit/api/test_diff_analysis_endpoint.py
+++ b/tests/unit/api/test_diff_analysis_endpoint.py
@@ -31,8 +31,6 @@ from chronovista.api.main import app
 from chronovista.models.batch_correction_models import CorrectionPattern
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Helpers

--- a/tests/unit/api/test_entity_creation_endpoints.py
+++ b/tests/unit/api/test_entity_creation_endpoints.py
@@ -54,7 +54,6 @@ from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -63,8 +62,6 @@ from chronovista.api.main import app
 from chronovista.services.tag_management import ClassifyResult
 
 # CRITICAL: ensures all async tests in this module are picked up by pytest-asyncio
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------

--- a/tests/unit/api/test_exception_handlers_rfc7807.py
+++ b/tests/unit/api/test_exception_handlers_rfc7807.py
@@ -11,12 +11,12 @@ the legacy ErrorResponse format. They should PASS after implementing T042-T052.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
-import pytest
 from fastapi import Request
 from fastapi.exceptions import RequestValidationError
-from pydantic import BaseModel, ValidationError as PydanticValidationError
+from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 
 from chronovista.api.exception_handlers import (
     api_error_handler,
@@ -37,8 +37,6 @@ from chronovista.exceptions import (
 )
 
 # Mark all tests as async
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # Test Fixtures and Utilities

--- a/tests/unit/api/test_phonetic_matches_endpoint.py
+++ b/tests/unit/api/test_phonetic_matches_endpoint.py
@@ -29,8 +29,6 @@ from chronovista.api.main import app
 from chronovista.services.phonetic_matcher import PhoneticMatch
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Helpers

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -13,8 +13,9 @@ without a real database connection.
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from datetime import UTC
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -24,8 +25,6 @@ from chronovista.api.deps import get_db, require_auth
 from chronovista.api.main import app
 
 # CRITICAL: ensures async tests work correctly with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Shared fixture: mocked async client
@@ -391,14 +390,14 @@ def _make_video_mock(
     upload_date: Any = None,
 ) -> MagicMock:
     """Build a mock Video ORM object."""
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     video = MagicMock()
     video.video_id = video_id
     video.title = title
     video.availability_status = availability_status
     video.channel_id = "UCtest"
-    video.upload_date = upload_date or datetime(2024, 1, 1, tzinfo=timezone.utc)
+    video.upload_date = upload_date or datetime(2024, 1, 1, tzinfo=UTC)
     return video
 
 
@@ -821,9 +820,9 @@ class TestSearchSegmentsBatchContextFetching:
         """
         client, mock_session = context_client
 
-        from datetime import datetime, timezone
+        from datetime import datetime
 
-        upload = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        upload = datetime(2024, 6, 1, tzinfo=UTC)
         seg1 = _make_segment_mock(seg_id=1, text="first segment", start_time=0.0, end_time=3.0)
         seg2 = _make_segment_mock(seg_id=2, text="second segment", start_time=3.0, end_time=6.0)
         video = _make_video_mock(upload_date=upload)

--- a/tests/unit/api/test_security_headers.py
+++ b/tests/unit/api/test_security_headers.py
@@ -7,8 +7,6 @@ from httpx import ASGITransport, AsyncClient
 
 from chronovista.api.main import app
 
-pytestmark = pytest.mark.asyncio
-
 EXPECTED_HEADERS = {
     "x-content-type-options": "nosniff",
     "x-frame-options": "DENY",

--- a/tests/unit/api/test_transcript_download.py
+++ b/tests/unit/api/test_transcript_download.py
@@ -20,7 +20,7 @@ Scenarios covered:
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -39,8 +39,6 @@ from chronovista.services.transcript_service import (
 
 # CRITICAL: Ensures all async tests work correctly with coverage tools.
 # Without this, pytest-cov may skip async tests entirely.
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -61,7 +59,6 @@ def _make_orm_pref(language_code: str = "en") -> MagicMock:
     with ``from_attributes=True``, so every required field must be
     present as an attribute on the mock.
     """
-    from datetime import timezone as tz
 
     mock = MagicMock()
     mock.user_id = "default"
@@ -70,7 +67,7 @@ def _make_orm_pref(language_code: str = "en") -> MagicMock:
     mock.priority = 1
     mock.auto_download_transcripts = True
     mock.learning_goal = None
-    mock.created_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=tz.utc)
+    mock.created_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
     return mock
 
 
@@ -89,7 +86,7 @@ def _make_db_transcript(
     by _transcript_repo.create_or_update(), so we set them explicitly.
     """
     if downloaded_at is None:
-        downloaded_at = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        downloaded_at = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
 
     mock = MagicMock()
     mock.video_id = video_id

--- a/tests/unit/api/test_video_transcript_summary_corrections.py
+++ b/tests/unit/api/test_video_transcript_summary_corrections.py
@@ -6,8 +6,6 @@ correctly surface whether any transcript segment has user corrections.
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from chronovista.api.routers.videos import build_transcript_summary
 from chronovista.api.schemas.videos import TranscriptSummary
 from chronovista.db.models import VideoTranscript

--- a/tests/unit/auth/test_oauth_service.py
+++ b/tests/unit/auth/test_oauth_service.py
@@ -5,9 +5,9 @@ Comprehensive tests for YouTubeOAuthService.
 from __future__ import annotations
 
 import json
-import tempfile
+from datetime import UTC
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -151,7 +151,6 @@ class TestYouTubeOAuthService:
 
     def test_load_token_success(self, oauth_service):
         """Test successful token loading."""
-        from datetime import datetime
 
         oauth_service.token_file = MagicMock()
         oauth_service.token_file.exists.return_value = True
@@ -252,14 +251,14 @@ class TestYouTubeOAuthService:
 
     def test_get_token_info_with_valid_credentials(self, oauth_service):
         """Test get_token_info with valid credentials."""
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         mock_credentials = MagicMock()
         mock_credentials.valid = True
         mock_credentials.expired = False
         mock_credentials.refresh_token = "refresh_token"
         mock_credentials.scopes = ["scope1", "scope2"]
-        mock_credentials.expiry = datetime.now(timezone.utc)
+        mock_credentials.expiry = datetime.now(UTC)
 
         oauth_service.token_file = MagicMock()
         oauth_service.token_file.exists.return_value = True
@@ -646,14 +645,14 @@ class TestYouTubeOAuthServiceInteractive:
 
     def test_get_token_info_authenticated(self, oauth_service):
         """Test get_token_info when authenticated."""
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         mock_credentials = MagicMock()
         mock_credentials.valid = True
         mock_credentials.expired = False
         mock_credentials.refresh_token = "refresh_token"
         mock_credentials.scopes = ["scope1", "scope2"]
-        mock_credentials.expiry = datetime.now(timezone.utc)
+        mock_credentials.expiry = datetime.now(UTC)
 
         oauth_service.token_file = MagicMock()
         oauth_service.token_file.exists.return_value = True

--- a/tests/unit/cli/commands/test_cache.py
+++ b/tests/unit/cli/commands/test_cache.py
@@ -8,8 +8,7 @@ parameters, exit codes, and error handling.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from pathlib import Path
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -17,7 +16,6 @@ import typer
 from typer.testing import CliRunner
 
 from chronovista.cli.commands import cache as cache_module
-from chronovista.models.enums import ImageQuality
 from chronovista.services.image_cache import CacheStats, WarmResult
 
 # Create test apps that wrap each command
@@ -96,12 +94,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, ["--dry-run"])
+            result = runner.invoke(test_warm_app, ["--dry-run"])
 
         assert result.exit_code == 0
         output = result.output if result.output else result.stdout
@@ -127,12 +124,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [ "--type", "channels"])
+            result = runner.invoke(test_warm_app, [ "--type", "channels"])
 
         assert result.exit_code == 0
 
@@ -151,12 +147,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [ "--type", "videos"])
+            result = runner.invoke(test_warm_app, [ "--type", "videos"])
 
         assert result.exit_code == 0
 
@@ -175,12 +170,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [ "--type", "all"])
+            result = runner.invoke(test_warm_app, [ "--type", "all"])
 
         assert result.exit_code == 0
 
@@ -199,12 +193,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [ "--limit", "5"])
+            result = runner.invoke(test_warm_app, [ "--limit", "5"])
 
         assert result.exit_code == 0
 
@@ -226,12 +219,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [ "--delay", "1.0"])
+            result = runner.invoke(test_warm_app, [ "--delay", "1.0"])
 
         assert result.exit_code == 0
 
@@ -300,12 +292,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service_with_failures,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [])
+            result = runner.invoke(test_warm_app, [])
 
         assert result.exit_code == 1
 
@@ -320,12 +311,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [])
+            result = runner.invoke(test_warm_app, [])
 
         assert result.exit_code == 0
 
@@ -369,12 +359,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service_with_no_urls,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [ "--type", "channels"])
+            result = runner.invoke(test_warm_app, [ "--type", "channels"])
 
         assert result.exit_code == 0
         # The summary table should include the No URL column with value 10
@@ -392,12 +381,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [ "--type", "videos"])
+            result = runner.invoke(test_warm_app, [ "--type", "videos"])
 
         assert result.exit_code == 0
 
@@ -416,14 +404,13 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(
-                    test_warm_app, ["--type", "videos", "--quality", "hqdefault"]
-                )
+            result = runner.invoke(
+                test_warm_app, ["--type", "videos", "--quality", "hqdefault"]
+            )
 
         assert result.exit_code == 0
 
@@ -442,12 +429,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [])
+            result = runner.invoke(test_warm_app, [])
 
         assert result.exit_code == 0
 
@@ -466,12 +452,11 @@ class TestCacheWarmCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=mock_image_cache_service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_warm_app, [])
+            result = runner.invoke(test_warm_app, [])
 
         assert result.exit_code == 0
 
@@ -503,8 +488,8 @@ class TestCacheStatusCommand:
                 video_count=2500,
                 video_missing_count=12,
                 total_size_bytes=500_000_000,  # 500 MB
-                oldest_file=datetime(2023, 1, 15, tzinfo=timezone.utc),
-                newest_file=datetime(2024, 12, 20, tzinfo=timezone.utc),
+                oldest_file=datetime(2023, 1, 15, tzinfo=UTC),
+                newest_file=datetime(2024, 12, 20, tzinfo=UTC),
             )
 
         service.get_stats = AsyncMock(side_effect=mock_get_stats)
@@ -534,8 +519,8 @@ class TestCacheStatusCommand:
                 video_count=1000,
                 video_missing_count=25,
                 total_size_bytes=100_000_000,
-                oldest_file=datetime(2023, 6, 1, tzinfo=timezone.utc),
-                newest_file=datetime(2024, 11, 30, tzinfo=timezone.utc),
+                oldest_file=datetime(2023, 6, 1, tzinfo=UTC),
+                newest_file=datetime(2024, 11, 30, tzinfo=UTC),
             )
 
         service.get_stats = AsyncMock(side_effect=mock_get_stats)
@@ -564,8 +549,8 @@ class TestCacheStatusCommand:
                 video_count=500,
                 video_missing_count=3,
                 total_size_bytes=50_000_000,
-                oldest_file=datetime(2023, 3, 10, tzinfo=timezone.utc),
-                newest_file=datetime(2024, 10, 15, tzinfo=timezone.utc),
+                oldest_file=datetime(2023, 3, 10, tzinfo=UTC),
+                newest_file=datetime(2024, 10, 15, tzinfo=UTC),
             )
 
         service.get_stats = AsyncMock(side_effect=mock_get_stats)
@@ -593,8 +578,8 @@ class TestCacheStatusCommand:
                 video_count=800,
                 video_missing_count=5,
                 total_size_bytes=75_000_000,
-                oldest_file=datetime(2023, 1, 1, tzinfo=timezone.utc),
-                newest_file=datetime(2024, 12, 31, tzinfo=timezone.utc),
+                oldest_file=datetime(2023, 1, 1, tzinfo=UTC),
+                newest_file=datetime(2024, 12, 31, tzinfo=UTC),
             )
 
         service.get_stats = AsyncMock(side_effect=mock_get_stats)
@@ -623,8 +608,8 @@ class TestCacheStatusCommand:
                 video_count=100,
                 video_missing_count=0,
                 total_size_bytes=10_000_000,
-                oldest_file=datetime(2024, 1, 1, tzinfo=timezone.utc),
-                newest_file=datetime(2024, 12, 1, tzinfo=timezone.utc),
+                oldest_file=datetime(2024, 1, 1, tzinfo=UTC),
+                newest_file=datetime(2024, 12, 1, tzinfo=UTC),
             )
 
         service.get_stats = AsyncMock(side_effect=mock_get_stats)
@@ -698,12 +683,11 @@ class TestCachePurgeCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_purge_app, ["--force"])
+            result = runner.invoke(test_purge_app, ["--force"])
 
         assert result.exit_code == 0
         output = result.output if result.output else result.stdout
@@ -734,12 +718,11 @@ class TestCachePurgeCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_purge_app, ["--force"])
+            result = runner.invoke(test_purge_app, ["--force"])
 
         assert result.exit_code == 0
 
@@ -768,14 +751,13 @@ class TestCachePurgeCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(
-                    test_purge_app, ["--type", "channels", "--force"]
-                )
+            result = runner.invoke(
+                test_purge_app, ["--type", "channels", "--force"]
+            )
 
         assert result.exit_code == 0
 
@@ -804,12 +786,11 @@ class TestCachePurgeCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_purge_app, ["--type", "videos", "--force"])
+            result = runner.invoke(test_purge_app, ["--type", "videos", "--force"])
 
         assert result.exit_code == 0
 
@@ -846,12 +827,11 @@ class TestCachePurgeCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_purge_app, ["--force"])
+            result = runner.invoke(test_purge_app, ["--force"])
 
         assert result.exit_code == 0
         output = result.output if result.output else result.stdout
@@ -880,13 +860,12 @@ class TestCachePurgeCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                # Simulate user typing "y" at the confirmation prompt
-                result = runner.invoke(test_purge_app, [], input="y\n")
+            # Simulate user typing "y" at the confirmation prompt
+            result = runner.invoke(test_purge_app, [], input="y\n")
 
         assert result.exit_code == 0
         # Verify purge was actually called
@@ -913,13 +892,12 @@ class TestCachePurgeCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                # Simulate user typing "n" at the confirmation prompt
-                result = runner.invoke(test_purge_app, [], input="n\n")
+            # Simulate user typing "n" at the confirmation prompt
+            result = runner.invoke(test_purge_app, [], input="n\n")
 
         assert result.exit_code == 1
         output = result.output if result.output else result.stdout
@@ -948,12 +926,11 @@ class TestCachePurgeCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_purge_app, ["--force"])
+            result = runner.invoke(test_purge_app, ["--force"])
 
         assert result.exit_code == 0
         output = result.output if result.output else result.stdout
@@ -986,11 +963,10 @@ class TestCachePurgeCommand:
         with patch(
             "chronovista.cli.commands.cache._build_cache_service",
             return_value=service,
+        ), patch(
+            "chronovista.cli.commands.cache.db_manager.get_session",
+            side_effect=mock_get_session,
         ):
-            with patch(
-                "chronovista.cli.commands.cache.db_manager.get_session",
-                side_effect=mock_get_session,
-            ):
-                result = runner.invoke(test_purge_app, ["--force"])
+            result = runner.invoke(test_purge_app, ["--force"])
 
         assert result.exit_code == 0

--- a/tests/unit/cli/commands/test_takeout.py
+++ b/tests/unit/cli/commands/test_takeout.py
@@ -4,21 +4,17 @@ Tests for Takeout CLI Commands.
 Comprehensive test coverage for CLI commands that explore and analyze Google Takeout data.
 """
 
-import asyncio
 import csv
 import json
 import shutil
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 # Mark all async tests in this module
-pytestmark = pytest.mark.asyncio
-
 from chronovista.cli.commands.takeout import (
     _analyze_channel_clusters,
     _analyze_playlist_overlap,
@@ -39,20 +35,9 @@ from chronovista.cli.commands.takeout import (
     _peek_subscriptions,
     _peek_watch_history,
     _show_detailed_playlist,
-    console,
 )
 from chronovista.models.takeout import (
-    ChannelSummary,
-    ContentGap,
-    DateRange,
-    PlaylistAnalysis,
     TakeoutAnalysis,
-    TakeoutData,
-    TakeoutPlaylist,
-    TakeoutPlaylistItem,
-    TakeoutSubscription,
-    TakeoutWatchEntry,
-    ViewingPatterns,
 )
 from chronovista.services.takeout_service import TakeoutService
 from tests.factories.takeout_data_factory import create_takeout_data
@@ -99,7 +84,7 @@ def sample_takeout_data():
         title="Test Video 1",
         title_url="https://www.youtube.com/watch?v=test_video_1",
         channel_name="Test Channel",
-        watched_at=datetime(2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc),
+        watched_at=datetime(2023, 1, 15, 14, 30, 0, tzinfo=UTC),
     )
 
     watch_entry_2 = create_takeout_watch_entry(
@@ -107,12 +92,12 @@ def sample_takeout_data():
         title="Test Video 2",
         title_url="https://www.youtube.com/watch?v=test_video_2",
         channel_name="Another Channel",
-        watched_at=datetime(2023, 1, 16, 15, 45, 0, tzinfo=timezone.utc),
+        watched_at=datetime(2023, 1, 16, 15, 45, 0, tzinfo=UTC),
     )
 
     playlist_item = create_takeout_playlist_item(
         video_id="test_video_1",
-        creation_timestamp=datetime(2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc),
+        creation_timestamp=datetime(2023, 1, 15, 14, 30, 0, tzinfo=UTC),
     )
 
     playlist = create_takeout_playlist(
@@ -329,14 +314,14 @@ class TestPeekWatchHistory:
                 title="Video 1",
                 title_url="https://www.youtube.com/watch?v=video1",
                 channel_name="Channel 1",
-                watched_at=datetime(2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc),
+                watched_at=datetime(2023, 1, 15, 14, 30, 0, tzinfo=UTC),
             ),
             create_takeout_watch_entry(
                 video_id="video2",
                 title="Video 2",
                 title_url="https://www.youtube.com/watch?v=video2",
                 channel_name="Channel 2",
-                watched_at=datetime(2023, 1, 16, 15, 45, 0, tzinfo=timezone.utc),
+                watched_at=datetime(2023, 1, 16, 15, 45, 0, tzinfo=UTC),
             ),
         ]
         mock_takeout_service.parse_watch_history.return_value = history
@@ -363,14 +348,14 @@ class TestPeekWatchHistory:
                 title="Video 1",
                 title_url="https://www.youtube.com/watch?v=video1",
                 channel_name="Target Channel",
-                watched_at=datetime(2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc),
+                watched_at=datetime(2023, 1, 15, 14, 30, 0, tzinfo=UTC),
             ),
             create_takeout_watch_entry(
                 video_id="video2",
                 title="Video 2",
                 title_url="https://www.youtube.com/watch?v=video2",
                 channel_name="Other Channel",
-                watched_at=datetime(2023, 1, 16, 15, 45, 0, tzinfo=timezone.utc),
+                watched_at=datetime(2023, 1, 16, 15, 45, 0, tzinfo=UTC),
             ),
         ]
         mock_takeout_service.parse_watch_history.return_value = history
@@ -396,13 +381,13 @@ class TestPeekWatchHistory:
                 video_id="old_video",
                 title="Old Video",
                 title_url="https://www.youtube.com/watch?v=old_video",
-                watched_at=datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+                watched_at=datetime(2023, 1, 1, 10, 0, 0, tzinfo=UTC),
             ),
             create_takeout_watch_entry(
                 video_id="new_video",
                 title="New Video",
                 title_url="https://www.youtube.com/watch?v=new_video",
-                watched_at=datetime(2023, 1, 20, 15, 0, 0, tzinfo=timezone.utc),
+                watched_at=datetime(2023, 1, 20, 15, 0, 0, tzinfo=UTC),
             ),
         ]
         mock_takeout_service.parse_watch_history.return_value = history
@@ -522,13 +507,13 @@ class TestShowDetailedPlaylist:
                 create_takeout_playlist_item(
                     video_id="video1",
                     creation_timestamp=datetime(
-                        2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc
+                        2023, 1, 15, 14, 30, 0, tzinfo=UTC
                     ),
                 ),
                 create_takeout_playlist_item(
                     video_id="video2",
                     creation_timestamp=datetime(
-                        2023, 1, 16, 15, 45, 0, tzinfo=timezone.utc
+                        2023, 1, 16, 15, 45, 0, tzinfo=UTC
                     ),
                 ),
             ],

--- a/tests/unit/cli/commands/test_takeout_cli_commands.py
+++ b/tests/unit/cli/commands/test_takeout_cli_commands.py
@@ -11,9 +11,9 @@ These tests focus on the actual CLI command entry points that weren't covered
 in the existing test_takeout.py file.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+from unittest.mock import AsyncMock, mock_open, patch
 
 import pytest
 import typer
@@ -339,8 +339,8 @@ class TestAnalyzeComprehensiveCommand:
             playlist_count=5,
             subscription_count=50,
             date_range=DateRange(
-                start_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
-                end_date=datetime(2023, 12, 31, tzinfo=timezone.utc),
+                start_date=datetime(2022, 1, 1, tzinfo=UTC),
+                end_date=datetime(2023, 12, 31, tzinfo=UTC),
                 total_days=730,
             ),
             data_completeness=0.8,

--- a/tests/unit/cli/sync/test_sync_base.py
+++ b/tests/unit/cli/sync/test_sync_base.py
@@ -6,10 +6,7 @@ Tests SyncResult model and utility functions.
 
 from __future__ import annotations
 
-from typing import FrozenSet
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from chronovista.cli.sync.base import (
     SyncResult,

--- a/tests/unit/cli/sync/test_sync_playlists.py
+++ b/tests/unit/cli/sync/test_sync_playlists.py
@@ -9,8 +9,8 @@ API interactions, database operations, and dry-run mode.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -41,7 +41,7 @@ class TestPlaylistsCommand:
     @pytest.fixture
     def mock_playlist_1(self) -> YouTubePlaylistResponse:
         """Create a mock playlist response."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -68,7 +68,7 @@ class TestPlaylistsCommand:
     @pytest.fixture
     def mock_playlist_2(self) -> YouTubePlaylistResponse:
         """Create another mock playlist response."""
-        published = datetime(2024, 2, 10, 8, 30, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 2, 10, 8, 30, 0, tzinfo=UTC)
         snippet = PlaylistSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,

--- a/tests/unit/cli/sync/test_transformers.py
+++ b/tests/unit/cli/sync/test_transformers.py
@@ -12,7 +12,7 @@ Mypy doesn't understand this, so we ignore call-arg errors in this file.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -169,7 +169,7 @@ class TestExtractChannelCreate:
             title="Test Channel",
             description="A test channel",
             custom_url="@testchannel",
-            published_at=datetime.now(timezone.utc),
+            published_at=datetime.now(UTC),
             thumbnails={
                 "high": Thumbnail(
                     url="https://example.com/thumb.jpg",
@@ -229,7 +229,7 @@ class TestExtractChannelCreate:
         snippet = ChannelSnippet(
             title="Test Channel",
             description="",
-            published_at=datetime.now(timezone.utc),
+            published_at=datetime.now(UTC),
             default_language="invalid_lang",
         )
         channel = YouTubeChannelResponse(
@@ -254,7 +254,7 @@ class TestExtractVideoCreate:
 
     def test_extract_full_video(self) -> None:
         """Test extracting video with all fields."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = VideoSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -320,7 +320,7 @@ class TestExtractVideoCreate:
 
     def test_extract_video_with_channel_override(self) -> None:
         """Test extracting video with channel_id override."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = VideoSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -423,7 +423,7 @@ class TestExtractPlaylistCreate:
 
     def test_extract_playlist_create_valid_response(self) -> None:
         """Test extracting playlist with full valid response."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -481,7 +481,7 @@ class TestExtractPlaylistCreate:
 
     def test_extract_playlist_create_with_language(self) -> None:
         """Test extracting playlist with different language codes."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -503,7 +503,7 @@ class TestExtractPlaylistCreate:
 
     def test_extract_playlist_create_invalid_language_defaults_to_none(self) -> None:
         """Test extracting playlist with invalid language code defaults to None."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -525,7 +525,7 @@ class TestExtractPlaylistCreate:
 
     def test_extract_playlist_create_private_status(self) -> None:
         """Test extracting playlist with private status."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -550,7 +550,7 @@ class TestExtractPlaylistCreate:
 
     def test_extract_playlist_create_unlisted_status(self) -> None:
         """Test extracting playlist with unlisted status."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -575,7 +575,7 @@ class TestExtractPlaylistCreate:
 
     def test_extract_playlist_create_invalid_privacy_defaults_to_private(self) -> None:
         """Test extracting playlist with invalid privacy status defaults to private."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -600,7 +600,7 @@ class TestExtractPlaylistCreate:
 
     def test_extract_playlist_create_no_content_details(self) -> None:
         """Test extracting playlist without content details defaults video_count to 0."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -633,7 +633,7 @@ class TestExtractPlaylistMembershipCreate:
 
     def test_extract_playlist_membership_create_valid(self) -> None:
         """Test extracting playlist membership with valid data."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistItemSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -685,7 +685,7 @@ class TestExtractPlaylistMembershipCreate:
 
     def test_extract_playlist_membership_create_missing_content_details(self) -> None:
         """Test extracting playlist membership without content_details returns None."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistItemSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -713,7 +713,7 @@ class TestExtractPlaylistMembershipCreate:
 
     def test_extract_playlist_membership_create_missing_video_id(self) -> None:
         """Test extracting playlist membership without video_id returns None."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistItemSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,
@@ -745,7 +745,7 @@ class TestExtractPlaylistMembershipCreate:
 
     def test_extract_playlist_membership_create_position_zero(self) -> None:
         """Test extracting playlist membership with position 0 (first item)."""
-        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        published = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
         snippet = PlaylistItemSnippet(
             published_at=published,
             channel_id=self.VALID_CHANNEL_ID,

--- a/tests/unit/cli/test_auth_commands_comprehensive.py
+++ b/tests/unit/cli/test_auth_commands_comprehensive.py
@@ -457,14 +457,13 @@ class TestAuthCommandsEdgeCases:
         # Check that commands are registered using typer's command inspection
         commands = auth_app.registered_commands
         if hasattr(commands, "values"):
-            command_names = [cmd.name for cmd in commands.values()]
+            [cmd.name for cmd in commands.values()]
         else:
             # If it's a list, extract command names differently
-            command_names = [
+            [
                 cmd.name if hasattr(cmd, "name") else str(cmd) for cmd in commands
             ]
 
-        expected_commands = ["login", "logout", "status", "refresh"]
 
         # Check that auth app has expected commands
         assert isinstance(auth_app, object)

--- a/tests/unit/cli/test_category_commands.py
+++ b/tests/unit/cli/test_category_commands.py
@@ -15,10 +15,7 @@ import pytest
 from typer.testing import CliRunner
 
 from chronovista.cli.category_commands import category_app, resolve_category_identifier
-from chronovista.db.models import Video as VideoDB
 from chronovista.db.models import VideoCategory as VideoCategoryDB
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestCategoryCommands:

--- a/tests/unit/cli/test_correction_commands.py
+++ b/tests/unit/cli/test_correction_commands.py
@@ -33,8 +33,6 @@ from chronovista.models.batch_correction_models import (
 from chronovista.models.enums import CorrectionType
 from chronovista.services.cross_segment_discovery import CrossSegmentCandidate
 
-pytestmark = pytest.mark.asyncio
-
 
 class TestFindReplaceCommand:
     """Test suite for the ``corrections find-replace`` CLI command."""
@@ -2296,6 +2294,7 @@ class TestAnalyzeDiffsCommand:
         mock_db.get_session = _mock_session_gen_for_analyze(mock_session)
 
         import uuid
+
         from uuid_utils import uuid7
 
         entity_id = uuid.UUID(bytes=uuid7().bytes)
@@ -2894,7 +2893,7 @@ def _make_cross_segment_candidate(
     confidence: float = 0.75,
     is_partially_corrected: bool = False,
     video_id: str = "dQw4w9WgXcQ",
-) -> "CrossSegmentCandidate":
+) -> CrossSegmentCandidate:
     """Build a ``CrossSegmentCandidate`` Pydantic model for use in CLI tests."""
     from chronovista.services.cross_segment_discovery import CrossSegmentCandidate
 

--- a/tests/unit/cli/test_enrich_commands.py
+++ b/tests/unit/cli/test_enrich_commands.py
@@ -5,18 +5,18 @@ Covers T048c: CLI tests for --priority flag in tests/unit/cli/test_enrich_comman
 Also covers T035f: CLI tests for `chronovista enrich` with flags
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
-import sys
+
+from datetime import UTC
 
 import pytest
 from typer.testing import CliRunner
 
 from chronovista.cli.commands.enrich import (
+    EXIT_CODE_PARTIAL_SUCCESS,
+    EXIT_CODE_SUCCESS,
+    VALID_PRIORITIES,
     app,
     validate_priority,
-    VALID_PRIORITIES,
-    EXIT_CODE_SUCCESS,
-    EXIT_CODE_PARTIAL_SUCCESS,
 )
 
 runner = CliRunner()
@@ -473,10 +473,10 @@ class TestStatusCommandWithMockedDatabase:
 
     def test_status_command_uses_rich_console(self) -> None:
         """Test that status command uses Rich for formatted output."""
-        from chronovista.cli.commands.enrich import console
-
         # Console should be a Rich Console instance
         from rich.console import Console
+
+        from chronovista.cli.commands.enrich import console
         assert isinstance(console, Console)
 
 
@@ -498,7 +498,7 @@ class TestOutputFlagCLI:
         # Check if --output or related option is in help
         # Note: This test documents expected behavior - if --output is not
         # yet implemented, this test will fail and guide implementation
-        output_lower = result.output.lower()
+        result.output.lower()
         # The flag may be named --output, --report, or similar
         has_output_option = (
             "--output" in result.output
@@ -683,7 +683,6 @@ class TestEnrichmentLoggingSetup:
     def test_setup_logging_returns_path(self) -> None:
         """Test that _setup_enrichment_logging returns a Path object."""
         from pathlib import Path
-        import shutil
 
         from chronovista.cli.commands.enrich import _setup_enrichment_logging
 
@@ -705,7 +704,6 @@ class TestEnrichmentLoggingSetup:
     def test_setup_logging_creates_logs_directory(self) -> None:
         """Test that _setup_enrichment_logging creates logs directory if needed."""
         from pathlib import Path
-        import shutil
 
         from chronovista.cli.commands.enrich import _setup_enrichment_logging
 
@@ -713,7 +711,7 @@ class TestEnrichmentLoggingSetup:
 
         # Note: we don't delete logs dir as it may have other log files
         try:
-            log_file = _setup_enrichment_logging("20250115-103046")
+            _setup_enrichment_logging("20250115-103046")
 
             # The logs directory should exist
             assert log_dir.exists()
@@ -725,7 +723,6 @@ class TestEnrichmentLoggingSetup:
 
     def test_setup_logging_creates_log_file(self) -> None:
         """Test that _setup_enrichment_logging creates the log file."""
-        from pathlib import Path
 
         from chronovista.cli.commands.enrich import _setup_enrichment_logging
 
@@ -741,7 +738,6 @@ class TestEnrichmentLoggingSetup:
 
     def test_setup_logging_auto_generates_timestamp_if_none(self) -> None:
         """Test that _setup_enrichment_logging generates timestamp if None."""
-        from pathlib import Path
 
         from chronovista.cli.commands.enrich import _setup_enrichment_logging
 
@@ -1153,7 +1149,6 @@ class TestSyncLikesFlag:
 
         # Verify that the logic is implemented in the actual code
         # by reading the implementation file
-        import inspect
         from pathlib import Path
 
         enrich_file = Path(__file__).parent.parent.parent.parent / "src" / "chronovista" / "cli" / "commands" / "enrich.py"
@@ -1489,8 +1484,6 @@ class TestNoAutoResolveFlag:
         a message should inform the user how many playlists were skipped.
         """
         # Simulate scenario: 5 playlists total, 2 already linked, 3 unlinked
-        total_playlists = 5
-        linked_playlists = 2
         unlinked_playlists = 3
         no_auto_resolve = True
 
@@ -1646,7 +1639,6 @@ class TestSkipUnresolvedFlag:
         - Show count of skipped/unmatched playlists
         - Exit with code 4 (partial success)
         """
-        skip_unresolved = True
         linked = 8
         unmatched = 2
 
@@ -1672,7 +1664,6 @@ class TestSkipUnresolvedFlag:
         - All playlists are linked successfully
         - Exit code is 0 (success)
         """
-        skip_unresolved = True
         unambiguous_count = 10
         ambiguous_count = 0
 
@@ -1692,7 +1683,6 @@ class TestSkipUnresolvedFlag:
         FR-010 specifies Exit Code 4 for partial success with --skip-unresolved.
         """
         skip_unresolved = True
-        linked = 5
         ambiguous = 3
 
         # When ambiguous matches exist and skip_unresolved is True
@@ -1737,7 +1727,6 @@ class TestSkipUnresolvedFlag:
         - --no-auto-resolve takes precedence (no auto-resolution at all)
         - --skip-unresolved has no effect
         """
-        skip_unresolved = True
         no_auto_resolve = True
         include_playlists = True
 
@@ -1754,7 +1743,7 @@ class TestSaveReport:
 
     def test_save_report_creates_file(self) -> None:
         """Test that _save_report creates the output file."""
-        from datetime import datetime, timezone
+        from datetime import datetime
         from pathlib import Path
 
         from chronovista.cli.commands.enrich import _save_report
@@ -1765,7 +1754,7 @@ class TestSaveReport:
         )
 
         report = EnrichmentReport(
-            timestamp=datetime(2025, 1, 15, 10, 30, 45, tzinfo=timezone.utc),
+            timestamp=datetime(2025, 1, 15, 10, 30, 45, tzinfo=UTC),
             priority="high",
             summary=EnrichmentSummary(
                 videos_processed=5,
@@ -1808,9 +1797,9 @@ class TestSaveReport:
 
     def test_save_report_creates_parent_directories(self) -> None:
         """Test that _save_report creates parent directories if needed."""
-        from datetime import datetime, timezone
-        from pathlib import Path
         import shutil
+        from datetime import datetime
+        from pathlib import Path
 
         from chronovista.cli.commands.enrich import _save_report
         from chronovista.models.enrichment_report import (
@@ -1819,7 +1808,7 @@ class TestSaveReport:
         )
 
         report = EnrichmentReport(
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(UTC),
             priority="medium",
             summary=EnrichmentSummary(
                 videos_processed=0,
@@ -1850,9 +1839,9 @@ class TestSaveReport:
 
     def test_save_report_serializes_datetime_as_iso8601(self) -> None:
         """Test that _save_report serializes datetime in ISO 8601 format."""
-        from datetime import datetime, timezone
-        from pathlib import Path
         import json
+        from datetime import datetime
+        from pathlib import Path
 
         from chronovista.cli.commands.enrich import _save_report
         from chronovista.models.enrichment_report import (
@@ -1861,7 +1850,7 @@ class TestSaveReport:
         )
 
         report = EnrichmentReport(
-            timestamp=datetime(2025, 1, 15, 10, 30, 45, tzinfo=timezone.utc),
+            timestamp=datetime(2025, 1, 15, 10, 30, 45, tzinfo=UTC),
             priority="low",
             summary=EnrichmentSummary(
                 videos_processed=0,
@@ -1895,9 +1884,9 @@ class TestSaveReport:
 
     def test_save_report_includes_error_messages(self) -> None:
         """Test that _save_report includes error messages in details (T060)."""
-        from datetime import datetime, timezone
-        from pathlib import Path
         import json
+        from datetime import datetime
+        from pathlib import Path
 
         from chronovista.cli.commands.enrich import _save_report
         from chronovista.models.enrichment_report import (
@@ -1907,7 +1896,7 @@ class TestSaveReport:
         )
 
         report = EnrichmentReport(
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(UTC),
             priority="high",
             summary=EnrichmentSummary(
                 videos_processed=2,

--- a/tests/unit/cli/test_enrich_commands_container.py
+++ b/tests/unit/cli/test_enrich_commands_container.py
@@ -11,7 +11,7 @@ Coverage targets:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -38,7 +38,7 @@ def runner() -> CliRunner:
 def mock_enrichment_report() -> EnrichmentReport:
     """Create a mock enrichment report."""
     return EnrichmentReport(
-        timestamp=datetime(2025, 1, 22, 10, 30, 45, tzinfo=timezone.utc),
+        timestamp=datetime(2025, 1, 22, 10, 30, 45, tzinfo=UTC),
         priority="high",
         summary=EnrichmentSummary(
             videos_processed=10,
@@ -140,7 +140,7 @@ class TestEnrichRunCommandContainerIntegration:
         )
 
         # Execute command
-        result = runner.invoke(app, ["run", "--dry-run"])
+        runner.invoke(app, ["run", "--dry-run"])
 
         # Verify container method was called
         mock_container.create_enrichment_service.assert_called_once()
@@ -193,7 +193,7 @@ class TestEnrichRunCommandContainerIntegration:
         mock_enrichment_service.enrich_playlists = AsyncMock(return_value=(5, 4, 1))
 
         # Execute command with include-playlists
-        result = runner.invoke(app, ["run", "--include-playlists", "--dry-run"])
+        runner.invoke(app, ["run", "--include-playlists", "--dry-run"])
 
         # Verify container was called with include_playlists=True
         mock_container.create_enrichment_service.assert_called_once_with(
@@ -247,7 +247,7 @@ class TestEnrichRunCommandContainerIntegration:
         )
 
         # Execute command without include-playlists
-        result = runner.invoke(app, ["run", "--dry-run"])
+        runner.invoke(app, ["run", "--dry-run"])
 
         # Verify container was called with include_playlists=False
         mock_container.create_enrichment_service.assert_called_once_with(
@@ -307,7 +307,6 @@ class TestEnrichStatusCommandContainerIntegration:
         mock_enrichment_service.get_status = AsyncMock()
         # Create an EnrichmentStatus object from the dict
         from chronovista.services.enrichment.enrichment_service import (
-            EnrichmentStatus,
             PriorityTierEstimate,
         )
 
@@ -381,8 +380,8 @@ class TestEnrichChannelsCommandContainerIntegration:
         )
 
         mock_result = ChannelEnrichmentResult(
-            started_at=datetime.now(timezone.utc),
-            completed_at=datetime.now(timezone.utc),
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
             channels_processed=20,
             channels_enriched=18,
             channels_skipped=2,
@@ -393,7 +392,7 @@ class TestEnrichChannelsCommandContainerIntegration:
         mock_enrichment_service.enrich_channels = AsyncMock(return_value=mock_result)
 
         # Execute command
-        result = runner.invoke(app, ["channels", "--dry-run"])
+        runner.invoke(app, ["channels", "--dry-run"])
 
         # Verify container method was called
         mock_container.create_enrichment_service.assert_called_once()
@@ -489,7 +488,7 @@ class TestAutoSeedFlagContainerIntegration:
         )
 
         # Execute command with auto-seed
-        result = runner.invoke(app, ["run", "--auto-seed", "--dry-run"])
+        runner.invoke(app, ["run", "--auto-seed", "--dry-run"])
 
         # Verify topic seeder was created
         mock_container.create_topic_seeder.assert_called_once()
@@ -560,7 +559,7 @@ class TestAutoSeedFlagContainerIntegration:
         )
 
         # Execute command with auto-seed
-        result = runner.invoke(app, ["run", "--auto-seed", "--dry-run"])
+        runner.invoke(app, ["run", "--auto-seed", "--dry-run"])
 
         # Verify category seeder was created
         mock_container.create_category_seeder.assert_called_once()
@@ -629,7 +628,7 @@ class TestSyncLikesFlagContainerIntegration:
             snippet=ChannelSnippet(
                 title="Test Channel",
                 description="",
-                publishedAt=datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                publishedAt=datetime(2020, 1, 1, 0, 0, 0, tzinfo=UTC),
             ),
         )
         mock_video = YouTubeVideoResponse(
@@ -639,7 +638,7 @@ class TestSyncLikesFlagContainerIntegration:
                 description="",
                 channelId="UC1234567890123456789012",
                 channelTitle="Test Channel",
-                publishedAt=datetime(2022, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                publishedAt=datetime(2022, 1, 1, 0, 0, 0, tzinfo=UTC),
             ),
         )
 
@@ -648,7 +647,7 @@ class TestSyncLikesFlagContainerIntegration:
 
         # Execute command with sync-likes (but dry-run to avoid actual DB operations)
         # Note: sync-likes is skipped in dry-run mode
-        result = runner.invoke(app, ["run", "--sync-likes", "--limit", "1"])
+        runner.invoke(app, ["run", "--sync-likes", "--limit", "1"])
 
         # Verify youtube_service was accessed from container
         assert mock_container.youtube_service is mock_youtube_service

--- a/tests/unit/cli/test_entity_commands.py
+++ b/tests/unit/cli/test_entity_commands.py
@@ -28,8 +28,6 @@ from typer.testing import CliRunner
 from chronovista.cli.entity_commands import entity_app
 
 # CRITICAL: Module-level asyncio marker ensures async tests work with coverage.
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -146,7 +144,11 @@ class TestScanAuditFlag:
             import asyncio
 
             captured_coro.append(coro)
-            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(coro)  # type: ignore[arg-type]
+            finally:
+                loop.close()
 
         with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
             result = runner.invoke(entity_app, ["scan", "--audit"])
@@ -192,7 +194,11 @@ class TestScanAuditFlag:
         def fake_asyncio_run(coro: object) -> None:
             import asyncio
 
-            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(coro)  # type: ignore[arg-type]
+            finally:
+                loop.close()
 
         with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
             result = runner.invoke(entity_app, ["scan", "--audit"])
@@ -236,7 +242,11 @@ class TestScanAuditFlag:
         def fake_asyncio_run(coro: object) -> None:
             import asyncio
 
-            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(coro)  # type: ignore[arg-type]
+            finally:
+                loop.close()
 
         with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
             result = runner.invoke(entity_app, ["scan", "--audit"])
@@ -274,7 +284,11 @@ class TestScanAuditFlag:
         def fake_asyncio_run(coro: object) -> None:
             import asyncio
 
-            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(coro)  # type: ignore[arg-type]
+            finally:
+                loop.close()
 
         with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
             result = runner.invoke(entity_app, ["scan", "--audit"])
@@ -309,7 +323,11 @@ class TestScanAuditFlag:
         def fake_asyncio_run(coro: object) -> None:
             import asyncio
 
-            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(coro)  # type: ignore[arg-type]
+            finally:
+                loop.close()
 
         with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
             result = runner.invoke(entity_app, ["scan", "--audit"])
@@ -340,7 +358,11 @@ class TestScanAuditFlag:
         def fake_asyncio_run(coro: object) -> None:
             import asyncio
 
-            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(coro)  # type: ignore[arg-type]
+            finally:
+                loop.close()
 
         with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
             result = runner.invoke(entity_app, ["scan", "--audit"])
@@ -397,7 +419,11 @@ class TestScanAuditFlag:
         def fake_asyncio_run(coro: object) -> None:
             import asyncio
 
-            asyncio.get_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(coro)  # type: ignore[arg-type]
+            finally:
+                loop.close()
 
         with patch("chronovista.cli.entity_commands.asyncio.run", side_effect=fake_asyncio_run):
             result = runner.invoke(entity_app, ["scan", "--audit", "--dry-run"])

--- a/tests/unit/cli/test_entity_commands_scan_entity_id.py
+++ b/tests/unit/cli/test_entity_commands_scan_entity_id.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from typing import Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -31,8 +32,6 @@ from typer.testing import CliRunner
 from chronovista.cli.entity_commands import entity_app
 
 # CRITICAL: Module-level asyncio marker ensures async tests run with coverage.
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -69,7 +68,7 @@ def _make_scan_result(**kwargs: Any) -> MagicMock:
     result.unique_videos = kwargs.get("unique_videos", 1)
     result.duration_seconds = kwargs.get("duration_seconds", 0.5)
     result.dry_run = kwargs.get("dry_run", False)
-    result.dry_run_matches = kwargs.get("dry_run_matches", None)
+    result.dry_run_matches = kwargs.get("dry_run_matches")
     result.failed_batches = kwargs.get("failed_batches", 0)
     return result
 
@@ -142,13 +141,13 @@ class TestEntityIdUuidValidation:
         """A well-formed UUID string must not trigger the format-error path."""
         valid_uuid = str(_make_uuid())
 
-        entity = _make_entity_mock(status="active")
+        _make_entity_mock(status="active")
 
         with (
             patch("chronovista.cli.entity_commands.db_manager") as mock_db,
             patch(
                 "chronovista.cli.entity_commands.EntityMentionScanService"
-            ) as mock_service_cls,
+            ),
             patch("chronovista.cli.entity_commands.asyncio.run") as mock_asyncio_run,
         ):
             mock_db.get_session_factory.return_value = MagicMock()

--- a/tests/unit/cli/test_language_commands.py
+++ b/tests/unit/cli/test_language_commands.py
@@ -8,8 +8,7 @@ module, including helper functions, database operations, and CLI commands.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
-from typing import List
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,13 +19,11 @@ from chronovista.cli.language_commands import (
     DEFAULT_USER_ID,
     LANGUAGE_NAMES,
     OutputFormat,
-    _get_preferences,
     _get_terminal_width,
     _is_tty,
     _truncate_text,
     detect_system_locale,
     get_language_display_name,
-    language_app,
     parse_language_input,
     suggest_similar_codes,
     validate_language_code,
@@ -34,7 +31,6 @@ from chronovista.cli.language_commands import (
 from chronovista.cli.main import app
 from chronovista.models.enums import LanguageCode, LanguagePreferenceType
 from chronovista.models.user_language_preference import UserLanguagePreference
-
 
 # -------------------------------------------------------------------------
 # Fixtures
@@ -48,7 +44,7 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture
-def mock_preferences() -> List[UserLanguagePreference]:
+def mock_preferences() -> list[UserLanguagePreference]:
     """
     Create a list of mock UserLanguagePreference objects for testing.
 
@@ -57,7 +53,7 @@ def mock_preferences() -> List[UserLanguagePreference]:
     List[UserLanguagePreference]
         List of mock language preferences.
     """
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return [
         UserLanguagePreference(
             user_id=DEFAULT_USER_ID,
@@ -90,7 +86,7 @@ def mock_preferences() -> List[UserLanguagePreference]:
 
 
 @pytest.fixture
-def mock_db_preferences() -> List[MagicMock]:
+def mock_db_preferences() -> list[MagicMock]:
     """
     Create mock database preference objects.
 
@@ -99,7 +95,7 @@ def mock_db_preferences() -> List[MagicMock]:
     List[MagicMock]
         List of mock database objects that mimic UserLanguagePreferenceDB.
     """
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     prefs = []
     for code, ptype, priority in [
         (LanguageCode.ENGLISH.value, LanguagePreferenceType.FLUENT.value, 1),
@@ -396,7 +392,7 @@ class TestGetPreferences:
     """Tests for _get_preferences() async helper function."""
 
     async def test_get_preferences_returns_list(
-        self, mock_db_preferences: List[MagicMock]
+        self, mock_db_preferences: list[MagicMock]
     ) -> None:
         """Test _get_preferences returns list of preferences."""
         with patch(
@@ -469,7 +465,7 @@ class TestLanguageListCommand:
             assert "--from-locale" in result.stdout
 
     def test_list_with_preferences_shows_grouped_table(
-        self, runner: CliRunner, mock_preferences: List[UserLanguagePreference]
+        self, runner: CliRunner, mock_preferences: list[UserLanguagePreference]
     ) -> None:
         """T012: Preferences are displayed in grouped table."""
         with patch("chronovista.cli.language_commands._get_preferences") as mock_get:
@@ -491,7 +487,7 @@ class TestLanguageListCommand:
             assert "Auto-Download" in result.stdout
 
     def test_list_format_json_outputs_valid_json(
-        self, runner: CliRunner, mock_preferences: List[UserLanguagePreference]
+        self, runner: CliRunner, mock_preferences: list[UserLanguagePreference]
     ) -> None:
         """T013: --format json outputs valid JSON."""
         import json
@@ -516,7 +512,7 @@ class TestLanguageListCommand:
             assert output_data["learning"][0]["language_code"] == "es"
 
     def test_list_format_yaml_outputs_valid_yaml(
-        self, runner: CliRunner, mock_preferences: List[UserLanguagePreference]
+        self, runner: CliRunner, mock_preferences: list[UserLanguagePreference]
     ) -> None:
         """T014: --format yaml outputs valid YAML."""
         import yaml
@@ -538,7 +534,7 @@ class TestLanguageListCommand:
             assert len(output_data["learning"]) == 1
 
     def test_list_type_filter_shows_only_filtered(
-        self, runner: CliRunner, mock_preferences: List[UserLanguagePreference]
+        self, runner: CliRunner, mock_preferences: list[UserLanguagePreference]
     ) -> None:
         """T015: --type fluent filters to fluent only."""
         with patch("chronovista.cli.language_commands._get_preferences") as mock_get:
@@ -874,7 +870,7 @@ class TestLanguageAddCommand:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         ]
 
@@ -1121,7 +1117,7 @@ class TestLanguageResetCommand:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             UserLanguagePreference(
                 user_id=DEFAULT_USER_ID,
@@ -1130,7 +1126,7 @@ class TestLanguageResetCommand:
                 priority=2,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             UserLanguagePreference(
                 user_id=DEFAULT_USER_ID,
@@ -1139,7 +1135,7 @@ class TestLanguageResetCommand:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal="B2 by December",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             UserLanguagePreference(
                 user_id=DEFAULT_USER_ID,
@@ -1148,7 +1144,7 @@ class TestLanguageResetCommand:
                 priority=2,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             UserLanguagePreference(
                 user_id=DEFAULT_USER_ID,
@@ -1157,7 +1153,7 @@ class TestLanguageResetCommand:
                 priority=1,
                 auto_download_transcripts=False,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             UserLanguagePreference(
                 user_id=DEFAULT_USER_ID,
@@ -1166,7 +1162,7 @@ class TestLanguageResetCommand:
                 priority=2,
                 auto_download_transcripts=False,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             UserLanguagePreference(
                 user_id=DEFAULT_USER_ID,
@@ -1175,7 +1171,7 @@ class TestLanguageResetCommand:
                 priority=1,
                 auto_download_transcripts=False,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -1223,7 +1219,7 @@ class TestLanguageResetCommand:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             UserLanguagePreference(
                 user_id=DEFAULT_USER_ID,
@@ -1232,7 +1228,7 @@ class TestLanguageResetCommand:
                 priority=2,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             UserLanguagePreference(
                 user_id=DEFAULT_USER_ID,
@@ -1241,7 +1237,7 @@ class TestLanguageResetCommand:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal="B2",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -1286,7 +1282,7 @@ class TestLanguageResetCommand:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         ]
 
@@ -1329,7 +1325,7 @@ class TestLanguageResetCommand:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         ]
 
@@ -1369,7 +1365,7 @@ class TestLanguageResetCommand:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         ]
 
@@ -1486,7 +1482,7 @@ class TestLanguageSetCommandFlags:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         ]
 
@@ -1580,12 +1576,11 @@ class TestUpgradePromptForSyncCommands:
     @pytest.mark.asyncio
     async def test_upgrade_prompt_appears_when_no_preferences_configured(self) -> None:
         """T075 [P] [US8]: Test upgrade prompt appears when no preferences configured."""
+        # Reset module-level flag
+        import chronovista.cli.language_commands as lang_cmd
         from chronovista.cli.language_commands import (
             check_and_prompt_language_preferences,
         )
-
-        # Reset module-level flag
-        import chronovista.cli.language_commands as lang_cmd
 
         lang_cmd._upgrade_prompt_shown = False
 
@@ -1605,12 +1600,11 @@ class TestUpgradePromptForSyncCommands:
     @pytest.mark.asyncio
     async def test_upgrade_prompt_does_not_appear_when_preferences_exist(self) -> None:
         """T076 [P] [US8]: Test upgrade prompt does NOT appear when preferences exist."""
+        # Reset module-level flag
+        import chronovista.cli.language_commands as lang_cmd
         from chronovista.cli.language_commands import (
             check_and_prompt_language_preferences,
         )
-
-        # Reset module-level flag
-        import chronovista.cli.language_commands as lang_cmd
 
         lang_cmd._upgrade_prompt_shown = False
 
@@ -1622,7 +1616,7 @@ class TestUpgradePromptForSyncCommands:
                 priority=1,
                 auto_download_transcripts=True,
                 learning_goal=None,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         ]
 
@@ -1640,12 +1634,11 @@ class TestUpgradePromptForSyncCommands:
     @pytest.mark.asyncio
     async def test_upgrade_prompt_appears_only_once_per_session(self) -> None:
         """T077 [P] [US8]: Test upgrade prompt appears only once per session."""
+        # Reset module-level flag
+        import chronovista.cli.language_commands as lang_cmd
         from chronovista.cli.language_commands import (
             check_and_prompt_language_preferences,
         )
-
-        # Reset module-level flag
-        import chronovista.cli.language_commands as lang_cmd
 
         lang_cmd._upgrade_prompt_shown = False
 
@@ -1670,12 +1663,11 @@ class TestUpgradePromptForSyncCommands:
     @pytest.mark.asyncio
     async def test_accepting_upgrade_prompt_enters_first_run_setup(self) -> None:
         """T078 [P] [US8]: Test accepting upgrade prompt enters first-run setup."""
+        # Reset module-level flag
+        import chronovista.cli.language_commands as lang_cmd
         from chronovista.cli.language_commands import (
             check_and_prompt_language_preferences,
         )
-
-        # Reset module-level flag
-        import chronovista.cli.language_commands as lang_cmd
 
         lang_cmd._upgrade_prompt_shown = False
 
@@ -1691,7 +1683,7 @@ class TestUpgradePromptForSyncCommands:
                         priority=1,
                         auto_download_transcripts=True,
                         learning_goal=None,
-                        created_at=datetime.now(timezone.utc),
+                        created_at=datetime.now(UTC),
                     )
                 ],  # Preferences exist after setup
             ]
@@ -1714,12 +1706,11 @@ class TestUpgradePromptForSyncCommands:
     @pytest.mark.asyncio
     async def test_declining_upgrade_prompt_proceeds_with_defaults(self) -> None:
         """T079 [P] [US8]: Test declining upgrade prompt proceeds with defaults."""
+        # Reset module-level flag
+        import chronovista.cli.language_commands as lang_cmd
         from chronovista.cli.language_commands import (
             check_and_prompt_language_preferences,
         )
-
-        # Reset module-level flag
-        import chronovista.cli.language_commands as lang_cmd
 
         lang_cmd._upgrade_prompt_shown = False
 
@@ -1874,7 +1865,7 @@ class TestNonTTYOutput:
             assert "Available Language Codes" in result.stdout
 
     def test_list_preferences_non_tty_output(
-        self, runner: CliRunner, mock_preferences: List[UserLanguagePreference]
+        self, runner: CliRunner, mock_preferences: list[UserLanguagePreference]
     ) -> None:
         """T086: Test list output works in non-TTY mode."""
         with patch("chronovista.cli.language_commands._is_tty") as mock_tty:
@@ -1888,7 +1879,7 @@ class TestNonTTYOutput:
                 assert "Fluent" in result.stdout or "fluent" in result.stdout.lower()
 
     def test_json_output_always_plain(
-        self, runner: CliRunner, mock_preferences: List[UserLanguagePreference]
+        self, runner: CliRunner, mock_preferences: list[UserLanguagePreference]
     ) -> None:
         """T086: Test JSON output is always plain (no Rich formatting)."""
         with patch("chronovista.cli.language_commands._get_preferences") as mock_get:
@@ -1900,7 +1891,7 @@ class TestNonTTYOutput:
             assert "fluent" in output_data
 
     def test_yaml_output_always_plain(
-        self, runner: CliRunner, mock_preferences: List[UserLanguagePreference]
+        self, runner: CliRunner, mock_preferences: list[UserLanguagePreference]
     ) -> None:
         """T086: Test YAML output is always plain (no Rich formatting)."""
         with patch("chronovista.cli.language_commands._get_preferences") as mock_get:

--- a/tests/unit/cli/test_phase9_error_handling.py
+++ b/tests/unit/cli/test_phase9_error_handling.py
@@ -21,16 +21,13 @@ from googleapiclient.errors import HttpError
 from sqlalchemy.exc import SQLAlchemyError
 
 from chronovista.exceptions import (
-    AuthenticationError,
     EXIT_CODE_AUTHENTICATION_FAILED,
-    EXIT_CODE_GENERAL_ERROR,
+    AuthenticationError,
     NetworkError,
     YouTubeAPIError,
 )
 
 # Mark all async tests in this module
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # Test Helpers

--- a/tests/unit/cli/test_recover_commands.py
+++ b/tests/unit/cli/test_recover_commands.py
@@ -8,14 +8,11 @@ dry-run mode, summary reports, and dependency checks.
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import AsyncGenerator
-from datetime import datetime, timezone
-from pathlib import Path
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from typer.testing import CliRunner
 
 from chronovista.cli.main import app
@@ -48,7 +45,7 @@ def create_mock_video_db(video_id: str, availability_status: AvailabilityStatus 
     mock_video.video_id = video_id
     mock_video.availability_status = availability_status.value
     mock_video.unavailability_first_detected = None
-    mock_video.created_at = datetime.now(timezone.utc)
+    mock_video.created_at = datetime.now(UTC)
     return mock_video
 
 
@@ -737,7 +734,7 @@ class TestErrorHandling:
         mock_recover: MagicMock,
     ) -> None:
         """Test that CDXError returns EXIT_CODE_NETWORK_ERROR."""
-        from chronovista.exceptions import CDXError, EXIT_CODE_NETWORK_ERROR
+        from chronovista.exceptions import EXIT_CODE_NETWORK_ERROR, CDXError
 
         session_gen, session = create_async_mock_session()
         mock_get_session.return_value = session_gen

--- a/tests/unit/cli/test_seed_commands.py
+++ b/tests/unit/cli/test_seed_commands.py
@@ -13,13 +13,10 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from typer.testing import CliRunner
 
 from chronovista.cli.commands.seed import seed_app
 from chronovista.services.enrichment.seeders import CategorySeedResult, TopicSeedResult
-
-pytestmark = pytest.mark.asyncio
 
 runner = CliRunner()
 
@@ -80,7 +77,7 @@ class TestTopicsCommandDryRun:
         mock_seeder_instance = MagicMock()
         mock_seeder_class.return_value = mock_seeder_instance
 
-        result = runner.invoke(seed_app, ["topics", "--dry-run"])
+        runner.invoke(seed_app, ["topics", "--dry-run"])
 
         # Verify seed() was not called
         mock_seeder_instance.seed.assert_not_called()

--- a/tests/unit/cli/test_sync_commands_container.py
+++ b/tests/unit/cli/test_sync_commands_container.py
@@ -11,8 +11,7 @@ Coverage targets:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -43,7 +42,7 @@ def mock_youtube_channel() -> YouTubeChannelResponse:
         snippet=ChannelSnippet(
             title="Test Channel",
             description="Test channel description",
-            publishedAt=datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            publishedAt=datetime(2020, 1, 1, 0, 0, 0, tzinfo=UTC),
         ),
     )
 
@@ -56,7 +55,7 @@ def mock_youtube_playlist() -> YouTubePlaylistResponse:
         snippet=PlaylistSnippet(
             title="Test Playlist",
             description="Test playlist description",
-            publishedAt=datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            publishedAt=datetime(2021, 1, 1, 0, 0, 0, tzinfo=UTC),
             channelId="UC1234567890123456789012",
         ),
     )
@@ -72,7 +71,7 @@ def mock_youtube_video() -> YouTubeVideoResponse:
             description="Test video description",
             channelId="UC1234567890123456789012",
             channelTitle="Test Channel",
-            publishedAt=datetime(2022, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            publishedAt=datetime(2022, 1, 1, 0, 0, 0, tzinfo=UTC),
         ),
     )
 
@@ -146,13 +145,13 @@ class TestSyncChannelCommand:
                 video_count=None,
                 country=None,
                 default_language=None,
-                created_at=datetime.now(timezone.utc),
-                updated_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
             )
         )
 
         # Execute command
-        result = runner.invoke(app, ["sync", "channel"])
+        runner.invoke(app, ["sync", "channel"])
 
         # Verify container methods were called
         mock_container.create_channel_repository.assert_called_once()
@@ -194,7 +193,7 @@ class TestSyncChannelCommand:
         mock_topic_category_repo.exists = AsyncMock(return_value=True)
 
         # Execute command with topic filter
-        result = runner.invoke(app, ["sync", "channel", "--topic", "25"])
+        runner.invoke(app, ["sync", "channel", "--topic", "25"])
 
         # Topic repository should be created to validate topic
         mock_container.create_topic_category_repository.assert_called()
@@ -237,7 +236,7 @@ class TestSyncPlaylistsCommand:
         mock_playlist_repo.create_or_update = AsyncMock(return_value=MagicMock())
 
         # Execute command
-        result = runner.invoke(app, ["sync", "playlists"])
+        runner.invoke(app, ["sync", "playlists"])
 
         # Verify container methods were called
         mock_container.create_playlist_repository.assert_called_once()
@@ -260,7 +259,7 @@ class TestSyncPlaylistsCommand:
         )
 
         # Execute command with dry-run
-        result = runner.invoke(app, ["sync", "playlists", "--dry-run"])
+        runner.invoke(app, ["sync", "playlists", "--dry-run"])
 
         # In dry-run mode, repository should NOT be created
         mock_container.create_playlist_repository.assert_not_called()
@@ -308,7 +307,7 @@ class TestSyncPlaylistsCommand:
         mock_playlist_repo.create_or_update = AsyncMock(return_value=MagicMock())
 
         # Execute command with include-items
-        result = runner.invoke(app, ["sync", "playlists", "--include-items"])
+        runner.invoke(app, ["sync", "playlists", "--include-items"])
 
         # Verify additional repositories were created for items
         mock_container.create_playlist_membership_repository.assert_called()
@@ -337,8 +336,8 @@ class TestSyncTopicsCommand:
 
         # Mock YouTube service
         from chronovista.models.api_responses import (
-            YouTubeVideoCategoryResponse,
             CategorySnippet,
+            YouTubeVideoCategoryResponse,
         )
 
         mock_category = YouTubeVideoCategoryResponse(
@@ -363,7 +362,7 @@ class TestSyncTopicsCommand:
         )
 
         # Execute command
-        result = runner.invoke(app, ["sync", "topics"])
+        runner.invoke(app, ["sync", "topics"])
 
         # Verify container methods were called
         mock_container.create_topic_category_repository.assert_called_once()
@@ -426,7 +425,7 @@ class TestSyncLikedCommand:
         mock_user_video_repo.record_like = AsyncMock()
 
         # Execute command
-        result = runner.invoke(app, ["sync", "liked"])
+        runner.invoke(app, ["sync", "liked"])
 
         # Verify container methods were called
         mock_container.create_video_repository.assert_called()
@@ -473,7 +472,7 @@ class TestSyncLikedCommand:
         mock_video_repo.exists = AsyncMock(return_value=True)
 
         # Execute command with dry-run
-        result = runner.invoke(app, ["sync", "liked", "--dry-run"])
+        runner.invoke(app, ["sync", "liked", "--dry-run"])
 
         # In dry-run mode, should not update database
         mock_user_video_repo.update_like_status_batch.assert_not_called()
@@ -503,8 +502,8 @@ class TestSyncAllCommand:
 
         # Mock YouTube service
         from chronovista.models.api_responses import (
-            YouTubeVideoCategoryResponse,
             CategorySnippet,
+            YouTubeVideoCategoryResponse,
         )
 
         mock_category = YouTubeVideoCategoryResponse(
@@ -533,7 +532,7 @@ class TestSyncAllCommand:
         )
 
         # Execute command
-        result = runner.invoke(app, ["sync", "all"])
+        runner.invoke(app, ["sync", "all"])
 
         # Verify topic repository was created
         mock_container.create_topic_category_repository.assert_called()
@@ -588,7 +587,7 @@ class TestProcessWatchHistoryBatch:
                 action="Watched",
                 channel_id="UC1234567890123456789012",
                 channel_name="Test Channel",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
             )
         ]
 

--- a/tests/unit/cli/test_sync_transcripts_command.py
+++ b/tests/unit/cli/test_sync_transcripts_command.py
@@ -17,8 +17,6 @@ Test organization:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -57,9 +55,9 @@ def mock_video_db() -> MagicMock:
 
 
 @pytest.fixture
-def mock_video_db_list() -> List[MagicMock]:
+def mock_video_db_list() -> list[MagicMock]:
     """Create a list of mock Video database models."""
-    videos: List[MagicMock] = []
+    videos: list[MagicMock] = []
     for i in range(3):
         video = MagicMock(spec=VideoDB)
         video.video_id = f"test_video_{i}"
@@ -134,7 +132,7 @@ class TestSyncTranscriptsDryRun:
         mock_container: MagicMock,
         mock_check_auth: MagicMock,
         runner: CliRunner,
-        mock_video_db_list: List[MagicMock],
+        mock_video_db_list: list[MagicMock],
     ) -> None:
         """Test that --dry-run shows preview without downloading transcripts."""
         # Setup authentication
@@ -160,7 +158,6 @@ class TestSyncTranscriptsDryRun:
         ]
 
         # Mock repository to return videos without transcripts
-        from chronovista.models.video import VideoSearchFilters
 
         mock_video_repo.search_videos = AsyncMock(return_value=mock_video_db_list)
 
@@ -186,7 +183,7 @@ class TestSyncTranscriptsDryRun:
         mock_container: MagicMock,
         mock_check_auth: MagicMock,
         runner: CliRunner,
-        mock_video_db_list: List[MagicMock],
+        mock_video_db_list: list[MagicMock],
     ) -> None:
         """Test that --dry-run displays table with video information."""
         # Setup authentication
@@ -229,7 +226,7 @@ class TestSyncTranscriptsDryRun:
         mock_container: MagicMock,
         mock_check_auth: MagicMock,
         runner: CliRunner,
-        mock_video_db_list: List[MagicMock],
+        mock_video_db_list: list[MagicMock],
     ) -> None:
         """Test that --dry-run shows whether --force flag is enabled."""
         # Setup authentication
@@ -319,7 +316,7 @@ class TestSyncTranscriptsVideoIdFilter:
         mock_container.transcript_service = mock_transcript_service
 
         # Execute command with specific video ID
-        result = runner.invoke(
+        runner.invoke(
             app, ["sync", "transcripts", "--video-id", "dQw4w9WgXcQ"]
         )
 
@@ -389,7 +386,7 @@ class TestSyncTranscriptsVideoIdFilter:
         mock_container.transcript_service = mock_transcript_service
 
         # Execute command with multiple video IDs
-        result = runner.invoke(
+        runner.invoke(
             app,
             ["sync", "transcripts", "--video-id", "video1", "--video-id", "video2"],
         )
@@ -446,7 +443,7 @@ class TestSyncTranscriptsAuthentication:
         mock_check_auth.return_value = False
 
         # Execute command
-        result = runner.invoke(app, ["sync", "transcripts"])
+        runner.invoke(app, ["sync", "transcripts"])
 
         # Verify authentication check was called
         mock_check_auth.assert_called_once()
@@ -573,7 +570,7 @@ class TestSyncTranscriptsDownload:
         mock_container.transcript_service = mock_transcript_service
 
         # Execute command with Spanish language preference
-        result = runner.invoke(
+        runner.invoke(
             app, ["sync", "transcripts", "--limit", "1", "--language", "es"]
         )
 
@@ -630,7 +627,7 @@ class TestSyncTranscriptsDownload:
         mock_container.transcript_service = mock_transcript_service
 
         # Execute command
-        result = runner.invoke(app, ["sync", "transcripts", "--limit", "1"])
+        runner.invoke(app, ["sync", "transcripts", "--limit", "1"])
 
         # Verify create_or_update was called with raw_transcript_data
         call_args = mock_video_transcript_repo.create_or_update.call_args
@@ -763,7 +760,7 @@ class TestSyncTranscriptsFlags:
         mock_container: MagicMock,
         mock_check_auth: MagicMock,
         runner: CliRunner,
-        mock_video_db_list: List[MagicMock],
+        mock_video_db_list: list[MagicMock],
     ) -> None:
         """Test that --limit flag restricts number of videos processed."""
         # Setup authentication
@@ -787,10 +784,9 @@ class TestSyncTranscriptsFlags:
         mock_video_repo.search_videos = AsyncMock(return_value=many_videos)
 
         # Execute command with limit
-        result = runner.invoke(app, ["sync", "transcripts", "--limit", "5"])
+        runner.invoke(app, ["sync", "transcripts", "--limit", "5"])
 
         # Verify search_videos was called with limit
-        call_args = mock_video_repo.search_videos.call_args
         # The command internally handles limiting
 
     @patch("chronovista.cli.sync_commands.check_authenticated")
@@ -853,7 +849,7 @@ class TestSyncTranscriptsFlags:
         mock_container.transcript_service = mock_transcript_service
 
         # Execute command with force flag
-        result = runner.invoke(app, ["sync", "transcripts", "--limit", "1", "--force"])
+        runner.invoke(app, ["sync", "transcripts", "--limit", "1", "--force"])
 
         # Verify transcript was downloaded even though it exists
         mock_transcript_service.get_transcript.assert_called()

--- a/tests/unit/cli/test_tag_commands.py
+++ b/tests/unit/cli/test_tag_commands.py
@@ -8,19 +8,12 @@ stats, and by-video commands. These test the CLI interface for YouTube video tag
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from chronovista.cli.tag_commands import tag_app
-from chronovista.db.models import Video as VideoDB
-from chronovista.db.models import VideoTag as VideoTagDB
-from chronovista.models.video_tag import VideoTagStatistics
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestTagCommands:
@@ -98,7 +91,7 @@ class TestTagCommands:
         self, mock_asyncio: MagicMock, runner: CliRunner
     ) -> None:
         """Test show tag command with -r short flag."""
-        result = runner.invoke(tag_app, ["show", "--tag", "music", "-r", "5"])
+        runner.invoke(tag_app, ["show", "--tag", "music", "-r", "5"])
 
     @patch("chronovista.cli.tag_commands.asyncio.run")
     def test_show_tag_with_dash_prefix(
@@ -135,7 +128,7 @@ class TestTagCommands:
         self, mock_asyncio: MagicMock, runner: CliRunner
     ) -> None:
         """Test videos by tag command with -l short flag."""
-        result = runner.invoke(tag_app, ["videos", "--tag", "gaming", "-l", "15"])
+        runner.invoke(tag_app, ["videos", "--tag", "gaming", "-l", "15"])
 
     @patch("chronovista.cli.tag_commands.asyncio.run")
     def test_videos_by_tag_with_dash_prefix(
@@ -172,7 +165,7 @@ class TestTagCommands:
         self, mock_asyncio: MagicMock, runner: CliRunner
     ) -> None:
         """Test search tags command with -l short flag."""
-        result = runner.invoke(tag_app, ["search", "--pattern", "music", "-l", "40"])
+        runner.invoke(tag_app, ["search", "--pattern", "music", "-l", "40"])
 
     @patch("chronovista.cli.tag_commands.asyncio.run")
     def test_search_tags_with_dash_prefix(

--- a/tests/unit/cli/test_takeout_recover_command.py
+++ b/tests/unit/cli/test_takeout_recover_command.py
@@ -5,9 +5,8 @@ Unit tests for the `chronovista takeout recover` CLI command (T025e).
 Tests cover dry-run mode, verbose output, and error handling.
 """
 
-from datetime import datetime, timezone
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -32,13 +31,13 @@ class TestTakeoutRecoverCommand:
             video_id="dQw4w9WgXcQ",
             old_title="[Placeholder] Video dQw4w9WgXcQ",
             new_title="Never Gonna Give You Up",
-            source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            source_date=datetime(2024, 1, 15, tzinfo=UTC),
         )
         channel_action = ChannelRecoveryAction(
             channel_id="UCtest123",
             channel_name="Test Channel",
             action_type="create",
-            source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            source_date=datetime(2024, 1, 15, tzinfo=UTC),
         )
 
         result = RecoveryResult(
@@ -47,8 +46,8 @@ class TestTakeoutRecoverCommand:
             channels_created=2,
             channels_updated=3,
             takeouts_scanned=3,
-            oldest_takeout_date=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            newest_takeout_date=datetime(2024, 6, 15, tzinfo=timezone.utc),
+            oldest_takeout_date=datetime(2023, 1, 1, tzinfo=UTC),
+            newest_takeout_date=datetime(2024, 6, 15, tzinfo=UTC),
             video_actions=[video_action],
             channel_actions=[channel_action],
         )

--- a/tests/unit/cli/test_topic_commands.py
+++ b/tests/unit/cli/test_topic_commands.py
@@ -7,15 +7,12 @@ list, show, channels, and videos commands.
 
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from chronovista.cli.topic_commands import topic_app
-from chronovista.db.models import TopicCategory as TopicCategoryDB
 
 
 class TestTopicCommands:

--- a/tests/unit/config/test_database.py
+++ b/tests/unit/config/test_database.py
@@ -8,8 +8,6 @@ import pytest
 
 from chronovista.config.database import DatabaseManager, db_manager, get_db_session
 
-pytestmark = pytest.mark.asyncio
-
 
 class TestDatabaseManager:
     """Test DatabaseManager functionality."""

--- a/tests/unit/models/conftest.py
+++ b/tests/unit/models/conftest.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 
-import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 

--- a/tests/unit/models/test_batch_correction_models.py
+++ b/tests/unit/models/test_batch_correction_models.py
@@ -23,8 +23,6 @@ from chronovista.models.batch_correction_models import (
 )
 
 # CRITICAL: Ensure async tests work with coverage tooling.
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Shared helpers

--- a/tests/unit/models/test_channel.py
+++ b/tests/unit/models/test_channel.py
@@ -7,7 +7,7 @@ serialization, and business logic testing using factory-boy for DRY principles.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -267,8 +267,8 @@ class TestChannelFactory:
 
     def test_channel_timestamps(self):
         """Test Channel with custom timestamps."""
-        created_time = datetime(2023, 1, 1, tzinfo=timezone.utc)
-        updated_time = datetime(2023, 12, 1, tzinfo=timezone.utc)
+        created_time = datetime(2023, 1, 1, tzinfo=UTC)
+        updated_time = datetime(2023, 12, 1, tzinfo=UTC)
 
         channel = ChannelFactory.build(created_at=created_time, updated_at=updated_time)
 
@@ -286,8 +286,8 @@ class TestChannelFactory:
             "default_language": "en",
             "country": "CA",
             "thumbnail_url": "https://yt3.ggpht.com/orm-test=s240-c-k-c0x00ffffff-no-rj",
-            "created_at": datetime(2023, 6, 15, 10, 30, tzinfo=timezone.utc),
-            "updated_at": datetime(2023, 12, 1, 16, 45, tzinfo=timezone.utc),
+            "created_at": datetime(2023, 6, 15, 10, 30, tzinfo=UTC),
+            "updated_at": datetime(2023, 12, 1, 16, 45, tzinfo=UTC),
         }
 
         channel = Channel.model_validate(channel_data)

--- a/tests/unit/models/test_channel_keyword.py
+++ b/tests/unit/models/test_channel_keyword.py
@@ -7,7 +7,7 @@ for all ChannelKeyword model variants using factory pattern for DRY.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import cast
 
 import pytest
@@ -209,7 +209,7 @@ class TestChannelKeyword:
 
     def test_create_valid_channel_keyword(self):
         """Test creating valid ChannelKeyword with keyword arguments."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         keyword = cast(
             ChannelKeyword,
             ChannelKeywordFactory.build(
@@ -233,7 +233,7 @@ class TestChannelKeyword:
             channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
             keyword = "unboxing"
             keyword_order = 7
-            created_at = datetime.now(timezone.utc)
+            created_at = datetime.now(UTC)
 
         mock_db = MockChannelKeywordDB()
         keyword = ChannelKeyword.model_validate(mock_db, from_attributes=True)
@@ -449,7 +449,7 @@ class TestChannelKeywordModelInteractions:
         )
 
         # Simulate creation
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         keyword_full = ChannelKeywordFactory.build(
             channel_id=keyword_create.channel_id,
             keyword=keyword_create.keyword,

--- a/tests/unit/models/test_correction_actors.py
+++ b/tests/unit/models/test_correction_actors.py
@@ -7,16 +7,12 @@ the ``auto_actor`` helper produces correctly formatted actor strings.
 
 from __future__ import annotations
 
-import pytest
-
 from chronovista.models.correction_actors import (
     ACTOR_CLI_BATCH,
     ACTOR_CLI_INTERACTIVE,
     ACTOR_USER_LOCAL,
     auto_actor,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestActorConstants:

--- a/tests/unit/models/test_enrichment_report.py
+++ b/tests/unit/models/test_enrichment_report.py
@@ -8,7 +8,7 @@ metadata enrichment reporting models.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -101,7 +101,7 @@ class TestEnrichmentSummary:
         ]
 
         for field in fields:
-            kwargs = {f: 0 for f in fields}
+            kwargs = dict.fromkeys(fields, 0)
             kwargs[field] = -1
 
             with pytest.raises(ValidationError) as exc_info:
@@ -362,7 +362,7 @@ class TestEnrichmentReport:
 
     def test_create_valid_enrichment_report(self):
         """Test creating valid EnrichmentReport with all fields."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=10,
             videos_updated=8,
@@ -395,7 +395,7 @@ class TestEnrichmentReport:
 
     def test_create_enrichment_report_minimal(self):
         """Test creating EnrichmentReport with minimal fields."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,
@@ -438,7 +438,7 @@ class TestEnrichmentReport:
 
     def test_priority_required(self):
         """Test priority is required."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,
@@ -456,7 +456,7 @@ class TestEnrichmentReport:
 
     def test_priority_min_length(self):
         """Test priority has minimum length of 1."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,
@@ -474,14 +474,14 @@ class TestEnrichmentReport:
 
     def test_summary_required(self):
         """Test summary is required."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
 
         with pytest.raises(ValidationError):
             EnrichmentReport.model_validate({"timestamp": timestamp, "priority": "high"})
 
     def test_details_defaults_to_empty_list(self):
         """Test details defaults to empty list."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,
@@ -505,7 +505,7 @@ class TestEnrichmentReport:
 
     def test_json_serialization(self):
         """Test EnrichmentReport can be serialized to JSON."""
-        timestamp = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
         summary = EnrichmentSummary(
             videos_processed=5,
             videos_updated=4,
@@ -583,7 +583,7 @@ class TestEnrichmentReport:
 
     def test_iso_8601_timestamp_format(self):
         """Test timestamp uses ISO 8601 format in JSON."""
-        timestamp = datetime(2024, 1, 15, 10, 30, 45, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,
@@ -610,7 +610,7 @@ class TestEnrichmentReport:
 
     def test_roundtrip_json_serialization(self):
         """Test that report can be serialized and deserialized without data loss."""
-        timestamp = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
         summary = EnrichmentSummary(
             videos_processed=10,
             videos_updated=9,
@@ -661,7 +661,7 @@ class TestEnrichmentReport:
 
     def test_model_dump_functionality(self):
         """Test model_dump() method for serialization."""
-        timestamp = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
         summary = EnrichmentSummary(
             videos_processed=3,
             videos_updated=2,
@@ -694,7 +694,7 @@ class TestEnrichmentReportModelInteractions:
     def test_complete_enrichment_workflow(self):
         """Test complete workflow of creating enrichment report."""
         # Simulate enrichment operation
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
 
         # Create summary
         summary = EnrichmentSummary(
@@ -735,7 +735,7 @@ class TestEnrichmentReportModelInteractions:
 
     def test_error_handling_in_enrichment_report(self):
         """Test enrichment report with error details."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=5,
             videos_updated=3,
@@ -776,7 +776,7 @@ class TestEnrichmentReportModelInteractions:
 
     def test_priority_levels(self):
         """Test different priority levels in enrichment reports."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,
@@ -801,7 +801,7 @@ class TestEnrichmentReportModelInteractions:
 
     def test_empty_enrichment_report(self):
         """Test enrichment report with no processed videos."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,
@@ -826,7 +826,7 @@ class TestEnrichmentReportModelInteractions:
 
     def test_large_enrichment_report(self):
         """Test enrichment report with many details."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=1000,
             videos_updated=900,
@@ -870,7 +870,7 @@ class TestEnrichmentReportJSONSerialization:
 
     def test_model_dump_json_produces_valid_json(self) -> None:
         """Test that model_dump_json() produces valid JSON."""
-        timestamp = datetime(2024, 6, 15, 12, 30, 45, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 6, 15, 12, 30, 45, tzinfo=UTC)
         summary = EnrichmentSummary(
             videos_processed=25,
             videos_updated=20,
@@ -908,7 +908,7 @@ class TestEnrichmentReportJSONSerialization:
     def test_datetime_fields_serialize_as_iso8601(self) -> None:
         """Test that datetime fields serialize as ISO 8601 strings."""
         # Use a specific timestamp with milliseconds
-        timestamp = datetime(2024, 12, 25, 8, 30, 15, 123456, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 12, 25, 8, 30, 15, 123456, tzinfo=UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,
@@ -1004,7 +1004,7 @@ class TestEnrichmentReportJSONSerialization:
 
     def test_report_with_empty_details_list(self) -> None:
         """Test that report with empty details list serializes correctly."""
-        timestamp = datetime(2024, 3, 10, 15, 0, 0, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 3, 10, 15, 0, 0, tzinfo=UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,
@@ -1033,7 +1033,7 @@ class TestEnrichmentReportJSONSerialization:
 
     def test_report_with_multiple_status_types(self) -> None:
         """Test report with multiple details having different statuses."""
-        timestamp = datetime(2024, 7, 20, 10, 15, 30, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 7, 20, 10, 15, 30, tzinfo=UTC)
         summary = EnrichmentSummary(
             videos_processed=5,
             videos_updated=2,

--- a/tests/unit/models/test_entity_mention.py
+++ b/tests/unit/models/test_entity_mention.py
@@ -10,7 +10,7 @@ for EntityMentionBase, EntityMentionCreate, and EntityMention models
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -27,8 +27,6 @@ from chronovista.models.entity_mention import (
 )
 from chronovista.models.enums import DetectionMethod
 from tests.factories.entity_mention_factory import (
-    EntityMentionBaseFactory,
-    EntityMentionCreateFactory,
     EntityMentionFactory,
     EntityMentionTestData,
     create_entity_mention,
@@ -37,8 +35,6 @@ from tests.factories.entity_mention_factory import (
 )
 
 # CRITICAL: Ensure async tests work with coverage tooling.
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
@@ -101,7 +97,7 @@ def _make_entity_mention(**overrides: Any) -> EntityMention:
         "mention_text": _VALID_MENTION_TEXT,
         "detection_method": DetectionMethod.RULE_MATCH,
         "confidence": 1.0,
-        "created_at": datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+        "created_at": datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
     }
     defaults.update(overrides)
     return EntityMention(**defaults)
@@ -665,7 +661,7 @@ class TestEntityMention:
         """EntityMention is created successfully with all required fields."""
         mention_id = _uuid7()
         entity_id = _uuid7()
-        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
 
         mention = EntityMention(
             id=mention_id,
@@ -730,7 +726,7 @@ class TestEntityMention:
                 video_id=_VALID_VIDEO_ID,
                 language_code="en",
                 mention_text="Elon Musk",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
 
     def test_missing_created_at_raises_validation_error(self) -> None:
@@ -761,7 +757,7 @@ class TestEntityMention:
         """
         mention_id = _uuid7()
         entity_id = _uuid7()
-        now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
 
         orm_like = MagicMock()
         orm_like.id = mention_id
@@ -809,7 +805,7 @@ class TestEntityMention:
         orm_like.match_start = None
         orm_like.match_end = None
         orm_like.correction_id = None
-        orm_like.created_at = datetime.now(timezone.utc)
+        orm_like.created_at = datetime.now(UTC)
 
         mention = EntityMention.model_validate(orm_like)
         assert mention.detection_method == DetectionMethod.SPACY_NER
@@ -830,7 +826,7 @@ class TestEntityMention:
             orm_like.match_start = None
             orm_like.match_end = None
             orm_like.correction_id = None
-            orm_like.created_at = datetime.now(timezone.utc)
+            orm_like.created_at = datetime.now(UTC)
 
             mention = EntityMention.model_validate(orm_like)
             assert mention.detection_method == detection_method

--- a/tests/unit/models/test_enums.py
+++ b/tests/unit/models/test_enums.py
@@ -7,8 +7,6 @@ ensuring proper value validation and serialization.
 
 from __future__ import annotations
 
-import pytest
-
 from chronovista.models.enums import (
     DownloadReason,
     LanguageCode,

--- a/tests/unit/models/test_playlist.py
+++ b/tests/unit/models/test_playlist.py
@@ -7,7 +7,7 @@ for all Playlist model variants using factory pattern for DRY.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -353,8 +353,8 @@ class TestPlaylist:
 
     def test_create_valid_playlist(self):
         """Test creating valid Playlist with keyword arguments."""
-        created_at = datetime.now(timezone.utc)
-        updated_at = datetime.now(timezone.utc)
+        created_at = datetime.now(UTC)
+        updated_at = datetime.now(UTC)
 
         playlist = PlaylistFactory.build(
             playlist_id="PLMYEtPqzjdeev14J_RpAU_RQKyeaROB8T",
@@ -391,8 +391,8 @@ class TestPlaylist:
             privacy_status = "unlisted"
             channel_id = "UCYCvGbr7chpyTgFpgUOVjjw"
             video_count = 30
-            created_at = datetime.now(timezone.utc)
-            updated_at = datetime.now(timezone.utc)
+            created_at = datetime.now(UTC)
+            updated_at = datetime.now(UTC)
 
         mock_db = MockPlaylistDB()
         playlist = Playlist.model_validate(mock_db, from_attributes=True)
@@ -600,7 +600,7 @@ class TestPlaylistModelInteractions:
         )
 
         # Simulate creation
-        created_at = datetime.now(timezone.utc)
+        created_at = datetime.now(UTC)
         updated_at = created_at
 
         playlist_full = PlaylistFactory.build(
@@ -628,7 +628,7 @@ class TestPlaylistModelInteractions:
         update_data = playlist_update.model_dump(exclude_unset=True)
         updated_data.update(update_data)
         updated_data["updated_at"] = datetime.now(
-            timezone.utc
+            UTC
         )  # Simulate timestamp update
 
         playlist_updated = Playlist.model_validate(updated_data)

--- a/tests/unit/models/test_pydantic_validators.py
+++ b/tests/unit/models/test_pydantic_validators.py
@@ -4,12 +4,12 @@ Tests for Pydantic model validators across all models.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
 
-from chronovista.models.channel import ChannelCreate, ChannelUpdate
+from chronovista.models.channel import ChannelCreate
 from chronovista.models.enums import (
     DownloadReason,
     LanguageCode,
@@ -18,7 +18,7 @@ from chronovista.models.enums import (
 )
 from chronovista.models.user_language_preference import UserLanguagePreferenceCreate
 from chronovista.models.user_video import GoogleTakeoutWatchHistoryItem, UserVideoCreate
-from chronovista.models.video import VideoCreate, VideoUpdate
+from chronovista.models.video import VideoCreate
 from chronovista.models.video_transcript import VideoTranscriptCreate
 
 
@@ -141,7 +141,7 @@ class TestVideoValidators:
                 video_id="",
                 channel_id="UCtest123456789012345678",
                 title="Test",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=120,
             )
 
@@ -152,7 +152,7 @@ class TestVideoValidators:
                 video_id="   ",
                 channel_id="UCtest123456789012345678",
                 title="Test",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=120,
             )
 
@@ -165,7 +165,7 @@ class TestVideoValidators:
                 video_id="x" * 21,
                 channel_id="UCtest123456789012345678",
                 title="Test",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=120,
             )
 
@@ -176,7 +176,7 @@ class TestVideoValidators:
                 video_id="x" * 22,
                 channel_id="UCtest123456789012345678",
                 title="Test",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=120,
             )
 
@@ -186,7 +186,7 @@ class TestVideoValidators:
             video_id="dQw4w9WgXcQ",
             channel_id="UCtest123456789012345678",
             title="Test",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=120,
         )
         assert video.video_id == "dQw4w9WgXcQ"
@@ -200,7 +200,7 @@ class TestVideoValidators:
                 video_id="dQw4w9WgXcQ",
                 channel_id="",
                 title="Test",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=120,
             )
 
@@ -213,7 +213,7 @@ class TestVideoValidators:
                 video_id="dQw4w9WgXcQ",
                 channel_id="UCtest1234567890123456787",
                 title="",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=120,
             )
 
@@ -226,7 +226,7 @@ class TestVideoValidators:
                 video_id="dQw4w9WgXcQ",
                 channel_id="UCtest1234567890123456787",
                 title="Test",
-                upload_date=datetime.now(timezone.utc),
+                upload_date=datetime.now(UTC),
                 duration=-1,
             )
 
@@ -236,7 +236,7 @@ class TestVideoValidators:
             video_id="dQw4w9WgXcQ",
             channel_id="UCtest123456789012345678",
             title="Test",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=212,
         )
         assert video.duration == 212
@@ -253,7 +253,7 @@ class TestUserVideoValidators:
             UserVideoCreate(
                 user_id="",
                 video_id="dQw4w9WgXcQ",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
             )
 
     def test_video_id_validation_empty(self):
@@ -262,7 +262,7 @@ class TestUserVideoValidators:
             ValidationError, match="VideoId must be exactly 11 characters long"
         ):
             UserVideoCreate(
-                user_id="test_user", video_id="", watched_at=datetime.now(timezone.utc)
+                user_id="test_user", video_id="", watched_at=datetime.now(UTC)
             )
 
     def test_rewatch_count_validation_negative(self):
@@ -273,7 +273,7 @@ class TestUserVideoValidators:
             UserVideoCreate(
                 user_id="test_user",
                 video_id="dQw4w9WgXcQ",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 rewatch_count=-1,
             )
 

--- a/tests/unit/models/test_recovery_models.py
+++ b/tests/unit/models/test_recovery_models.py
@@ -7,10 +7,8 @@ RecoveryCandidate, VideoRecoveryAction, ChannelRecoveryAction, RecoveryResult,
 RecoveryOptions, and helper functions.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-
-import pytest
 
 from chronovista.models.takeout.recovery import (
     CHANNEL_PLACEHOLDER_PREFIX,
@@ -37,7 +35,7 @@ class TestHistoricalTakeout:
         """Test creating a basic HistoricalTakeout."""
         takeout = HistoricalTakeout(
             path=Path("/takeouts/2024-01-15"),
-            export_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            export_date=datetime(2024, 1, 15, tzinfo=UTC),
         )
         assert takeout.path == Path("/takeouts/2024-01-15")
         assert takeout.export_date.year == 2024
@@ -49,7 +47,7 @@ class TestHistoricalTakeout:
         """Test creating a HistoricalTakeout with all data types available."""
         takeout = HistoricalTakeout(
             path=Path("/takeouts/full-export"),
-            export_date=datetime(2023, 6, 1, tzinfo=timezone.utc),
+            export_date=datetime(2023, 6, 1, tzinfo=UTC),
             has_watch_history=True,
             has_playlists=True,
             has_subscriptions=True,
@@ -62,7 +60,7 @@ class TestHistoricalTakeout:
         """Test creating a HistoricalTakeout with only watch history."""
         takeout = HistoricalTakeout(
             path=Path("/takeouts/partial"),
-            export_date=datetime(2022, 12, 25, tzinfo=timezone.utc),
+            export_date=datetime(2022, 12, 25, tzinfo=UTC),
             has_watch_history=True,
             has_playlists=False,
             has_subscriptions=False,
@@ -82,9 +80,9 @@ class TestRecoveredVideoMetadata:
             channel_name="RickAstleyVEVO",
             channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
             channel_url="https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw",
-            watched_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+            watched_at=datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
             source_takeout=Path("/takeouts/2024-01-15"),
-            source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            source_date=datetime(2024, 1, 15, tzinfo=UTC),
         )
         assert metadata.video_id == "dQw4w9WgXcQ"
         assert metadata.title == "Never Gonna Give You Up"
@@ -96,7 +94,7 @@ class TestRecoveredVideoMetadata:
             video_id="abc123XYZ_-",
             title="Some Video Title",
             source_takeout=Path("/takeouts/2023-06-01"),
-            source_date=datetime(2023, 6, 1, tzinfo=timezone.utc),
+            source_date=datetime(2023, 6, 1, tzinfo=UTC),
         )
         assert metadata.video_id == "abc123XYZ_-"
         assert metadata.channel_name is None
@@ -114,7 +112,7 @@ class TestRecoveredChannelMetadata:
             channel_name="RickAstleyVEVO",
             channel_url="https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw",
             source_takeout=Path("/takeouts/2024-01-15"),
-            source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            source_date=datetime(2024, 1, 15, tzinfo=UTC),
             video_count=42,
         )
         assert metadata.channel_id == "UCuAXFkgsw1L7xaCfnd5JJOw"
@@ -127,7 +125,7 @@ class TestRecoveredChannelMetadata:
             channel_id="UCtest123",
             channel_name="Test Channel",
             source_takeout=Path("/takeouts/test"),
-            source_date=datetime.now(timezone.utc),
+            source_date=datetime.now(UTC),
         )
         assert metadata.video_count == 0
 
@@ -167,7 +165,7 @@ class TestVideoRecoveryAction:
             video_id="dQw4w9WgXcQ",
             old_title="[Placeholder] Video dQw4w9WgXcQ",
             new_title="Never Gonna Give You Up",
-            source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            source_date=datetime(2024, 1, 15, tzinfo=UTC),
             action_type="update_title",
         )
         assert action.action_type == "update_title"
@@ -183,7 +181,7 @@ class TestVideoRecoveryAction:
             old_channel_id="UCplaceholder",
             new_channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
             channel_name="RickAstleyVEVO",
-            source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            source_date=datetime(2024, 1, 15, tzinfo=UTC),
             action_type="both",
         )
         assert action.action_type == "both"
@@ -201,7 +199,7 @@ class TestChannelRecoveryAction:
             channel_name="RickAstleyVEVO",
             channel_url="https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw",
             action_type="create",
-            source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            source_date=datetime(2024, 1, 15, tzinfo=UTC),
         )
         assert action.action_type == "create"
 
@@ -211,7 +209,7 @@ class TestChannelRecoveryAction:
             channel_id="UCtest123",
             channel_name="Updated Channel Name",
             action_type="update_name",
-            source_date=datetime.now(timezone.utc),
+            source_date=datetime.now(UTC),
         )
         assert action.action_type == "update_name"
 
@@ -259,12 +257,12 @@ class TestRecoveryResult:
             video_id="dQw4w9WgXcQ",
             old_title="[Placeholder] Video dQw4w9WgXcQ",
             new_title="Never Gonna Give You Up",
-            source_date=datetime.now(timezone.utc),
+            source_date=datetime.now(UTC),
         )
         channel_action = ChannelRecoveryAction(
             channel_id="UCtest123",
             channel_name="Test Channel",
-            source_date=datetime.now(timezone.utc),
+            source_date=datetime.now(UTC),
         )
         result = RecoveryResult(
             videos_recovered=1,

--- a/tests/unit/models/test_tag_normalization_models.py
+++ b/tests/unit/models/test_tag_normalization_models.py
@@ -8,7 +8,7 @@ tag aliases, named entities, and entity aliases using factory patterns.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -16,21 +16,23 @@ from uuid_utils import uuid7
 
 from chronovista.db.models import (
     CanonicalTag as CanonicalTagDB,
+)
+from chronovista.db.models import (
     EntityAlias as EntityAliasDB,
+)
+from chronovista.db.models import (
     NamedEntity as NamedEntityDB,
+)
+from chronovista.db.models import (
     TagAlias as TagAliasDB,
 )
 from chronovista.models.canonical_tag import (
     CanonicalTag,
-    CanonicalTagBase,
     CanonicalTagCreate,
     CanonicalTagUpdate,
 )
 from chronovista.models.entity_alias import (
-    EntityAlias,
-    EntityAliasBase,
     EntityAliasCreate,
-    EntityAliasUpdate,
 )
 from chronovista.models.enums import (
     CreationMethod,
@@ -41,37 +43,27 @@ from chronovista.models.enums import (
 )
 from chronovista.models.named_entity import (
     NamedEntity,
-    NamedEntityBase,
     NamedEntityCreate,
-    NamedEntityUpdate,
 )
 from chronovista.models.tag_alias import (
-    TagAlias,
-    TagAliasBase,
     TagAliasCreate,
-    TagAliasUpdate,
 )
 from tests.factories import (
     CanonicalTagBaseFactory,
     CanonicalTagCreateFactory,
     CanonicalTagFactory,
     CanonicalTagTestData,
-    CanonicalTagUpdateFactory,
     EntityAliasBaseFactory,
     EntityAliasCreateFactory,
     EntityAliasFactory,
     EntityAliasTestData,
-    EntityAliasUpdateFactory,
     NamedEntityBaseFactory,
     NamedEntityCreateFactory,
-    NamedEntityFactory,
     NamedEntityTestData,
-    NamedEntityUpdateFactory,
     TagAliasBaseFactory,
     TagAliasCreateFactory,
     TagAliasFactory,
     TagAliasTestData,
-    TagAliasUpdateFactory,
 )
 
 
@@ -128,7 +120,7 @@ class TestCanonicalTagModels:
         """Test creating full CanonicalTag with all fields."""
         tag_id = uuid.UUID(bytes=uuid7().bytes)
         entity_id = uuid.UUID(bytes=uuid7().bytes)
-        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
 
         tag = CanonicalTagFactory.build(
             id=tag_id,
@@ -225,8 +217,8 @@ class TestCanonicalTagModels:
                 merged_into_id=tag_id,  # Same as id - should fail
                 alias_count=1,
                 video_count=0,
-                created_at=datetime.now(timezone.utc),
-                updated_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
             )
 
     def test_canonical_tag_update_partial_fields(self) -> None:
@@ -302,7 +294,7 @@ class TestTagAliasModels:
         """Test creating full TagAlias with all fields."""
         alias_id = uuid.UUID(bytes=uuid7().bytes)
         canonical_tag_id = uuid.UUID(bytes=uuid7().bytes)
-        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
 
         alias = TagAliasFactory.build(
             id=alias_id,
@@ -438,8 +430,8 @@ class TestNamedEntityModels:
                 video_count=0,
                 channel_count=0,
                 confidence=1.0,
-                created_at=datetime.now(timezone.utc),
-                updated_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
             )
 
     def test_named_entity_confidence_out_of_range_high(self) -> None:
@@ -582,7 +574,7 @@ class TestEntityAliasModels:
         """Test creating full EntityAlias with all fields."""
         alias_id = uuid.UUID(bytes=uuid7().bytes)
         entity_id = uuid.UUID(bytes=uuid7().bytes)
-        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        now = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
 
         alias = EntityAliasFactory.build(
             id=alias_id,

--- a/tests/unit/models/test_takeout_data.py
+++ b/tests/unit/models/test_takeout_data.py
@@ -4,7 +4,7 @@ Tests for takeout data models.
 Comprehensive test coverage for Google Takeout data parsing models.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from tests.factories.takeout_data_factory import (
@@ -143,7 +143,7 @@ class TestTakeoutWatchEntry:
             title_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             raw_time="2023-01-15T14:30:00Z",
         )
-        expected_time = datetime(2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc)
+        expected_time = datetime(2023, 1, 15, 14, 30, 0, tzinfo=UTC)
         assert entry.watched_at == expected_time
 
     def test_watched_at_parsing_iso_format_with_timezone(self):
@@ -170,7 +170,7 @@ class TestTakeoutWatchEntry:
 
     def test_watched_at_provided_explicitly(self):
         """Test that explicitly provided watched_at is preserved."""
-        explicit_time = datetime(2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc)
+        explicit_time = datetime(2023, 1, 15, 14, 30, 0, tzinfo=UTC)
         entry = create_minimal_takeout_watch_entry(
             title="Test Video",
             title_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
@@ -181,7 +181,7 @@ class TestTakeoutWatchEntry:
 
     def test_all_fields_present(self):
         """Test creation with all fields present."""
-        watched_time = datetime(2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc)
+        watched_time = datetime(2023, 1, 15, 14, 30, 0, tzinfo=UTC)
         entry = create_takeout_watch_entry(
             video_id="dQw4w9WgXcQ",
             title="Test Video",
@@ -246,7 +246,7 @@ class TestTakeoutPlaylistItem:
 
     def test_explicit_creation_timestamp_preserved(self):
         """Test that explicitly provided creation_timestamp is preserved."""
-        explicit_time = datetime(2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc)
+        explicit_time = datetime(2023, 1, 15, 14, 30, 0, tzinfo=UTC)
         item = create_takeout_playlist_item(
             video_id="dQw4w9WgXcQ",
             raw_timestamp="2023-06-15T14:30:00+00:00",
@@ -480,9 +480,9 @@ class TestTakeoutData:
 
     def test_date_range_calculation(self):
         """Test date range calculation from watch history."""
-        time1 = datetime(2023, 1, 15, tzinfo=timezone.utc)
-        time2 = datetime(2023, 6, 15, tzinfo=timezone.utc)
-        time3 = datetime(2023, 3, 15, tzinfo=timezone.utc)
+        time1 = datetime(2023, 1, 15, tzinfo=UTC)
+        time2 = datetime(2023, 6, 15, tzinfo=UTC)
+        time3 = datetime(2023, 3, 15, tzinfo=UTC)
 
         watch_entries = [
             create_takeout_watch_entry(
@@ -539,8 +539,8 @@ class TestTakeoutData:
 
     def test_date_range_preserved_when_provided(self):
         """Test that explicitly provided date_range is preserved."""
-        time1 = datetime(2023, 1, 15, tzinfo=timezone.utc)
-        time2 = datetime(2023, 6, 15, tzinfo=timezone.utc)
+        time1 = datetime(2023, 1, 15, tzinfo=UTC)
+        time2 = datetime(2023, 6, 15, tzinfo=UTC)
         explicit_range = (time1, time2)
 
         data = create_takeout_data(

--- a/tests/unit/models/test_topic_category.py
+++ b/tests/unit/models/test_topic_category.py
@@ -7,8 +7,8 @@ for all TopicCategory model variants using factory pattern for DRY.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import cast
-from datetime import datetime, timezone
 
 import pytest
 from pydantic import ValidationError
@@ -268,7 +268,7 @@ class TestTopicCategory:
 
     def test_create_valid_topic_category(self):
         """Test creating valid TopicCategory with keyword arguments."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         topic = cast(TopicCategory, TopicCategoryFactory.build(
             topic_id="education",
             category_name="Education",
@@ -291,7 +291,7 @@ class TestTopicCategory:
             category_name = "Science & Technology"
             parent_topic_id = "education"
             topic_type = "youtube"
-            created_at = datetime.now(timezone.utc)
+            created_at = datetime.now(UTC)
 
         mock_db = MockTopicCategoryDB()
         topic = TopicCategory.model_validate(mock_db, from_attributes=True)
@@ -564,7 +564,7 @@ class TestTopicCategoryModelInteractions:
         )
 
         # Simulate creation
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         topic_full = cast(TopicCategory, TopicCategoryFactory.build(
             topic_id=topic_create.topic_id,
             category_name=topic_create.category_name,

--- a/tests/unit/models/test_transcript_correction.py
+++ b/tests/unit/models/test_transcript_correction.py
@@ -9,7 +9,7 @@ TranscriptCorrectionRead models (Feature 033, FR-018 append-only).
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -30,8 +30,6 @@ from tests.factories.transcript_correction_factory import (
 )
 
 # CRITICAL: Ensure async tests work with coverage tooling.
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
@@ -402,7 +400,7 @@ class TestTranscriptCorrectionRead:
 
     def _make_read(self, **overrides: Any) -> TranscriptCorrectionRead:
         """Build a valid TranscriptCorrectionRead with optional field overrides."""
-        now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
         defaults: dict[str, Any] = {
             "id": _make_uuid7(),
             "video_id": _VALID_VIDEO_ID,
@@ -426,7 +424,7 @@ class TestTranscriptCorrectionRead:
     def test_valid_read_with_required_fields(self) -> None:
         """TranscriptCorrectionRead is valid with all required fields present."""
         correction_id = _make_uuid7()
-        now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
 
         correction = TranscriptCorrectionRead(
             id=correction_id,
@@ -537,7 +535,7 @@ class TestTranscriptCorrectionRead:
                 original_text="teh",
                 corrected_text="the",
                 version_number=1,
-                corrected_at=datetime.now(timezone.utc),
+                corrected_at=datetime.now(UTC),
             )
 
     def test_missing_corrected_at_raises_validation_error(self) -> None:

--- a/tests/unit/models/test_transcript_segment.py
+++ b/tests/unit/models/test_transcript_segment.py
@@ -6,8 +6,8 @@ Tests model field types, constraints, relationships, and cascade delete behavior
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict, cast
+from datetime import UTC, datetime
+from typing import Any, cast
 
 import pytest
 from pydantic import ValidationError
@@ -17,9 +17,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import (
     Channel,
-    TranscriptSegment as TranscriptSegmentDB,
     Video,
     VideoTranscript,
+)
+from chronovista.db.models import (
+    TranscriptSegment as TranscriptSegmentDB,
 )
 from chronovista.models.transcript_segment import (
     TranscriptSegment,
@@ -28,7 +30,6 @@ from chronovista.models.transcript_segment import (
     TranscriptSegmentResponse,
 )
 from tests.factories.transcript_segment_factory import (
-    TranscriptSegmentFactory,
     TranscriptSegmentTestData,
     create_batch_transcript_segments,
     create_corrected_transcript_segment,
@@ -69,7 +70,7 @@ class TestTranscriptSegmentSQLAlchemyModel:
             video_id="dQw4w9WgXcQ",
             channel_id=channel.channel_id,
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=300,
         )
         db_session.add(video)
@@ -123,7 +124,7 @@ class TestTranscriptSegmentSQLAlchemyModel:
             video_id="dQw4w9WgXcQ",
             channel_id=channel.channel_id,
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=300,
         )
         db_session.add(video)
@@ -173,7 +174,7 @@ class TestTranscriptSegmentSQLAlchemyModel:
             video_id="dQw4w9WgXcQ",
             channel_id=channel.channel_id,
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=300,
         )
         db_session.add(video)
@@ -254,7 +255,7 @@ class TestTranscriptSegmentSQLAlchemyModel:
             video_id="dQw4w9WgXcQ",
             channel_id=channel.channel_id,
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=300,
         )
         db_session.add(video)
@@ -309,7 +310,7 @@ class TestTranscriptSegmentSQLAlchemyModel:
             video_id="dQw4w9WgXcQ",
             channel_id=channel.channel_id,
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=300,
         )
         db_session.add(video)
@@ -375,7 +376,7 @@ class TestTranscriptSegmentSQLAlchemyModel:
             video_id="dQw4w9WgXcQ",
             channel_id=channel.channel_id,
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=300,
         )
         db_session.add(video)
@@ -421,7 +422,7 @@ class TestTranscriptSegmentSQLAlchemyModel:
             video_id="dQw4w9WgXcQ",
             channel_id=channel.channel_id,
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=300,
         )
         db_session.add(video)
@@ -469,7 +470,7 @@ class TestTranscriptSegmentSQLAlchemyModel:
             video_id="dQw4w9WgXcQ",
             channel_id=channel.channel_id,
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=300,
         )
         db_session.add(video)
@@ -515,7 +516,7 @@ class TestTranscriptSegmentSQLAlchemyModel:
             video_id="dQw4w9WgXcQ",
             channel_id=channel.channel_id,
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=300,
         )
         db_session.add(video)
@@ -614,7 +615,7 @@ class TestTranscriptSegmentPydanticModels:
             sequence_number=0,
             has_correction=False,
             corrected_text=None,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         assert segment.display_text == "Original text"
 
@@ -631,7 +632,7 @@ class TestTranscriptSegmentPydanticModels:
             sequence_number=0,
             has_correction=True,
             corrected_text="Corrected text",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         assert segment.display_text == "Corrected text"
 
@@ -701,7 +702,7 @@ class TestTranscriptSegmentPydanticModels:
             sequence_number=10,
             has_correction=False,
             corrected_text=None,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         response = TranscriptSegmentResponse.from_segment(full_segment)
         assert response.segment_id == 42
@@ -722,7 +723,7 @@ class TestTranscriptSegmentPydanticModels:
             sequence_number=0,
             has_correction=True,
             corrected_text="Corrected text",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         response = TranscriptSegmentResponse.from_segment(full_segment)
         assert response.text == "Corrected text"
@@ -917,7 +918,7 @@ class TestValidationEdgeCases:
         # Test sample snippets from test data
         for i, snippet in enumerate(TranscriptSegmentTestData.SAMPLE_SNIPPETS):
             # Type annotations for mypy
-            snippet_dict = cast(Dict[str, Any], snippet)
+            snippet_dict = cast(dict[str, Any], snippet)
             segment = TranscriptSegmentCreate.from_snippet(
                 video_id="dQw4w9WgXcQ",
                 language_code="en",

--- a/tests/unit/models/test_user_language_preference.py
+++ b/tests/unit/models/test_user_language_preference.py
@@ -7,7 +7,7 @@ serialization, and business logic testing using factory-boy for DRY principles.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -279,7 +279,7 @@ class TestUserLanguagePreferenceFactory:
 
     def test_user_language_preference_timestamps(self):
         """Test UserLanguagePreference with custom timestamps."""
-        created_time = datetime(2023, 1, 1, tzinfo=timezone.utc)
+        created_time = datetime(2023, 1, 1, tzinfo=UTC)
 
         preference = UserLanguagePreferenceFactory.build(created_at=created_time)
 
@@ -294,7 +294,7 @@ class TestUserLanguagePreferenceFactory:
             "priority": 1,
             "auto_download_transcripts": True,
             "learning_goal": "Native Italian speaker",
-            "created_at": datetime(2023, 6, 15, 10, 30, tzinfo=timezone.utc),
+            "created_at": datetime(2023, 6, 15, 10, 30, tzinfo=UTC),
         }
 
         preference = UserLanguagePreference.model_validate(preference_data)

--- a/tests/unit/models/test_user_video.py
+++ b/tests/unit/models/test_user_video.py
@@ -7,7 +7,7 @@ serialization, and business logic testing using factory-boy for DRY principles.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -33,7 +33,6 @@ from tests.factories.user_video_factory import (
     create_batch_user_videos,
     create_google_takeout_item,
     create_user_video,
-    create_user_video_base,
     create_user_video_create,
     create_user_video_search_filters,
     create_user_video_statistics,
@@ -105,7 +104,7 @@ class TestUserVideoBaseFactory:
         data = {
             "user_id": "validate_user",
             "video_id": "3tmd-ClpJxA",
-            "watched_at": datetime(2023, 12, 1, 10, 30, 0, tzinfo=timezone.utc),
+            "watched_at": datetime(2023, 12, 1, 10, 30, 0, tzinfo=UTC),
             "rewatch_count": 2,
             "liked": True,
             "saved_to_playlist": True,
@@ -181,8 +180,8 @@ class TestUserVideoFactory:
 
     def test_user_video_timestamps(self):
         """Test UserVideo with custom timestamps."""
-        created_time = datetime(2023, 1, 1, tzinfo=timezone.utc)
-        updated_time = datetime(2023, 12, 1, tzinfo=timezone.utc)
+        created_time = datetime(2023, 1, 1, tzinfo=UTC)
+        updated_time = datetime(2023, 12, 1, tzinfo=UTC)
 
         user_video = UserVideoFactory.build(
             created_at=created_time, updated_at=updated_time
@@ -560,12 +559,12 @@ class TestAdditionalValidationEdgeCases:
         video_data = {
             "user_id": "orm_user",
             "video_id": "dQw4w9WgXcQ",
-            "watched_at": datetime(2023, 12, 1, 10, 30, 0, tzinfo=timezone.utc),
+            "watched_at": datetime(2023, 12, 1, 10, 30, 0, tzinfo=UTC),
             "rewatch_count": 2,
             "liked": True,
             "saved_to_playlist": True,
-            "created_at": datetime(2023, 12, 1, 10, 35, 0, tzinfo=timezone.utc),
-            "updated_at": datetime(2023, 12, 1, 11, 30, 0, tzinfo=timezone.utc),
+            "created_at": datetime(2023, 12, 1, 10, 35, 0, tzinfo=UTC),
+            "updated_at": datetime(2023, 12, 1, 11, 30, 0, tzinfo=UTC),
         }
 
         user_video = UserVideo.model_validate(video_data)
@@ -600,13 +599,13 @@ class TestAdditionalValidationEdgeCases:
         filters = UserVideoSearchFiltersFactory.build(
             user_ids=["user1", "user2", "user3"],
             video_ids=["dQw4w9WgXcQ", "9bZkp7q19f0"],
-            watched_after=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            watched_before=datetime(2023, 12, 31, tzinfo=timezone.utc),
+            watched_after=datetime(2023, 1, 1, tzinfo=UTC),
+            watched_before=datetime(2023, 12, 31, tzinfo=UTC),
             liked_only=True,
             playlist_saved_only=True,
             min_rewatch_count=2,
-            created_after=datetime(2023, 6, 1, tzinfo=timezone.utc),
-            created_before=datetime(2023, 11, 30, tzinfo=timezone.utc),
+            created_after=datetime(2023, 6, 1, tzinfo=UTC),
+            created_before=datetime(2023, 11, 30, tzinfo=UTC),
         )
 
         assert filters.user_ids is not None
@@ -625,7 +624,7 @@ class TestAdditionalValidationEdgeCases:
             playlist_saved_count=75,
             rewatch_count=100,
             unique_videos=450,
-            most_watched_date=datetime(2023, 11, 15, tzinfo=timezone.utc),
+            most_watched_date=datetime(2023, 11, 15, tzinfo=UTC),
             watch_streak_days=21,
         )
 
@@ -658,7 +657,7 @@ class TestAdditionalValidationEdgeCases:
         original = UserVideoFactory.build(
             user_id="serialize_test",
             video_id="dQw4w9WgXcQ",  # Valid 11-character video ID
-            watched_at=datetime(2023, 12, 1, 15, 30, tzinfo=timezone.utc),
+            watched_at=datetime(2023, 12, 1, 15, 30, tzinfo=UTC),
             rewatch_count=3,
             liked=True,
             saved_to_playlist=True,

--- a/tests/unit/models/test_video.py
+++ b/tests/unit/models/test_video.py
@@ -7,7 +7,7 @@ serialization, and business logic testing using factory-boy for DRY principles.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -164,7 +164,7 @@ class TestVideoBaseFactory:
             "channel_id": "UCuAXFkgsw1L7xaCfnd5JJOw",  # Valid 24-char channel ID
             "title": "Validation Test Video",
             "description": "Test video for validation",
-            "upload_date": datetime(2023, 12, 1, 10, 30, 0, tzinfo=timezone.utc),
+            "upload_date": datetime(2023, 12, 1, 10, 30, 0, tzinfo=UTC),
             "duration": 300,
             "made_for_kids": False,
             "self_declared_made_for_kids": False,
@@ -278,8 +278,8 @@ class TestVideoFactory:
 
     def test_video_timestamps(self):
         """Test Video with custom timestamps."""
-        created_time = datetime(2023, 1, 1, tzinfo=timezone.utc)
-        updated_time = datetime(2023, 12, 1, tzinfo=timezone.utc)
+        created_time = datetime(2023, 1, 1, tzinfo=UTC)
+        updated_time = datetime(2023, 12, 1, tzinfo=UTC)
 
         video = VideoFactory.build(created_at=created_time, updated_at=updated_time)
 
@@ -293,7 +293,7 @@ class TestVideoFactory:
             "channel_id": "UCuAXFkgsw1L7xaCfnd5JJOw",
             "title": "ORM Test Video",
             "description": "Testing ORM compatibility",
-            "upload_date": datetime(2023, 6, 15, 10, 30, tzinfo=timezone.utc),
+            "upload_date": datetime(2023, 6, 15, 10, 30, tzinfo=UTC),
             "duration": 600,
             "made_for_kids": False,
             "self_declared_made_for_kids": False,
@@ -301,8 +301,8 @@ class TestVideoFactory:
             "view_count": 25000,
             "like_count": 1500,
             "availability_status": "available",
-            "created_at": datetime(2023, 6, 15, 10, 30, tzinfo=timezone.utc),
-            "updated_at": datetime(2023, 6, 15, 12, 45, tzinfo=timezone.utc),
+            "created_at": datetime(2023, 6, 15, 10, 30, tzinfo=UTC),
+            "updated_at": datetime(2023, 6, 15, 12, 45, tzinfo=UTC),
         }
 
         video = Video.model_validate(video_data)
@@ -348,8 +348,8 @@ class TestVideoSearchFiltersFactory:
 
     def test_video_search_filters_comprehensive(self):
         """Test VideoSearchFilters with all fields."""
-        upload_after = datetime(2023, 1, 1, tzinfo=timezone.utc)
-        upload_before = datetime(2023, 12, 31, tzinfo=timezone.utc)
+        upload_after = datetime(2023, 1, 1, tzinfo=UTC)
+        upload_before = datetime(2023, 12, 31, tzinfo=UTC)
 
         filters = VideoSearchFiltersFactory.build(
             channel_ids=[

--- a/tests/unit/models/test_video_category.py
+++ b/tests/unit/models/test_video_category.py
@@ -7,7 +7,7 @@ for all VideoCategory model variants.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -275,8 +275,8 @@ class TestVideoCategory:
 
     def test_create_valid_video_category(self):
         """Test creating valid VideoCategory with keyword arguments."""
-        created_at = datetime.now(timezone.utc)
-        updated_at = datetime.now(timezone.utc)
+        created_at = datetime.now(UTC)
+        updated_at = datetime.now(UTC)
 
         category = VideoCategory(
             category_id="10",
@@ -300,8 +300,8 @@ class TestVideoCategory:
             category_id = "20"
             name = "Gaming"
             assignable = True
-            created_at = datetime.now(timezone.utc)
-            updated_at = datetime.now(timezone.utc)
+            created_at = datetime.now(UTC)
+            updated_at = datetime.now(UTC)
 
         mock_db = MockVideoCategoryDB()
         category = VideoCategory.model_validate(mock_db, from_attributes=True)
@@ -314,8 +314,8 @@ class TestVideoCategory:
 
     def test_model_is_instance_of_base(self):
         """Test that VideoCategory is instance of VideoCategoryBase."""
-        created_at = datetime.now(timezone.utc)
-        updated_at = datetime.now(timezone.utc)
+        created_at = datetime.now(UTC)
+        updated_at = datetime.now(UTC)
 
         category = VideoCategory(
             category_id="1",
@@ -334,7 +334,7 @@ class TestVideoCategory:
                 "category_id": "1",
                 "name": "Test",
                 "assignable": True,
-                "updated_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(UTC),
             })
 
         # Missing updated_at
@@ -343,13 +343,13 @@ class TestVideoCategory:
                 "category_id": "1",
                 "name": "Test",
                 "assignable": True,
-                "created_at": datetime.now(timezone.utc),
+                "created_at": datetime.now(UTC),
             })
 
     def test_model_dump_includes_timestamps(self):
         """Test model_dump() includes timestamp fields."""
-        created_at = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-        updated_at = datetime(2024, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
+        created_at = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        updated_at = datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC)
 
         category = VideoCategory(
             category_id="10",
@@ -381,7 +381,7 @@ class TestVideoCategoryModelInteractions:
         )
 
         # Simulate creation
-        created_at = datetime.now(timezone.utc)
+        created_at = datetime.now(UTC)
         updated_at = created_at
 
         category_full = VideoCategory(
@@ -402,7 +402,7 @@ class TestVideoCategoryModelInteractions:
         updated_data = category_full.model_dump()
         update_data = category_update.model_dump(exclude_unset=True)
         updated_data.update(update_data)
-        updated_data["updated_at"] = datetime.now(timezone.utc)
+        updated_data["updated_at"] = datetime.now(UTC)
 
         category_updated = VideoCategory.model_validate(updated_data)
 
@@ -455,8 +455,8 @@ class TestVideoCategoryModelInteractions:
     def test_model_config_validation(self):
         """Test model configuration settings."""
         # Test validate_assignment works
-        created_at = datetime.now(timezone.utc)
-        updated_at = datetime.now(timezone.utc)
+        created_at = datetime.now(UTC)
+        updated_at = datetime.now(UTC)
 
         category = VideoCategory(
             category_id="10",

--- a/tests/unit/models/test_video_localization.py
+++ b/tests/unit/models/test_video_localization.py
@@ -7,8 +7,8 @@ for all VideoLocalization model variants using factory pattern for DRY.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import cast
-from datetime import datetime, timezone
 
 import pytest
 from pydantic import ValidationError
@@ -242,7 +242,7 @@ class TestVideoLocalization:
 
     def test_create_valid_video_localization(self):
         """Test creating valid VideoLocalization with keyword arguments."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         localization = cast(VideoLocalization, VideoLocalizationFactory.build(
             video_id="dQw4w9WgXcQ",
             language_code=LanguageCode.JAPANESE,
@@ -266,7 +266,7 @@ class TestVideoLocalization:
             language_code = LanguageCode.GERMAN
             localized_title = "Test Video"
             localized_description = "Beschreibung"
-            created_at = datetime.now(timezone.utc)
+            created_at = datetime.now(UTC)
 
         mock_db = MockVideoLocalizationDB()
         localization = VideoLocalization.model_validate(mock_db, from_attributes=True)
@@ -402,7 +402,7 @@ class TestVideoLocalizationModelInteractions:
         )
 
         # Simulate creation
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         localization_full = cast(VideoLocalization, VideoLocalizationFactory.build(
             video_id=localization_create.video_id,
             language_code=localization_create.language_code,

--- a/tests/unit/models/test_video_tag.py
+++ b/tests/unit/models/test_video_tag.py
@@ -7,7 +7,7 @@ for all VideoTag model variants using factory pattern for DRY.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import cast
 
 import pytest
@@ -188,7 +188,7 @@ class TestVideoTag:
 
     def test_create_valid_video_tag(self):
         """Test creating valid VideoTag with keyword arguments."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         tag = cast(VideoTag, VideoTagFactory.build(
             video_id="dQw4w9WgXcQ", tag="tutorial", tag_order=1, created_at=now
         ))
@@ -206,7 +206,7 @@ class TestVideoTag:
             video_id = "dQw4w9WgXcQ"
             tag = "education"
             tag_order = 2
-            created_at = datetime.now(timezone.utc)
+            created_at = datetime.now(UTC)
 
         mock_db = MockVideoTagDB()
         tag = VideoTag.model_validate(mock_db, from_attributes=True)
@@ -356,7 +356,7 @@ class TestVideoTagModelInteractions:
         )
 
         # Simulate creation
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         tag_full = VideoTagFactory.build(
             video_id=tag_create.video_id,
             tag=tag_create.tag,

--- a/tests/unit/models/test_video_topic.py
+++ b/tests/unit/models/test_video_topic.py
@@ -5,7 +5,7 @@ Tests for VideoTopic, VideoTopicCreate, VideoTopicUpdate models
 including validation, field validation, and edge cases.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -144,7 +144,7 @@ class TestVideoTopicSearchFilters:
 
     def test_video_topic_search_filters_with_data(self):
         """Test VideoTopicSearchFilters with filter data."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         filters = VideoTopicSearchFilters(
             video_ids=[TestIds.TEST_VIDEO_1, TestIds.TEST_VIDEO_2],
             topic_ids=[TestIds.MUSIC_TOPIC, TestIds.GAMING_TOPIC],
@@ -206,7 +206,7 @@ class TestVideoTopic:
 
     def test_video_topic_from_dict(self):
         """Test VideoTopic creation from dictionary (as from database)."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         video_topic = VideoTopic(
             video_id=TestIds.TEST_VIDEO_1,
@@ -227,7 +227,7 @@ class TestVideoTopic:
             video_id=TestIds.TEST_VIDEO_1,
             topic_id=TestIds.MUSIC_TOPIC,
             relevance_type="primary",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         # Should validate when assigning new values

--- a/tests/unit/models/test_video_transcript.py
+++ b/tests/unit/models/test_video_transcript.py
@@ -7,7 +7,7 @@ serialization, and business logic testing using factory-boy for DRY principles.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -337,7 +337,7 @@ class TestVideoTranscriptFactory:
 
     def test_video_transcript_timestamps(self):
         """Test VideoTranscript with custom timestamps."""
-        downloaded_time = datetime(2023, 1, 1, tzinfo=timezone.utc)
+        downloaded_time = datetime(2023, 1, 1, tzinfo=UTC)
 
         transcript = VideoTranscriptFactory.build(downloaded_at=downloaded_time)
 
@@ -356,7 +356,7 @@ class TestVideoTranscriptFactory:
             "is_auto_synced": False,
             "track_kind": "standard",
             "caption_name": "Italiano (manuale)",
-            "downloaded_at": datetime(2023, 6, 15, 10, 30, tzinfo=timezone.utc),
+            "downloaded_at": datetime(2023, 6, 15, 10, 30, tzinfo=UTC),
         }
 
         transcript = VideoTranscript.model_validate(transcript_data)
@@ -455,8 +455,8 @@ class TestTranscriptSearchFiltersFactory:
 
     def test_transcript_search_filters_comprehensive(self):
         """Test TranscriptSearchFilters with all fields."""
-        download_after = datetime(2023, 1, 1, tzinfo=timezone.utc)
-        download_before = datetime(2023, 12, 31, tzinfo=timezone.utc)
+        download_after = datetime(2023, 1, 1, tzinfo=UTC)
+        download_before = datetime(2023, 12, 31, tzinfo=UTC)
 
         filters = TranscriptSearchFiltersFactory.build(
             video_ids=["dQw4w9WgXcQ", "9bZkp7q19f0", "3tmd-ClpJxA"],

--- a/tests/unit/models/test_youtube_types.py
+++ b/tests/unit/models/test_youtube_types.py
@@ -5,7 +5,6 @@ Comprehensive test coverage for YouTube ID validation functions and type aliases
 """
 
 import re
-from typing import Any
 
 import pytest
 

--- a/tests/unit/parsers/test_takeout_parser.py
+++ b/tests/unit/parsers/test_takeout_parser.py
@@ -8,7 +8,7 @@ import json
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 
@@ -220,7 +220,7 @@ class TestTakeoutParserAction:
 class TestTakeoutParserFileProcessing:
     """Test file parsing functionality."""
 
-    def create_test_file(self, data: List[Dict[str, Any]]) -> Path:
+    def create_test_file(self, data: list[dict[str, Any]]) -> Path:
         """Create a temporary JSON file with test data."""
         temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
         json.dump(data, temp_file)
@@ -229,7 +229,7 @@ class TestTakeoutParserFileProcessing:
 
     def test_parse_watch_history_file_valid_data(self):
         """Test parsing a valid watch history file."""
-        test_data: List[Dict[str, Any]] = [
+        test_data: list[dict[str, Any]] = [
             {
                 "header": "YouTube",
                 "title": "Watched Never Gonna Give You Up",
@@ -274,7 +274,7 @@ class TestTakeoutParserFileProcessing:
 
     def test_parse_watch_history_file_empty_data(self):
         """Test parsing an empty file."""
-        test_data: List[Dict[str, Any]] = []
+        test_data: list[dict[str, Any]] = []
         file_path = self.create_test_file(test_data)
 
         try:
@@ -285,7 +285,7 @@ class TestTakeoutParserFileProcessing:
 
     def test_parse_watch_history_file_non_youtube_entries(self):
         """Test parsing file with non-YouTube entries."""
-        test_data: List[Dict[str, Any]] = [
+        test_data: list[dict[str, Any]] = [
             {
                 "header": "Google Search",
                 "title": "Searched for cats",
@@ -310,7 +310,7 @@ class TestTakeoutParserFileProcessing:
 
     def test_parse_watch_history_file_invalid_entries(self):
         """Test parsing file with invalid entries."""
-        test_data: List[Dict[str, Any]] = [
+        test_data: list[dict[str, Any]] = [
             {
                 "header": "YouTube",
                 "title": "",  # Empty title
@@ -347,7 +347,7 @@ class TestTakeoutParserFileProcessing:
 
     def test_parse_watch_history_file_no_subtitles(self):
         """Test parsing entries without subtitle information."""
-        test_data: List[Dict[str, Any]] = [
+        test_data: list[dict[str, Any]] = [
             {
                 "header": "YouTube",
                 "title": "Watched Video Without Channel Info",
@@ -408,7 +408,7 @@ class TestTakeoutParserFileProcessing:
 class TestTakeoutParserCounting:
     """Test entry counting functionality."""
 
-    def create_test_file(self, data: List[Dict[str, Any]]) -> Path:
+    def create_test_file(self, data: list[dict[str, Any]]) -> Path:
         """Create a temporary JSON file with test data."""
         temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
         json.dump(data, temp_file)
@@ -466,7 +466,7 @@ class TestTakeoutParserCounting:
 
     def test_count_entries_empty_file(self):
         """Test counting entries in empty file."""
-        test_data: List[Dict[str, Any]] = []
+        test_data: list[dict[str, Any]] = []
         file_path = self.create_test_file(test_data)
 
         try:
@@ -508,7 +508,7 @@ class TestTakeoutParserCounting:
 class TestTakeoutParserEdgeCases:
     """Test edge cases and error handling."""
 
-    def create_test_file(self, data: List[Dict[str, Any]]) -> Path:
+    def create_test_file(self, data: list[dict[str, Any]]) -> Path:
         """Create a temporary JSON file with test data."""
         temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
         json.dump(data, temp_file)
@@ -607,7 +607,7 @@ class TestTakeoutParserEdgeCases:
 
     def test_parse_watch_history_file_with_malformed_entry(self):
         """Test parsing file with one malformed entry that causes exception."""
-        test_data: List[Dict[str, Any]] = [
+        test_data: list[dict[str, Any]] = [
             {
                 "header": "YouTube",
                 "title": "Watched Good Video",

--- a/tests/unit/repositories/test_base_repository.py
+++ b/tests/unit/repositories/test_base_repository.py
@@ -4,6 +4,7 @@ Tests for BaseSQLAlchemyRepository functionality.
 
 from __future__ import annotations
 
+from datetime import UTC
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -13,8 +14,6 @@ from chronovista.db.models import Video as VideoDB
 from chronovista.models.video import VideoCreate, VideoUpdate
 from chronovista.repositories.base import BaseSQLAlchemyRepository
 from tests.factories.video_factory import VideoCreateFactory, create_video_update
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestBaseSQLAlchemyRepository:
@@ -27,7 +26,7 @@ class TestBaseSQLAlchemyRepository:
             super().__init__(VideoDB)
 
     @pytest.fixture
-    def repository(self) -> "TestBaseSQLAlchemyRepository.MockRepository":
+    def repository(self) -> TestBaseSQLAlchemyRepository.MockRepository:
         """Create repository instance for testing."""
         return self.MockRepository()
 
@@ -39,14 +38,14 @@ class TestBaseSQLAlchemyRepository:
     @pytest.fixture
     def mock_video_create(self) -> VideoCreate:
         """Create mock VideoCreate object."""
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         return VideoCreate(
             video_id="dQw4w9WgXcQ",
             channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
             title="Test Video",
             description="Test description",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=120,
         )
 
@@ -199,14 +198,14 @@ class TestBaseSQLAlchemyRepository:
     @pytest.mark.asyncio
     async def test_create_error_handling(self, repository, mock_session: AsyncMock):
         """Test create method error handling."""
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         # Use valid Video data but mock session to raise exception during add
         valid_obj = VideoCreateFactory.build(
             video_id="dQw4w9WgXcQ",
             channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
             title="Test Video",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=120,
         )
 
@@ -257,7 +256,7 @@ class TestBaseRepositoryEdgeCases:
             super().__init__(VideoDB)
 
     @pytest.fixture
-    def repository(self) -> "TestBaseRepositoryEdgeCases.MockRepository":
+    def repository(self) -> TestBaseRepositoryEdgeCases.MockRepository:
         """Create repository instance for testing."""
         return self.MockRepository()
 
@@ -308,13 +307,13 @@ class TestBaseRepositoryEdgeCases:
     @pytest.mark.asyncio
     async def test_session_operations_order(self, repository, mock_session: AsyncMock):
         """Test that session operations are called in correct order."""
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         mock_video_create = VideoCreate(
             video_id="dQw4w9WgXcQ",
             channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
             title="Test",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=120,
         )
         mock_video_db = MagicMock()

--- a/tests/unit/repositories/test_canonical_tag_repository.py
+++ b/tests/unit/repositories/test_canonical_tag_repository.py
@@ -12,8 +12,8 @@ Tests the five query methods:
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,13 +21,14 @@ from uuid_utils import uuid7
 
 from chronovista.db.models import (
     CanonicalTag as CanonicalTagDB,
+)
+from chronovista.db.models import (
     TagAlias as TagAliasDB,
+)
+from chronovista.db.models import (
     Video as VideoDB,
-    VideoTag,
 )
 from chronovista.repositories.canonical_tag_repository import CanonicalTagRepository
-
-pytestmark = pytest.mark.asyncio
 
 
 def _make_uuid() -> uuid.UUID:
@@ -86,7 +87,7 @@ def _make_video(
     video = VideoDB(
         video_id=video_id,
         title=title,
-        upload_date=upload_date or datetime(2024, 6, 15, tzinfo=timezone.utc),
+        upload_date=upload_date or datetime(2024, 6, 15, tzinfo=UTC),
         duration=300,
         made_for_kids=False,
         self_declared_made_for_kids=False,
@@ -601,12 +602,12 @@ class TestCanonicalTagRepositoryGetVideosByNormalizedForm:
         video_new = _make_video(
             video_id="vid_new",
             title="New Video",
-            upload_date=datetime(2025, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2025, 1, 15, tzinfo=UTC),
         )
         video_old = _make_video(
             video_id="vid_old",
             title="Old Video",
-            upload_date=datetime(2020, 6, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 6, 1, tzinfo=UTC),
         )
 
         count_result = MagicMock()

--- a/tests/unit/repositories/test_channel_repository.py
+++ b/tests/unit/repositories/test_channel_repository.py
@@ -4,7 +4,7 @@ Tests for ChannelRepository functionality.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,8 +18,6 @@ from chronovista.models.channel import (
 )
 from chronovista.models.enums import LanguageCode
 from chronovista.repositories.channel_repository import ChannelRepository
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestChannelRepository:
@@ -47,8 +45,8 @@ class TestChannelRepository:
             default_language="en",
             country="GB",
             thumbnail_url="https://yt3.ggpht.com/test.jpg",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
     @pytest.fixture
@@ -298,7 +296,7 @@ class TestChannelRepository:
             repository,
             "get_channel_statistics",
             new=AsyncMock(return_value=expected_stats),
-        ) as mock_get_stats:
+        ):
 
             result = await repository.get_channel_statistics(mock_session)
 

--- a/tests/unit/repositories/test_channel_repository_coverage.py
+++ b/tests/unit/repositories/test_channel_repository_coverage.py
@@ -6,17 +6,14 @@ Focuses on uncovered lines in channel repository methods.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Channel as ChannelDB
-from chronovista.models.channel import ChannelCreate, ChannelUpdate
+from chronovista.models.channel import ChannelCreate
 from chronovista.repositories.channel_repository import ChannelRepository
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestChannelRepositoryCoverage:

--- a/tests/unit/repositories/test_channel_repository_search_coverage.py
+++ b/tests/unit/repositories/test_channel_repository_search_coverage.py
@@ -15,8 +15,6 @@ from chronovista.models.channel import ChannelSearchFilters
 from chronovista.models.enums import LanguageCode
 from chronovista.repositories.channel_repository import ChannelRepository
 
-pytestmark = pytest.mark.asyncio
-
 
 class TestChannelRepositorySearchCoverage:
     """Test channel repository search_channels method comprehensively."""

--- a/tests/unit/repositories/test_channel_topic_repository.py
+++ b/tests/unit/repositories/test_channel_topic_repository.py
@@ -5,30 +5,21 @@ Tests the ChannelTopicRepository class for managing channel-topic relationships
 with comprehensive coverage of CRUD operations, search, and analytics.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import ChannelTopic as ChannelTopicDB
-from chronovista.models.channel_topic import (
-    ChannelTopicCreate,
-    ChannelTopicSearchFilters,
-    ChannelTopicUpdate,
-)
 from chronovista.repositories.channel_topic_repository import ChannelTopicRepository
 from tests.factories import (
-    ChannelTopicTestData,
     TestIds,
     create_channel_topic_create,
     create_channel_topic_filters,
-    create_channel_topic_update,
 )
 
 # Mark all tests as async for this module
-pytestmark = pytest.mark.asyncio
-
 
 class TestChannelTopicRepository:
     """Test ChannelTopicRepository functionality."""
@@ -56,7 +47,7 @@ class TestChannelTopicRepository:
         return ChannelTopicDB(
             channel_id=TestIds.TEST_CHANNEL_1,
             topic_id=TestIds.MUSIC_TOPIC,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
     @pytest.mark.asyncio
@@ -171,7 +162,7 @@ class TestChannelTopicRepository:
             side_effect=lambda session, obj_in: ChannelTopicDB(
                 channel_id=obj_in.channel_id,
                 topic_id=obj_in.topic_id,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -404,7 +395,7 @@ class TestChannelTopicRepository:
             ChannelTopicDB(
                 channel_id=TestIds.TEST_CHANNEL_1,
                 topic_id=TestIds.MUSIC_TOPIC,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         ]
         repository.bulk_create_channel_topics = AsyncMock(return_value=created_topics)
@@ -447,7 +438,7 @@ class TestChannelTopicRepository:
         new_topic = ChannelTopicDB(
             channel_id=TestIds.TEST_CHANNEL_1,
             topic_id=TestIds.MUSIC_TOPIC,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         repository.create = AsyncMock(return_value=new_topic)
 

--- a/tests/unit/repositories/test_entity_mention_repository.py
+++ b/tests/unit/repositories/test_entity_mention_repository.py
@@ -25,9 +25,9 @@ test_canonical_tag_repository.py) and avoids any real database I/O.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.dialects import postgresql as pg_dialect
@@ -41,7 +41,6 @@ from chronovista.models.enums import DetectionMethod
 from chronovista.repositories.entity_mention_repository import EntityMentionRepository
 from tests.factories.entity_mention_factory import (
     EntityMentionCreateFactory,
-    EntityMentionFactory,
     create_entity_mention,
     create_entity_mention_create,
 )
@@ -60,8 +59,6 @@ _pg_insert_patcher.start()
 # CRITICAL: ensures every async test in this module is recognised by
 # pytest-asyncio regardless of how coverage is invoked
 # (see CLAUDE.md §pytest-asyncio Coverage Integration Issues).
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -132,7 +129,7 @@ def _make_entity_mention_db(
         mention_text=mention_text,
         detection_method=detection_method,
         confidence=confidence,
-        created_at=datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+        created_at=datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
     )
 
 
@@ -2723,7 +2720,7 @@ class TestCreateManualAssociation:
         mention.confidence = None
         mention.detection_method = "manual"
         mention.mention_text = canonical_name
-        mention.created_at = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        mention.created_at = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
         return mention
 
     async def test_create_successful(
@@ -2748,7 +2745,7 @@ class TestCreateManualAssociation:
             entity_id=entity_id, canonical_name=canonical_name, status="active"
         )
         video_db = self._make_video_db(video_id=video_id)
-        new_mention = self._make_mention_db(
+        self._make_mention_db(
             entity_id=entity_id, video_id=video_id, canonical_name=canonical_name
         )
 
@@ -3031,7 +3028,7 @@ class TestGetEntityVideoListMultiSource:
         upload_date: Any = None,
     ) -> MagicMock:
         """Build a mock row matching the main query's column shape."""
-        from datetime import datetime as dt, timezone as tz
+        from datetime import datetime as dt
 
         row = MagicMock()
         row.video_id = video_id
@@ -3041,7 +3038,7 @@ class TestGetEntityVideoListMultiSource:
         row.detection_methods = detection_methods or ["rule_match"]
         row.has_manual = has_manual
         row.first_mention_time = first_mention_time
-        row.upload_date = upload_date or dt(2024, 6, 15, tzinfo=tz.utc)
+        row.upload_date = upload_date or dt(2024, 6, 15, tzinfo=UTC)
         return row
 
     @staticmethod
@@ -3246,10 +3243,10 @@ class TestGetEntityVideoListMultiSource:
     ) -> None:
         """upload_date is present in each result dict as an ISO string."""
         entity_id = _uuid()
-        from datetime import datetime as dt, timezone as tz
+        from datetime import datetime as dt
 
         row = self._make_video_row(
-            upload_date=dt(2024, 12, 25, 10, 0, 0, tzinfo=tz.utc),
+            upload_date=dt(2024, 12, 25, 10, 0, 0, tzinfo=UTC),
             detection_methods=["rule_match"],
         )
 
@@ -3361,7 +3358,7 @@ class TestDeleteManualAssociation:
         mention.confidence = None
         mention.detection_method = "manual"
         mention.mention_text = "Joanna Hausmann"
-        mention.created_at = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        mention.created_at = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
         return mention
 
     def _make_transcript_mention(
@@ -3381,7 +3378,7 @@ class TestDeleteManualAssociation:
         mention.confidence = 0.95
         mention.detection_method = "rule_match"
         mention.mention_text = "Joanna Hausmann"
-        mention.created_at = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        mention.created_at = datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC)
         return mention
 
     async def test_delete_successful_calls_session_delete(

--- a/tests/unit/repositories/test_playlist_membership_repository.py
+++ b/tests/unit/repositories/test_playlist_membership_repository.py
@@ -5,7 +5,7 @@ Comprehensive test suite covering all CRUD operations and specialized queries
 for playlist-video relationships.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,11 +16,9 @@ from chronovista.models.playlist_membership import PlaylistMembershipCreate
 from chronovista.repositories.playlist_membership_repository import (
     PlaylistMembershipRepository,
 )
-from tests.factories.id_factory import TestIds, YouTubeIdFactory
+from tests.factories.id_factory import TestIds
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 class TestPlaylistMembershipRepository:
     """Test the PlaylistMembershipRepository CRUD operations and specialized queries."""
@@ -42,7 +40,7 @@ class TestPlaylistMembershipRepository:
             playlist_id=TestIds.TEST_PLAYLIST_1,
             video_id=TestIds.TEST_VIDEO_1,
             position=0,
-            added_at=datetime.now(timezone.utc),
+            added_at=datetime.now(UTC),
         )
 
     def test_repository_initialization(self, repository):
@@ -73,13 +71,13 @@ class TestPlaylistMembershipRepository:
             playlist_id=TestIds.TEST_PLAYLIST_1,
             video_id=TestIds.TEST_VIDEO_1,
             position=0,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         mock_membership2 = DBPlaylistMembership(
             playlist_id=TestIds.TEST_PLAYLIST_1,
             video_id=TestIds.TEST_VIDEO_2,
             position=1,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         # Mock result
@@ -124,13 +122,13 @@ class TestPlaylistMembershipRepository:
             playlist_id=TestIds.TEST_PLAYLIST_1,
             video_id=TestIds.TEST_VIDEO_1,
             position=0,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         mock_membership2 = DBPlaylistMembership(
             playlist_id=TestIds.TEST_PLAYLIST_2,
             video_id=TestIds.TEST_VIDEO_1,
             position=5,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         # Mock result
@@ -201,7 +199,7 @@ class TestPlaylistMembershipRepository:
             playlist_id=TestIds.TEST_PLAYLIST_1,
             video_id=TestIds.TEST_VIDEO_1,
             position=0,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = mock_membership
@@ -235,7 +233,7 @@ class TestPlaylistMembershipRepository:
             playlist_id=TestIds.TEST_PLAYLIST_1,
             video_id=TestIds.TEST_VIDEO_1,
             position=0,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = mock_membership
@@ -271,7 +269,7 @@ class TestPlaylistMembershipRepository:
             playlist_id=TestIds.TEST_PLAYLIST_1,
             video_id=TestIds.TEST_VIDEO_1,
             position=0,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = mock_membership
@@ -381,7 +379,7 @@ class TestPlaylistMembershipRepository:
             video_id=sample_membership_create.video_id,
             position=sample_membership_create.position,
             added_at=sample_membership_create.added_at,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         # Setup session mocks

--- a/tests/unit/repositories/test_playlist_repository.py
+++ b/tests/unit/repositories/test_playlist_repository.py
@@ -4,7 +4,7 @@ Tests for PlaylistRepository functionality.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,8 +20,6 @@ from chronovista.models.playlist import (
 )
 from chronovista.repositories.playlist_repository import PlaylistRepository
 from tests.factories.playlist_factory import PlaylistTestData, create_playlist_create
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestPlaylistRepository:
@@ -48,8 +46,8 @@ class TestPlaylistRepository:
             privacy_status="public",
             channel_id="UC_x5XG1OV2P6uZZ5FSM9Ttw",
             video_count=10,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
     @pytest.fixture
@@ -277,8 +275,8 @@ class TestPlaylistRepository:
             min_video_count=5,
             max_video_count=50,
             has_description=True,
-            created_after=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            created_before=datetime(2023, 12, 31, tzinfo=timezone.utc),
+            created_after=datetime(2023, 1, 1, tzinfo=UTC),
+            created_before=datetime(2023, 12, 31, tzinfo=UTC),
         )
 
         mock_playlists = [MagicMock(), MagicMock()]
@@ -578,7 +576,7 @@ class TestPlaylistRepository:
             repository,
             "get_by_playlist_id",
             new=AsyncMock(return_value=sample_playlist_db),
-        ) as mock_get:
+        ):
 
             result = await repository.delete_by_playlist_id(
                 mock_session, "PLrAXtmRdnqDpVC2bT0Bz-8Q5RWmF6gBkR"
@@ -600,7 +598,7 @@ class TestPlaylistRepository:
         mock_playlists = [MagicMock(), MagicMock(), MagicMock()]
         with patch.object(
             repository, "get_by_channel_id", new=AsyncMock(return_value=mock_playlists)
-        ) as mock_get_by_channel:
+        ):
 
             result = await repository.delete_by_channel_id(mock_session, "UC123")
 
@@ -619,7 +617,7 @@ class TestPlaylistRepository:
             repository,
             "get_by_playlist_id",
             new=AsyncMock(return_value=target_playlist),
-        ) as mock_get:
+        ):
 
             # Mock similar playlists
             similar_playlist = MagicMock()
@@ -646,7 +644,7 @@ class TestPlaylistRepository:
         """Test finding similar playlists when target doesn't exist."""
         with patch.object(
             repository, "get_by_playlist_id", new=AsyncMock(return_value=None)
-        ) as mock_get:
+        ):
 
             result = await repository.find_similar_playlists(
                 mock_session, "PLnonexistent"
@@ -715,7 +713,7 @@ class TestPlaylistRepositoryIntegration:
         with (
             patch.object(
                 repository, "get_by_playlist_id", new=AsyncMock(return_value=None)
-            ) as mock_get,
+            ),
             patch.object(
                 repository, "create", new=AsyncMock(return_value=mock_playlist_db)
             ) as mock_create,

--- a/tests/unit/repositories/test_tag_normalization_repos.py
+++ b/tests/unit/repositories/test_tag_normalization_repos.py
@@ -8,8 +8,7 @@ tag aliases, named entities, and entity aliases.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,21 +16,16 @@ from uuid_utils import uuid7
 
 from chronovista.db.models import (
     CanonicalTag as CanonicalTagDB,
+)
+from chronovista.db.models import (
     EntityAlias as EntityAliasDB,
+)
+from chronovista.db.models import (
     NamedEntity as NamedEntityDB,
+)
+from chronovista.db.models import (
     TagAlias as TagAliasDB,
 )
-from chronovista.models.canonical_tag import CanonicalTagCreate
-from chronovista.models.entity_alias import EntityAliasCreate
-from chronovista.models.enums import (
-    CreationMethod,
-    DiscoveryMethod,
-    EntityAliasType,
-    EntityType,
-    TagStatus,
-)
-from chronovista.models.named_entity import NamedEntityCreate
-from chronovista.models.tag_alias import TagAliasCreate
 from chronovista.repositories.canonical_tag_repository import CanonicalTagRepository
 from chronovista.repositories.entity_alias_repository import EntityAliasRepository
 from chronovista.repositories.named_entity_repository import NamedEntityRepository

--- a/tests/unit/repositories/test_tag_operation_log_repository.py
+++ b/tests/unit/repositories/test_tag_operation_log_repository.py
@@ -16,9 +16,9 @@ Mock strategy: every test creates a MagicMock(spec=AsyncSession) whose
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,7 +30,6 @@ from chronovista.repositories.tag_operation_log_repository import (
     TagOperationLogRepository,
 )
 from tests.factories.tag_operation_log_factory import (
-    TagOperationLogFactory,
     create_merge_operation_log,
     create_split_operation_log,
     create_tag_operation_log,
@@ -38,8 +37,6 @@ from tests.factories.tag_operation_log_factory import (
 
 # Ensures every async test in this module is recognised by pytest-asyncio
 # regardless of how coverage is invoked (see CLAUDE.md §pytest-asyncio section).
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -106,7 +103,7 @@ def _make_log_db(
         affected_alias_ids=affected_alias_ids or [],
         reason=reason,
         performed_by=performed_by,
-        performed_at=performed_at or datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+        performed_at=performed_at or datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
         rollback_data=rollback_data or {},
         rolled_back=rolled_back,
         rolled_back_at=rolled_back_at,
@@ -165,7 +162,7 @@ class TestTagOperationLogRepositoryCreate:
         session.add, flush, and refresh in order.
         """
         obj_in = TagOperationLogCreate(operation_type="create")
-        db_log = _make_log_db(operation_type="create")
+        _make_log_db(operation_type="create")
         mock_session.refresh.side_effect = lambda obj: None
 
         # Patch the ORM constructor so we control the returned object.
@@ -187,7 +184,7 @@ class TestTagOperationLogRepositoryCreate:
 
         mock_session.refresh.side_effect = _fake_refresh
 
-        returned = await repository.create(mock_session, obj_in=obj_in)
+        await repository.create(mock_session, obj_in=obj_in)
 
         mock_session.add.assert_called_once()
         mock_session.flush.assert_awaited_once()

--- a/tests/unit/repositories/test_topic_category_repository.py
+++ b/tests/unit/repositories/test_topic_category_repository.py
@@ -4,7 +4,7 @@ Tests for TopicCategoryRepository functionality.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,8 +18,6 @@ from chronovista.models.topic_category import (
     TopicCategoryStatistics,
 )
 from chronovista.repositories.topic_category_repository import TopicCategoryRepository
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestTopicCategoryRepository:
@@ -43,7 +41,7 @@ class TestTopicCategoryRepository:
             category_name="Technology",
             parent_topic_id=None,
             topic_type="youtube",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
     @pytest.fixture
@@ -54,7 +52,7 @@ class TestTopicCategoryRepository:
             category_name="Programming",
             parent_topic_id="/m/019_rr",
             topic_type=TopicType.YOUTUBE,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
     @pytest.fixture
@@ -141,21 +139,20 @@ class TestTopicCategoryRepository:
         """Test creating a new topic."""
         with patch.object(
             repository, "get_by_topic_id", new=AsyncMock(return_value=None)
-        ) as mock_get:
-            with patch.object(
-                repository, "create", new=AsyncMock(return_value=sample_topic_db)
-            ) as mock_create:
-                result = await repository.create_or_update(
-                    mock_session, sample_topic_create
-                )
+        ) as mock_get, patch.object(
+            repository, "create", new=AsyncMock(return_value=sample_topic_db)
+        ) as mock_create:
+            result = await repository.create_or_update(
+                mock_session, sample_topic_create
+            )
 
-                assert result == sample_topic_db
-                mock_get.assert_called_once_with(
-                    mock_session, sample_topic_create.topic_id
-                )
-                mock_create.assert_called_once_with(
-                    mock_session, obj_in=sample_topic_create
-                )
+            assert result == sample_topic_db
+            mock_get.assert_called_once_with(
+                mock_session, sample_topic_create.topic_id
+            )
+            mock_create.assert_called_once_with(
+                mock_session, obj_in=sample_topic_create
+            )
 
     @pytest.mark.asyncio
     async def test_create_or_update_existing_topic(
@@ -168,19 +165,18 @@ class TestTopicCategoryRepository:
         """Test updating an existing topic."""
         with patch.object(
             repository, "get_by_topic_id", new=AsyncMock(return_value=sample_topic_db)
-        ) as mock_get:
-            with patch.object(
-                repository, "update", new=AsyncMock(return_value=sample_topic_db)
-            ) as mock_update:
-                result = await repository.create_or_update(
-                    mock_session, sample_topic_create
-                )
+        ) as mock_get, patch.object(
+            repository, "update", new=AsyncMock(return_value=sample_topic_db)
+        ) as mock_update:
+            result = await repository.create_or_update(
+                mock_session, sample_topic_create
+            )
 
-                assert result == sample_topic_db
-                mock_get.assert_called_once_with(
-                    mock_session, sample_topic_create.topic_id
-                )
-                mock_update.assert_called_once()
+            assert result == sample_topic_db
+            mock_get.assert_called_once_with(
+                mock_session, sample_topic_create.topic_id
+            )
+            mock_update.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_root_topics(
@@ -330,17 +326,16 @@ class TestTopicCategoryRepository:
         """Test bulk creating new topics."""
         with patch.object(
             repository, "get_by_topic_id", new=AsyncMock(return_value=None)
-        ) as mock_get:
-            with patch.object(
-                repository, "create", new=AsyncMock(return_value=sample_topic_db)
-            ) as mock_create:
-                result = await repository.bulk_create(
-                    mock_session, [sample_topic_create]
-                )
+        ) as mock_get, patch.object(
+            repository, "create", new=AsyncMock(return_value=sample_topic_db)
+        ) as mock_create:
+            result = await repository.bulk_create(
+                mock_session, [sample_topic_create]
+            )
 
-                assert result == [sample_topic_db]
-                mock_get.assert_called_once()
-                mock_create.assert_called_once()
+            assert result == [sample_topic_db]
+            mock_get.assert_called_once()
+            mock_create.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_bulk_create_existing_topics(
@@ -488,8 +483,8 @@ class TestTopicCategoryRepositoryAdditionalMethods:
             parent_topic_ids=["/m/parent"],
             topic_types=[TopicType.YOUTUBE],
             is_root_topic=True,
-            created_after=datetime.now(timezone.utc),
-            created_before=datetime.now(timezone.utc),
+            created_after=datetime.now(UTC),
+            created_before=datetime.now(UTC),
         )
         mock_topics = [MagicMock()]
         mock_result = MagicMock()

--- a/tests/unit/repositories/test_transcript_correction_repository.py
+++ b/tests/unit/repositories/test_transcript_correction_repository.py
@@ -21,7 +21,7 @@ follows the pattern used in ``test_canonical_tag_repository.py`` and
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -31,7 +31,6 @@ from uuid_utils import uuid7
 
 from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
 from chronovista.models.enums import CorrectionType
-from chronovista.models.transcript_correction import TranscriptCorrectionCreate
 from chronovista.repositories.transcript_correction_repository import (
     TranscriptCorrectionRepository,
 )
@@ -42,8 +41,6 @@ from tests.factories.transcript_correction_factory import (
 
 # Ensures every async test in this module is recognised by pytest-asyncio
 # regardless of how coverage is invoked (see CLAUDE.md §pytest-asyncio section).
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -111,7 +108,7 @@ def _make_correction_db(
         corrected_text=corrected_text,
         correction_note=correction_note,
         corrected_by_user_id=corrected_by_user_id,
-        corrected_at=corrected_at or datetime.now(tz=timezone.utc),
+        corrected_at=corrected_at or datetime.now(tz=UTC),
         version_number=version_number,
     )
 
@@ -876,7 +873,6 @@ class TestTranscriptCorrectionRepositoryBatchId:
         batch_id: count, actor, pattern/replacement text, and timestamp.
         """
         from chronovista.models.batch_correction_models import BatchListItem
-        from tests.factories.batch_correction_factory import BatchListItemFactory
 
         batch_id_a = _make_uuid()
         batch_id_b = _make_uuid()
@@ -888,7 +884,7 @@ class TestTranscriptCorrectionRepositoryBatchId:
         row_a.corrected_by_user_id = "user:batch"
         row_a.pattern = "Chomski"
         row_a.replacement = "Chomsky"
-        row_a.batch_timestamp = datetime(2025, 2, 1, 10, 0, 0, tzinfo=timezone.utc)
+        row_a.batch_timestamp = datetime(2025, 2, 1, 10, 0, 0, tzinfo=UTC)
 
         row_b = MagicMock()
         row_b.batch_id = batch_id_b
@@ -896,7 +892,7 @@ class TestTranscriptCorrectionRepositoryBatchId:
         row_b.corrected_by_user_id = "cli"
         row_b.pattern = "teh"
         row_b.replacement = "the"
-        row_b.batch_timestamp = datetime(2025, 1, 15, 8, 0, 0, tzinfo=timezone.utc)
+        row_b.batch_timestamp = datetime(2025, 1, 15, 8, 0, 0, tzinfo=UTC)
 
         mock_result = MagicMock()
         mock_result.all.return_value = [row_a, row_b]
@@ -1006,7 +1002,7 @@ class TestTranscriptCorrectionRepositoryBatchId:
         row_a.corrected_by_user_id = "user:batch"
         row_a.pattern = "errr"
         row_a.replacement = "err"
-        row_a.batch_timestamp = datetime(2025, 3, 1, tzinfo=timezone.utc)
+        row_a.batch_timestamp = datetime(2025, 3, 1, tzinfo=UTC)
 
         row_b = MagicMock()
         row_b.batch_id = batch_id_b
@@ -1014,7 +1010,7 @@ class TestTranscriptCorrectionRepositoryBatchId:
         row_b.corrected_by_user_id = "cli"
         row_b.pattern = "seperate"
         row_b.replacement = "separate"
-        row_b.batch_timestamp = datetime(2025, 2, 1, tzinfo=timezone.utc)
+        row_b.batch_timestamp = datetime(2025, 2, 1, tzinfo=UTC)
 
         mock_result = MagicMock()
         mock_result.all.return_value = [row_a, row_b]
@@ -1085,7 +1081,6 @@ class TestTranscriptCorrectionRepositoryBatchId:
         matches the shape expected from the real repository's aggregation result.
         """
         from tests.factories.batch_correction_factory import (
-            BatchListItemFactory,
             create_batch_list_item,
         )
 
@@ -1114,7 +1109,7 @@ class TestTranscriptCorrectionRepositoryBatchId:
         model definition.
         """
         batch_id = _make_uuid()
-        ts = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        ts = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
 
         row = MagicMock()
         row.batch_id = batch_id

--- a/tests/unit/repositories/test_transcript_correction_repository_batch.py
+++ b/tests/unit/repositories/test_transcript_correction_repository_batch.py
@@ -17,7 +17,7 @@ follows the pattern used in ``test_transcript_correction_repository.py``.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, time, timezone
+from datetime import UTC, datetime, time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -37,8 +37,6 @@ from chronovista.repositories.transcript_correction_repository import (
 
 # Ensures every async test in this module is recognised by pytest-asyncio
 # regardless of how coverage is invoked (see CLAUDE.md §pytest-asyncio section).
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -75,7 +73,7 @@ def _make_correction_db(
         corrected_text=corrected_text,
         correction_note=correction_note,
         corrected_by_user_id=corrected_by_user_id,
-        corrected_at=corrected_at or datetime.now(tz=timezone.utc),
+        corrected_at=corrected_at or datetime.now(tz=UTC),
         version_number=version_number,
     )
 
@@ -257,9 +255,9 @@ class TestGetAllFiltered:
         mock_session: MagicMock,
     ) -> None:
         """The since filter applies an inclusive >= comparison on corrected_at."""
-        since_dt = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        since_dt = datetime(2025, 6, 1, 0, 0, 0, tzinfo=UTC)
         c1 = _make_correction_db(
-            corrected_at=datetime(2025, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+            corrected_at=datetime(2025, 7, 1, 12, 0, 0, tzinfo=UTC)
         )
         _setup_scalars_return(mock_session, [c1])
 
@@ -282,9 +280,9 @@ class TestGetAllFiltered:
         mock_session: MagicMock,
     ) -> None:
         """The until filter applies an inclusive <= comparison on corrected_at."""
-        until_dt = datetime(2025, 12, 31, 18, 30, 0, tzinfo=timezone.utc)
+        until_dt = datetime(2025, 12, 31, 18, 30, 0, tzinfo=UTC)
         c1 = _make_correction_db(
-            corrected_at=datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+            corrected_at=datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
         )
         _setup_scalars_return(mock_session, [c1])
 
@@ -303,7 +301,7 @@ class TestGetAllFiltered:
         This ensures date-only values (e.g., ``datetime(2025, 12, 31)``)
         include the entire day rather than cutting off at midnight.
         """
-        until_midnight = datetime(2025, 12, 31, 0, 0, 0, tzinfo=timezone.utc)
+        until_midnight = datetime(2025, 12, 31, 0, 0, 0, tzinfo=UTC)
         assert until_midnight.time() == time(0, 0, 0)
 
         _setup_scalars_return(mock_session, [])
@@ -323,7 +321,7 @@ class TestGetAllFiltered:
         mock_session: MagicMock,
     ) -> None:
         """When until has a non-midnight time, it is used as-is (no end-of-day adjustment)."""
-        until_dt = datetime(2025, 12, 31, 14, 30, 0, tzinfo=timezone.utc)
+        until_dt = datetime(2025, 12, 31, 14, 30, 0, tzinfo=UTC)
         assert until_dt.time() != time(0, 0, 0)
 
         _setup_scalars_return(mock_session, [])
@@ -370,7 +368,7 @@ class TestGetAllFiltered:
         c1 = _make_correction_db(
             video_id="vid_combined",
             correction_type=CorrectionType.CONTEXT_CORRECTION.value,
-            corrected_at=datetime(2025, 8, 15, 10, 0, 0, tzinfo=timezone.utc),
+            corrected_at=datetime(2025, 8, 15, 10, 0, 0, tzinfo=UTC),
         )
         _setup_scalars_return(mock_session, [c1])
 
@@ -378,8 +376,8 @@ class TestGetAllFiltered:
             mock_session,
             video_ids=["vid_combined"],
             correction_type=CorrectionType.CONTEXT_CORRECTION,
-            since=datetime(2025, 1, 1, tzinfo=timezone.utc),
-            until=datetime(2025, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
+            since=datetime(2025, 1, 1, tzinfo=UTC),
+            until=datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC),
         )
 
         assert len(results) == 1
@@ -395,8 +393,8 @@ class TestGetAllFiltered:
 
         await repository.get_all_filtered(
             mock_session,
-            since=datetime(2025, 3, 1, tzinfo=timezone.utc),
-            until=datetime(2025, 3, 31, 23, 59, 59, tzinfo=timezone.utc),
+            since=datetime(2025, 3, 1, tzinfo=UTC),
+            until=datetime(2025, 3, 31, 23, 59, 59, tzinfo=UTC),
         )
 
         # Verify both >= and <= predicates on corrected_at appear in SQL
@@ -423,10 +421,10 @@ class TestGetAllFiltered:
         The SQL must include an ORDER BY corrected_at ASC clause.
         """
         c_early = _make_correction_db(
-            corrected_at=datetime(2025, 1, 1, tzinfo=timezone.utc)
+            corrected_at=datetime(2025, 1, 1, tzinfo=UTC)
         )
         c_late = _make_correction_db(
-            corrected_at=datetime(2025, 12, 31, tzinfo=timezone.utc)
+            corrected_at=datetime(2025, 12, 31, tzinfo=UTC)
         )
         _setup_scalars_return(mock_session, [c_early, c_late])
 

--- a/tests/unit/repositories/test_transcript_segment_repository.py
+++ b/tests/unit/repositories/test_transcript_segment_repository.py
@@ -7,8 +7,7 @@ per Feature 008: Transcript Segment Table (Phase 2).
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -19,8 +18,6 @@ from chronovista.models.transcript_segment import TranscriptSegmentCreate
 from chronovista.repositories.transcript_segment_repository import (
     TranscriptSegmentRepository,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestTranscriptSegmentRepository:
@@ -38,9 +35,9 @@ class TestTranscriptSegmentRepository:
         return session
 
     @pytest.fixture
-    def sample_segments(self) -> List[TranscriptSegmentDB]:
+    def sample_segments(self) -> list[TranscriptSegmentDB]:
         """Create sample segments: [0-2.5], [2.5-5.0], [5.0-7.5]."""
-        base_time = datetime.now(timezone.utc)
+        base_time = datetime.now(UTC)
         return [
             TranscriptSegmentDB(
                 id=1,
@@ -84,9 +81,9 @@ class TestTranscriptSegmentRepository:
         ]
 
     @pytest.fixture
-    def sample_segments_with_gap(self) -> List[TranscriptSegmentDB]:
+    def sample_segments_with_gap(self) -> list[TranscriptSegmentDB]:
         """Create sample segments with gap: [0-2.0], [5.0-7.0] (gap 2.0-5.0)."""
-        base_time = datetime.now(timezone.utc)
+        base_time = datetime.now(UTC)
         return [
             TranscriptSegmentDB(
                 id=1,
@@ -120,7 +117,7 @@ class TestTranscriptSegmentRepository:
         self,
         repository: TranscriptSegmentRepository,
         mock_session: AsyncMock,
-        sample_segments: List[TranscriptSegmentDB],
+        sample_segments: list[TranscriptSegmentDB],
     ):
         """Test that get_segment_at_time returns the segment containing the timestamp.
 
@@ -146,7 +143,7 @@ class TestTranscriptSegmentRepository:
         self,
         repository: TranscriptSegmentRepository,
         mock_session: AsyncMock,
-        sample_segments: List[TranscriptSegmentDB],
+        sample_segments: list[TranscriptSegmentDB],
     ):
         """Test half-open interval: timestamp at boundary returns segment starting there (FR-EDGE-01).
 
@@ -174,7 +171,7 @@ class TestTranscriptSegmentRepository:
         self,
         repository: TranscriptSegmentRepository,
         mock_session: AsyncMock,
-        sample_segments_with_gap: List[TranscriptSegmentDB],
+        sample_segments_with_gap: list[TranscriptSegmentDB],
     ):
         """Test that timestamp in gap between segments returns previous segment.
 
@@ -226,7 +223,7 @@ class TestTranscriptSegmentRepository:
         self,
         repository: TranscriptSegmentRepository,
         mock_session: AsyncMock,
-        sample_segments: List[TranscriptSegmentDB],
+        sample_segments: list[TranscriptSegmentDB],
     ):
         """Test that get_segments_in_range returns all overlapping segments.
 
@@ -276,7 +273,7 @@ class TestTranscriptSegmentRepository:
         self,
         repository: TranscriptSegmentRepository,
         mock_session: AsyncMock,
-        sample_segments: List[TranscriptSegmentDB],
+        sample_segments: list[TranscriptSegmentDB],
     ):
         """Test that get_context_window returns segments +/-window_seconds from timestamp.
 
@@ -302,7 +299,7 @@ class TestTranscriptSegmentRepository:
         self,
         repository: TranscriptSegmentRepository,
         mock_session: AsyncMock,
-        sample_segments: List[TranscriptSegmentDB],
+        sample_segments: list[TranscriptSegmentDB],
     ):
         """Test that context window clamps start time at 0."""
         mock_result = MagicMock()
@@ -440,7 +437,7 @@ class TestTranscriptSegmentRepositoryEdgeCases:
             sequence_number=0,
             has_correction=False,
             corrected_text=None,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         mock_result = MagicMock()
@@ -471,7 +468,7 @@ class TestTranscriptSegmentRepositoryEdgeCases:
             sequence_number=0,
             has_correction=False,
             corrected_text=None,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         mock_result = MagicMock()
@@ -515,7 +512,7 @@ class TestTranscriptSegmentRepositoryEdgeCases:
             sequence_number=1,
             has_correction=False,
             corrected_text=None,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         mock_session.execute.side_effect = [mock_result_exact, mock_result_gap]
@@ -545,7 +542,7 @@ class TestTranscriptSegmentRepositoryEdgeCases:
             sequence_number=0,
             has_correction=False,
             corrected_text=None,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         mock_result = MagicMock()

--- a/tests/unit/repositories/test_transcript_segment_repository_batch.py
+++ b/tests/unit/repositories/test_transcript_segment_repository_batch.py
@@ -8,9 +8,8 @@ Batch Correction Tools (T004, T005).
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import List
-from unittest.mock import AsyncMock, MagicMock, call
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,8 +19,6 @@ from chronovista.repositories.transcript_segment_repository import (
     TranscriptSegmentRepository,
     _escape_like_pattern,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 def _make_segment(
@@ -46,7 +43,7 @@ def _make_segment(
         duration=2.5,
         end_time=2.5,
         sequence_number=sequence_number,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
 
@@ -65,7 +62,7 @@ class TestFindByTextPatternSubstring:
         return session
 
     def _setup_scalars_result(
-        self, mock_session: AsyncMock, segments: List[TranscriptSegmentDB]
+        self, mock_session: AsyncMock, segments: list[TranscriptSegmentDB]
     ) -> None:
         """Configure mock session to return segments via scalars().all()."""
         mock_result = MagicMock()
@@ -154,7 +151,7 @@ class TestFindByTextPatternRegex:
         return session
 
     def _setup_scalars_result(
-        self, mock_session: AsyncMock, segments: List[TranscriptSegmentDB]
+        self, mock_session: AsyncMock, segments: list[TranscriptSegmentDB]
     ) -> None:
         """Configure mock session to return segments via scalars().all()."""
         mock_result = MagicMock()
@@ -254,7 +251,7 @@ class TestFindByTextPatternFilters:
         return session
 
     def _setup_scalars_result(
-        self, mock_session: AsyncMock, segments: List[TranscriptSegmentDB]
+        self, mock_session: AsyncMock, segments: list[TranscriptSegmentDB]
     ) -> None:
         """Configure mock session to return segments via scalars().all()."""
         mock_result = MagicMock()
@@ -392,7 +389,7 @@ class TestFindByTextPatternEffectiveText:
         return session
 
     def _setup_scalars_result(
-        self, mock_session: AsyncMock, segments: List[TranscriptSegmentDB]
+        self, mock_session: AsyncMock, segments: list[TranscriptSegmentDB]
     ) -> None:
         """Configure mock session to return segments via scalars().all()."""
         mock_result = MagicMock()
@@ -490,7 +487,7 @@ class TestFindByTextPatternEdgeCases:
         return session
 
     def _setup_scalars_result(
-        self, mock_session: AsyncMock, segments: List[TranscriptSegmentDB]
+        self, mock_session: AsyncMock, segments: list[TranscriptSegmentDB]
     ) -> None:
         """Configure mock session to return segments via scalars().all()."""
         mock_result = MagicMock()
@@ -797,7 +794,7 @@ class TestFindCandidateVideoIdsForCrossSegment:
         return AsyncMock(spec=AsyncSession)
 
     def _setup_scalars_result(
-        self, mock_session: AsyncMock, video_ids: List[str]
+        self, mock_session: AsyncMock, video_ids: list[str]
     ) -> None:
         """Configure mock session to return video_id strings via scalars().all()."""
         mock_result = MagicMock()
@@ -1073,7 +1070,7 @@ class TestFindByTextPatternLiteralEscaping:
         return AsyncMock(spec=AsyncSession)
 
     def _setup_scalars_result(
-        self, mock_session: AsyncMock, segments: List[TranscriptSegmentDB]
+        self, mock_session: AsyncMock, segments: list[TranscriptSegmentDB]
     ) -> None:
         """Configure mock session to return segments via scalars().all()."""
         mock_result = MagicMock()

--- a/tests/unit/repositories/test_user_language_preference_repository.py
+++ b/tests/unit/repositories/test_user_language_preference_repository.py
@@ -8,7 +8,6 @@ specialized queries, and edge case handling.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,8 +19,6 @@ from chronovista.models.user_language_preference import UserLanguagePreferenceCr
 from chronovista.repositories.user_language_preference_repository import (
     UserLanguagePreferenceRepository,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestUserLanguagePreferenceRepository:
@@ -62,7 +59,7 @@ class TestUserLanguagePreferenceRepository:
         )
 
     @pytest.fixture
-    def sample_preferences_list(self) -> List[UserLanguagePreferenceDB]:
+    def sample_preferences_list(self) -> list[UserLanguagePreferenceDB]:
         """Create list of sample preferences."""
         return [
             UserLanguagePreferenceDB(
@@ -161,7 +158,7 @@ class TestUserLanguagePreferenceRepository:
         self,
         repository: UserLanguagePreferenceRepository,
         mock_session: AsyncMock,
-        sample_preferences_list: List[UserLanguagePreferenceDB],
+        sample_preferences_list: list[UserLanguagePreferenceDB],
     ):
         """Test getting all preferences for a user."""
         # Mock execute to return scalars
@@ -181,7 +178,7 @@ class TestUserLanguagePreferenceRepository:
         self,
         repository: UserLanguagePreferenceRepository,
         mock_session: AsyncMock,
-        sample_preferences_list: List[UserLanguagePreferenceDB],
+        sample_preferences_list: list[UserLanguagePreferenceDB],
     ):
         """Test getting preferences filtered by type."""
         # Filter list to only fluent preferences
@@ -289,7 +286,7 @@ class TestUserLanguagePreferenceRepository:
             repository,
             "get_by_composite_key",
             new=AsyncMock(return_value=sample_preference_db),
-        ) as mock_get:
+        ):
 
             result = await repository.update_priority(
                 mock_session, "test_user", "en-US", 5
@@ -308,7 +305,7 @@ class TestUserLanguagePreferenceRepository:
         """Test updating priority of non-existent preference."""
         with patch.object(
             repository, "get_by_composite_key", new=AsyncMock(return_value=None)
-        ) as mock_get:
+        ):
 
             result = await repository.update_priority(
                 mock_session, "test_user", "non-existent", 5
@@ -420,7 +417,7 @@ class TestUserLanguagePreferenceRepository:
         await repository.get_by_composite_key(mock_session, "test_user", "EN-US")
 
         # Verify the query used lowercase language code
-        call_args = mock_session.execute.call_args[0][0]
+        mock_session.execute.call_args[0][0]
         # This is a simplified check - in a real test you'd inspect the SQL query
         mock_session.execute.assert_called_once()
 
@@ -566,7 +563,7 @@ class TestUserLanguagePreferenceRepositoryVideoIntegration:
         return AsyncMock(spec=AsyncSession)
 
     @pytest.fixture
-    def sample_preferences_with_priorities(self) -> List[UserLanguagePreferenceDB]:
+    def sample_preferences_with_priorities(self) -> list[UserLanguagePreferenceDB]:
         """Create sample preferences with different priorities and types."""
         return [
             UserLanguagePreferenceDB(
@@ -671,7 +668,7 @@ class TestUserLanguagePreferenceRepositoryVideoIntegration:
         self,
         repository: UserLanguagePreferenceRepository,
         mock_session: AsyncMock,
-        sample_preferences_with_priorities: List[UserLanguagePreferenceDB],
+        sample_preferences_with_priorities: list[UserLanguagePreferenceDB],
     ):
         """Test successful video localization retrieval."""
         # Mock get_user_preferences
@@ -740,7 +737,7 @@ class TestUserLanguagePreferenceRepositoryVideoIntegration:
         self,
         repository: UserLanguagePreferenceRepository,
         mock_session: AsyncMock,
-        sample_preferences_with_priorities: List[UserLanguagePreferenceDB],
+        sample_preferences_with_priorities: list[UserLanguagePreferenceDB],
     ):
         """Test successful localization targets retrieval."""
         # Mock get_user_preferences
@@ -807,7 +804,7 @@ class TestUserLanguagePreferenceRepositoryVideoIntegration:
         self,
         repository: UserLanguagePreferenceRepository,
         mock_session: AsyncMock,
-        sample_preferences_with_priorities: List[UserLanguagePreferenceDB],
+        sample_preferences_with_priorities: list[UserLanguagePreferenceDB],
     ):
         """Test successful localization coverage analysis."""
         # Mock get_user_preferences
@@ -889,7 +886,7 @@ class TestUserLanguagePreferenceRepositoryVideoIntegration:
         self,
         repository: UserLanguagePreferenceRepository,
         mock_session: AsyncMock,
-        sample_preferences_with_priorities: List[UserLanguagePreferenceDB],
+        sample_preferences_with_priorities: list[UserLanguagePreferenceDB],
     ):
         """Test localization coverage when there are no videos with localizations."""
         # Mock get_user_preferences
@@ -897,10 +894,10 @@ class TestUserLanguagePreferenceRepositoryVideoIntegration:
             repository,
             "get_user_preferences",
             new=AsyncMock(return_value=sample_preferences_with_priorities),
-        ) as mock_get_prefs:
+        ):
 
             # Mock empty language coverage
-            mock_language_coverage: Dict[str, int] = {}
+            mock_language_coverage: dict[str, int] = {}
 
             with patch(
                 "chronovista.repositories.video_localization_repository.VideoLocalizationRepository"
@@ -934,7 +931,7 @@ class TestUserLanguagePreferenceRepositoryVideoIntegration:
         self,
         repository: UserLanguagePreferenceRepository,
         mock_session: AsyncMock,
-        sample_preferences_with_priorities: List[UserLanguagePreferenceDB],
+        sample_preferences_with_priorities: list[UserLanguagePreferenceDB],
     ):
         """Test localization coverage when user has no localized videos."""
         # Mock get_user_preferences
@@ -942,7 +939,7 @@ class TestUserLanguagePreferenceRepositoryVideoIntegration:
             repository,
             "get_user_preferences",
             new=AsyncMock(return_value=sample_preferences_with_priorities),
-        ) as mock_get_prefs:
+        ):
 
             # Mock language coverage with languages not in user's preferences
             mock_language_coverage = {

--- a/tests/unit/repositories/test_user_video_repository.py
+++ b/tests/unit/repositories/test_user_video_repository.py
@@ -7,8 +7,8 @@ Google Takeout integration, analytics, and specialized queries.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
-from typing import List, cast
+from datetime import UTC, datetime, timedelta
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,8 +22,6 @@ from chronovista.models.user_video import (
     UserVideoStatistics,
 )
 from chronovista.repositories.user_video_repository import UserVideoRepository
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestUserVideoRepository:
@@ -46,12 +44,12 @@ class TestUserVideoRepository:
         return UserVideoDB(
             user_id="test_user",
             video_id="dQw4w9WgXcQ",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             rewatch_count=2,
             liked=True,
             saved_to_playlist=False,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
     @pytest.fixture
@@ -60,16 +58,16 @@ class TestUserVideoRepository:
         return UserVideoCreate(
             user_id="test_user",
             video_id="dQw4w9WgXcQ",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             rewatch_count=0,
             liked=False,
             saved_to_playlist=False,
         )
 
     @pytest.fixture
-    def sample_user_videos_list(self) -> List[UserVideoDB]:
+    def sample_user_videos_list(self) -> list[UserVideoDB]:
         """Create list of sample user videos."""
-        base_time = datetime.now(timezone.utc)
+        base_time = datetime.now(UTC)
         return [
             UserVideoDB(
                 user_id="test_user",
@@ -187,7 +185,7 @@ class TestUserVideoRepository:
         self,
         repository: UserVideoRepository,
         mock_session: AsyncSession,
-        sample_user_videos_list: List[UserVideoDB],
+        sample_user_videos_list: list[UserVideoDB],
     ):
         """Test getting user's watch history."""
         # Mock execute to return scalars
@@ -209,7 +207,7 @@ class TestUserVideoRepository:
         self,
         repository: UserVideoRepository,
         mock_session: AsyncSession,
-        sample_user_videos_list: List[UserVideoDB],
+        sample_user_videos_list: list[UserVideoDB],
     ):
         """Test getting user's liked videos."""
         # Filter list to only liked videos
@@ -233,7 +231,7 @@ class TestUserVideoRepository:
         self,
         repository: UserVideoRepository,
         mock_session: AsyncSession,
-        sample_user_videos_list: List[UserVideoDB],
+        sample_user_videos_list: list[UserVideoDB],
     ):
         """Test getting user's most watched videos."""
         # Sort by rewatch count descending
@@ -259,7 +257,7 @@ class TestUserVideoRepository:
         self,
         repository: UserVideoRepository,
         mock_session: AsyncSession,
-        sample_user_videos_list: List[UserVideoDB],
+        sample_user_videos_list: list[UserVideoDB],
     ):
         """Test searching user videos with no filters."""
         filters = UserVideoSearchFilters()
@@ -280,7 +278,7 @@ class TestUserVideoRepository:
         self,
         repository: UserVideoRepository,
         mock_session: AsyncSession,
-        sample_user_videos_list: List[UserVideoDB],
+        sample_user_videos_list: list[UserVideoDB],
     ):
         """Test searching user videos with filters."""
         filters = UserVideoSearchFilters(
@@ -317,14 +315,14 @@ class TestUserVideoRepository:
             playlist_saved_count=3,
             rewatch_count=2,
             unique_videos=8,
-            most_watched_date=datetime.now(timezone.utc),
+            most_watched_date=datetime.now(UTC),
             watch_streak_days=7,
         )
 
         # Mock the entire method to avoid SQLAlchemy query construction issues
         with patch.object(
             repository, "get_user_statistics", return_value=expected_stats
-        ) as mock_get_stats:
+        ):
             result = await repository.get_user_statistics(mock_session, "test_user")
 
             assert isinstance(result, UserVideoStatistics)
@@ -335,7 +333,7 @@ class TestUserVideoRepository:
             assert result.unique_videos == 8
             assert result.watch_streak_days == 7
             assert result.most_watched_date is not None
-            assert result.most_watched_date.date() == datetime.now(timezone.utc).date()
+            assert result.most_watched_date.date() == datetime.now(UTC).date()
 
     @pytest.mark.asyncio
     async def test_get_user_statistics_no_data(
@@ -356,7 +354,7 @@ class TestUserVideoRepository:
         # Mock the entire method
         with patch.object(
             repository, "get_user_statistics", return_value=expected_stats
-        ) as mock_get_stats:
+        ):
             result = await repository.get_user_statistics(mock_session, "test_user")
 
             assert isinstance(result, UserVideoStatistics)
@@ -512,10 +510,10 @@ class TestUserVideoRepository:
                 repository,
                 "get_by_composite_key",
                 side_effect=[None, sample_user_video_db],
-            ) as mock_get,
+            ),
             patch.object(
                 repository, "create", return_value=sample_user_video_db
-            ) as mock_create,
+            ),
         ):
 
             result = await repository.import_from_takeout_batch(
@@ -561,7 +559,7 @@ class TestUserVideoRepository:
         sample_user_video_create: UserVideoCreate,
     ):
         """Test recording a new watch interaction."""
-        watch_time = datetime.now(timezone.utc)
+        watch_time = datetime.now(UTC)
 
         # Mock get_by_composite_key to return None (new interaction)
         with (
@@ -594,13 +592,13 @@ class TestUserVideoRepository:
         sample_user_video_db: UserVideoDB,
     ):
         """Test recording a watch on existing interaction (rewatch)."""
-        watch_time = datetime.now(timezone.utc)
+        watch_time = datetime.now(UTC)
         original_rewatch_count = sample_user_video_db.rewatch_count
 
         # Mock get_by_composite_key to return existing interaction
         with patch.object(
             repository, "get_by_composite_key", return_value=sample_user_video_db
-        ) as mock_get:
+        ):
             result = await repository.record_watch(
                 mock_session,
                 "test_user",
@@ -634,8 +632,8 @@ class TestUserVideoRepository:
         self, repository: UserVideoRepository, mock_session: AsyncSession
     ):
         """Test getting watch count aggregated by date range."""
-        start_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        end_date = datetime(2025, 1, 31, tzinfo=timezone.utc)
+        start_date = datetime(2025, 1, 1, tzinfo=UTC)
+        end_date = datetime(2025, 1, 31, tzinfo=UTC)
 
         # Mock aggregated results
         mock_result = MagicMock()
@@ -810,7 +808,7 @@ class TestUserVideoRepositoryEdgeCases:
         # Mock get_by_composite_key to raise an exception
         with patch.object(
             repository, "get_by_composite_key", side_effect=Exception("Database error")
-        ) as mock_get:
+        ):
             result = await repository.import_from_takeout_batch(
                 mock_session, "test_user", [invalid_item]
             )
@@ -840,8 +838,8 @@ class TestUserVideoRepositoryEdgeCases:
         self, repository: UserVideoRepository, mock_session: AsyncSession
     ):
         """Test getting watch count when no data exists in range."""
-        start_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        end_date = datetime(2025, 1, 31, tzinfo=timezone.utc)
+        start_date = datetime(2025, 1, 1, tzinfo=UTC)
+        end_date = datetime(2025, 1, 31, tzinfo=UTC)
 
         mock_result = MagicMock()
         mock_result.__iter__ = lambda self: iter([])
@@ -914,7 +912,7 @@ class TestGoogleTakeoutIntegration:
         assert result.user_id == "test_user"
         assert result.video_id == "dQw4w9WgXcQ"
         assert result.watched_at == datetime(
-            2025, 1, 15, 10, 30, 0, tzinfo=timezone.utc
+            2025, 1, 15, 10, 30, 0, tzinfo=UTC
         )
         assert result.rewatch_count == 0
 
@@ -986,9 +984,9 @@ class TestGoogleTakeoutIntegration:
         existing_video = UserVideoDB(
             user_id="test_user",
             video_id="jNQXAC9IVRw",
-            watched_at=datetime(2025, 1, 14, tzinfo=timezone.utc),
-            created_at=datetime(2025, 1, 14, tzinfo=timezone.utc),
-            updated_at=datetime(2025, 1, 14, tzinfo=timezone.utc),
+            watched_at=datetime(2025, 1, 14, tzinfo=UTC),
+            created_at=datetime(2025, 1, 14, tzinfo=UTC),
+            updated_at=datetime(2025, 1, 14, tzinfo=UTC),
         )
 
         # Mock repository methods with side effects
@@ -1000,8 +998,8 @@ class TestGoogleTakeoutIntegration:
         with (
             patch.object(
                 repository, "get_by_composite_key", side_effect=get_calls
-            ) as mock_get,
-            patch.object(repository, "create", return_value=MagicMock()) as mock_create,
+            ),
+            patch.object(repository, "create", return_value=MagicMock()),
         ):
 
             result = await repository.import_from_takeout_batch(
@@ -1043,8 +1041,8 @@ class TestUserVideoRepositoryRecordLike:
             rewatch_count=0,
             liked=True,
             saved_to_playlist=False,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         with (
@@ -1077,17 +1075,17 @@ class TestUserVideoRepositoryRecordLike:
         existing_interaction = UserVideoDB(
             user_id="test_user",
             video_id="dQw4w9WgXcQ",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             rewatch_count=2,
             liked=False,
             saved_to_playlist=True,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         with patch.object(
             repository, "get_by_composite_key", return_value=existing_interaction
-        ) as mock_get:
+        ):
             result = await repository.record_like(
                 mock_session, "test_user", "dQw4w9WgXcQ", liked=True
             )
@@ -1103,7 +1101,7 @@ class TestUserVideoRepositoryRecordLike:
         self, repository: UserVideoRepository, mock_session: AsyncSession
     ):
         """Test record_like does not modify watched_at or rewatch_count."""
-        original_watched_at = datetime.now(timezone.utc) - timedelta(days=5)
+        original_watched_at = datetime.now(UTC) - timedelta(days=5)
         original_rewatch_count = 3
 
         existing_interaction = UserVideoDB(
@@ -1113,13 +1111,13 @@ class TestUserVideoRepositoryRecordLike:
             rewatch_count=original_rewatch_count,
             liked=False,
             saved_to_playlist=False,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         with patch.object(
             repository, "get_by_composite_key", return_value=existing_interaction
-        ) as mock_get:
+        ):
             result = await repository.record_like(
                 mock_session, "test_user", "dQw4w9WgXcQ", liked=True
             )
@@ -1139,17 +1137,17 @@ class TestUserVideoRepositoryRecordLike:
         existing_interaction = UserVideoDB(
             user_id="test_user",
             video_id="dQw4w9WgXcQ",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             rewatch_count=0,
             liked=True,
             saved_to_playlist=False,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         with patch.object(
             repository, "get_by_composite_key", return_value=existing_interaction
-        ) as mock_get:
+        ):
             result = await repository.record_like(
                 mock_session, "test_user", "dQw4w9WgXcQ", liked=False
             )
@@ -1170,14 +1168,14 @@ class TestUserVideoRepositoryRecordLike:
             rewatch_count=0,
             liked=False,
             saved_to_playlist=False,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         with (
             patch.object(
                 repository, "get_by_composite_key", return_value=None
-            ) as mock_get,
+            ),
             patch.object(
                 repository, "create", return_value=new_interaction
             ) as mock_create,

--- a/tests/unit/repositories/test_video_category_repository.py
+++ b/tests/unit/repositories/test_video_category_repository.py
@@ -7,7 +7,7 @@ video categories.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,8 +19,6 @@ from chronovista.models.video_category import (
     VideoCategoryUpdate,
 )
 from chronovista.repositories.video_category_repository import VideoCategoryRepository
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestVideoCategoryRepository:
@@ -43,7 +41,7 @@ class TestVideoCategoryRepository:
             category_id="10",
             name="Music",
             assignable=True,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         return category
 
@@ -193,17 +191,16 @@ class TestVideoCategoryRepository:
 
         with patch.object(
             repository, "get", new=AsyncMock(return_value=None)
-        ) as mock_get:
-            with patch.object(
-                repository, "create", new=AsyncMock(return_value=sample_category_db)
-            ) as mock_create:
-                result = await repository.bulk_create(
-                    mock_session, categories_to_create
-                )
+        ) as mock_get, patch.object(
+            repository, "create", new=AsyncMock(return_value=sample_category_db)
+        ) as mock_create:
+            result = await repository.bulk_create(
+                mock_session, categories_to_create
+            )
 
-                assert len(result) == 2
-                assert mock_get.call_count == 2
-                assert mock_create.call_count == 2
+            assert len(result) == 2
+            assert mock_get.call_count == 2
+            assert mock_create.call_count == 2
 
     async def test_bulk_create_existing_categories(
         self,
@@ -243,17 +240,16 @@ class TestVideoCategoryRepository:
 
         with patch.object(
             repository, "get", new=AsyncMock(side_effect=mock_get_side_effect)
-        ) as mock_get:
-            with patch.object(
-                repository, "create", new=AsyncMock(return_value=sample_category_db)
-            ) as mock_create:
-                result = await repository.bulk_create(
-                    mock_session, categories_to_create
-                )
+        ) as mock_get, patch.object(
+            repository, "create", new=AsyncMock(return_value=sample_category_db)
+        ) as mock_create:
+            result = await repository.bulk_create(
+                mock_session, categories_to_create
+            )
 
-                assert len(result) == 3
-                assert mock_get.call_count == 3
-                assert mock_create.call_count == 2  # Only for new categories
+            assert len(result) == 3
+            assert mock_get.call_count == 3
+            assert mock_create.call_count == 2  # Only for new categories
 
     async def test_bulk_create_empty_list(
         self, repository: VideoCategoryRepository, mock_session: MagicMock
@@ -289,21 +285,20 @@ class TestVideoCategoryRepository:
         """Test creating a new category via create_or_update."""
         with patch.object(
             repository, "get", new=AsyncMock(return_value=None)
-        ) as mock_get:
-            with patch.object(
-                repository, "create", new=AsyncMock(return_value=sample_category_db)
-            ) as mock_create:
-                result = await repository.create_or_update(
-                    mock_session, sample_category_create
-                )
+        ) as mock_get, patch.object(
+            repository, "create", new=AsyncMock(return_value=sample_category_db)
+        ) as mock_create:
+            result = await repository.create_or_update(
+                mock_session, sample_category_create
+            )
 
-                assert result == sample_category_db
-                mock_get.assert_called_once_with(
-                    mock_session, sample_category_create.category_id
-                )
-                mock_create.assert_called_once_with(
-                    mock_session, obj_in=sample_category_create
-                )
+            assert result == sample_category_db
+            mock_get.assert_called_once_with(
+                mock_session, sample_category_create.category_id
+            )
+            mock_create.assert_called_once_with(
+                mock_session, obj_in=sample_category_create
+            )
 
     async def test_create_or_update_existing_category(
         self,
@@ -315,19 +310,18 @@ class TestVideoCategoryRepository:
         """Test updating an existing category via create_or_update."""
         with patch.object(
             repository, "get", new=AsyncMock(return_value=sample_category_db)
-        ) as mock_get:
-            with patch.object(
-                repository, "update", new=AsyncMock(return_value=sample_category_db)
-            ) as mock_update:
-                result = await repository.create_or_update(
-                    mock_session, sample_category_create
-                )
+        ) as mock_get, patch.object(
+            repository, "update", new=AsyncMock(return_value=sample_category_db)
+        ) as mock_update:
+            result = await repository.create_or_update(
+                mock_session, sample_category_create
+            )
 
-                assert result == sample_category_db
-                mock_get.assert_called_once_with(
-                    mock_session, sample_category_create.category_id
-                )
-                mock_update.assert_called_once()
+            assert result == sample_category_db
+            mock_get.assert_called_once_with(
+                mock_session, sample_category_create.category_id
+            )
+            mock_update.assert_called_once()
 
     async def test_delete_by_category_id(
         self,
@@ -518,15 +512,14 @@ class TestVideoCategoryRepositoryAdditionalMethods:
 
         with patch.object(
             repository, "get", new=AsyncMock(return_value=None)
+        ), patch.object(
+            repository, "create", new=AsyncMock(side_effect=mock_categories_db)
         ):
-            with patch.object(
-                repository, "create", new=AsyncMock(side_effect=mock_categories_db)
-            ):
-                result = await repository.bulk_create(mock_session, categories)
+            result = await repository.bulk_create(mock_session, categories)
 
-                # Should return in same order as input
-                assert len(result) == 3
-                assert result == mock_categories_db
+            # Should return in same order as input
+            assert len(result) == 3
+            assert result == mock_categories_db
 
     async def test_create_or_update_preserves_fields(
         self, repository: VideoCategoryRepository, mock_session
@@ -545,19 +538,18 @@ class TestVideoCategoryRepositoryAdditionalMethods:
 
         with patch.object(
             repository, "get", new=AsyncMock(return_value=existing_category)
-        ):
-            with patch.object(
-                repository, "update", new=AsyncMock(return_value=existing_category)
-            ) as mock_update:
-                await repository.create_or_update(mock_session, category_create)
+        ), patch.object(
+            repository, "update", new=AsyncMock(return_value=existing_category)
+        ) as mock_update:
+            await repository.create_or_update(mock_session, category_create)
 
-                # Verify update was called with correct data
-                mock_update.assert_called_once()
-                call_args = mock_update.call_args
-                update_obj = call_args.kwargs["obj_in"]
-                assert isinstance(update_obj, VideoCategoryUpdate)
-                assert update_obj.name == "New Music Name"
-                assert update_obj.assignable is False
+            # Verify update was called with correct data
+            mock_update.assert_called_once()
+            call_args = mock_update.call_args
+            update_obj = call_args.kwargs["obj_in"]
+            assert isinstance(update_obj, VideoCategoryUpdate)
+            assert update_obj.name == "New Music Name"
+            assert update_obj.assignable is False
 
     async def test_find_by_name_with_special_characters(
         self, repository: VideoCategoryRepository, mock_session

--- a/tests/unit/repositories/test_video_localization_repository.py
+++ b/tests/unit/repositories/test_video_localization_repository.py
@@ -7,7 +7,7 @@ including CRUD, composite key handling, multi-language analytics, and search.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -29,8 +29,6 @@ from tests.factories import (
     VideoLocalizationTestData,
     create_video_localization_create,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestVideoLocalizationRepository:
@@ -59,7 +57,7 @@ class TestVideoLocalizationRepository:
             language_code=LanguageCode.ENGLISH.value,
             localized_title="Never Gonna Give You Up",
             localized_description="Official music video description",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
     @pytest.fixture
@@ -85,7 +83,7 @@ class TestVideoLocalizationRepository:
             language_code=LanguageCode.ENGLISH.value,
             localized_title="Test Title",
             localized_description="Test Description",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         mock_result = MagicMock()
@@ -130,7 +128,7 @@ class TestVideoLocalizationRepository:
             language_code=LanguageCode.ENGLISH.value,
             localized_title="Test Title",
             localized_description="Test Description",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         mock_result = MagicMock()
@@ -215,14 +213,14 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="English Title",
                 localized_description="English Description",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id="dQw4w9WgXcQ",
                 language_code=LanguageCode.SPANISH.value,
                 localized_title="Título en Español",
                 localized_description="Descripción en español",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -250,14 +248,14 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="English Title 1",
                 localized_description="English Description 1",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id="9bZkp7q19f0",
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="English Title 2",
                 localized_description="English Description 2",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -285,7 +283,7 @@ class TestVideoLocalizationRepository:
             language_code=LanguageCode.ENGLISH.value,
             localized_title="Test Title",
             localized_description="Test Description",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         mock_result = MagicMock()
@@ -318,7 +316,7 @@ class TestVideoLocalizationRepository:
             language_code=sample_localization_create.language_code,
             localized_title=sample_localization_create.localized_title,
             localized_description=sample_localization_create.localized_description,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         # Mock that localization doesn't exist
@@ -355,7 +353,7 @@ class TestVideoLocalizationRepository:
             language_code=sample_localization_create.language_code,
             localized_title="Old Title",
             localized_description="Old Description",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         updated_localization = VideoLocalizationDB(
@@ -363,7 +361,7 @@ class TestVideoLocalizationRepository:
             language_code=sample_localization_create.language_code,
             localized_title=sample_localization_create.localized_title,
             localized_description=sample_localization_create.localized_description,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         # Mock that localization exists
@@ -405,7 +403,7 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="Tutorial Video",
                 localized_description="Learning tutorial",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         ]
 
@@ -433,14 +431,14 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="Title 1",
                 localized_description="Description 1",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id="9bZkp7q19f0",
                 language_code=LanguageCode.SPANISH.value,
                 localized_title="Título 2",
                 localized_description="Descripción 2",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -678,14 +676,14 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="Title 1",
                 localized_description="Description 1",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id="9bZkp7q19f0",
                 language_code=LanguageCode.SPANISH.value,
                 localized_title="Título 2",
                 localized_description="Descripción 2",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -731,14 +729,14 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="English Title",
                 localized_description="English Description",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id=video_id,
                 language_code=LanguageCode.SPANISH.value,
                 localized_title="Título en Español",
                 localized_description="Descripción en español",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -774,14 +772,14 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="English Title",
                 localized_description="English Description",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id="dQw4w9WgXcQ",
                 language_code=LanguageCode.SPANISH.value,
                 localized_title="Título en Español",
                 localized_description="Descripción en español",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -818,14 +816,14 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="Title 1",
                 localized_description="Description 1",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id="9bZkp7q19f0",
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="Title 2",
                 localized_description="Description 2",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -862,7 +860,7 @@ class TestVideoLocalizationRepository:
             language_code=LanguageCode.ENGLISH.value,
             localized_title="Title to Delete",
             localized_description="Description to delete",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         mock_result = MagicMock()
@@ -899,21 +897,21 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="Video 1 English",
                 localized_description="English description",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id="dQw4w9WgXcQ",
                 language_code=LanguageCode.SPANISH.value,
                 localized_title="Video 1 Español",
                 localized_description="Descripción en español",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id="9bZkp7q19f0",
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="Video 2 English",
                 localized_description="English description",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -948,7 +946,7 @@ class TestVideoLocalizationRepository:
             language_code=LanguageCode.ENGLISH.value,
             localized_title="Python Programming Tutorial",
             localized_description="Learn Python programming",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         similar_localizations = [
@@ -957,14 +955,14 @@ class TestVideoLocalizationRepository:
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="Advanced Python Programming",
                 localized_description="Advanced Python concepts",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
             VideoLocalizationDB(
                 video_id="similar_video2",
                 language_code=LanguageCode.ENGLISH.value,
                 localized_title="JavaScript Tutorial",
                 localized_description="Learn JavaScript",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             ),
         ]
 
@@ -1130,10 +1128,10 @@ class TestVideoLocalizationRepositoryErrorHandling:
     ):
         """Test handling None values in composite key operations."""
         # Act & Assert
-        result = await repository.get_by_composite_key(mock_session, None, LanguageCode.ENGLISH.value)  # type: ignore
+        await repository.get_by_composite_key(mock_session, None, LanguageCode.ENGLISH.value)  # type: ignore
         # Should handle gracefully without crashing
 
-        result = await repository.get_by_composite_key(mock_session, "video_id", None)  # type: ignore
+        await repository.get_by_composite_key(mock_session, "video_id", None)  # type: ignore
         # Should handle gracefully without crashing
 
     @pytest.mark.asyncio

--- a/tests/unit/repositories/test_video_repository.py
+++ b/tests/unit/repositories/test_video_repository.py
@@ -4,19 +4,17 @@ Tests for VideoRepository functionality.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Video as VideoDB
-from chronovista.models.enums import AvailabilityStatus, LanguageCode
+from chronovista.models.enums import LanguageCode
 from chronovista.models.video import VideoCreate, VideoStatistics
 from chronovista.repositories.video_repository import VideoRepository
 from tests.factories.video_factory import create_video_search_filters
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestVideoRepository:
@@ -153,7 +151,7 @@ class TestVideoRepository:
             repository,
             "get_video_statistics",
             new=AsyncMock(return_value=expected_stats),
-        ) as mock_stats:
+        ):
 
             result = await repository.get_video_statistics(mock_session)
 
@@ -398,10 +396,10 @@ class TestVideoRepository:
         self, repository: VideoRepository, mock_session: AsyncMock
     ):
         """Test finding videos by date range."""
-        from datetime import datetime, timezone
+        from datetime import datetime
 
-        start_date = datetime(2023, 1, 1, tzinfo=timezone.utc)
-        end_date = datetime(2023, 12, 31, tzinfo=timezone.utc)
+        start_date = datetime(2023, 1, 1, tzinfo=UTC)
+        end_date = datetime(2023, 12, 31, tzinfo=UTC)
 
         mock_videos = [MagicMock(), MagicMock()]
         mock_result = MagicMock()
@@ -563,14 +561,14 @@ class TestVideoRepositorySearchFilters:
         self, repository: VideoRepository, mock_session: AsyncMock, mock_videos
     ):
         """Test search videos with upload date filters."""
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = mock_videos
         mock_session.execute.return_value = mock_result
 
-        upload_after = datetime(2023, 1, 1, tzinfo=timezone.utc)
-        upload_before = datetime(2023, 12, 31, tzinfo=timezone.utc)
+        upload_after = datetime(2023, 1, 1, tzinfo=UTC)
+        upload_before = datetime(2023, 12, 31, tzinfo=UTC)
 
         filters = create_video_search_filters(
             upload_after=upload_after, upload_before=upload_before
@@ -751,7 +749,7 @@ class TestVideoRepositoryStatistics:
             repository,
             "get_video_statistics",
             new=AsyncMock(return_value=expected_stats),
-        ) as mock_stats:
+        ):
 
             result = await repository.get_video_statistics(mock_session)
 
@@ -795,7 +793,7 @@ class TestVideoRepositoryStatistics:
             repository,
             "get_video_statistics",
             new=AsyncMock(return_value=expected_stats),
-        ) as mock_stats:
+        ):
 
             result = await repository.get_video_statistics(mock_session)
 
@@ -1351,7 +1349,7 @@ class TestVideoRepositoryAdvancedCoverage:
         # Mock get_by_video_id to return video
         with patch.object(
             repository, "get_by_video_id", new=AsyncMock(return_value=sample_video_db)
-        ) as mock_get:
+        ):
 
             # Mock localization data
             mock_localization = MagicMock()
@@ -1409,7 +1407,7 @@ class TestVideoRepositoryAdvancedCoverage:
         # Mock get_by_video_id to return video
         with patch.object(
             repository, "get_by_video_id", new=AsyncMock(return_value=sample_video_db)
-        ) as mock_get:
+        ):
 
             with patch(
                 "chronovista.repositories.video_localization_repository.VideoLocalizationRepository"

--- a/tests/unit/repositories/test_video_tag_repository.py
+++ b/tests/unit/repositories/test_video_tag_repository.py
@@ -4,7 +4,7 @@ Tests for VideoTagRepository functionality.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,8 +18,6 @@ from chronovista.models.video_tag import (
 )
 from chronovista.repositories.video_tag_repository import VideoTagRepository
 from tests.factories.video_tag_factory import VideoTagTestData, create_video_tag_create
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestVideoTagRepository:
@@ -42,7 +40,7 @@ class TestVideoTagRepository:
             video_id="dQw4w9WgXcQ",
             tag="music",
             tag_order=1,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
     @pytest.fixture
@@ -320,8 +318,8 @@ class TestVideoTagRepository:
             tag_pattern="music",
             min_tag_order=1,
             max_tag_order=5,
-            created_after=datetime(2023, 1, 1, tzinfo=timezone.utc),
-            created_before=datetime(2023, 12, 31, tzinfo=timezone.utc),
+            created_after=datetime(2023, 1, 1, tzinfo=UTC),
+            created_before=datetime(2023, 12, 31, tzinfo=UTC),
         )
 
         mock_tags = [MagicMock(), MagicMock()]
@@ -528,7 +526,7 @@ class TestVideoTagRepositoryIntegration:
         with (
             patch.object(
                 repository, "get_by_composite_key", AsyncMock(return_value=None)
-            ) as mock_get,
+            ),
             patch.object(
                 repository, "create", AsyncMock(return_value=mock_tag_db)
             ) as mock_create,

--- a/tests/unit/repositories/test_video_topic_repository.py
+++ b/tests/unit/repositories/test_video_topic_repository.py
@@ -5,30 +5,21 @@ Tests the VideoTopicRepository class for managing video-topic relationships
 with comprehensive coverage of CRUD operations, search, and analytics.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import VideoTopic as VideoTopicDB
-from chronovista.models.video_topic import (
-    VideoTopicCreate,
-    VideoTopicSearchFilters,
-    VideoTopicUpdate,
-)
 from chronovista.repositories.video_topic_repository import VideoTopicRepository
 from tests.factories import (
     TestIds,
-    VideoTopicTestData,
     create_video_topic_create,
     create_video_topic_filters,
-    create_video_topic_update,
 )
 
 # Mark all tests as async for this module
-pytestmark = pytest.mark.asyncio
-
 
 class TestVideoTopicRepository:
     """Test VideoTopicRepository functionality."""
@@ -59,7 +50,7 @@ class TestVideoTopicRepository:
             video_id=TestIds.TEST_VIDEO_1,
             topic_id=TestIds.MUSIC_TOPIC,
             relevance_type="primary",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
     @pytest.mark.asyncio
@@ -175,7 +166,7 @@ class TestVideoTopicRepository:
                 video_id=obj_in.video_id,
                 topic_id=obj_in.topic_id,
                 relevance_type=obj_in.relevance_type,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -404,7 +395,7 @@ class TestVideoTopicRepository:
                 video_id=TestIds.TEST_VIDEO_1,
                 topic_id=TestIds.MUSIC_TOPIC,
                 relevance_type="primary",
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         ]
         repository.bulk_create_video_topics = AsyncMock(return_value=created_topics)
@@ -432,7 +423,7 @@ class TestVideoTopicRepository:
             video_id=sample_video_topic_create.video_id,
             topic_id=sample_video_topic_create.topic_id,
             relevance_type="secondary",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         repository.get_by_composite_key = AsyncMock(return_value=existing_topic)
         repository.update = AsyncMock(return_value=existing_topic)
@@ -461,7 +452,7 @@ class TestVideoTopicRepository:
             video_id=sample_video_topic_create.video_id,
             topic_id=sample_video_topic_create.topic_id,
             relevance_type=sample_video_topic_create.relevance_type,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         repository.create = AsyncMock(return_value=new_topic)
 
@@ -489,7 +480,7 @@ class TestVideoTopicRepository:
             video_id=TestIds.TEST_VIDEO_1,
             topic_id=TestIds.MUSIC_TOPIC,
             relevance_type="primary",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         def mock_get_existing(session, video_id, topic_id):
@@ -504,7 +495,7 @@ class TestVideoTopicRepository:
             video_id=TestIds.TEST_VIDEO_1,
             topic_id=TestIds.GAMING_TOPIC,
             relevance_type="relevant",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
         repository.create = AsyncMock(return_value=new_topic)
 

--- a/tests/unit/repositories/test_video_transcript_repository.py
+++ b/tests/unit/repositories/test_video_transcript_repository.py
@@ -7,8 +7,8 @@ transcript management, quality indicators, and specialized queries.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict, List
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,8 +28,6 @@ from chronovista.models.video_transcript import (
 from chronovista.repositories.video_transcript_repository import (
     VideoTranscriptRepository,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestVideoTranscriptRepository:
@@ -60,7 +58,7 @@ class TestVideoTranscriptRepository:
             is_auto_synced=False,
             track_kind=TrackKind.STANDARD.value,
             caption_name="English (CC)",
-            downloaded_at=datetime.now(timezone.utc),
+            downloaded_at=datetime.now(UTC),
         )
 
     @pytest.fixture
@@ -80,9 +78,9 @@ class TestVideoTranscriptRepository:
         )
 
     @pytest.fixture
-    def sample_transcripts_list(self) -> List[VideoTranscriptDB]:
+    def sample_transcripts_list(self) -> list[VideoTranscriptDB]:
         """Create list of sample transcripts."""
-        base_time = datetime.now(timezone.utc)
+        base_time = datetime.now(UTC)
         return [
             VideoTranscriptDB(
                 video_id="dQw4w9WgXcQ",
@@ -188,7 +186,7 @@ class TestVideoTranscriptRepository:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_list: List[VideoTranscriptDB],
+        sample_transcripts_list: list[VideoTranscriptDB],
     ):
         """Test getting all transcripts for a video."""
         # Mock execute to return scalars
@@ -208,7 +206,7 @@ class TestVideoTranscriptRepository:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_list: List[VideoTranscriptDB],
+        sample_transcripts_list: list[VideoTranscriptDB],
     ):
         """Test getting transcripts filtered by language."""
         # Filter list to only English transcripts
@@ -232,7 +230,7 @@ class TestVideoTranscriptRepository:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_list: List[VideoTranscriptDB],
+        sample_transcripts_list: list[VideoTranscriptDB],
     ):
         """Test getting transcripts by language with limit."""
         mock_result = MagicMock()
@@ -253,7 +251,7 @@ class TestVideoTranscriptRepository:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_list: List[VideoTranscriptDB],
+        sample_transcripts_list: list[VideoTranscriptDB],
     ):
         """Test getting high-quality transcripts."""
         # Filter to high-quality transcripts (CC, manual, or high confidence)
@@ -281,7 +279,7 @@ class TestVideoTranscriptRepository:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_list: List[VideoTranscriptDB],
+        sample_transcripts_list: list[VideoTranscriptDB],
     ):
         """Test searching transcripts with various filters."""
         filters = TranscriptSearchFilters(
@@ -308,7 +306,7 @@ class TestVideoTranscriptRepository:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_list: List[VideoTranscriptDB],
+        sample_transcripts_list: list[VideoTranscriptDB],
     ):
         """Test searching transcripts with empty filters (returns all)."""
         filters = TranscriptSearchFilters()
@@ -485,7 +483,7 @@ class TestVideoTranscriptRepository:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_list: List[VideoTranscriptDB],
+        sample_transcripts_list: list[VideoTranscriptDB],
     ):
         """Test getting transcripts with computed quality scores."""
         with patch.object(
@@ -584,7 +582,7 @@ class TestVideoTranscriptRepository:
             confidence_score=0.3,
             track_kind=TrackKind.ASR.value,
             is_auto_synced=True,
-            downloaded_at=datetime.now(timezone.utc),
+            downloaded_at=datetime.now(UTC),
         )
 
         score = repository._compute_quality_score(low_quality_transcript)
@@ -654,7 +652,7 @@ class TestVideoTranscriptRepositoryEdgeCases:
         self, repository: VideoTranscriptRepository, mock_session: AsyncMock
     ):
         """Test search with date range filters."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         filters = TranscriptSearchFilters(
             downloaded_after=now,
             downloaded_before=now,
@@ -721,7 +719,7 @@ class TestVideoTranscriptRepositoryEdgeCases:
             confidence_score=None,  # Missing confidence
             track_kind=TrackKind.STANDARD.value,
             is_auto_synced=False,
-            downloaded_at=datetime.now(timezone.utc),
+            downloaded_at=datetime.now(UTC),
         )
 
         score = repository._compute_quality_score(transcript)
@@ -748,7 +746,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
         return AsyncMock(spec=AsyncSession)
 
     @pytest.fixture
-    def sample_raw_transcript_data(self) -> Dict[str, Any]:
+    def sample_raw_transcript_data(self) -> dict[str, Any]:
         """Sample raw transcript data with timestamps."""
         return {
             "video_id": "dQw4w9WgXcQ",
@@ -766,7 +764,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
         }
 
     @pytest.fixture
-    def sample_raw_transcript_data_empty_snippets(self) -> Dict[str, Any]:
+    def sample_raw_transcript_data_empty_snippets(self) -> dict[str, Any]:
         """Sample raw transcript data with empty snippets array."""
         return {
             "video_id": "dQw4w9WgXcQ",
@@ -781,7 +779,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
 
     @pytest.fixture
     def sample_transcript_create_with_raw_data(
-        self, sample_raw_transcript_data: Dict[str, Any]
+        self, sample_raw_transcript_data: dict[str, Any]
     ) -> VideoTranscriptCreate:
         """Create sample transcript creation object for testing."""
         return VideoTranscriptCreate(
@@ -798,7 +796,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
         )
 
     def test_derive_metadata_with_valid_snippets(
-        self, repository: VideoTranscriptRepository, sample_raw_transcript_data: Dict[str, Any]
+        self, repository: VideoTranscriptRepository, sample_raw_transcript_data: dict[str, Any]
     ):
         """T016: Test _derive_metadata with valid raw data containing snippets.
 
@@ -823,7 +821,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
     def test_derive_metadata_with_empty_snippets(
         self,
         repository: VideoTranscriptRepository,
-        sample_raw_transcript_data_empty_snippets: Dict[str, Any]
+        sample_raw_transcript_data_empty_snippets: dict[str, Any]
     ):
         """T017: Test _derive_metadata with empty snippets array.
 
@@ -890,7 +888,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
         sample_transcript_create_with_raw_data: VideoTranscriptCreate,
-        sample_raw_transcript_data: Dict[str, Any],
+        sample_raw_transcript_data: dict[str, Any],
     ):
         """T019: Test create_or_update creating a NEW transcript with raw_transcript_data.
 
@@ -907,7 +905,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
             mock_get.return_value = None
 
             # Mock the database object that will be created
-            mock_created_transcript = VideoTranscriptDB(
+            VideoTranscriptDB(
                 video_id="dQw4w9WgXcQ",
                 language_code="en",
                 transcript_text="Never gonna give you up Never gonna let you down Never gonna run around and desert you",
@@ -918,7 +916,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
                 is_auto_synced=False,
                 track_kind=TrackKind.STANDARD.value,
                 caption_name="English (CC)",
-                downloaded_at=datetime.now(timezone.utc),
+                downloaded_at=datetime.now(UTC),
                 # Feature 007 fields
                 raw_transcript_data=sample_raw_transcript_data,
                 has_timestamps=True,
@@ -937,7 +935,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
             mock_execute_result.rowcount = 0
             mock_session.execute.return_value = mock_execute_result
 
-            result = await repository.create_or_update(
+            await repository.create_or_update(
                 mock_session,
                 sample_transcript_create_with_raw_data,
                 raw_transcript_data=sample_raw_transcript_data,
@@ -971,7 +969,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
         sample_transcript_create_with_raw_data: VideoTranscriptCreate,
-        sample_raw_transcript_data: Dict[str, Any],
+        sample_raw_transcript_data: dict[str, Any],
     ):
         """T020: Test create_or_update UPDATING an existing transcript with fresh raw_transcript_data.
 
@@ -993,7 +991,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
             is_auto_synced=True,
             track_kind=TrackKind.ASR.value,
             caption_name="English (Auto)",
-            downloaded_at=datetime.now(timezone.utc),
+            downloaded_at=datetime.now(UTC),
             # Old Feature 007 fields
             raw_transcript_data={"old": "data"},
             has_timestamps=False,
@@ -1018,7 +1016,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
             mock_execute_result.rowcount = 0
             mock_session.execute.return_value = mock_execute_result
 
-            result = await repository.create_or_update(
+            await repository.create_or_update(
                 mock_session,
                 sample_transcript_create_with_raw_data,
                 raw_transcript_data=sample_raw_transcript_data,
@@ -1064,7 +1062,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
             is_auto_synced=False,
             track_kind=TrackKind.STANDARD.value,
             caption_name="English (CC)",
-            downloaded_at=datetime.now(timezone.utc),
+            downloaded_at=datetime.now(UTC),
             # Feature 007 fields
             raw_transcript_data={"snippets": [{"text": "test", "start": 0.0, "duration": 1.0}]},
             has_timestamps=True,
@@ -1116,7 +1114,7 @@ class TestVideoTranscriptRepositoryTimestampPreservation:
             mock_session.refresh.return_value = None
 
             # Call WITHOUT raw_transcript_data parameter
-            result = await repository.create_or_update(
+            await repository.create_or_update(
                 mock_session,
                 sample_transcript_create_with_raw_data,
                 # No raw_transcript_data parameter
@@ -1161,9 +1159,9 @@ class TestVideoTranscriptRepositoryMetadataQueries:
         return AsyncMock(spec=AsyncSession)
 
     @pytest.fixture
-    def sample_transcripts_with_metadata(self) -> List[VideoTranscriptDB]:
+    def sample_transcripts_with_metadata(self) -> list[VideoTranscriptDB]:
         """Create sample transcripts with varying metadata for filter testing."""
-        base_time = datetime.now(timezone.utc)
+        base_time = datetime.now(UTC)
 
         return [
             # Transcript 1: Has timestamps, 3 segments, 7.8 seconds
@@ -1253,7 +1251,7 @@ class TestVideoTranscriptRepositoryMetadataQueries:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_with_metadata: List[VideoTranscriptDB],
+        sample_transcripts_with_metadata: list[VideoTranscriptDB],
     ):
         """T031: Test filter_by_metadata with has_timestamps=True filter.
 
@@ -1289,7 +1287,7 @@ class TestVideoTranscriptRepositoryMetadataQueries:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_with_metadata: List[VideoTranscriptDB],
+        sample_transcripts_with_metadata: list[VideoTranscriptDB],
     ):
         """T032: Test filter_by_metadata with min_segment_count filter.
 
@@ -1327,7 +1325,7 @@ class TestVideoTranscriptRepositoryMetadataQueries:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_with_metadata: List[VideoTranscriptDB],
+        sample_transcripts_with_metadata: list[VideoTranscriptDB],
     ):
         """T033: Test filter_by_metadata with min_duration filter (600 seconds = 10 minutes).
 
@@ -1367,7 +1365,7 @@ class TestVideoTranscriptRepositoryMetadataQueries:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_with_metadata: List[VideoTranscriptDB],
+        sample_transcripts_with_metadata: list[VideoTranscriptDB],
     ):
         """T034: Test filter_by_metadata with combined filters (AND logic).
 
@@ -1415,7 +1413,7 @@ class TestVideoTranscriptRepositoryMetadataQueries:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_transcripts_with_metadata: List[VideoTranscriptDB],
+        sample_transcripts_with_metadata: list[VideoTranscriptDB],
     ):
         """T035: Test filter_by_metadata pagination (limit/offset).
 
@@ -1485,7 +1483,7 @@ class TestVideoTranscriptRepositoryMetadataQueries:
             is_auto_synced=True,
             track_kind=TrackKind.ASR.value,
             caption_name="English (Auto)",
-            downloaded_at=datetime.now(timezone.utc),
+            downloaded_at=datetime.now(UTC),
             # No timestamps
             raw_transcript_data=None,
             has_timestamps=False,
@@ -1524,7 +1522,7 @@ class TestVideoTranscriptRepositoryMetadataQueries:
             is_auto_synced=False,
             track_kind=TrackKind.STANDARD.value,
             caption_name="English (CC)",
-            downloaded_at=datetime.now(timezone.utc),
+            downloaded_at=datetime.now(UTC),
             # Has timestamps
             raw_transcript_data={"snippets": [{"text": "test", "start": 0.0, "duration": 2.5}]},
             has_timestamps=True,
@@ -1572,7 +1570,7 @@ class TestVideoTranscriptRepositorySourceTracking:
         return AsyncMock(spec=AsyncSession)
 
     @pytest.fixture
-    def sample_raw_data_with_source(self) -> Dict[str, Any]:
+    def sample_raw_data_with_source(self) -> dict[str, Any]:
         """Create sample raw data with source field set."""
         return {
             "video_id": "srcTest1234",  # Valid 11-character video ID
@@ -1588,7 +1586,7 @@ class TestVideoTranscriptRepositorySourceTracking:
         }
 
     @pytest.fixture
-    def sample_raw_data_without_source(self) -> Dict[str, Any]:
+    def sample_raw_data_without_source(self) -> dict[str, Any]:
         """Create sample raw data missing source field."""
         return {
             "video_id": "noSrcTest12",  # Valid 11-character video ID
@@ -1608,7 +1606,7 @@ class TestVideoTranscriptRepositorySourceTracking:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_raw_data_with_source: Dict[str, Any],
+        sample_raw_data_with_source: dict[str, Any],
     ):
         """T049: Test that source is extracted from raw_transcript_data during create_or_update.
 
@@ -1677,7 +1675,7 @@ class TestVideoTranscriptRepositorySourceTracking:
         Verifies that filter_by_metadata correctly filters transcripts by their
         source field, returning only transcripts from the specified source.
         """
-        base_time = datetime.now(timezone.utc)
+        base_time = datetime.now(UTC)
 
         # Create sample transcripts with different sources
         transcripts_mixed_sources = [
@@ -1774,7 +1772,7 @@ class TestVideoTranscriptRepositorySourceTracking:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_raw_data_without_source: Dict[str, Any],
+        sample_raw_data_without_source: dict[str, Any],
     ):
         """T051: Test default source value when missing from raw_data.
 
@@ -1856,7 +1854,7 @@ class TestSegmentCreationInCreateOrUpdate:
         return session
 
     @pytest.fixture
-    def sample_raw_transcript_data(self) -> Dict[str, Any]:
+    def sample_raw_transcript_data(self) -> dict[str, Any]:
         """Sample raw transcript data with timestamps."""
         return {
             "video_id": "dQw4w9WgXcQ",
@@ -1892,7 +1890,7 @@ class TestSegmentCreationInCreateOrUpdate:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_raw_transcript_data: Dict[str, Any],
+        sample_raw_transcript_data: dict[str, Any],
     ) -> None:
         """Test that _create_segments_from_raw_data creates segment records."""
         # Call the private method directly
@@ -1922,7 +1920,7 @@ class TestSegmentCreationInCreateOrUpdate:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_raw_transcript_data: Dict[str, Any],
+        sample_raw_transcript_data: dict[str, Any],
     ) -> None:
         """Test that segments are created with correct field values."""
         from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
@@ -1956,7 +1954,7 @@ class TestSegmentCreationInCreateOrUpdate:
         self,
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
-        sample_raw_transcript_data: Dict[str, Any],
+        sample_raw_transcript_data: dict[str, Any],
     ) -> None:
         """Test that existing segments are deleted before creating new ones (idempotent)."""
         # Mock execute to show some rows were deleted
@@ -1981,7 +1979,7 @@ class TestSegmentCreationInCreateOrUpdate:
         mock_session: AsyncMock,
     ) -> None:
         """Test handling of empty snippets array."""
-        raw_data: Dict[str, Any] = {
+        raw_data: dict[str, Any] = {
             "video_id": "dQw4w9WgXcQ",
             "language_code": "en",
             "snippets": [],
@@ -2011,7 +2009,7 @@ class TestSegmentCreationInCreateOrUpdate:
         mock_session: AsyncMock,
     ) -> None:
         """Test handling when snippets is not a list."""
-        raw_data: Dict[str, Any] = {
+        raw_data: dict[str, Any] = {
             "video_id": "dQw4w9WgXcQ",
             "language_code": "en",
             "snippets": "not a list",  # Invalid type
@@ -2039,7 +2037,7 @@ class TestSegmentCreationInCreateOrUpdate:
         mock_session: AsyncMock,
     ) -> None:
         """Test that malformed snippets are skipped without failing."""
-        raw_data: Dict[str, Any] = {
+        raw_data: dict[str, Any] = {
             "video_id": "dQw4w9WgXcQ",
             "language_code": "en",
             "snippets": [
@@ -2072,7 +2070,7 @@ class TestSegmentCreationInCreateOrUpdate:
         mock_session: AsyncMock,
     ) -> None:
         """Test that type conversion errors in snippets are handled gracefully."""
-        raw_data: Dict[str, Any] = {
+        raw_data: dict[str, Any] = {
             "video_id": "dQw4w9WgXcQ",
             "language_code": "en",
             "snippets": [
@@ -2099,7 +2097,7 @@ class TestSegmentCreationInCreateOrUpdate:
         repository: VideoTranscriptRepository,
         mock_session: AsyncMock,
         sample_transcript_create: VideoTranscriptCreate,
-        sample_raw_transcript_data: Dict[str, Any],
+        sample_raw_transcript_data: dict[str, Any],
     ) -> None:
         """Test that create_or_update calls _create_segments_from_raw_data."""
         # Mock get_by_composite_key to return None (new transcript)

--- a/tests/unit/schemas/test_scan_schemas.py
+++ b/tests/unit/schemas/test_scan_schemas.py
@@ -23,9 +23,6 @@ from chronovista.api.schemas.entity_mentions import (
 )
 from chronovista.models.enums import EntityType
 
-pytestmark = pytest.mark.asyncio
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/schemas/test_transcript_corrections_schemas.py
+++ b/tests/unit/schemas/test_transcript_corrections_schemas.py
@@ -16,7 +16,7 @@ Key behavioral notes verified against the actual schema implementation:
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 
@@ -31,8 +31,6 @@ from chronovista.api.schemas.transcript_corrections import (
     SegmentCorrectionState,
 )
 from chronovista.models.enums import CorrectionType
-
-pytestmark = pytest.mark.asyncio
 
 # ---------------------------------------------------------------------------
 # Helpers / shared fixtures
@@ -64,7 +62,7 @@ def _make_audit_record_dict(
         "corrected_text": corrected_text,
         "correction_note": correction_note,
         "corrected_by_user_id": corrected_by_user_id,
-        "corrected_at": corrected_at or datetime.now(tz=timezone.utc),
+        "corrected_at": corrected_at or datetime.now(tz=UTC),
         "version_number": version_number,
     }
 
@@ -275,7 +273,7 @@ class TestCorrectionAuditRecord:
     def test_valid_construction_from_dict_all_fields(self) -> None:
         """CorrectionAuditRecord is constructible from a complete dict."""
         record_id = uuid.uuid4()
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
 
         record = CorrectionAuditRecord(
             id=record_id,
@@ -311,7 +309,7 @@ class TestCorrectionAuditRecord:
         SimpleNamespace is used here as a lightweight stand-in.
         """
         record_id = uuid.uuid4()
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
 
         orm_like = SimpleNamespace(
             id=record_id,

--- a/tests/unit/scripts/test_backfill_batch_ids.py
+++ b/tests/unit/scripts/test_backfill_batch_ids.py
@@ -16,11 +16,9 @@ References
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, call, patch
-
-import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # ---------------------------------------------------------------------------
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
@@ -32,18 +30,15 @@ import pytest
 # all async tests run correctly with pytest-cov.  Sync tests receive the
 # marker too, which produces benign warnings but does NOT affect correctness.
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 # ---------------------------------------------------------------------------
 # Lazy imports from the script (avoids sys.path manipulation at import time
 # since the script bootstraps its own path).  The script adds ``src/`` on
 # first import, so we do a direct import after ensuring the path is set.
 # ---------------------------------------------------------------------------
-
 from scripts.utilities.backfill_batch_ids import (  # noqa: E402
     DEFAULT_WINDOW_SECONDS,
-    BatchGroup,
     CorrectionRow,
+    _group_key,
     assign_batch_id,
     build_parser,
     fetch_unassigned_corrections,
@@ -51,8 +46,6 @@ from scripts.utilities.backfill_batch_ids import (  # noqa: E402
     identify_batches_by_text,
     identify_batches_by_timestamp,
     run_backfill,
-    _group_key,
-    _display_summary,
 )
 
 # Backward-compatible alias for existing tests
@@ -61,7 +54,6 @@ identify_batches = identify_batches_by_text
 from tests.factories.transcript_correction_factory import (
     TranscriptCorrectionFactory,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -96,7 +88,7 @@ def _make_row(
         Lightweight data container for one correction row.
     """
     if corrected_at is None:
-        corrected_at = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        corrected_at = datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC)
     return CorrectionRow(
         id=id,
         corrected_by_user_id=corrected_by_user_id,
@@ -119,7 +111,7 @@ def _at(seconds_offset: float) -> datetime:
     datetime
         Base time plus the given offset.
     """
-    base = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    base = datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC)
     return base + timedelta(seconds=seconds_offset)
 
 
@@ -485,7 +477,7 @@ class TestFetchUnassignedCorrections:
 
     async def test_multiple_rows_all_mapped(self) -> None:
         """All rows from fetchall must be mapped to CorrectionRow instances."""
-        base_time = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        base_time = datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC)
         raw_rows = []
         for i in range(5):
             r = MagicMock()
@@ -828,7 +820,6 @@ class TestProgressReporting:
 
         captured: dict[str, Any] = {}
 
-        original_display = _display_summary
 
         def _capture_display(**kwargs: Any) -> None:
             captured.update(kwargs)

--- a/tests/unit/services/enrichment/conftest.py
+++ b/tests/unit/services/enrichment/conftest.py
@@ -7,8 +7,7 @@ for mocking YouTube API responses in tests.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Optional
+from datetime import UTC, datetime
 
 import pytest
 
@@ -28,18 +27,18 @@ def make_video_response(
     description: str = "",
     channel_id: str = "UCuAXFkgsw1L7xaCfnd5JJOw",
     channel_title: str = "Test Channel",
-    published_at: Optional[datetime] = None,
+    published_at: datetime | None = None,
     duration: str = "PT10M30S",
     view_count: int = 1000,
-    like_count: Optional[int] = 50,
-    comment_count: Optional[int] = 10,
+    like_count: int | None = 50,
+    comment_count: int | None = 10,
     category_id: str = "10",
-    tags: Optional[list[str]] = None,
-    topic_categories: Optional[list[str]] = None,
+    tags: list[str] | None = None,
+    topic_categories: list[str] | None = None,
     made_for_kids: bool = False,
-    self_declared_made_for_kids: Optional[bool] = None,
-    default_language: Optional[str] = None,
-    default_audio_language: Optional[str] = None,
+    self_declared_made_for_kids: bool | None = None,
+    default_language: str | None = None,
+    default_audio_language: str | None = None,
 ) -> YouTubeVideoResponse:
     """
     Create a valid YouTubeVideoResponse instance for testing.
@@ -87,7 +86,7 @@ def make_video_response(
         A valid Pydantic model instance.
     """
     if published_at is None:
-        published_at = datetime.now(timezone.utc)
+        published_at = datetime.now(UTC)
 
     snippet = VideoSnippet(
         publishedAt=published_at,

--- a/tests/unit/services/enrichment/test_advisory_lock.py
+++ b/tests/unit/services/enrichment/test_advisory_lock.py
@@ -24,8 +24,6 @@ from chronovista.services.enrichment.enrichment_service import (
     LockInfo,
 )
 
-pytestmark = pytest.mark.asyncio
-
 
 class TestLockInfo:
     """Test LockInfo model."""
@@ -85,7 +83,7 @@ class TestEnrichmentLockConstants:
     def test_lock_file_path(self) -> None:
         """Test that LOCK_FILE is in correct location."""
         expected_path = Path.home() / ".chronovista" / "enrichment.lock"
-        assert EnrichmentLock.LOCK_FILE == expected_path
+        assert expected_path == EnrichmentLock.LOCK_FILE
 
 
 class TestEnrichmentLockInitialization:

--- a/tests/unit/services/enrichment/test_category_seeder.py
+++ b/tests/unit/services/enrichment/test_category_seeder.py
@@ -13,17 +13,11 @@ Tests cover:
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
-from chronovista.models.video_category import VideoCategoryCreate
 from chronovista.repositories.video_category_repository import VideoCategoryRepository
 from chronovista.services.enrichment.seeders import CategorySeeder, CategorySeedResult
 from chronovista.services.youtube_service import YouTubeService
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestCategorySeederConstants:
@@ -36,7 +30,7 @@ class TestCategorySeederConstants:
     def test_default_regions_list(self) -> None:
         """Test default regions match expected list."""
         expected_regions = ["US", "GB", "JP", "DE", "BR", "IN", "MX"]
-        assert CategorySeeder.DEFAULT_REGIONS == expected_regions
+        assert expected_regions == CategorySeeder.DEFAULT_REGIONS
 
     def test_get_default_region_count(self) -> None:
         """Test class method for getting default region count."""

--- a/tests/unit/services/enrichment/test_channel_enrichment.py
+++ b/tests/unit/services/enrichment/test_channel_enrichment.py
@@ -7,9 +7,9 @@ dry-run mode, limit parameter, shutdown handling, error isolation, and field ext
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -25,8 +25,6 @@ from chronovista.services.enrichment.enrichment_service import (
 )
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 def make_channel_response(
     channel_id: str,
@@ -77,7 +75,7 @@ def make_channel_response(
         country=country,
         defaultLanguage=default_language,
         customUrl=custom_url,
-        publishedAt=datetime.now(timezone.utc),
+        publishedAt=datetime.now(UTC),
     )
 
     statistics = ChannelStatisticsResponse(
@@ -152,8 +150,8 @@ class TestChannelEnrichmentResultModel:
 
     def test_timing_fields(self) -> None:
         """Test timing fields on ChannelEnrichmentResult."""
-        started = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
-        completed = datetime(2024, 1, 15, 12, 5, 30, tzinfo=timezone.utc)
+        started = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+        completed = datetime(2024, 1, 15, 12, 5, 30, tzinfo=UTC)
 
         result = ChannelEnrichmentResult(
             started_at=started,
@@ -255,7 +253,7 @@ class TestExtractChannelUpdate:
             snippet=ChannelSnippet(
                 title="Test Channel",
                 description="Test description",
-                publishedAt=datetime.now(timezone.utc),
+                publishedAt=datetime.now(UTC),
             ),
             statistics=None,
         )

--- a/tests/unit/services/enrichment/test_deleted_detection.py
+++ b/tests/unit/services/enrichment/test_deleted_detection.py
@@ -7,17 +7,15 @@ Covers T040a-c:
 - T040c: Unit test verifying local recovery doesn't set availability_status to unavailable
 """
 
-from datetime import datetime, timezone
-from typing import Any, Dict, List
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from chronovista.models.enums import AvailabilityStatus
 from chronovista.models.api_responses import YouTubeVideoResponse
-from chronovista.models.enrichment_report import EnrichmentReport, EnrichmentSummary
+from chronovista.models.enums import AvailabilityStatus
 from chronovista.services.enrichment.enrichment_service import (
-    BATCH_SIZE,
     EnrichmentService,
 )
 
@@ -29,20 +27,18 @@ def make_video_response(video_id: str, **kwargs: Any) -> YouTubeVideoResponse:
     This helper ensures tests return proper Pydantic objects instead of dicts.
     The snippet field requires publishedAt and channelId, so we provide defaults.
     """
-    data: Dict[str, Any] = {"id": video_id, **kwargs}
+    data: dict[str, Any] = {"id": video_id, **kwargs}
 
     # If snippet is provided, ensure required fields are present
     if "snippet" in data:
         snippet = data["snippet"]
         if isinstance(snippet, dict):
             if "publishedAt" not in snippet:
-                snippet["publishedAt"] = datetime.now(timezone.utc).isoformat()
+                snippet["publishedAt"] = datetime.now(UTC).isoformat()
             if "channelId" not in snippet:
                 snippet["channelId"] = "UC_test_channel"
 
     return YouTubeVideoResponse.model_validate(data)
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.asyncio
@@ -408,7 +404,7 @@ class TestGetVideosForEnrichmentDeletedFilter:
         mock_session.execute = AsyncMock(return_value=mock_result)
 
         # Call the actual method to check query construction
-        result = await service._get_videos_for_enrichment(
+        await service._get_videos_for_enrichment(
             mock_session, "high", None, include_deleted=False
         )
 
@@ -433,7 +429,7 @@ class TestGetVideosForEnrichmentDeletedFilter:
         mock_session.execute = AsyncMock(return_value=mock_result)
 
         # Call with include_deleted=True
-        result = await service._get_videos_for_enrichment(
+        await service._get_videos_for_enrichment(
             mock_session, "high", None, include_deleted=True
         )
 
@@ -624,8 +620,8 @@ class TestLocalRecoveryDoesNotSetAvailabilityStatusUnavailable:
         "availability_status should only be set to unavailable after YouTube API verification"
         """
         from chronovista.models.takeout.takeout_data import TakeoutWatchEntry
-        from chronovista.services.seeding.video_seeder import VideoSeeder
         from chronovista.repositories.video_repository import VideoRepository
+        from chronovista.services.seeding.video_seeder import VideoSeeder
 
         # Create a seeder
         seeder = VideoSeeder(video_repo=VideoRepository())
@@ -640,7 +636,7 @@ class TestLocalRecoveryDoesNotSetAvailabilityStatusUnavailable:
                 channel_name="RickAstleyVEVO",
                 channel_url="https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw",
                 channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 raw_time="2024-01-15T10:30:00Z",
             ),
             # Entry with missing channel info (common for deleted videos in Takeout)
@@ -651,7 +647,7 @@ class TestLocalRecoveryDoesNotSetAvailabilityStatusUnavailable:
                 channel_name=None,
                 channel_url=None,
                 channel_id=None,
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 raw_time="2024-01-15T10:30:00Z",
             ),
             # Entry with URL as title (indicates incomplete data)
@@ -662,7 +658,7 @@ class TestLocalRecoveryDoesNotSetAvailabilityStatusUnavailable:
                 channel_name=None,
                 channel_url=None,
                 channel_id=None,
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 raw_time="2024-01-15T10:30:00Z",
             ),
         ]
@@ -701,15 +697,13 @@ class TestLocalRecoveryDoesNotSetAvailabilityStatusUnavailable:
         When creating placeholder videos for playlist items not in watch history,
         availability_status must be available.
         """
-        from chronovista.services.seeding.playlist_membership_seeder import (
-            PlaylistMembershipSeeder,
-        )
-        from chronovista.repositories.video_repository import VideoRepository
-        from chronovista.repositories.playlist_repository import PlaylistRepository
-
         # The seeder creates VideoCreate with availability_status=AvailabilityStatus.AVAILABLE
         # We verify this by checking the source code documentation
         import inspect
+
+        from chronovista.services.seeding.playlist_membership_seeder import (
+            PlaylistMembershipSeeder,
+        )
         source = inspect.getsource(PlaylistMembershipSeeder)
 
         # Verify the code explicitly sets availability_status=AvailabilityStatus.AVAILABLE
@@ -738,7 +732,7 @@ class TestLocalRecoveryDoesNotSetAvailabilityStatusUnavailable:
             channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",  # 24 characters starting with UC
             title="Complete Video",
             description="",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=0,
             availability_status=AvailabilityStatus.AVAILABLE,  # This is what Takeout recovery uses
         )
@@ -750,7 +744,7 @@ class TestLocalRecoveryDoesNotSetAvailabilityStatusUnavailable:
             channel_id="UCplaceholder01234567890",  # 24 characters (UC + 22)
             title="[Placeholder] Video abc123XYZ_-",
             description="",
-            upload_date=datetime.now(timezone.utc),
+            upload_date=datetime.now(UTC),
             duration=0,
             availability_status=AvailabilityStatus.AVAILABLE,  # Still False even for placeholders
         )
@@ -762,8 +756,8 @@ class TestLocalRecoveryDoesNotSetAvailabilityStatusUnavailable:
 
         This is a code analysis test that ensures our invariant is maintained.
         """
-        from pathlib import Path
         import re
+        from pathlib import Path
 
         # Get the project source directory
         src_dir = Path(__file__).parent.parent.parent.parent.parent / "src"

--- a/tests/unit/services/enrichment/test_enrichment_service_categories.py
+++ b/tests/unit/services/enrichment/test_enrichment_service_categories.py
@@ -17,25 +17,19 @@ Additional tests:
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from chronovista.models.video import VideoUpdate
 from chronovista.models.video_category import (
-    VideoCategory,
     VideoCategoryCreate,
     VideoCategoryUpdate,
 )
-from chronovista.models.video import VideoUpdate
-from chronovista.models.youtube_types import create_test_video_id
 from chronovista.services.enrichment.enrichment_service import (
-    BATCH_SIZE,
     EnrichmentService,
 )
-
-pytestmark = pytest.mark.asyncio
 
 # Valid test video ID (must be exactly 11 characters)
 VALID_VIDEO_ID = "dQw4w9WgXcQ"
@@ -134,7 +128,6 @@ class TestEnrichCategoriesMethod:
     ) -> None:
         """Test that enrich_categories() extracts category from API data correctly."""
         # Given API data with category ID
-        video_id = VALID_VIDEO_ID
         category_id = CATEGORY_ID_MUSIC
 
         # Mock category repository to return matching category
@@ -162,10 +155,9 @@ class TestEnrichCategoriesMethod:
     ) -> None:
         """Test that enrich_categories() handles empty category ID correctly."""
         video_id = VALID_VIDEO_ID
-        category_id = ""
 
         # API response with empty categoryId
-        api_data: Dict[str, Any] = {
+        api_data: dict[str, Any] = {
             "id": video_id,
             "snippet": {
                 "title": "Video Title",
@@ -187,7 +179,7 @@ class TestEnrichCategoriesMethod:
         video_id = VALID_VIDEO_ID
 
         # API response without categoryId field
-        api_data: Dict[str, Any] = {
+        api_data: dict[str, Any] = {
             "id": video_id,
             "snippet": {
                 "title": "Video Title",
@@ -209,7 +201,7 @@ class TestEnrichCategoriesMethod:
         video_id = VALID_VIDEO_ID
 
         # API response with explicit None categoryId
-        api_data: Dict[str, Any] = {
+        api_data: dict[str, Any] = {
             "id": video_id,
             "snippet": {
                 "title": "Video Title",
@@ -227,7 +219,6 @@ class TestEnrichCategoriesMethod:
         self, service: EnrichmentService, mock_session: AsyncMock
     ) -> None:
         """Test that enrich_categories() returns True when category is successfully assigned."""
-        video_id = VALID_VIDEO_ID
         category_id = CATEGORY_ID_MUSIC
 
         # Mock category repository to return matching category
@@ -250,7 +241,6 @@ class TestEnrichCategoriesMethod:
         self, service: EnrichmentService, mock_session: AsyncMock
     ) -> None:
         """Test that enrich_categories() returns False when category is not found."""
-        video_id = VALID_VIDEO_ID
         category_id = "99999"  # Non-existent category
 
         with patch.object(
@@ -393,7 +383,7 @@ class TestCategoryIdExtraction:
             ("44", "Trailers"),
         ]
 
-        for category_id, category_name in common_categories:
+        for category_id, _category_name in common_categories:
             api_data = {"snippet": {"categoryId": category_id}}
             extracted = api_data["snippet"]["categoryId"]
             assert extracted == category_id
@@ -424,7 +414,6 @@ class TestUnrecognizedCategoryHandling:
         video_id = VALID_VIDEO_ID
 
         # Expected log message format
-        expected_log_content = "Unrecognized category"
 
         # When processing unrecognized category, implementation should log:
         # logger.warning(f"Unrecognized category ID '{category_id}' for video {video_id}")
@@ -442,7 +431,6 @@ class TestUnrecognizedCategoryHandling:
         self, mock_session: AsyncMock, mock_video_category_repository: MagicMock
     ) -> None:
         """Test that video's category_id is left null for unrecognized categories."""
-        video_id = VALID_VIDEO_ID
         unrecognized_category_id = "99999"
 
         # Mock repository returns None (category not found)
@@ -515,7 +503,7 @@ class TestUnrecognizedCategoryHandling:
         education_category.category_id = "27"
         education_category.name = "Education"
 
-        async def get_mock(session: Any, category_id: str) -> Optional[MagicMock]:
+        async def get_mock(session: Any, category_id: str) -> MagicMock | None:
             categories = {
                 "10": music_category,
                 "20": gaming_category,
@@ -534,8 +522,8 @@ class TestUnrecognizedCategoryHandling:
             ("vid5", "27"),  # Education - should work
         ]
 
-        assigned_categories: List[MagicMock] = []
-        for video_id, category_id in batch:
+        assigned_categories: list[MagicMock] = []
+        for _video_id, category_id in batch:
             category = await mock_video_category_repository.get(
                 mock_session, category_id
             )
@@ -760,7 +748,7 @@ class TestCategoryValidation:
             "28": make_category("28", "Science & Technology"),
         }
 
-        async def get_mock(session: Any, category_id: str) -> Optional[MagicMock]:
+        async def get_mock(session: Any, category_id: str) -> MagicMock | None:
             return pre_seeded.get(category_id)
 
         async def exists_mock(session: Any, category_id: str) -> bool:
@@ -915,7 +903,6 @@ class TestCategoryEnrichmentIntegration:
         self, service: EnrichmentService, mock_session: AsyncMock
     ) -> None:
         """Test error handling during category enrichment."""
-        video_id = VALID_VIDEO_ID
         category_id = "10"
 
         with patch.object(
@@ -941,7 +928,7 @@ class TestCategoryEnrichmentIntegration:
 
         # Extract update data (mimics _extract_video_update behavior)
         snippet = api_response.get("snippet", {})
-        update_data: Dict[str, Any] = {}
+        update_data: dict[str, Any] = {}
 
         if snippet.get("title"):
             update_data["title"] = snippet["title"]
@@ -1084,7 +1071,7 @@ class TestCategoryEnrichmentInVideoUpdate:
         }
 
         snippet = api_data.get("snippet", {})
-        update_data: Dict[str, Any] = {}
+        update_data: dict[str, Any] = {}
 
         # Extract category
         if snippet.get("categoryId"):

--- a/tests/unit/services/enrichment/test_enrichment_service_phase4.py
+++ b/tests/unit/services/enrichment/test_enrichment_service_phase4.py
@@ -5,15 +5,14 @@ Covers T035a-g: batch video fetch, video field updates, channel creation,
 quota estimation, and enrichment flow.
 """
 
-from datetime import datetime, timezone
-from typing import Any, Dict
+from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from chronovista.models.enums import AvailabilityStatus
 from chronovista.models.api_responses import YouTubeVideoResponse
-from chronovista.models.enrichment_report import EnrichmentReport, EnrichmentSummary
+from chronovista.models.enums import AvailabilityStatus
 from chronovista.services.enrichment.enrichment_service import (
     BATCH_SIZE,
     EnrichmentService,
@@ -31,20 +30,18 @@ def make_video_response(video_id: str, **kwargs: Any) -> YouTubeVideoResponse:
     This helper ensures tests return proper Pydantic objects instead of dicts.
     The snippet field requires publishedAt and channelId, so we provide defaults.
     """
-    data: Dict[str, Any] = {"id": video_id, **kwargs}
+    data: dict[str, Any] = {"id": video_id, **kwargs}
 
     # If snippet is provided, ensure required fields are present
     if "snippet" in data:
         snippet = data["snippet"]
         if isinstance(snippet, dict):
             if "publishedAt" not in snippet:
-                snippet["publishedAt"] = datetime.now(timezone.utc).isoformat()
+                snippet["publishedAt"] = datetime.now(UTC).isoformat()
             if "channelId" not in snippet:
                 snippet["channelId"] = "UC_test_channel"
 
     return YouTubeVideoResponse.model_validate(data)
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestParseISO8601Duration:
@@ -201,7 +198,7 @@ class TestExtractVideoUpdate:
             "snippet": {"publishedAt": "2024-01-15T14:30:00Z"},
         }
         update = service._extract_video_update_from_dict(api_data)
-        assert update["upload_date"] == datetime(2024, 1, 15, 14, 30, 0, tzinfo=timezone.utc)
+        assert update["upload_date"] == datetime(2024, 1, 15, 14, 30, 0, tzinfo=UTC)
 
     def test_extract_statistics(self, service: EnrichmentService) -> None:
         """Test extracting view/like/comment counts."""

--- a/tests/unit/services/enrichment/test_enrichment_service_tags.py
+++ b/tests/unit/services/enrichment/test_enrichment_service_tags.py
@@ -15,20 +15,15 @@ Additional tests:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set, Tuple
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from chronovista.models.video_tag import VideoTag, VideoTagCreate
-from chronovista.models.youtube_types import create_test_video_id
+from chronovista.models.video_tag import VideoTagCreate
 from chronovista.services.enrichment.enrichment_service import (
-    BATCH_SIZE,
     EnrichmentService,
 )
-
-pytestmark = pytest.mark.asyncio
 
 # Valid test video ID (must be exactly 11 characters)
 VALID_VIDEO_ID = "dQw4w9WgXcQ"
@@ -120,7 +115,7 @@ class TestEnrichTagsMethod:
     ) -> None:
         """Test that enrich_tags() handles empty tag list correctly."""
         video_id = "videoWithNoTags"
-        tags: List[str] = []
+        tags: list[str] = []
 
         with patch.object(
             service.video_tag_repository, "replace_video_tags", new=AsyncMock(return_value=[])
@@ -140,7 +135,7 @@ class TestEnrichTagsMethod:
         video_id = "videoMissingTags"
 
         # API response without tags field
-        api_data: Dict[str, Any] = {
+        api_data: dict[str, Any] = {
             "id": video_id,
             "snippet": {
                 "title": "Video Title",
@@ -163,7 +158,7 @@ class TestEnrichTagsMethod:
         video_id = "videoWithNoneTags"
 
         # API response with explicit None tags
-        api_data: Dict[str, Any] = {
+        api_data: dict[str, Any] = {
             "id": video_id,
             "snippet": {
                 "title": "Video Title",
@@ -338,7 +333,6 @@ class TestTagReplacement:
     ) -> None:
         """Test that existing tags are deleted before inserting new ones."""
         video_id = "testReplace123"
-        old_tags = ["old1", "old2", "old3"]
         new_tags = ["new1", "new2"]
 
         # Simulate replace_video_tags behavior
@@ -419,7 +413,7 @@ class TestTagReplacement:
     ) -> None:
         """Test that replacing with empty list clears all tags."""
         video_id = "clearAllTest"
-        new_tags: List[str] = []
+        new_tags: list[str] = []
 
         mock_video_tag_repository.replace_video_tags = AsyncMock(return_value=[])
 
@@ -764,7 +758,6 @@ class TestVideosMissingTagsStatus:
     async def test_status_shows_videos_missing_tags_percentage(self) -> None:
         """Test that status shows percentage of videos missing tags."""
         total_videos = 1000
-        videos_with_tags = 750
         videos_without_tags = 250
 
         percentage_missing = (videos_without_tags / total_videos) * 100
@@ -982,7 +975,7 @@ class TestTagOrderHandling:
         # The create objects should have correct orders (using valid video ID)
         creates = [
             VideoTagCreate(video_id=VALID_VIDEO_ID, tag=t, tag_order=o)
-            for t, o in zip(tags, tag_orders)
+            for t, o in zip(tags, tag_orders, strict=False)
         ]
 
         assert creates[0].tag_order == 0
@@ -1050,7 +1043,7 @@ class TestEnrichTagsImplementation:
     ) -> None:
         """Test that enrich_tags returns 0 for empty tag list."""
         video_id = VALID_VIDEO_ID
-        tags: List[str] = []
+        tags: list[str] = []
 
         mock_replace = AsyncMock(return_value=[])
         with patch.object(

--- a/tests/unit/services/enrichment/test_enrichment_service_topics.py
+++ b/tests/unit/services/enrichment/test_enrichment_service_topics.py
@@ -20,22 +20,17 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import unquote
 
 import pytest
 
-from chronovista.models.topic_category import TopicCategory, TopicCategoryCreate
-from chronovista.models.video_topic import VideoTopic, VideoTopicCreate
-from chronovista.models.youtube_types import create_test_topic_id, create_test_video_id
+from chronovista.models.topic_category import TopicCategoryCreate
+from chronovista.models.video_topic import VideoTopicCreate
 from chronovista.services.enrichment.enrichment_service import (
-    BATCH_SIZE,
     EnrichmentService,
 )
-
-pytestmark = pytest.mark.asyncio
 
 # Valid test IDs (must match validation constraints)
 VALID_VIDEO_ID = "dQw4w9WgXcQ"  # 11 characters
@@ -131,11 +126,6 @@ class TestEnrichTopicsMethod:
         """Test that enrich_topics() extracts topics from API data correctly."""
         # Given API data with topic URLs
         video_id = VALID_VIDEO_ID
-        topic_urls = [
-            "https://en.wikipedia.org/wiki/Music",
-            "https://en.wikipedia.org/wiki/Rock_music",
-            "https://en.wikipedia.org/wiki/Pop_music",
-        ]
 
         # Mock topic category repository to return matching topics
         music_topic = MagicMock(topic_id=VALID_TOPIC_ID_MUSIC, category_name="Music")
@@ -161,8 +151,6 @@ class TestEnrichTopicsMethod:
         self, service: EnrichmentService, mock_session: AsyncMock
     ) -> None:
         """Test that enrich_topics() handles empty topic URL list correctly."""
-        video_id = VALID_VIDEO_ID
-        topic_urls: List[str] = []
 
         # When topic_urls is empty, should return 0 without calling repository
         # (similar to enrich_tags behavior)
@@ -180,7 +168,7 @@ class TestEnrichTopicsMethod:
         video_id = VALID_VIDEO_ID
 
         # API response without topicDetails field
-        api_data: Dict[str, Any] = {
+        api_data: dict[str, Any] = {
             "id": video_id,
             "snippet": {
                 "title": "Video Title",
@@ -205,7 +193,7 @@ class TestEnrichTopicsMethod:
         video_id = VALID_VIDEO_ID
 
         # API response with explicit None topicCategories
-        api_data: Dict[str, Any] = {
+        api_data: dict[str, Any] = {
             "id": video_id,
             "topicDetails": {
                 "topicCategories": None,  # Explicit None
@@ -245,7 +233,7 @@ class TestEnrichTopicsMethod:
 class TestWikipediaURLParsing:
     """Tests for Wikipedia URL parsing (regex) (T084b)."""
 
-    def extract_topic_name_from_url(self, url: str) -> Optional[str]:
+    def extract_topic_name_from_url(self, url: str) -> str | None:
         """
         Extract topic name from Wikipedia URL.
 
@@ -592,7 +580,6 @@ class TestUnrecognizedTopicHandling:
         topic_name = "UnknownGenre"
 
         # Expected log message format
-        expected_log_content = f"Unrecognized topic"
 
         # When processing unrecognized topic, implementation should log:
         # logger.warning(f"Unrecognized topic '{topic_name}' from URL: {url}")
@@ -610,13 +597,11 @@ class TestUnrecognizedTopicHandling:
     ) -> None:
         """Test that unrecognized topics are skipped (not created)."""
         # Given topic URLs with one recognized and one unrecognized
-        recognized_url = "https://en.wikipedia.org/wiki/Music"
-        unrecognized_url = "https://en.wikipedia.org/wiki/UnknownTopic"
 
         music_topic = MagicMock(topic_id=VALID_TOPIC_ID_MUSIC, category_name="Music")
 
         # Repository returns match for Music, no match for UnknownTopic
-        async def find_by_name_mock(session: Any, name: str) -> List[MagicMock]:
+        async def find_by_name_mock(session: Any, name: str) -> list[MagicMock]:
             if name == "Music" or name.lower() == "music":
                 return [music_topic]
             return []
@@ -656,7 +641,7 @@ class TestUnrecognizedTopicHandling:
         rock_topic = MagicMock(topic_id=VALID_TOPIC_ID_ROCK, category_name="Rock music")
 
         # Repository returns matches for known topics
-        async def find_by_name_mock(session: Any, name: str) -> List[MagicMock]:
+        async def find_by_name_mock(session: Any, name: str) -> list[MagicMock]:
             name_normalized = name.replace("_", " ").lower()
             if name_normalized == "music":
                 return [music_topic]
@@ -669,7 +654,7 @@ class TestUnrecognizedTopicHandling:
         )
 
         # When processing all URLs
-        matched_topics: List[MagicMock] = []
+        matched_topics: list[MagicMock] = []
         skipped_count = 0
 
         for url in topic_urls:
@@ -715,7 +700,7 @@ class TestUnrecognizedTopicHandling:
 class TestMalformedURLHandling:
     """Tests for malformed URL handling (T084e)."""
 
-    def extract_topic_name_from_url(self, url: Optional[str]) -> Optional[str]:
+    def extract_topic_name_from_url(self, url: str | None) -> str | None:
         """Helper to extract topic name from URL with error handling."""
         if url is None:
             return None
@@ -796,7 +781,7 @@ class TestMalformedURLHandling:
         ]
 
         # Processing should not raise exceptions
-        results: List[Optional[str]] = []
+        results: list[str | None] = []
         for url in malformed_urls:
             try:
                 result = self.extract_topic_name_from_url(url)
@@ -850,7 +835,6 @@ class TestTopicReplacement:
     ) -> None:
         """Test that existing topics are deleted before inserting new ones."""
         video_id = VALID_VIDEO_ID
-        old_topic_ids = ["/m/old1", "/m/old2", "/m/old3"]
         new_topic_ids = [VALID_TOPIC_ID_MUSIC, VALID_TOPIC_ID_ROCK]
 
         # First: delete existing topics
@@ -879,7 +863,7 @@ class TestTopicReplacement:
 
         mock_topics_db = [
             MagicMock(video_id=video_id, topic_id=t, relevance_type=r)
-            for t, r in zip(new_topic_ids, relevance_types)
+            for t, r in zip(new_topic_ids, relevance_types, strict=False)
         ]
         mock_video_topic_repository.replace_video_topics = AsyncMock(
             return_value=mock_topics_db
@@ -933,7 +917,7 @@ class TestTopicReplacement:
     ) -> None:
         """Test that replacing with empty list clears all topics."""
         video_id = VALID_VIDEO_ID
-        new_topic_ids: List[str] = []
+        new_topic_ids: list[str] = []
 
         mock_video_topic_repository.replace_video_topics = AsyncMock(return_value=[])
 
@@ -1117,7 +1101,7 @@ class TestMultipleTopicsPerVideo:
 
         mock_topics_db = [
             MagicMock(video_id=video_id, topic_id=t, relevance_type=r)
-            for t, r in zip(topic_ids, relevance_types)
+            for t, r in zip(topic_ids, relevance_types, strict=False)
         ]
         mock_video_topic_repository.replace_video_topics = AsyncMock(
             return_value=mock_topics_db
@@ -1163,10 +1147,9 @@ class TestVideosWithNoTopics:
         self, mock_session: AsyncMock
     ) -> None:
         """Test that no placeholder topics are created for videos without topics."""
-        from typing import Any, Dict
 
         video_id = VALID_VIDEO_ID
-        api_data: Dict[str, Any] = {
+        api_data: dict[str, Any] = {
             "id": video_id,
             "snippet": {
                 "title": "Video Without Topics",
@@ -1183,10 +1166,9 @@ class TestVideosWithNoTopics:
         self, mock_session: AsyncMock
     ) -> None:
         """Test that empty topicCategories array results in no placeholder topics."""
-        from typing import Any, Dict
 
         video_id = VALID_VIDEO_ID
-        api_data: Dict[str, Any] = {
+        api_data: dict[str, Any] = {
             "id": video_id,
             "topicDetails": {
                 "topicCategories": [],  # Empty array
@@ -1202,9 +1184,8 @@ class TestVideosWithNoTopics:
         self, mock_session: AsyncMock
     ) -> None:
         """Test that count of videos without topics is tracked."""
-        from typing import Any, Dict, List
 
-        videos_data: List[Dict[str, Any]] = [
+        videos_data: list[dict[str, Any]] = [
             {
                 "id": "vid1",
                 "topicDetails": {
@@ -1309,9 +1290,8 @@ class TestTopicEnrichmentIntegration:
         self, service: EnrichmentService, mock_session: AsyncMock
     ) -> None:
         """Test topic enrichment within batch video processing."""
-        from typing import Any, Dict, List
 
-        videos: List[Dict[str, Any]] = [
+        videos: list[dict[str, Any]] = [
             {
                 "id": "vid1_abcdef",
                 "topicDetails": {

--- a/tests/unit/services/enrichment/test_enrichment_unavailability.py
+++ b/tests/unit/services/enrichment/test_enrichment_unavailability.py
@@ -17,8 +17,7 @@ API errors. First empty API response sets unavailability_first_detected; second
 consecutive empty response confirms by setting availability_status=UNAVAILABLE.
 """
 
-from datetime import datetime, timezone
-from typing import Any
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,8 +26,6 @@ from chronovista.models.enums import AvailabilityStatus
 from chronovista.services.enrichment.enrichment_service import EnrichmentService
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 class TestVideoMultiCycleConfirmation:
     """Tests for video multi-cycle unavailability confirmation (FR-024, FR-026)."""
@@ -103,7 +100,7 @@ class TestVideoMultiCycleConfirmation:
         """
         # Create a video with unavailability_first_detected already set
         # (simulating first cycle already occurred)
-        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
         mock_video = MagicMock()
         mock_video.video_id = "secondCycle456"
         mock_video.availability_status = AvailabilityStatus.AVAILABLE
@@ -138,13 +135,13 @@ class TestVideoMultiCycleConfirmation:
         but the second sync succeeds.
         """
         from chronovista.models.api_responses import (
-            YouTubeVideoResponse,
-            VideoSnippet,
             VideoContentDetails,
+            VideoSnippet,
+            YouTubeVideoResponse,
         )
 
         # Create a video with unavailability_first_detected set (first cycle occurred)
-        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
         mock_video = MagicMock()
         mock_video.video_id = "transientError789"
         mock_video.title = "[Placeholder] Video transientError789"
@@ -158,7 +155,7 @@ class TestVideoMultiCycleConfirmation:
             etag="test_etag",
             id="transientError789",
             snippet=VideoSnippet(
-                publishedAt=datetime.now(timezone.utc),
+                publishedAt=datetime.now(UTC),
                 channelId="UCuAXFkgsw1L7xaCfnd5JJOw",
                 title="Recovered Video",
                 description="This video is back",
@@ -217,9 +214,9 @@ class TestVideoMultiCycleConfirmation:
         This is the happy path baseline test.
         """
         from chronovista.models.api_responses import (
-            YouTubeVideoResponse,
-            VideoSnippet,
             VideoContentDetails,
+            VideoSnippet,
+            YouTubeVideoResponse,
         )
 
         # Create a normal video with no unavailability flags
@@ -236,7 +233,7 @@ class TestVideoMultiCycleConfirmation:
             etag="test_etag",
             id="normalVideo123",
             snippet=VideoSnippet(
-                publishedAt=datetime.now(timezone.utc),
+                publishedAt=datetime.now(UTC),
                 channelId="UCuAXFkgsw1L7xaCfnd5JJOw",
                 title="Normal Video",
                 description="Normal video metadata",
@@ -322,7 +319,6 @@ class TestChannelMultiCycleConfirmation:
         - NOT change availability_status (remains AVAILABLE)
         - Increment channels_skipped counter
         """
-        from chronovista.models.api_responses import YouTubeChannelResponse
 
         # Create a channel with no prior unavailability flag
         mock_channel = MagicMock()
@@ -369,10 +365,9 @@ class TestChannelMultiCycleConfirmation:
         - Clear unavailability_first_detected (reset for next cycle)
         - Increment channels_skipped counter
         """
-        from chronovista.models.api_responses import YouTubeChannelResponse
 
         # Create a channel with unavailability_first_detected already set
-        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
         mock_channel = MagicMock()
         mock_channel.channel_id = "UCsecondChannel"
         mock_channel.availability_status = AvailabilityStatus.AVAILABLE
@@ -421,13 +416,13 @@ class TestChannelMultiCycleConfirmation:
         but the second sync succeeds.
         """
         from chronovista.models.api_responses import (
-            YouTubeChannelResponse,
             ChannelSnippet,
             ChannelStatisticsResponse,
+            YouTubeChannelResponse,
         )
 
         # Create a channel with unavailability_first_detected set (first cycle occurred)
-        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
         mock_channel = MagicMock()
         mock_channel.channel_id = "UCtransientChannel"
         mock_channel.title = "Transient Channel"
@@ -442,7 +437,7 @@ class TestChannelMultiCycleConfirmation:
             snippet=ChannelSnippet(
                 title="Recovered Channel",
                 description="Channel description",
-                publishedAt=datetime.now(timezone.utc),
+                publishedAt=datetime.now(UTC),
                 thumbnails={},
             ),
             statistics=ChannelStatisticsResponse(
@@ -521,9 +516,9 @@ class TestRestorationBehavior:
         - Update video metadata normally
         """
         from chronovista.models.api_responses import (
-            YouTubeVideoResponse,
-            VideoSnippet,
             VideoContentDetails,
+            VideoSnippet,
+            YouTubeVideoResponse,
         )
 
         # Create a previously unavailable video
@@ -542,7 +537,7 @@ class TestRestorationBehavior:
             etag="test_etag",
             id="restoredVideo123",
             snippet=VideoSnippet(
-                publishedAt=datetime.now(timezone.utc),
+                publishedAt=datetime.now(UTC),
                 channelId="UCuAXFkgsw1L7xaCfnd5JJOw",
                 title="Restored Video",
                 description="This video has been restored",
@@ -610,9 +605,9 @@ class TestRestorationBehavior:
         - Update channel metadata normally
         """
         from chronovista.models.api_responses import (
-            YouTubeChannelResponse,
             ChannelSnippet,
             ChannelStatisticsResponse,
+            YouTubeChannelResponse,
         )
 
         # Create a previously unavailable channel
@@ -632,7 +627,7 @@ class TestRestorationBehavior:
             snippet=ChannelSnippet(
                 title="Restored Channel Title",
                 description="Channel has been restored",
-                publishedAt=datetime.now(timezone.utc),
+                publishedAt=datetime.now(UTC),
                 thumbnails={},
             ),
             statistics=ChannelStatisticsResponse(
@@ -690,14 +685,14 @@ class TestRestorationBehavior:
         The restoration should clear the flag regardless of how it got there.
         """
         from chronovista.models.api_responses import (
-            YouTubeVideoResponse,
-            VideoSnippet,
             VideoContentDetails,
+            VideoSnippet,
+            YouTubeVideoResponse,
         )
 
         # Create a video with both UNAVAILABLE status AND a pending flag
         # (edge case - shouldn't happen normally, but test robustness)
-        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
         mock_video = MagicMock()
         mock_video.video_id = "edgeCaseVideo"
         mock_video.title = "[Placeholder] Video edgeCaseVideo"
@@ -713,7 +708,7 @@ class TestRestorationBehavior:
             etag="test_etag",
             id="edgeCaseVideo",
             snippet=VideoSnippet(
-                publishedAt=datetime.now(timezone.utc),
+                publishedAt=datetime.now(UTC),
                 channelId="UCuAXFkgsw1L7xaCfnd5JJOw",
                 title="Edge Case Video",
                 description="Testing edge case",
@@ -744,7 +739,7 @@ class TestRestorationBehavior:
             mock_get.return_value = [mock_video]
 
             # Enrich videos
-            report = await service.enrich_videos(
+            await service.enrich_videos(
                 mock_session, include_deleted=True, check_prerequisites=False
             )
 
@@ -835,7 +830,7 @@ class TestDryRunBehavior:
         - Return False (not confirmed)
         """
         # Create a video with unavailability_first_detected set (ready for second cycle)
-        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        first_detection_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
         mock_video = MagicMock()
         mock_video.video_id = "dryRunVideo456"
         mock_video.availability_status = AvailabilityStatus.AVAILABLE

--- a/tests/unit/services/enrichment/test_error_handling.py
+++ b/tests/unit/services/enrichment/test_error_handling.py
@@ -21,29 +21,23 @@ from __future__ import annotations
 import asyncio
 import logging
 import signal
-import sys
-from datetime import datetime, timezone
-from http.client import HTTPException
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from googleapiclient.errors import HttpError
 
-from chronovista.models.enums import AvailabilityStatus
 from chronovista.models.api_responses import YouTubeVideoResponse
 from chronovista.models.enrichment_report import (
-    EnrichmentDetail,
     EnrichmentReport,
-    EnrichmentSummary,
 )
+from chronovista.models.enums import AvailabilityStatus
 from chronovista.services.enrichment.enrichment_service import (
     BATCH_SIZE,
     EXIT_CODE_LOCK_FAILED,
     EXIT_CODE_NO_CREDENTIALS,
     EnrichmentService,
-    EnrichmentStatus,
     LockAcquisitionError,
     estimate_quota_cost,
 )
@@ -51,8 +45,6 @@ from chronovista.services.enrichment.enrichment_service import (
 # Mark all async tests in this module - required for coverage to properly run async tests
 # Note: PytestWarnings about non-async functions having asyncio mark are expected
 # with module-level pytestmark; they don't cause test failures.
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # Test Constants and Fixtures
@@ -70,21 +62,21 @@ def make_video_response(video_id: str, **kwargs: Any) -> YouTubeVideoResponse:
     This helper ensures tests return proper Pydantic objects instead of dicts.
     The snippet field requires publishedAt and channelId, so we provide defaults.
     """
-    data: Dict[str, Any] = {"id": video_id, **kwargs}
+    data: dict[str, Any] = {"id": video_id, **kwargs}
 
     # If snippet is provided, ensure required fields are present
     if "snippet" in data:
         snippet = data["snippet"]
         if isinstance(snippet, dict):
             if "publishedAt" not in snippet:
-                snippet["publishedAt"] = datetime.now(timezone.utc).isoformat()
+                snippet["publishedAt"] = datetime.now(UTC).isoformat()
             if "channelId" not in snippet:
                 snippet["channelId"] = "UC_test_channel"
 
     return YouTubeVideoResponse.model_validate(data)
 
 
-def make_video_responses(video_dicts: List[Dict[str, Any]]) -> List[YouTubeVideoResponse]:
+def make_video_responses(video_dicts: list[dict[str, Any]]) -> list[YouTubeVideoResponse]:
     """
     Convert a list of video dictionaries to YouTubeVideoResponse objects.
     """
@@ -249,7 +241,7 @@ class TestQuotaExceededHandling:
             mock_get.return_value = mock_videos
 
             # Mock to simulate quota error after first batch
-            api_responses: List[YouTubeVideoResponse] = [
+            api_responses: list[YouTubeVideoResponse] = [
                 make_video_response("vid0", snippet={"title": "Updated Title 0"})
             ]
 
@@ -337,7 +329,7 @@ class TestNetworkRetryExponentialBackoff:
 
         # Simulate retry behavior
         result = None
-        for attempt in range(3):
+        for _attempt in range(3):
             try:
                 result = await mock_youtube_service.fetch_videos_batched([VALID_VIDEO_ID])
                 break
@@ -366,7 +358,7 @@ class TestNetworkRetryExponentialBackoff:
 
         # Simulate retry behavior
         result = None
-        for attempt in range(3):
+        for _attempt in range(3):
             try:
                 result = await mock_youtube_service.fetch_videos_batched([VALID_VIDEO_ID])
                 break
@@ -437,7 +429,7 @@ class TestNetworkRetryExponentialBackoff:
 
         # Simulate retry
         result = None
-        for attempt in range(3):
+        for _attempt in range(3):
             try:
                 result = await mock_youtube_service.fetch_videos_batched([VALID_VIDEO_ID])
                 break
@@ -580,7 +572,6 @@ class TestSIGINTGracefulShutdown:
         self, mock_session: AsyncMock, enrichment_service: EnrichmentService
     ) -> None:
         """Test that graceful shutdown saves progress."""
-        videos_processed = 0
 
         mock_videos = [
             MagicMock(
@@ -1286,7 +1277,6 @@ class TestRecoveryAfterTransientErrors:
         self, mock_session: AsyncMock, enrichment_service: EnrichmentService
     ) -> None:
         """Test that state is preserved after recovery."""
-        processed_videos: list[str] = []
 
         mock_videos = [
             MagicMock(
@@ -1364,7 +1354,6 @@ class TestDryRunErrorHandling:
         mock_video = MagicMock()
         mock_video.video_id = VALID_VIDEO_ID
         mock_video.title = "[Placeholder] Video"
-        original_title = mock_video.title
 
         with patch.object(
             enrichment_service,

--- a/tests/unit/services/enrichment/test_logging.py
+++ b/tests/unit/services/enrichment/test_logging.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,10 +21,10 @@ import pytest
 
 from chronovista.services.enrichment.enrichment_service import (
     EnrichmentService,
+)
+from chronovista.services.enrichment.enrichment_service import (
     logger as enrichment_logger,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 def generate_default_log_path(
@@ -50,7 +50,7 @@ def generate_default_log_path(
         Full path to the log file
     """
     if timestamp is None:
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
 
     # Format: enrichment-YYYYMMDD-HHMMSS.log
     timestamp_str = timestamp.strftime("%Y%m%d-%H%M%S")
@@ -138,7 +138,7 @@ class TestLogFilePathFormat:
 
     def test_default_log_path_format(self, tmp_path: Path) -> None:
         """Test that default log path follows expected format."""
-        timestamp = datetime(2024, 6, 15, 14, 30, 45, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 6, 15, 14, 30, 45, tzinfo=UTC)
         path = generate_default_log_path(tmp_path, timestamp)
 
         # Verify path format
@@ -154,7 +154,7 @@ class TestLogFilePathFormat:
 
     def test_log_path_includes_timestamp(self, tmp_path: Path) -> None:
         """Test that log path includes timestamp."""
-        timestamp = datetime(2024, 12, 25, 8, 0, 0, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 12, 25, 8, 0, 0, tzinfo=UTC)
         path = generate_default_log_path(tmp_path, timestamp)
 
         # Should contain date components

--- a/tests/unit/services/enrichment/test_playlist_enrichment.py
+++ b/tests/unit/services/enrichment/test_playlist_enrichment.py
@@ -12,13 +12,9 @@ Covers Phase 9: User Story 7 - Enrich Playlist Metadata:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set, Tuple
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
-
-pytestmark = pytest.mark.asyncio
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 
 class TestEnrichPlaylistsMethod:
@@ -116,10 +112,6 @@ class TestPlaylistFieldUpdates:
 
     async def test_description_update_from_api(self) -> None:
         """Test that playlist description is updated from API response."""
-        db_playlist: dict[str, Any] = {
-            "playlist_id": "PLtest456",
-            "description": None,
-        }
 
         api_response: dict[str, Any] = {
             "snippet": {
@@ -148,7 +140,6 @@ class TestPlaylistFieldUpdates:
 
     async def test_item_count_update_from_api(self) -> None:
         """Test that playlist item count is updated from API response."""
-        db_playlist: dict[str, Any] = {"video_count": 0}
 
         api_response: dict[str, Any] = {"contentDetails": {"itemCount": 157}}
 
@@ -223,7 +214,7 @@ class TestDeletedPlaylistHandling:
 
         # Mark as deleted
         playlist["is_deleted"] = True
-        playlist["deleted_at"] = datetime.now(timezone.utc)
+        playlist["deleted_at"] = datetime.now(UTC)
 
         assert playlist["is_deleted"] is True
         assert playlist["deleted_at"] is not None
@@ -235,7 +226,7 @@ class TestDeletedPlaylistHandling:
             "playlist_id": "PLrecovered",
             "title": "[Placeholder] Playlist PLrecovered",
             "is_deleted": True,
-            "deleted_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "deleted_at": datetime(2024, 1, 1, tzinfo=UTC),
         }
 
         # API now returns this playlist
@@ -320,10 +311,9 @@ class TestDryRunModeForPlaylists:
             )
         )
 
-        dry_run = True
 
         # Even in dry run, should call API to show what would be updated
-        result = await mock_youtube_service.fetch_playlists_batched(["PL001"])
+        await mock_youtube_service.fetch_playlists_batched(["PL001"])
 
         mock_youtube_service.fetch_playlists_batched.assert_called_once()
 
@@ -466,7 +456,6 @@ class TestIntegrationWithVideoEnrichment:
 
     async def test_video_only_enrichment_no_playlist_fields(self) -> None:
         """Test that video-only enrichment doesn't include playlist fields."""
-        include_playlists = False
 
         video_only_summary = {
             "videos_processed": 500,
@@ -481,7 +470,7 @@ class TestIntegrationWithVideoEnrichment:
 
     async def test_playlist_enrichment_after_video_enrichment(self) -> None:
         """Test that playlist enrichment runs after video enrichment."""
-        enrichment_order: List[str] = []
+        enrichment_order: list[str] = []
 
         # Mock video enrichment
         async def mock_video_enrichment() -> dict[str, int]:
@@ -539,7 +528,7 @@ class TestPlaylistBatchProcessing:
 
     async def test_empty_playlist_list_returns_zero_counts(self) -> None:
         """Test that empty playlist list returns zero counts."""
-        playlist_ids: List[str] = []
+        playlist_ids: list[str] = []
 
         result: dict[str, Any] = {
             "playlists_processed": len(playlist_ids),
@@ -556,7 +545,7 @@ class TestPlaylistEnrichmentErrorHandling:
 
     async def test_api_error_logged_and_continued(self) -> None:
         """Test that API errors are logged and processing continues."""
-        errors: List[Dict[str, Any]] = []
+        errors: list[dict[str, Any]] = []
 
         # Simulate processing with an error
         try:
@@ -570,8 +559,8 @@ class TestPlaylistEnrichmentErrorHandling:
     async def test_individual_playlist_error_doesnt_stop_batch(self) -> None:
         """Test that error on one playlist doesn't stop processing others."""
         playlist_ids = ["PL001", "PL002", "PL003"]
-        results: List[Dict[str, Any]] = []
-        errors: List[Dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
+        errors: list[dict[str, Any]] = []
 
         for playlist_id in playlist_ids:
             try:

--- a/tests/unit/services/enrichment/test_priority_selection.py
+++ b/tests/unit/services/enrichment/test_priority_selection.py
@@ -6,7 +6,6 @@ Covers T048a-b:
 - T048b: Unit tests for each priority tier (HIGH, MEDIUM, LOW, ALL)
 """
 
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,12 +13,9 @@ import pytest
 from chronovista.models.enums import AvailabilityStatus
 from chronovista.services.enrichment.enrichment_service import (
     EnrichmentService,
-    VIDEO_PLACEHOLDER_PREFIX,
     is_placeholder_channel_name,
     is_placeholder_video_title,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/enrichment/test_report_generation.py
+++ b/tests/unit/services/enrichment/test_report_generation.py
@@ -14,10 +14,8 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-
-import pytest
 
 from chronovista.models.enrichment_report import (
     EnrichmentDetail,
@@ -31,7 +29,7 @@ def create_sample_report(
     num_details: int = 3,
 ) -> EnrichmentReport:
     """Create a sample EnrichmentReport for testing."""
-    timestamp = datetime.now(timezone.utc)
+    timestamp = datetime.now(UTC)
     summary = EnrichmentSummary(
         videos_processed=num_details,
         videos_updated=num_details - 1 if num_details > 0 else 0,
@@ -98,7 +96,7 @@ def generate_default_report_path(
         Full path to the report file
     """
     if timestamp is None:
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
 
     # Format: enrichment-YYYYMMDD-HHMMSS.json
     timestamp_str = timestamp.strftime("%Y%m%d-%H%M%S")
@@ -294,12 +292,12 @@ class TestDefaultPathGeneration:
 
     def test_default_path_format(self, tmp_path: Path) -> None:
         """Test that default path follows expected format."""
-        timestamp = datetime(2024, 6, 15, 14, 30, 45, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 6, 15, 14, 30, 45, tzinfo=UTC)
         path = generate_default_report_path(tmp_path, timestamp)
 
         # Verify path format
         assert path.parent.name == "exports"
-        assert "enrichment-20240615-143045.json" == path.name
+        assert path.name == "enrichment-20240615-143045.json"
 
     def test_default_path_in_exports_directory(self, tmp_path: Path) -> None:
         """Test that default path is in exports directory."""
@@ -310,7 +308,7 @@ class TestDefaultPathGeneration:
 
     def test_default_path_includes_timestamp(self, tmp_path: Path) -> None:
         """Test that default path includes timestamp."""
-        timestamp = datetime(2024, 12, 25, 8, 0, 0, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 12, 25, 8, 0, 0, tzinfo=UTC)
         path = generate_default_report_path(tmp_path, timestamp)
 
         # Should contain date components
@@ -416,7 +414,7 @@ class TestReportIncludesAllDetails:
 
     def test_report_includes_error_details(self, tmp_path: Path) -> None:
         """Test that report includes error details with messages."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=2,
             videos_updated=0,
@@ -476,7 +474,7 @@ class TestReportIncludesAllDetails:
 
     def test_report_includes_mixed_status_details(self, tmp_path: Path) -> None:
         """Test that report includes details with all status types."""
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
         summary = EnrichmentSummary(
             videos_processed=4,
             videos_updated=1,
@@ -536,7 +534,7 @@ class TestReportTimestamp:
 
     def test_report_preserves_utc_timezone(self, tmp_path: Path) -> None:
         """Test that report preserves UTC timezone."""
-        timestamp = datetime(2024, 6, 15, 12, 30, 45, tzinfo=timezone.utc)
+        timestamp = datetime(2024, 6, 15, 12, 30, 45, tzinfo=UTC)
         summary = EnrichmentSummary(
             videos_processed=0,
             videos_updated=0,

--- a/tests/unit/services/enrichment/test_seeding_idempotency.py
+++ b/tests/unit/services/enrichment/test_seeding_idempotency.py
@@ -13,15 +13,10 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
-from chronovista.models.video_category import VideoCategoryCreate
 from chronovista.repositories.topic_category_repository import TopicCategoryRepository
 from chronovista.repositories.video_category_repository import VideoCategoryRepository
 from chronovista.services.enrichment.seeders import CategorySeeder, TopicSeeder
 from chronovista.services.youtube_service import YouTubeService
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestTopicSeederIdempotency:
@@ -483,7 +478,7 @@ class TestSC015IdempotencyVerification:
     async def test_topic_seeder_preserves_parent_child_relationships(self) -> None:
         """Test that TopicSeeder preserves parent-child relationships."""
         # All child topics should have valid parent references
-        for topic_id, (name, parent_id, wiki_slug) in TopicSeeder.YOUTUBE_TOPICS.items():
+        for _topic_id, (_name, parent_id, _wiki_slug) in TopicSeeder.YOUTUBE_TOPICS.items():
             if parent_id is not None:
                 # Parent must exist in the topics dict
                 assert parent_id in TopicSeeder.YOUTUBE_TOPICS

--- a/tests/unit/services/enrichment/test_status_queries.py
+++ b/tests/unit/services/enrichment/test_status_queries.py
@@ -7,19 +7,15 @@ Covers:
 - T054d: Performance test for status query structure
 """
 
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from sqlalchemy import func, select
 
 from chronovista.services.enrichment.enrichment_service import (
     BATCH_SIZE,
     EnrichmentService,
     estimate_quota_cost,
 )
-
-pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/enrichment/test_topic_seeder.py
+++ b/tests/unit/services/enrichment/test_topic_seeder.py
@@ -14,14 +14,9 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from chronovista.models.enums import TopicType
-from chronovista.models.topic_category import TopicCategoryCreate
 from chronovista.repositories.topic_category_repository import TopicCategoryRepository
 from chronovista.services.enrichment.seeders import TopicSeeder, TopicSeedResult
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestTopicSeederConstants:
@@ -67,7 +62,7 @@ class TestTopicSeederConstants:
 
     def test_all_topics_have_freebase_format(self) -> None:
         """Test that all topic IDs use Freebase format (/m/...)."""
-        for topic_id in TopicSeeder.YOUTUBE_TOPICS.keys():
+        for topic_id in TopicSeeder.YOUTUBE_TOPICS:
             assert topic_id.startswith("/m/"), f"Topic ID {topic_id} should use Freebase format"
             assert len(topic_id) > 3, f"Topic ID {topic_id} should have content after /m/"
 
@@ -79,7 +74,7 @@ class TestTopicSeederConstants:
 
     def test_child_topics_have_valid_parent(self) -> None:
         """Test that all child topics reference valid parent IDs."""
-        for topic_id, (name, parent_id, wiki_slug) in TopicSeeder.YOUTUBE_TOPICS.items():
+        for topic_id, (_name, parent_id, _wiki_slug) in TopicSeeder.YOUTUBE_TOPICS.items():
             if parent_id is not None:  # Child topic
                 assert parent_id in TopicSeeder.YOUTUBE_TOPICS, \
                     f"Child topic {topic_id} references non-existent parent {parent_id}"

--- a/tests/unit/services/recovery/conftest.py
+++ b/tests/unit/services/recovery/conftest.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import itertools
 import shutil
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -26,8 +26,6 @@ from uuid import uuid4
 import pytest
 
 # Mark all tests in this module as async by default
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture(autouse=True)
 def _clean_test_cache():
@@ -123,8 +121,8 @@ def make_recovered_video_data(**overrides: Any) -> dict[str, Any]:
         "channel_id": f"UC{uuid4().hex[:22]}",  # Valid ChannelId format
         "view_count": 10000,
         "like_count": 500,
-        "upload_date": datetime(2021, 6, 15, 12, 0, 0, tzinfo=timezone.utc),
-        "thumbnail_url": f"https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+        "upload_date": datetime(2021, 6, 15, 12, 0, 0, tzinfo=UTC),
+        "thumbnail_url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
         "tags": ["music", "entertainment", "viral"],
         "category_id": "10",  # Music category
         "snapshot_timestamp": timestamp,
@@ -246,7 +244,7 @@ def make_cdx_cache_entry(**overrides: Any) -> dict[str, Any]:
 
     defaults = {
         "video_id": video_id,
-        "fetched_at": datetime.now(timezone.utc),
+        "fetched_at": datetime.now(UTC),
         "snapshots": default_snapshots,
         "raw_count": 25,  # Total snapshots before filtering
     }

--- a/tests/unit/services/recovery/test_cdx_client.py
+++ b/tests/unit/services/recovery/test_cdx_client.py
@@ -16,20 +16,17 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, Mock, mock_open, patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
-from chronovista.exceptions import CDXError
 from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
 from chronovista.services.recovery.models import CdxCacheEntry, CdxSnapshot
 
 # Mark all tests in this module as async by default
-pytestmark = pytest.mark.asyncio
-
 
 # =============================================================================
 # TestRateLimiter - Token-bucket rate limiting logic
@@ -517,7 +514,7 @@ class TestCDXCaching:
         # Create a fresh cache entry (fetched 1 hour ago)
         cache_entry = CdxCacheEntry(
             video_id="dQw4w9WgXcQ",
-            fetched_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            fetched_at=datetime.now(UTC) - timedelta(hours=1),
             snapshots=[
                 CdxSnapshot(
                     timestamp="20220106075526",
@@ -605,7 +602,7 @@ class TestCDXCaching:
         # Create an expired cache entry (fetched 25 hours ago)
         cache_entry = CdxCacheEntry(
             video_id="dQw4w9WgXcQ",
-            fetched_at=datetime.now(timezone.utc) - timedelta(hours=25),
+            fetched_at=datetime.now(UTC) - timedelta(hours=25),
             snapshots=[
                 CdxSnapshot(
                     timestamp="20220106075526",
@@ -1018,7 +1015,7 @@ class TestCDXYearFilteringIntegration:
         # Create a fresh cache entry (stored newest-first, as _parse_cdx_response does)
         cache_entry = CdxCacheEntry(
             video_id="dQw4w9WgXcQ",
-            fetched_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            fetched_at=datetime.now(UTC) - timedelta(hours=1),
             snapshots=[
                 CdxSnapshot(
                     timestamp="20200601120000",
@@ -1409,7 +1406,7 @@ class TestFetchChannelSnapshots:
         # Create a fresh cache entry (fetched 1 hour ago)
         cache_entry = CdxCacheEntry(
             video_id="UCuAXFkgsw1L7xaCfnd5JJOw",
-            fetched_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            fetched_at=datetime.now(UTC) - timedelta(hours=1),
             snapshots=[
                 CdxSnapshot(
                     timestamp="20220106075526",
@@ -1592,7 +1589,7 @@ class TestFetchChannelSnapshots:
         # Create a fresh cache entry (stored newest-first, as _parse_cdx_response does)
         cache_entry = CdxCacheEntry(
             video_id="UCuAXFkgsw1L7xaCfnd5JJOw",
-            fetched_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            fetched_at=datetime.now(UTC) - timedelta(hours=1),
             snapshots=[
                 CdxSnapshot(
                     timestamp="20200601120000",

--- a/tests/unit/services/recovery/test_models.py
+++ b/tests/unit/services/recovery/test_models.py
@@ -6,7 +6,7 @@ Covers CdxSnapshot, RecoveredVideoData, RecoveryResult, and CdxCacheEntry models
 with validation, computed properties, and edge cases.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from pydantic import ValidationError
@@ -157,7 +157,7 @@ class TestCdxSnapshot:
             length=50000,
         )
 
-        expected_datetime = datetime(2022, 1, 6, 7, 55, 26, tzinfo=timezone.utc)
+        expected_datetime = datetime(2022, 1, 6, 7, 55, 26, tzinfo=UTC)
         assert snapshot.datetime == expected_datetime
 
 
@@ -785,7 +785,7 @@ class TestCdxCacheEntry:
 
     def test_valid_cache_entry(self) -> None:
         """Test creating valid CdxCacheEntry."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         snapshots = [
             CdxSnapshot(
                 timestamp="20220106075526",
@@ -835,14 +835,14 @@ class TestCdxCacheEntry:
         assert "fetched_at" in str(exc_info.value).lower()
 
         # UTC datetime should pass
-        utc_datetime = datetime(2022, 1, 6, 7, 55, 26, tzinfo=timezone.utc)
+        utc_datetime = datetime(2022, 1, 6, 7, 55, 26, tzinfo=UTC)
         cache_entry = CdxCacheEntry(
             video_id="dQw4w9WgXcQ",
             fetched_at=utc_datetime,
             snapshots=snapshots,
             raw_count=1,
         )
-        assert cache_entry.fetched_at.tzinfo == timezone.utc
+        assert cache_entry.fetched_at.tzinfo == UTC
 
     def test_cache_validity_check(self) -> None:
         """Test is_valid method checks cache age against TTL."""
@@ -858,7 +858,7 @@ class TestCdxCacheEntry:
         ]
 
         # Recent cache (1 hour ago) - should be valid with 24hr TTL
-        recent = datetime.now(timezone.utc) - timedelta(hours=1)
+        recent = datetime.now(UTC) - timedelta(hours=1)
         cache_entry_recent = CdxCacheEntry(
             video_id="dQw4w9WgXcQ",
             fetched_at=recent,
@@ -868,7 +868,7 @@ class TestCdxCacheEntry:
         assert cache_entry_recent.is_valid(ttl_hours=24) is True
 
         # Old cache (25 hours ago) - should be expired with 24hr TTL
-        old = datetime.now(timezone.utc) - timedelta(hours=25)
+        old = datetime.now(UTC) - timedelta(hours=25)
         cache_entry_old = CdxCacheEntry(
             video_id="dQw4w9WgXcQ",
             fetched_at=old,
@@ -878,7 +878,7 @@ class TestCdxCacheEntry:
         assert cache_entry_old.is_valid(ttl_hours=24) is False
 
         # Edge case: exactly 24 hours ago
-        exactly_24h = datetime.now(timezone.utc) - timedelta(hours=24, seconds=1)
+        exactly_24h = datetime.now(UTC) - timedelta(hours=24, seconds=1)
         cache_entry_edge = CdxCacheEntry(
             video_id="dQw4w9WgXcQ",
             fetched_at=exactly_24h,
@@ -889,7 +889,7 @@ class TestCdxCacheEntry:
 
     def test_snapshots_list(self) -> None:
         """Test snapshots field accepts list of CdxSnapshot objects."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         snapshots = [
             CdxSnapshot(
                 timestamp="20220106075526",
@@ -922,7 +922,7 @@ class TestCdxCacheEntry:
 
     def test_raw_count_field(self) -> None:
         """Test raw_count field stores CDX entry count before filtering."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         snapshots = [
             CdxSnapshot(
                 timestamp="20220106075526",

--- a/tests/unit/services/recovery/test_orchestrator.py
+++ b/tests/unit/services/recovery/test_orchestrator.py
@@ -16,26 +16,20 @@ Test Coverage
 
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timezone
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import Video as VideoDB
 from chronovista.models.enums import AvailabilityStatus
-from chronovista.repositories.video_repository import VideoRepository
-from chronovista.repositories.video_tag_repository import VideoTagRepository
 from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
 from chronovista.services.recovery.models import CdxSnapshot, RecoveredVideoData
 from chronovista.services.recovery.orchestrator import recover_video
 from chronovista.services.recovery.page_parser import PageParser
 
 # Mark all tests in this module as async
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture(autouse=True)
 def _mock_channel_repo():
@@ -66,20 +60,20 @@ class TestOverwritePolicy:
             video_id="testVid0001",
             title="Existing Title",
             description="Existing Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id=None,  # NULL - should be filled
             category_id=None,  # NULL - should be filled
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with immutable field values
         recovered_data = RecoveredVideoData(
             channel_id="UC1234567890123456789012",
             category_id="10",
-            upload_date=datetime(2019, 6, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2019, 6, 15, tzinfo=UTC),
             snapshot_timestamp="20220106075526",
         )
 
@@ -140,13 +134,13 @@ class TestOverwritePolicy:
             video_id="testVid0002",
             title="Existing Title",
             description="Existing Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC_EXISTING_CHANNEL_ID",  # Has value - should NOT be overwritten
             category_id="20",  # Has value - should NOT be overwritten
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data attempting to overwrite immutable fields
@@ -208,15 +202,15 @@ class TestOverwritePolicy:
             video_id="testVid0003",
             title="Placeholder Title",
             description=None,  # NULL - should be filled
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             view_count=None,  # NULL - should be filled
             like_count=None,  # NULL - should be filled
             channel_name_hint=None,  # NULL - should be filled
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with mutable field values
@@ -283,16 +277,16 @@ class TestOverwritePolicy:
             video_id="testVid0004",
             title="Old Recovered Title",
             description="Old Recovered Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             view_count=50000,
             like_count=2000,
             recovery_source="wayback:20200106075526",  # Older snapshot
-            recovered_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            recovered_at=datetime(2023, 1, 1, tzinfo=UTC),
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data from a newer snapshot
@@ -357,14 +351,14 @@ class TestOverwritePolicy:
             video_id="testVid0005",
             title="Existing Title",
             description="Existing Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             view_count=50000,
             like_count=2000,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with NULL/missing fields but one valid field
@@ -429,14 +423,14 @@ class TestOverwritePolicy:
             video_id="testVid0006",
             title="Test Video",
             description="Test Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             recovered_at=None,
             recovery_source=None,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data
@@ -496,19 +490,19 @@ class TestOverwritePolicy:
             video_id="testVid0007",
             title="Test Video",
             description="Test Description",
-            upload_date=datetime(2026, 1, 25, tzinfo=timezone.utc),  # Bad date (future)
+            upload_date=datetime(2026, 1, 25, tzinfo=UTC),  # Bad date (future)
             duration=120,
             channel_id="UC1234567890123456789012",
             recovery_source="wayback:20180301000000",  # Older snapshot
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with correct upload_date from newer snapshot
         recovered_data = RecoveredVideoData(
             title="Recovered Title",
-            upload_date=datetime(2018, 2, 22, tzinfo=timezone.utc),  # Correct date
+            upload_date=datetime(2018, 2, 22, tzinfo=UTC),  # Correct date
             snapshot_timestamp="20200101000000",  # Newer snapshot
         )
 
@@ -563,19 +557,19 @@ class TestOverwritePolicy:
             video_id="testVid0008",
             title="Test Video",
             description="Test Description",
-            upload_date=datetime(2018, 2, 22, tzinfo=timezone.utc),
+            upload_date=datetime(2018, 2, 22, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             recovery_source="wayback:20210101000000",  # Newer snapshot
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data from an older snapshot
         recovered_data = RecoveredVideoData(
             title="Recovered Title",
-            upload_date=datetime(2018, 1, 15, tzinfo=timezone.utc),
+            upload_date=datetime(2018, 1, 15, tzinfo=UTC),
             snapshot_timestamp="20200101000000",  # Older snapshot
         )
 
@@ -639,12 +633,12 @@ class TestEligibilityChecks:
             video_id="testVid0007",
             title="Available Video",
             description="This video is still available",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.AVAILABLE.value,  # AVAILABLE
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Mock dependencies
@@ -696,12 +690,12 @@ class TestEligibilityChecks:
                 video_id=vid_id,
                 title=f"Video with status {status.value}",
                 description="Test video",
-                upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+                upload_date=datetime(2020, 1, 1, tzinfo=UTC),
                 duration=120,
                 channel_id="UC1234567890123456789012",
                 availability_status=status.value,
-                created_at=datetime.now(timezone.utc),
-                updated_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
             )
 
             with patch(
@@ -781,12 +775,12 @@ class TestEligibilityChecks:
             video_id="testVid0008",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Mock dependencies
@@ -854,12 +848,12 @@ class TestSnapshotIteration:
             video_id="testVid0009",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Multiple snapshots (newest-first order from CDXClient)
@@ -927,7 +921,7 @@ class TestSnapshotIteration:
                 mock_tag_repo_class.return_value = mock_tag_repo
 
                 # WHEN: We recover the video
-                result = await recover_video(
+                await recover_video(
                     session=session,
                     video_id="testVid0009",
                     cdx_client=cdx_client,
@@ -947,12 +941,12 @@ class TestSnapshotIteration:
             video_id="testVid0010",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Snapshots with removal notices
@@ -1031,12 +1025,12 @@ class TestSnapshotIteration:
             video_id="testVid0011",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Multiple snapshots (all could succeed)
@@ -1116,12 +1110,12 @@ class TestSnapshotIteration:
             video_id="testVid0012",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: 30 snapshots (more than the 20 limit)
@@ -1184,12 +1178,12 @@ class TestSnapshotIteration:
             video_id="testVid0013",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: 5 snapshots
@@ -1270,12 +1264,12 @@ class TestTagRecovery:
             video_id="testVid0014",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with tags
@@ -1316,7 +1310,7 @@ class TestTagRecovery:
                 mock_tag_repo_class.return_value = mock_tag_repo
 
                 # WHEN: We recover the video
-                result = await recover_video(
+                await recover_video(
                     session=session,
                     video_id="testVid0014",
                     cdx_client=cdx_client,
@@ -1339,12 +1333,12 @@ class TestTagRecovery:
             video_id="testVid0015",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with no tags
@@ -1385,7 +1379,7 @@ class TestTagRecovery:
                 mock_tag_repo_class.return_value = mock_tag_repo
 
                 # WHEN: We recover the video
-                result = await recover_video(
+                await recover_video(
                     session=session,
                     video_id="testVid0015",
                     cdx_client=cdx_client,
@@ -1404,12 +1398,12 @@ class TestTagRecovery:
             video_id="testVid0016",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with tags
@@ -1483,13 +1477,13 @@ class TestRecoveryResultConstruction:
             video_id="testVid0017",
             title="Existing Title",  # Existing
             description=None,  # NULL - will be filled
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",  # Existing - will be skipped
             view_count=None,  # NULL - will be filled
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data
@@ -1581,12 +1575,12 @@ class TestRecoveryResultConstruction:
             video_id="testVid0018",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data
@@ -1647,12 +1641,12 @@ class TestRecoveryResultConstruction:
             video_id="testVid0019",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id=None,  # Orphaned - no channel
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with a channel ID
@@ -1701,8 +1695,8 @@ class TestRecoveryResultConstruction:
                     channel_id=recovered_channel_id,
                     title="Deleted Channel",
                     availability_status=AvailabilityStatus.DELETED.value,
-                    created_at=datetime.now(timezone.utc),
-                    updated_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
+                    updated_at=datetime.now(UTC),
                 )
                 mock_channel_repo.get.return_value = unavailable_channel
 
@@ -1742,12 +1736,12 @@ class TestIdempotency:
             video_id="testVid0020",
             title="Original Title",
             description=None,
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data from a snapshot
@@ -1802,7 +1796,7 @@ class TestIdempotency:
                 video.title = "Recovered Title"
                 video.description = "Recovered Description"
                 video.recovery_source = "wayback:20220106075526"
-                video.recovered_at = datetime.now(timezone.utc)
+                video.recovered_at = datetime.now(UTC)
 
                 # WHEN: We recover the video second time (same snapshot)
                 result2 = await recover_video(
@@ -1829,16 +1823,16 @@ class TestIdempotency:
             video_id="testVid0021",
             title="Newer Recovered Title",
             description="Newer Recovered Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             view_count=100000,  # From newer snapshot
             like_count=None,  # Still NULL
             recovery_source="wayback:20220106075526",  # Newer snapshot
-            recovered_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            recovered_at=datetime(2023, 1, 1, tzinfo=UTC),
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data from an older snapshot
@@ -1906,15 +1900,15 @@ class TestIdempotency:
             video_id="testVid0022",
             title="Older Recovered Title",
             description="Older Recovered Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC1234567890123456789012",
             view_count=50000,  # From older snapshot
             recovery_source="wayback:20200106075526",  # Older snapshot
-            recovered_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            recovered_at=datetime(2023, 1, 1, tzinfo=UTC),
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data from a newer snapshot
@@ -1992,12 +1986,12 @@ class TestEdgeCases:
             video_id="edgCdxTmt01",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UCEdgeChannelId12345678",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Mock dependencies
@@ -2014,7 +2008,7 @@ class TestEdgeCases:
             mock_repo.get_by_video_id.return_value = video
 
             # Mock CDX client to raise TimeoutError
-            cdx_client.fetch_snapshots.side_effect = asyncio.TimeoutError()
+            cdx_client.fetch_snapshots.side_effect = TimeoutError()
 
             # WHEN: We attempt to recover the video
             result = await recover_video(
@@ -2038,12 +2032,12 @@ class TestEdgeCases:
             video_id="edgNoSnap02",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UCEdgeChannelId12345678",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Mock dependencies
@@ -2086,12 +2080,12 @@ class TestEdgeCases:
             video_id="edgDryRun03",
             title="Deleted Video",
             description=None,
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UCEdgeChannelId12345678",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Mock dependencies
@@ -2148,12 +2142,12 @@ class TestEdgeCases:
             video_id="edgExtTmt04",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UCEdgeChannelId12345678",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Multiple snapshots
@@ -2189,7 +2183,7 @@ class TestEdgeCases:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise asyncio.TimeoutError()
+                raise TimeoutError()
             else:
                 return RecoveredVideoData(
                     title="Recovered Title",
@@ -2234,12 +2228,12 @@ class TestEdgeCases:
             video_id="edgExtErr05",
             title="Deleted Video",
             description="Test video",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UCEdgeChannelId12345678",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Multiple snapshots
@@ -2365,8 +2359,8 @@ class TestStubChannelCreation:
             duration=120,
             channel_id=None,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with channel_id and channel_name_hint
@@ -2441,8 +2435,8 @@ class TestStubChannelCreation:
             duration=120,
             channel_id=None,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         recovered_data = RecoveredVideoData(
@@ -2509,8 +2503,8 @@ class TestStubChannelCreation:
             duration=120,
             channel_id=None,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         recovered_data = RecoveredVideoData(
@@ -2578,8 +2572,8 @@ class TestStubChannelCreation:
             duration=120,
             channel_id=None,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         recovered_data = RecoveredVideoData(
@@ -2646,8 +2640,8 @@ class TestStubChannelCreation:
             duration=120,
             channel_id=None,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         session = AsyncMock(spec=AsyncSession)
@@ -2707,11 +2701,11 @@ class TestYearFiltering:
             video_id="yearTest001",
             title="Year Filter Test",
             description="Testing year filtering",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         session = AsyncMock(spec=AsyncSession)
@@ -2752,11 +2746,11 @@ class TestYearFiltering:
             video_id="yearTest002",
             title="Year Filter Test",
             description="Testing year filtering",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         session = AsyncMock(spec=AsyncSession)
@@ -2795,11 +2789,11 @@ class TestYearFiltering:
             video_id="yearTest003",
             title="Year Filter Test",
             description="Testing year filtering",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         session = AsyncMock(spec=AsyncSession)
@@ -2839,11 +2833,11 @@ class TestYearFiltering:
             video_id="yearTest004",
             title="Year Filter Test",
             description="Testing year filtering",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         session = AsyncMock(spec=AsyncSession)
@@ -2894,8 +2888,8 @@ class TestRecoverChannel:
             title="Old Title",
             description="Old Description",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered channel data
@@ -2969,8 +2963,8 @@ class TestRecoverChannel:
             title="Test Channel",
             description="Test Description",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Mock dependencies
@@ -3016,8 +3010,8 @@ class TestRecoverChannel:
             title="Test Channel",
             description="Test Description",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Mock dependencies
@@ -3113,8 +3107,8 @@ class TestRecoverChannel:
             title="Available Channel",
             description="This channel is available",
             availability_status=AvailabilityStatus.AVAILABLE.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Mock dependencies
@@ -3155,8 +3149,8 @@ class TestRecoverChannel:
             title="Test Channel",
             description="Test Description",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Mock dependencies
@@ -3218,8 +3212,8 @@ class TestBuildChannelUpdate:
             country=None,  # NULL - should be filled
             default_language=None,  # NULL - should be filled
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with values for NULL fields
@@ -3265,8 +3259,8 @@ class TestBuildChannelUpdate:
             subscriber_count=10000,
             recovery_source="wayback:20220101000000",  # Older snapshot
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data from newer snapshot
@@ -3307,8 +3301,8 @@ class TestBuildChannelUpdate:
             subscriber_count=25000,
             recovery_source="wayback:20220101000000",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with NULL values (should not overwrite)
@@ -3352,8 +3346,8 @@ class TestBuildChannelUpdate:
             default_language="en",
             recovery_source="wayback:20230615120000",  # Newer snapshot
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered data with older timestamp (should skip)
@@ -3394,12 +3388,12 @@ class TestAutoChannelRecovery:
             video_id="autoTest001",
             title="Test Video",
             description="Test Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC0123456789ABCDEFGHIJKa",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: An unavailable channel
@@ -3410,8 +3404,8 @@ class TestAutoChannelRecovery:
             title="Old Channel Title",
             description="Old Description",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered video data
@@ -3506,12 +3500,12 @@ class TestAutoChannelRecovery:
             video_id="autoTest002",
             title="Test Video",
             description="Test Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC0223456789ABCDEFGHIJKa",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: An unavailable channel
@@ -3522,8 +3516,8 @@ class TestAutoChannelRecovery:
             title="Old Channel Title",
             description="Old Description",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered video data
@@ -3615,12 +3609,12 @@ class TestAutoChannelRecovery:
             video_id="autoTest003",
             title="Test Video",
             description="Test Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC0333456789ABCDEFGHIJKa",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: An available channel
@@ -3631,8 +3625,8 @@ class TestAutoChannelRecovery:
             title="Available Channel",
             description="Available Description",
             availability_status=AvailabilityStatus.AVAILABLE.value,  # Available!
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered video data
@@ -3710,12 +3704,12 @@ class TestAutoChannelRecovery:
             video_id="autoTest004",
             title="Test Video",
             description="Test Description",
-            upload_date=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            upload_date=datetime(2020, 1, 1, tzinfo=UTC),
             duration=120,
             channel_id="UC0443456789ABCDEFGHIJKa",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: An unavailable channel
@@ -3726,8 +3720,8 @@ class TestAutoChannelRecovery:
             title="Old Channel Title",
             description="Old Description",
             availability_status=AvailabilityStatus.DELETED.value,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # GIVEN: Recovered video data

--- a/tests/unit/services/recovery/test_page_parser.py
+++ b/tests/unit/services/recovery/test_page_parser.py
@@ -14,8 +14,6 @@ All tests mock httpx responses. No live HTTP calls are made.
 
 from __future__ import annotations
 
-import json
-from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -31,8 +29,6 @@ from chronovista.services.recovery.page_parser import (
 )
 
 # CRITICAL: Ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ============================================================================
 # HTML Test Fixtures
@@ -1709,9 +1705,8 @@ class TestSeleniumFallback:
                     "_extract_with_selenium",
                     new_callable=AsyncMock,
                 ) as mock_selenium:
-                    import asyncio
 
-                    mock_selenium.side_effect = asyncio.TimeoutError(
+                    mock_selenium.side_effect = TimeoutError(
                         "Selenium timeout"
                     )
 

--- a/tests/unit/services/test_asr_alias_registry.py
+++ b/tests/unit/services/test_asr_alias_registry.py
@@ -20,8 +20,6 @@ import uuid
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from chronovista.models.enums import EntityAliasType
 from chronovista.services.asr_alias_registry import (
     is_valid_asr_alias,
@@ -33,8 +31,6 @@ from chronovista.services.asr_alias_registry import (
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
 # with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/services/test_base_seeder.py
+++ b/tests/unit/services/test_base_seeder.py
@@ -4,9 +4,9 @@ Tests for BaseSeeder - abstract base class for all seeders.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Optional, Set
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -18,8 +18,6 @@ from chronovista.services.seeding.base_seeder import (
     SeedResult,
 )
 from tests.factories.takeout_data_factory import create_takeout_data
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestSeedResult:
@@ -153,7 +151,7 @@ class TestProgressCallback:
 class MockSeeder(BaseSeeder):
     """Mock implementation of BaseSeeder for testing."""
 
-    def __init__(self, data_type: str, dependencies: Optional[Set[str]] = None):
+    def __init__(self, data_type: str, dependencies: set[str] | None = None):
         super().__init__(dependencies)
         self.data_type = data_type
         self.seed_called = False
@@ -164,7 +162,7 @@ class MockSeeder(BaseSeeder):
         self,
         session: Any,
         takeout_data: TakeoutData,
-        progress: Optional[ProgressCallback] = None,
+        progress: ProgressCallback | None = None,
     ) -> SeedResult:
         """Mock seed implementation."""
         self.seed_called = True
@@ -273,7 +271,7 @@ class TestBaseSeeder:
 
         progress = ProgressCallback(progress_callback)
 
-        result = await seeder.seed(session, takeout_data, progress)
+        await seeder.seed(session, takeout_data, progress)
 
         assert seeder.seed_called
         assert seeder.seed_args[2] == progress
@@ -339,7 +337,7 @@ class TestSeederIntegration:
             progress_updates.append(
                 {
                     "data_type": data_type,
-                    "timestamp": datetime.now(timezone.utc),
+                    "timestamp": datetime.now(UTC),
                 }
             )
 
@@ -425,7 +423,7 @@ class TestSeederErrorScenarios:
             self,
             session: Any,
             takeout_data: TakeoutData,
-            progress: Optional[ProgressCallback] = None,
+            progress: ProgressCallback | None = None,
         ) -> SeedResult:
             """Simulate different types of failures."""
             if self.fail_type == "exception":

--- a/tests/unit/services/test_batch_correction_service.py
+++ b/tests/unit/services/test_batch_correction_service.py
@@ -15,6 +15,7 @@ Feature 038 — Entity Mention Detection (ASR alias hook)
 from __future__ import annotations
 
 import uuid
+from datetime import UTC
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -26,8 +27,6 @@ from chronovista.models.enums import EntityAliasType
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
 # with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1075,7 +1074,7 @@ def _make_correction_db(
     batch_id: Any = None,
 ) -> MagicMock:
     """Create a mock TranscriptCorrectionDB for testing."""
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     c = MagicMock()
     c.id = id
@@ -1087,7 +1086,7 @@ def _make_correction_db(
     c.corrected_text = corrected_text
     c.correction_note = correction_note
     c.corrected_by_user_id = corrected_by_user_id
-    c.corrected_at = corrected_at or datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    c.corrected_at = corrected_at or datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
     c.version_number = version_number
     c.batch_id = batch_id
     return c
@@ -1447,12 +1446,13 @@ class TestExportCorrections:
         mock_correction_repo: AsyncMock,
     ) -> None:
         """All filter params are passed through to the repository."""
-        from datetime import datetime, timezone
+        from datetime import datetime
+
         from chronovista.models.enums import CorrectionType
 
         mock_correction_repo.get_all_filtered.return_value = []
-        since = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        until = datetime(2025, 12, 31, tzinfo=timezone.utc)
+        since = datetime(2025, 1, 1, tzinfo=UTC)
+        until = datetime(2025, 12, 31, tzinfo=UTC)
 
         await service.export_corrections(
             mock_session,
@@ -1730,7 +1730,6 @@ class TestGetPatterns:
         mock_correction_repo: AsyncMock,
     ) -> None:
         """Return type is list[CorrectionPattern]."""
-        from chronovista.models.batch_correction_models import CorrectionPattern
 
         mock_correction_repo.get_correction_patterns.return_value = []
 
@@ -4700,9 +4699,9 @@ class TestMinimalTokenAliasRegistration:
         registered for the entity. The sub-token diff produces ("Chomski",
         "Chomsky") which must trigger a second alias registration.
         """
+        import uuid
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        import uuid
         from uuid_utils import uuid7
 
         entity_id = uuid.UUID(bytes=uuid7().bytes)
@@ -4755,9 +4754,9 @@ class TestMinimalTokenAliasRegistration:
         implementation must attempt alias creation for every non-empty,
         non-duplicate changed pair.
         """
+        import uuid
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        import uuid
         from uuid_utils import uuid7
 
         entity_id = uuid.UUID(bytes=uuid7().bytes)
@@ -4808,9 +4807,9 @@ class TestMinimalTokenAliasRegistration:
         registering the same ASR error form twice.  With "Chomski" → "Chomsky"
         the single token equals the full string, so only one alias is created.
         """
+        import uuid
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        import uuid
         from uuid_utils import uuid7
 
         entity_id = uuid.UUID(bytes=uuid7().bytes)
@@ -4861,7 +4860,7 @@ class TestMinimalTokenAliasRegistration:
         The hook is a no-op when the corrected text does not match any known
         entity — no alias repository calls must be made.
         """
-        from unittest.mock import AsyncMock, MagicMock, patch
+        from unittest.mock import AsyncMock, patch
 
         mock_session = AsyncMock()
 

--- a/tests/unit/services/test_channel_seeder.py
+++ b/tests/unit/services/test_channel_seeder.py
@@ -24,8 +24,6 @@ from tests.factories.takeout_watch_entry_factory import (
 )
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 class TestChannelSeeder:
     """Test the ChannelSeeder implementation."""
@@ -200,7 +198,7 @@ class TestChannelSeeder:
         progress = ProgressCallback(mock_progress)
         mock_channel_repo.get_by_channel_id.return_value = None
 
-        result = await channel_seeder.seed(
+        await channel_seeder.seed(
             mock_session, takeout_data_with_subscriptions, progress
         )
 

--- a/tests/unit/services/test_cross_segment_discovery.py
+++ b/tests/unit/services/test_cross_segment_discovery.py
@@ -27,7 +27,7 @@ Feature 045 — Correction Intelligence Pipeline (US5, T033)
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -45,8 +45,6 @@ from chronovista.services.cross_segment_discovery import (
 # CRITICAL: Module-level asyncio marker ensures async tests run with coverage
 # (see CLAUDE.md §pytest-asyncio Coverage Integration Issues).
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers / convenience

--- a/tests/unit/services/test_entity_mention_scan_service.py
+++ b/tests/unit/services/test_entity_mention_scan_service.py
@@ -33,8 +33,6 @@ import pytest
 
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
 # with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helper factories
@@ -88,7 +86,9 @@ def _make_segment_row(
 
 def _build_service(session_factory: Any) -> Any:
     """Import and construct EntityMentionScanService."""
-    from chronovista.services.entity_mention_scan_service import EntityMentionScanService
+    from chronovista.services.entity_mention_scan_service import (
+        EntityMentionScanService,
+    )
 
     return EntityMentionScanService(session_factory=session_factory)
 
@@ -138,8 +138,12 @@ class TestConstructor:
 
     def test_stores_session_factory(self) -> None:
         """Constructor must store the session_factory dependency."""
-        from chronovista.services.entity_mention_scan_service import EntityMentionScanService
-        from chronovista.repositories.entity_mention_repository import EntityMentionRepository
+        from chronovista.repositories.entity_mention_repository import (
+            EntityMentionRepository,
+        )
+        from chronovista.services.entity_mention_scan_service import (
+            EntityMentionScanService,
+        )
 
         factory = MagicMock()
         svc = EntityMentionScanService(session_factory=factory)
@@ -823,9 +827,9 @@ class TestBulkCreateConflictSkip:
 
     async def test_skipped_count_is_batch_minus_inserted(self) -> None:
         """mentions_skipped = len(batch_mentions) - inserted_count."""
-        from chronovista.services.entity_mention_scan_service import _EntityPattern
         from chronovista.models.entity_mention import EntityMentionCreate
         from chronovista.models.enums import DetectionMethod
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
 
         entity_id = _make_uuid()
         fake_pattern = _EntityPattern(
@@ -873,9 +877,9 @@ class TestBulkCreateConflictSkip:
 
     async def test_bulk_create_called_with_mention_list(self) -> None:
         """bulk_create_with_conflict_skip must be called with the mention list."""
-        from chronovista.services.entity_mention_scan_service import _EntityPattern
         from chronovista.models.entity_mention import EntityMentionCreate
         from chronovista.models.enums import DetectionMethod
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
 
         entity_id = _make_uuid()
         fake_pattern = _EntityPattern(
@@ -955,9 +959,9 @@ class TestCounterUpdate:
 
     async def test_update_entity_counters_called_in_live_mode(self) -> None:
         """In live mode with matches, update_entity_counters must be called."""
-        from chronovista.services.entity_mention_scan_service import _EntityPattern
         from chronovista.models.entity_mention import EntityMentionCreate
         from chronovista.models.enums import DetectionMethod
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
 
         entity_id = _make_uuid()
         fake_pattern = _EntityPattern(
@@ -1002,9 +1006,9 @@ class TestCounterUpdate:
 
     async def test_update_entity_counters_not_called_in_dry_run(self) -> None:
         """In dry-run mode, update_entity_counters must NOT be called."""
-        from chronovista.services.entity_mention_scan_service import _EntityPattern
         from chronovista.models.entity_mention import EntityMentionCreate
         from chronovista.models.enums import DetectionMethod
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
 
         entity_id = _make_uuid()
         fake_pattern = _EntityPattern(
@@ -1090,9 +1094,9 @@ class TestCounterUpdate:
         verifies that the service does not pre-filter entity IDs before
         delegating to the repository.
         """
-        from chronovista.services.entity_mention_scan_service import _EntityPattern
         from chronovista.models.entity_mention import EntityMentionCreate
         from chronovista.models.enums import DetectionMethod
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
 
         entity_id_a = _make_uuid()
         entity_id_b = _make_uuid()
@@ -1220,9 +1224,9 @@ class TestDryRunMode:
 
     async def test_dry_run_no_bulk_insert(self) -> None:
         """In dry-run mode, bulk_create_with_conflict_skip must NOT be called."""
-        from chronovista.services.entity_mention_scan_service import _EntityPattern
         from chronovista.models.entity_mention import EntityMentionCreate
         from chronovista.models.enums import DetectionMethod
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
 
         entity_id = _make_uuid()
         fake_pattern = _EntityPattern(
@@ -1303,9 +1307,9 @@ class TestDryRunMode:
 
     async def test_dry_run_populates_preview_data(self) -> None:
         """dry_run_matches must contain preview dicts when matches exist."""
-        from chronovista.services.entity_mention_scan_service import _EntityPattern
         from chronovista.models.entity_mention import EntityMentionCreate
         from chronovista.models.enums import DetectionMethod
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
 
         entity_id = _make_uuid()
         fake_pattern = _EntityPattern(
@@ -1518,9 +1522,9 @@ class TestScanResult:
 
     async def test_scan_result_unique_fields_populated(self) -> None:
         """unique_entities and unique_videos must reflect distinct IDs matched."""
-        from chronovista.services.entity_mention_scan_service import _EntityPattern
         from chronovista.models.entity_mention import EntityMentionCreate
         from chronovista.models.enums import DetectionMethod
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
 
         entity_id_1 = _make_uuid()
         entity_id_2 = _make_uuid()
@@ -2306,7 +2310,7 @@ class TestEntityIdsFilter:
         session.execute = AsyncMock(side_effect=[entity_result, alias_result])
 
         svc = _build_service(MagicMock())
-        patterns = await svc._load_entity_patterns(
+        await svc._load_entity_patterns(
             session,
             entity_type=None,
             new_entities_only=False,

--- a/tests/unit/services/test_historical_takeout_discovery.py
+++ b/tests/unit/services/test_historical_takeout_discovery.py
@@ -8,18 +8,15 @@ methods in TakeoutService (T025a-T025d coverage).
 import json
 import shutil
 import tempfile
-from datetime import datetime, timezone
+from collections.abc import Generator
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Dict, Generator, List
+from typing import Any
 
 import pytest
 
-pytestmark = pytest.mark.asyncio
-
 from chronovista.models.takeout.recovery import (
     HistoricalTakeout,
-    RecoveredChannelMetadata,
-    RecoveredVideoMetadata,
 )
 from chronovista.services.takeout_service import TakeoutService
 
@@ -187,7 +184,7 @@ class TestParseHistoricalWatchHistory:
         shutil.rmtree(temp_dir)
 
     @pytest.fixture
-    def sample_watch_history(self) -> List[dict[str, Any]]:
+    def sample_watch_history(self) -> list[dict[str, Any]]:
         """Sample watch history JSON data."""
         return [
             {
@@ -214,7 +211,7 @@ class TestParseHistoricalWatchHistory:
         ]
 
     async def test_parse_valid_watch_history(
-        self, temp_takeout_dir: Path, sample_watch_history: List[dict[str, Any]]
+        self, temp_takeout_dir: Path, sample_watch_history: list[dict[str, Any]]
     ) -> None:
         """Test parsing a valid watch history file."""
         youtube_dir = temp_takeout_dir / "YouTube and YouTube Music"
@@ -228,7 +225,7 @@ class TestParseHistoricalWatchHistory:
 
         takeout = HistoricalTakeout(
             path=youtube_dir,
-            export_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            export_date=datetime(2024, 1, 15, tzinfo=UTC),
             has_watch_history=True,
             has_playlists=False,
             has_subscriptions=False,
@@ -254,7 +251,7 @@ class TestParseHistoricalWatchHistory:
 
         takeout = HistoricalTakeout(
             path=youtube_dir,
-            export_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            export_date=datetime(2024, 1, 15, tzinfo=UTC),
             has_watch_history=True,
             has_playlists=False,
             has_subscriptions=False,
@@ -291,7 +288,7 @@ class TestParseHistoricalWatchHistory:
 
         takeout = HistoricalTakeout(
             path=youtube_dir,
-            export_date=datetime.now(timezone.utc),
+            export_date=datetime.now(UTC),
             has_watch_history=True,
             has_playlists=False,
             has_subscriptions=False,
@@ -330,7 +327,7 @@ class TestParseHistoricalWatchHistory:
 
         takeout = HistoricalTakeout(
             path=youtube_dir,
-            export_date=datetime.now(timezone.utc),
+            export_date=datetime.now(UTC),
             has_watch_history=True,
             has_playlists=False,
             has_subscriptions=False,
@@ -351,7 +348,7 @@ class TestParseHistoricalWatchHistory:
 
         takeout = HistoricalTakeout(
             path=youtube_dir,
-            export_date=datetime.now(timezone.utc),
+            export_date=datetime.now(UTC),
             has_watch_history=False,  # No watch history
             has_playlists=False,
             has_subscriptions=False,
@@ -373,7 +370,7 @@ class TestParseHistoricalWatchHistory:
 
         takeout = HistoricalTakeout(
             path=youtube_dir,
-            export_date=datetime.now(timezone.utc),
+            export_date=datetime.now(UTC),
             has_watch_history=True,
             has_playlists=False,
             has_subscriptions=False,
@@ -398,7 +395,7 @@ class TestBuildRecoveryMetadataMap:
         self,
         base_path: Path,
         name: str,
-        history_data: List[Dict[str, Any]],
+        history_data: list[dict[str, Any]],
     ) -> HistoricalTakeout:
         """Helper to create a takeout with watch history."""
         takeout_dir = base_path / name
@@ -416,10 +413,10 @@ class TestBuildRecoveryMetadataMap:
         date_match = re.search(r"(\d{4}-\d{2}-\d{2})", name)
         if date_match:
             export_date = datetime.strptime(date_match.group(1), "%Y-%m-%d").replace(
-                tzinfo=timezone.utc
+                tzinfo=UTC
             )
         else:
-            export_date = datetime.now(timezone.utc)
+            export_date = datetime.now(UTC)
 
         return HistoricalTakeout(
             path=youtube_dir,
@@ -573,7 +570,7 @@ class TestGetRecoverySummary:
         """Test summary with a single takeout."""
         takeout = HistoricalTakeout(
             path=Path("/takeouts/2024-01-15"),
-            export_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            export_date=datetime(2024, 1, 15, tzinfo=UTC),
             has_watch_history=True,
             has_playlists=True,
             has_subscriptions=False,
@@ -595,21 +592,21 @@ class TestGetRecoverySummary:
         takeouts = [
             HistoricalTakeout(
                 path=Path("/takeouts/2023-01-15"),
-                export_date=datetime(2023, 1, 15, tzinfo=timezone.utc),
+                export_date=datetime(2023, 1, 15, tzinfo=UTC),
                 has_watch_history=True,
                 has_playlists=False,
                 has_subscriptions=False,
             ),
             HistoricalTakeout(
                 path=Path("/takeouts/2024-06-15"),
-                export_date=datetime(2024, 6, 15, tzinfo=timezone.utc),
+                export_date=datetime(2024, 6, 15, tzinfo=UTC),
                 has_watch_history=True,
                 has_playlists=True,
                 has_subscriptions=False,
             ),
             HistoricalTakeout(
                 path=Path("/takeouts/2024-12-01"),
-                export_date=datetime(2024, 12, 1, tzinfo=timezone.utc),
+                export_date=datetime(2024, 12, 1, tzinfo=UTC),
                 has_watch_history=False,
                 has_playlists=False,
                 has_subscriptions=True,

--- a/tests/unit/services/test_image_cache.py
+++ b/tests/unit/services/test_image_cache.py
@@ -14,23 +14,19 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import httpx
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette.responses import Response
 
 from chronovista.services.image_cache import (
-    ImageCacheConfig,
-    ImageCacheService,
     _CACHE_CONTROL_HIT,
     _CACHE_CONTROL_PLACEHOLDER,
     _CHANNEL_PLACEHOLDER_SVG,
     _MAX_IMAGE_BYTES,
-    _MIN_IMAGE_BYTES,
     _VIDEO_PLACEHOLDER_SVG,
+    ImageCacheConfig,
+    ImageCacheService,
 )
 from tests.factories.channel_factory import ChannelTestData
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Fixtures
@@ -1000,7 +996,7 @@ class TestCacheInvalidation:
         This test verifies the service provides invalidation as a tool, but
         does NOT automatically invalidate on NULL → URL transitions.
         """
-        service = ImageCacheService(config=image_cache_config)
+        ImageCacheService(config=image_cache_config)
         channel_id = ChannelTestData.VALID_CHANNEL_IDS[0]
 
         # Create cached file (simulating old state with NULL URL that somehow
@@ -1032,7 +1028,7 @@ class TestCacheInvalidation:
 
         This supports FR-006 (image preservation for deleted content).
         """
-        service = ImageCacheService(config=image_cache_config)
+        ImageCacheService(config=image_cache_config)
         channel_id = ChannelTestData.VALID_CHANNEL_IDS[1]
 
         # Create cached file (from old non-NULL URL)

--- a/tests/unit/services/test_onboarding_service.py
+++ b/tests/unit/services/test_onboarding_service.py
@@ -53,8 +53,6 @@ from chronovista.models.enums import OperationType, PipelineStepStatus, TaskStat
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
 # with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -2367,7 +2365,6 @@ class TestFactoryEnrichMetadata:
 
 # Stand-in for ``unittest.mock.ANY`` used in ``assert_awaited_once_with``
 from unittest.mock import ANY as unittest_mock_any  # noqa: E402
-
 
 # ===========================================================================
 # Tests: _factory_normalize_tags

--- a/tests/unit/services/test_phonetic_matcher.py
+++ b/tests/unit/services/test_phonetic_matcher.py
@@ -29,22 +29,20 @@ from __future__ import annotations
 
 import uuid
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid_utils import uuid7
 
-from chronovista.services.phonetic_matcher import PhoneticMatcher, PhoneticMatch
 from chronovista.repositories.entity_mention_repository import (
     EntityMentionRepository,
 )
+from chronovista.services.phonetic_matcher import PhoneticMatch, PhoneticMatcher
 
 # CRITICAL: ensures every async test in this module is recognised by
 # pytest-asyncio regardless of how coverage is invoked
 # (see CLAUDE.md §pytest-asyncio Coverage Integration Issues).
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/services/test_playlist_membership_seeder.py
+++ b/tests/unit/services/test_playlist_membership_seeder.py
@@ -4,13 +4,12 @@ Tests for PlaylistMembershipSeeder - creates playlist-video relationships.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from chronovista.repositories.channel_repository import ChannelRepository
 from chronovista.repositories.playlist_membership_repository import (
     PlaylistMembershipRepository,
 )
@@ -24,8 +23,6 @@ from tests.factories.id_factory import TestIds, YouTubeIdFactory
 from tests.factories.takeout_data_factory import create_takeout_data
 from tests.factories.takeout_playlist_factory import create_takeout_playlist
 from tests.factories.takeout_playlist_item_factory import create_takeout_playlist_item
-
-pytestmark = pytest.mark.asyncio
 
 
 class TestPlaylistMembershipSeederInitialization:
@@ -86,15 +83,15 @@ class TestPlaylistMembershipSeederSeeding:
                     videos=[
                         create_takeout_playlist_item(
                             video_id=TestIds.NEVER_GONNA_GIVE_YOU_UP,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_1,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_2,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                     ],
                     video_count=3,
@@ -105,7 +102,7 @@ class TestPlaylistMembershipSeederSeeding:
                     videos=[
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_1,  # Same video in multiple playlists
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                     ],
                     video_count=1,
@@ -150,13 +147,13 @@ class TestPlaylistMembershipSeederSeeding:
         with (
             patch.object(
                 seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-            ) as mock_get_playlist,
+            ),
             patch.object(
                 seeder.video_repo, "get_by_video_id", return_value=mock_video
-            ) as mock_get_video,
+            ),
             patch.object(
                 seeder.membership_repo, "membership_exists", return_value=False
-            ) as mock_exists,
+            ),
             patch.object(seeder.membership_repo, "create") as mock_create,
         ):
 
@@ -181,18 +178,18 @@ class TestPlaylistMembershipSeederSeeding:
         # Mock repositories to return existing entities
         mock_playlist = Mock()
         mock_video = Mock()
-        mock_membership = Mock()
+        Mock()
 
         with (
             patch.object(
                 seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-            ) as mock_get_playlist,
+            ),
             patch.object(
                 seeder.video_repo, "get_by_video_id", return_value=mock_video
-            ) as mock_get_video,
+            ),
             patch.object(
                 seeder.membership_repo, "membership_exists", return_value=True
-            ) as mock_exists,
+            ),
         ):
 
             result = await seeder.seed(mock_session, sample_takeout_data)
@@ -216,13 +213,13 @@ class TestPlaylistMembershipSeederSeeding:
         with (
             patch.object(
                 seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-            ) as mock_get_playlist,
+            ),
             patch.object(
                 seeder.video_repo, "get_by_video_id", return_value=None
-            ) as mock_get_video,
+            ),
             patch.object(
                 seeder.membership_repo, "membership_exists", return_value=False
-            ) as mock_exists,
+            ),
             patch.object(seeder.video_repo, "create") as mock_video_create,
         ):
 
@@ -244,7 +241,7 @@ class TestPlaylistMembershipSeederSeeding:
         # Mock playlist doesn't exist
         with patch.object(
             seeder.playlist_repo, "get_by_playlist_id", return_value=None
-        ) as mock_get_playlist:
+        ):
             result = await seeder.seed(mock_session, sample_takeout_data)
 
             # Should handle missing playlists gracefully (may skip or create errors)
@@ -272,13 +269,13 @@ class TestPlaylistMembershipSeederSeeding:
         with (
             patch.object(
                 seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-            ) as mock_get_playlist,
+            ),
             patch.object(
                 seeder.video_repo, "get_by_video_id", return_value=mock_video
-            ) as mock_get_video,
+            ),
             patch.object(
                 seeder.membership_repo, "membership_exists", return_value=False
-            ) as mock_exists,
+            ),
         ):
 
             result = await seeder.seed(mock_session, sample_takeout_data, progress)
@@ -301,7 +298,7 @@ class TestPlaylistMembershipSeederSeeding:
             seeder.playlist_repo,
             "get_by_playlist_id",
             side_effect=Exception("Database error"),
-        ) as mock_get_playlist:
+        ):
             result = await seeder.seed(mock_session, sample_takeout_data)
 
             assert result.failed > 0
@@ -421,19 +418,19 @@ class TestPlaylistMembershipSeederPositioning:
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_1,
                             creation_timestamp=datetime(
-                                2024, 1, 1, tzinfo=timezone.utc
+                                2024, 1, 1, tzinfo=UTC
                             ),
                         ),
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_2,
                             creation_timestamp=datetime(
-                                2024, 1, 2, tzinfo=timezone.utc
+                                2024, 1, 2, tzinfo=UTC
                             ),
                         ),
                         create_takeout_playlist_item(
                             video_id=TestIds.NEVER_GONNA_GIVE_YOU_UP,
                             creation_timestamp=datetime(
-                                2024, 1, 3, tzinfo=timezone.utc
+                                2024, 1, 3, tzinfo=UTC
                             ),
                         ),
                     ],
@@ -449,17 +446,17 @@ class TestPlaylistMembershipSeederPositioning:
         with (
             patch.object(
                 seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-            ) as mock_get_playlist,
+            ),
             patch.object(
                 seeder.video_repo, "get_by_video_id", return_value=mock_video
-            ) as mock_get_video,
+            ),
             patch.object(
                 seeder.membership_repo, "membership_exists", return_value=False
-            ) as mock_exists,
+            ),
             patch.object(seeder.membership_repo, "create") as mock_create,
         ):
 
-            result = await seeder.seed(mock_session, data)
+            await seeder.seed(mock_session, data)
 
             # Verify that positions were assigned correctly
             assert mock_create.call_count == 3
@@ -510,7 +507,7 @@ class TestPlaylistMembershipSeederBatchProcessing:
             playlist_items.append(
                 create_takeout_playlist_item(
                     video_id=YouTubeIdFactory.create_video_id(f"video_{i}"),
-                    creation_timestamp=datetime.now(timezone.utc),
+                    creation_timestamp=datetime.now(UTC),
                 )
             )
 
@@ -535,13 +532,13 @@ class TestPlaylistMembershipSeederBatchProcessing:
         with (
             patch.object(
                 seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-            ) as mock_get_playlist,
+            ),
             patch.object(
                 seeder.video_repo, "get_by_video_id", return_value=mock_video
-            ) as mock_get_video,
+            ),
             patch.object(
                 seeder.membership_repo, "membership_exists", return_value=False
-            ) as mock_exists,
+            ),
         ):
 
             result = await seeder.seed(mock_session, large_data)
@@ -597,7 +594,7 @@ class TestPlaylistMembershipSeederEdgeCases:
 
         with patch.object(
             seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-        ) as mock_get_playlist:
+        ):
             result = await seeder.seed(mock_session, data)
 
             # Should handle empty playlist gracefully
@@ -620,7 +617,7 @@ class TestPlaylistMembershipSeederEdgeCases:
                     videos=[
                         create_takeout_playlist_item(
                             video_id="",  # Empty video ID (will be stripped to empty)
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                     ],
                     video_count=1,
@@ -632,7 +629,7 @@ class TestPlaylistMembershipSeederEdgeCases:
 
         with patch.object(
             seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-        ) as mock_get_playlist:
+        ):
             result = await seeder.seed(mock_session, data)
 
             # Should handle empty video ID gracefully (should fail)
@@ -654,15 +651,15 @@ class TestPlaylistMembershipSeederEdgeCases:
                     videos=[
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_1,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_1,  # Same video again
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_2,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                     ],
                     video_count=3,
@@ -676,15 +673,15 @@ class TestPlaylistMembershipSeederEdgeCases:
         with (
             patch.object(
                 seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-            ) as mock_get_playlist,
+            ),
             patch.object(
                 seeder.video_repo, "get_by_video_id", return_value=mock_video
-            ) as mock_get_video,
+            ),
             patch.object(
                 seeder.membership_repo,
                 "membership_exists",
                 side_effect=[False, True, False],
-            ) as mock_exists,
+            ),
         ):
 
             result = await seeder.seed(mock_session, data)
@@ -773,11 +770,11 @@ class TestPlaylistMembershipSeederIntegration:
                     videos=[
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_1,  # Exists
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                         create_takeout_playlist_item(
                             video_id="missingVid1",  # Doesn't exist (11 chars to match VideoId validation)
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                     ],
                     video_count=2,
@@ -794,13 +791,13 @@ class TestPlaylistMembershipSeederIntegration:
         with (
             patch.object(
                 seeder.playlist_repo, "get_by_playlist_id", return_value=mock_playlist
-            ) as mock_get_playlist,
+            ),
             patch.object(
                 seeder.video_repo, "get_by_video_id", side_effect=mock_get_video
-            ) as mock_get_video_method,
+            ),
             patch.object(
                 seeder.membership_repo, "membership_exists", return_value=False
-            ) as mock_exists,
+            ),
             patch.object(seeder.video_repo, "create") as mock_video_create,
         ):
 

--- a/tests/unit/services/test_playlist_recovery.py
+++ b/tests/unit/services/test_playlist_recovery.py
@@ -10,10 +10,10 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Dict, List
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -222,17 +222,17 @@ class TestPlaylistUpdateFromHistoricalData:
     async def test_historical_playlist_overwrite_newer_first(self) -> None:
         """Test that newer historical data overwrites older data."""
         # Older takeout
-        older_playlist_data = {
+        {
             "name": "Old Name",
             "video_count": 10,
-            "source_date": datetime(2022, 1, 1, tzinfo=timezone.utc),
+            "source_date": datetime(2022, 1, 1, tzinfo=UTC),
         }
 
         # Newer takeout
         newer_playlist_data = {
             "name": "Updated Name",
             "video_count": 15,
-            "source_date": datetime(2023, 6, 1, tzinfo=timezone.utc),
+            "source_date": datetime(2023, 6, 1, tzinfo=UTC),
         }
 
         # When processing oldest first, newer should overwrite
@@ -287,7 +287,7 @@ class TestMissingPlaylistFilesHandling:
             playlists_dir.exists.return_value = False
 
             # The service should return empty list for missing directory
-            result: List[TakeoutPlaylist] = []
+            result: list[TakeoutPlaylist] = []
             assert len(result) == 0
 
     async def test_parse_playlists_with_empty_directory(self) -> None:
@@ -298,7 +298,7 @@ class TestMissingPlaylistFilesHandling:
         mock_playlists_dir.glob.return_value = []
 
         # The service should return empty list
-        playlists: List[TakeoutPlaylist] = []
+        playlists: list[TakeoutPlaylist] = []
         assert len(playlists) == 0
 
     async def test_parse_playlists_with_corrupted_csv(self) -> None:
@@ -306,8 +306,8 @@ class TestMissingPlaylistFilesHandling:
         # This tests error handling when CSV parsing fails
         # The service should log a warning and skip the corrupted file
 
-        from unittest.mock import mock_open
         import csv
+        from unittest.mock import mock_open
 
         corrupted_csv_content = "Video ID,Playlist Video Creation Timestamp\n\"unclosed quote"
 
@@ -324,7 +324,6 @@ class TestMissingPlaylistFilesHandling:
     async def test_parse_playlists_with_missing_columns(self) -> None:
         """Test handling of CSV files with missing required columns."""
         # CSV without expected "Video ID" column
-        invalid_csv_content = "Wrong Column,Another Wrong Column\nvalue1,value2"
 
         # The service should handle missing columns gracefully
         # by checking for expected column names
@@ -361,14 +360,14 @@ class TestPlaylistRecoveryIntegration:
     async def test_full_playlist_recovery_workflow(self) -> None:
         """Test the complete playlist recovery workflow from takeout."""
         # Step 1: Discover historical takeouts
-        historical_takeouts: List[Dict[str, Any]] = [
-            {"path": Path("/takeouts/2022-01-01"), "date": datetime(2022, 1, 1, tzinfo=timezone.utc)},
-            {"path": Path("/takeouts/2023-06-15"), "date": datetime(2023, 6, 15, tzinfo=timezone.utc)},
-            {"path": Path("/takeouts/2024-01-01"), "date": datetime(2024, 1, 1, tzinfo=timezone.utc)},
+        historical_takeouts: list[dict[str, Any]] = [
+            {"path": Path("/takeouts/2022-01-01"), "date": datetime(2022, 1, 1, tzinfo=UTC)},
+            {"path": Path("/takeouts/2023-06-15"), "date": datetime(2023, 6, 15, tzinfo=UTC)},
+            {"path": Path("/takeouts/2024-01-01"), "date": datetime(2024, 1, 1, tzinfo=UTC)},
         ]
 
         # Step 2: Parse playlists from each takeout (oldest first)
-        all_playlists: Dict[str, Dict[str, Any]] = {}
+        all_playlists: dict[str, dict[str, Any]] = {}
 
         for takeout in sorted(historical_takeouts, key=lambda x: x["date"] if isinstance(x["date"], datetime) else datetime.min):
             # Simulated parsing
@@ -408,7 +407,7 @@ class TestPlaylistRecoveryIntegration:
         PLAYLIST_PLACEHOLDER_PREFIX = "[Placeholder] Playlist "
 
         # Database has placeholder playlist
-        db_playlist: Dict[str, Any] = {
+        db_playlist: dict[str, Any] = {
             "playlist_id": "PLtest123",
             "title": "[Placeholder] Playlist PLtest123",
             "description": None,

--- a/tests/unit/services/test_playlist_seeder.py
+++ b/tests/unit/services/test_playlist_seeder.py
@@ -4,7 +4,7 @@ Tests for PlaylistSeeder - creates playlists from takeout data.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -129,11 +129,11 @@ class TestPlaylistSeederSeeding:
                     videos=[
                         create_takeout_playlist_item(
                             video_id=TestIds.NEVER_GONNA_GIVE_YOU_UP,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_1,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                     ],
                     video_count=2,
@@ -144,7 +144,7 @@ class TestPlaylistSeederSeeding:
                     videos=[
                         create_takeout_playlist_item(
                             video_id=TestIds.TEST_VIDEO_2,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                     ],
                     video_count=1,
@@ -244,7 +244,7 @@ class TestPlaylistSeederSeeding:
         ) as mock_get:
             mock_get.return_value = None
 
-            result = await seeder.seed(mock_session, sample_takeout_data, progress)
+            await seeder.seed(mock_session, sample_takeout_data, progress)
 
             assert "playlists" in progress_calls
 
@@ -279,7 +279,7 @@ class TestPlaylistSeederSeeding:
             videos=[
                 create_takeout_playlist_item(
                     video_id=TestIds.TEST_VIDEO_1,
-                    creation_timestamp=datetime.now(timezone.utc),
+                    creation_timestamp=datetime.now(UTC),
                 ),
             ],
             video_count=1,
@@ -372,7 +372,7 @@ class TestPlaylistSeederBatchProcessing:
                     videos=[
                         create_takeout_playlist_item(
                             video_id=YouTubeIdFactory.create_video_id(f"video_{i}"),
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                     ],
                     video_count=1,
@@ -726,7 +726,7 @@ class TestPlaylistSeederReseedWithCascade:
                     videos=[
                         create_takeout_playlist_item(
                             video_id=TestIds.NEVER_GONNA_GIVE_YOU_UP,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         ),
                     ],
                     video_count=1,
@@ -832,7 +832,7 @@ class TestPlaylistSeederReseedWithCascade:
             ) as mock_get1,
             patch.object(
                 seeder.playlist_repo, "create", new_callable=AsyncMock
-            ) as mock_create1,
+            ),
         ):
             mock_delete1.return_value = 0
             mock_get1.return_value = None
@@ -850,7 +850,7 @@ class TestPlaylistSeederReseedWithCascade:
             ) as mock_get2,
             patch.object(
                 seeder.playlist_repo, "create", new_callable=AsyncMock
-            ) as mock_create2,
+            ),
         ):
             mock_delete2.return_value = 1
             mock_get2.return_value = None
@@ -917,7 +917,7 @@ class TestPlaylistSeederReseedWithCascade:
             ) as mock_get,
             patch.object(
                 seeder.playlist_repo, "create", new_callable=AsyncMock
-            ) as mock_create,
+            ),
         ):
             mock_get.return_value = None
 

--- a/tests/unit/services/test_preference_aware_transcript_filter.py
+++ b/tests/unit/services/test_preference_aware_transcript_filter.py
@@ -5,8 +5,7 @@ Comprehensive test coverage for preference-aware transcript filtering
 that implements the FLUENT/LEARNING/CURIOUS/EXCLUDE hierarchy.
 """
 
-from datetime import datetime, timezone
-from typing import List
+from datetime import UTC, datetime
 
 import pytest
 
@@ -68,9 +67,9 @@ class TestPreferenceAwareTranscriptFilterFluentDownloads:
         return PreferenceAwareTranscriptFilter()
 
     @pytest.fixture
-    def fluent_en_es_preferences(self) -> List[UserLanguagePreference]:
+    def fluent_en_es_preferences(self) -> list[UserLanguagePreference]:
         """Create fluent preferences for English and Spanish."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -123,7 +122,7 @@ class TestPreferenceAwareTranscriptFilterFluentDownloads:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """T091: FLUENT downloads should not have duplicates."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         prefs = [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -162,9 +161,9 @@ class TestPreferenceAwareTranscriptFilterExcluded:
         return PreferenceAwareTranscriptFilter()
 
     @pytest.fixture
-    def excluded_preferences(self) -> List[UserLanguagePreference]:
+    def excluded_preferences(self) -> list[UserLanguagePreference]:
         """Create excluded preferences for German and Russian."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -203,7 +202,7 @@ class TestPreferenceAwareTranscriptFilterExcluded:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """T092: EXCLUDE matches language variants."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         prefs = [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -234,9 +233,9 @@ class TestPreferenceAwareTranscriptFilterCurious:
         return PreferenceAwareTranscriptFilter()
 
     @pytest.fixture
-    def curious_preferences(self) -> List[UserLanguagePreference]:
+    def curious_preferences(self) -> list[UserLanguagePreference]:
         """Create curious preferences for Japanese and Korean."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -326,9 +325,9 @@ class TestPreferenceAwareTranscriptFilterDownloadSummary:
         return PreferenceAwareTranscriptFilter()
 
     @pytest.fixture
-    def mixed_preferences(self) -> List[UserLanguagePreference]:
+    def mixed_preferences(self) -> list[UserLanguagePreference]:
         """Create mixed preferences covering all types."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return [
             # Fluent: English (priority 1)
             UserLanguagePreference(
@@ -427,9 +426,9 @@ class TestPreferenceAwareTranscriptFilterLearning:
         return PreferenceAwareTranscriptFilter()
 
     @pytest.fixture
-    def learning_with_fluent(self) -> List[UserLanguagePreference]:
+    def learning_with_fluent(self) -> list[UserLanguagePreference]:
         """Create learning preferences with fluent target language."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return [
             # Fluent: English (translation target)
             UserLanguagePreference(
@@ -481,7 +480,7 @@ class TestPreferenceAwareTranscriptFilterLearning:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """LEARNING without any fluent preference has no translation target."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         prefs = [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -513,7 +512,7 @@ class TestPreferenceAwareTranscriptFilterGetTopFluent:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """Top fluent language respects priority ordering."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         prefs = [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -558,7 +557,7 @@ class TestPreferenceAwareTranscriptFilterGetDownloadLanguages:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """get_download_languages includes only fluent and learning."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         prefs = [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -617,7 +616,7 @@ class TestPreferenceAwareTranscriptFilterEdgeCases:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """A language can only be in one preference category per user."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         # In real usage, the same language wouldn't be in multiple categories
         # This test verifies the filter handles a single language preference correctly
         prefs = [
@@ -643,7 +642,7 @@ class TestPreferenceAwareTranscriptFilterEdgeCases:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """Languages not in available list are not in the plan."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         prefs = [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -667,7 +666,7 @@ class TestPreferenceAwareTranscriptFilterEdgeCases:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """Base language preference (e.g., 'en') matches variants (e.g., 'en-US')."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         prefs = [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -691,7 +690,7 @@ class TestPreferenceAwareTranscriptFilterEdgeCases:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """Variant preference (e.g., 'en-US') matches base and other variants."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         prefs = [
             UserLanguagePreference(
                 user_id="test_user_001",
@@ -727,7 +726,7 @@ class TestPreferenceAwareTranscriptFilterLearningTranslationPairing:
         priority: int = 1,
     ) -> UserLanguagePreference:
         """Helper to create a language preference."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return UserLanguagePreference(
             user_id="test_user_001",
             language_code=lang_code,
@@ -823,7 +822,7 @@ class TestPreferenceAwareTranscriptFilterGetTranslationPair:
         self, lang_code: LanguageCode, priority: int = 1
     ) -> UserLanguagePreference:
         """Helper to create a fluent language preference."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return UserLanguagePreference(
             user_id="test_user_001",
             language_code=lang_code,
@@ -868,7 +867,7 @@ class TestPreferenceAwareTranscriptFilterGetTranslationPair:
         self, filter_service: PreferenceAwareTranscriptFilter
     ):
         """Translation pair has None target when no fluent preferences exist."""
-        fluent_prefs: List[UserLanguagePreference] = []
+        fluent_prefs: list[UserLanguagePreference] = []
         available = ["it", "en", "fr"]
 
         result = filter_service.get_translation_pair("it", available, fluent_prefs)

--- a/tests/unit/services/test_seeding_orchestrator.py
+++ b/tests/unit/services/test_seeding_orchestrator.py
@@ -5,25 +5,22 @@ Tests for SeedingOrchestrator - dependency resolution and execution coordination
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional
 from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.exceptions import ValidationError
+from chronovista.models.takeout.takeout_data import TakeoutData
 from chronovista.services.seeding.base_seeder import (
     BaseSeeder,
     ProgressCallback,
     SeedResult,
 )
 from chronovista.services.seeding.orchestrator import SeedingOrchestrator
-from chronovista.models.takeout.takeout_data import TakeoutData
 from tests.factories.takeout_data_factory import create_takeout_data
 
 # CRITICAL: This line ensures async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 class MockSeeder(BaseSeeder):
     """Mock seeder for testing."""
@@ -43,7 +40,7 @@ class MockSeeder(BaseSeeder):
         self,
         session: AsyncSession,
         takeout_data: TakeoutData,
-        progress: Optional[ProgressCallback] = None,
+        progress: ProgressCallback | None = None,
     ) -> SeedResult:
         self.seed_called = True
         if progress:
@@ -195,7 +192,7 @@ class TestSeedingOrchestrator:
                 self,
                 session: AsyncSession,
                 takeout_data: TakeoutData,
-                progress: Optional[ProgressCallback] = None,
+                progress: ProgressCallback | None = None,
             ) -> SeedResult:
                 execution_log.append(self.data_type)
                 return await super().seed(session, takeout_data, progress)
@@ -231,7 +228,7 @@ class TestSeedingOrchestrator:
         seeder = MockSeeder("test_type")
         orchestrator.register_seeder(seeder)
 
-        results = await orchestrator.seed(
+        await orchestrator.seed(
             mock_session,
             mock_takeout_data,
             {"test_type"},
@@ -333,7 +330,7 @@ class TestSeedingOrchestrator:
         self, orchestrator, mock_session, mock_takeout_data
     ):
         """Test that orchestrator syncs saved_to_playlist flags after seeding."""
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
 
         # Register seeders for user_videos and playlist_memberships
         user_videos_seeder = MockSeeder("user_videos", dependencies=set())
@@ -354,7 +351,7 @@ class TestSeedingOrchestrator:
             mock_repo_instance.sync_saved_to_playlist_flags = mock_sync
             MockRepo.return_value = mock_repo_instance
 
-            results = await orchestrator.seed(
+            await orchestrator.seed(
                 mock_session,
                 mock_takeout_data,
                 {"user_videos", "playlist_memberships"},
@@ -368,7 +365,7 @@ class TestSeedingOrchestrator:
         self, orchestrator, mock_session, mock_takeout_data
     ):
         """Test that sync is skipped if user_videos or playlist_memberships not seeded."""
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
 
         # Only register user_videos seeder
         user_videos_seeder = MockSeeder("user_videos", dependencies=set())
@@ -383,7 +380,7 @@ class TestSeedingOrchestrator:
             mock_repo_instance.sync_saved_to_playlist_flags = mock_sync
             MockRepo.return_value = mock_repo_instance
 
-            results = await orchestrator.seed(
+            await orchestrator.seed(
                 mock_session,
                 mock_takeout_data,
                 {"user_videos"},  # Only user_videos, not playlist_memberships

--- a/tests/unit/services/test_segment_formatters.py
+++ b/tests/unit/services/test_segment_formatters.py
@@ -5,13 +5,10 @@ Tests human, JSON, and SRT output formats with special character handling.
 """
 
 import json
-from datetime import datetime, timezone
-
-import pytest
+from datetime import UTC, datetime
 
 from chronovista.models.transcript_segment import (
     TranscriptSegment,
-    TranscriptSegmentResponse,
 )
 from chronovista.services.segment_service import (
     OutputFormat,
@@ -65,7 +62,7 @@ def create_test_segment(
         sequence_number=id - 1,
         has_correction=has_correction,
         corrected_text=corrected_text,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
 

--- a/tests/unit/services/test_service_interfaces.py
+++ b/tests/unit/services/test_service_interfaces.py
@@ -7,7 +7,7 @@ Tests verify:
 3. ABCs define the expected abstract methods
 """
 
-from typing import Any, FrozenSet
+from typing import Any
 
 import pytest
 
@@ -37,7 +37,7 @@ class TestYouTubeServiceInterface:
 
     def test_interface_has_expected_abstract_methods(self) -> None:
         """Verify YouTubeServiceInterface defines expected abstract methods."""
-        abstract_methods: FrozenSet[str] = getattr(
+        abstract_methods: frozenset[str] = getattr(
             YouTubeServiceInterface, "__abstractmethods__", frozenset()
         )
 
@@ -85,7 +85,7 @@ class TestTranscriptServiceInterface:
 
     def test_interface_has_expected_abstract_methods(self) -> None:
         """Verify TranscriptServiceInterface defines expected abstract methods."""
-        abstract_methods: FrozenSet[str] = getattr(
+        abstract_methods: frozenset[str] = getattr(
             TranscriptServiceInterface, "__abstractmethods__", frozenset()
         )
 
@@ -117,7 +117,7 @@ class TestTakeoutServiceInterface:
 
     def test_interface_has_expected_abstract_methods(self) -> None:
         """Verify TakeoutServiceInterface defines expected abstract methods."""
-        abstract_methods: FrozenSet[str] = getattr(
+        abstract_methods: frozenset[str] = getattr(
             TakeoutServiceInterface, "__abstractmethods__", frozenset()
         )
 

--- a/tests/unit/services/test_tag_backfill.py
+++ b/tests/unit/services/test_tag_backfill.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -81,7 +80,7 @@ class TestNormalizeAndGroupCore:
         assert raw_forms == {"Python", "python", "#Python"}
 
         # Verify counts
-        counts_by_form = {form: count for form, count in groups["python"]}
+        counts_by_form = dict(groups["python"])
         assert counts_by_form["Python"] == 10
         assert counts_by_form["python"] == 5
         assert counts_by_form["#Python"] == 3
@@ -106,7 +105,7 @@ class TestNormalizeAndGroupCore:
         assert skipped_forms == {"#", "", "  "}
 
         # Verify counts
-        counts_by_form = {form: count for form, count in skip_list}
+        counts_by_form = dict(skip_list)
         assert counts_by_form["#"] == 3
         assert counts_by_form[""] == 0
         assert counts_by_form["  "] == 5
@@ -167,7 +166,7 @@ class TestNormalizeAndGroupCore:
         assert raw_forms == {"café", "cafe", "CAFE"}
 
         # Verify counts
-        counts_by_form = {form: count for form, count in groups["cafe"]}
+        counts_by_form = dict(groups["cafe"])
         assert counts_by_form["café"] == 80
         assert counts_by_form["cafe"] == 45
         assert counts_by_form["CAFE"] == 20
@@ -563,7 +562,7 @@ class TestKnownFalseMergePatterns:
     def test_contains_expected_patterns(self) -> None:
         """Verify the expected false-merge patterns are present."""
         expected = {"cafe", "resume", "cliche", "naive", "rape"}
-        assert KNOWN_FALSE_MERGE_PATTERNS == expected
+        assert expected == KNOWN_FALSE_MERGE_PATTERNS
 
     def test_is_frozenset(self) -> None:
         """Verify KNOWN_FALSE_MERGE_PATTERNS is immutable (frozenset)."""
@@ -795,6 +794,7 @@ class TestRunAnalysis:
     ) -> None:
         """Verify table format renders output and returns None."""
         import io
+
         from rich.console import Console
 
         # Mock table existence check

--- a/tests/unit/services/test_tag_management.py
+++ b/tests/unit/services/test_tag_management.py
@@ -42,8 +42,6 @@ from chronovista.services.tag_management import TagManagementService
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
 # with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -1365,7 +1363,6 @@ class TestMerge:
 
         # Inspect what rollback_data was passed to operation log repo
         call_kwargs = mock_operation_log_repo.create.call_args
-        from chronovista.models.tag_operation_log import TagOperationLogCreate
 
         obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
         rollback = obj_in.rollback_data
@@ -1887,7 +1884,6 @@ class TestSplit:
         )
 
         call_kwargs = mock_operation_log_repo.create.call_args
-        from chronovista.models.tag_operation_log import TagOperationLogCreate
 
         obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
         rollback = obj_in.rollback_data
@@ -2455,7 +2451,6 @@ class TestRename:
         )
 
         call_kwargs = mock_operation_log_repo.create.call_args
-        from chronovista.models.tag_operation_log import TagOperationLogCreate
 
         obj_in: TagOperationLogCreate = call_kwargs.kwargs["obj_in"]
         rollback = obj_in.rollback_data
@@ -2546,10 +2541,10 @@ class TestClassify:
         mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
 
         # No existing entity with same normalized form
-        alias_a = _make_tag_alias(
+        _make_tag_alias(
             raw_form="Elon Musk", normalized_form="elon musk", canonical_tag_id=tag.id
         )
-        alias_b = _make_tag_alias(
+        _make_tag_alias(
             raw_form="ElonMusk", normalized_form="elonmusk", canonical_tag_id=tag.id
         )
 
@@ -2790,7 +2785,6 @@ class TestClassify:
         - ``created_entity_alias_ids`` (list of str UUIDs)
         """
         from chronovista.models.enums import EntityType
-        from chronovista.models.tag_operation_log import TagOperationLogCreate
 
         tag = _make_canonical_tag(
             normalized_form="google",
@@ -3096,7 +3090,6 @@ class TestGetCollisions:
         Collision groups must be sorted by total_occurrence_count descending
         so the highest-impact collisions appear first.
         """
-        from chronovista.services.tag_management import CollisionGroup
 
         tag1 = _make_canonical_tag(normalized_form="cafe", canonical_form="Cafe", status="active")
         tag1.id = uuid.uuid4()
@@ -3368,7 +3361,6 @@ class TestDeprecate:
         - ``canonical_id``: str UUID of the tag
         - ``previous_status``: the status before deprecation ('active')
         """
-        from chronovista.models.tag_operation_log import TagOperationLogCreate
 
         tag = _make_canonical_tag(
             normalized_form="oldtag",
@@ -3409,7 +3401,6 @@ class TestDeprecate:
         The operation log entry must use operation_type='delete' (per spec),
         not 'deprecate' (which is not a valid operation type).
         """
-        from chronovista.models.tag_operation_log import TagOperationLogCreate
 
         tag = _make_canonical_tag(normalized_form="oldtag", status="active")
         mock_canonical_tag_repo.get_by_normalized_form.return_value = tag

--- a/tests/unit/services/test_takeout_recovery_service.py
+++ b/tests/unit/services/test_takeout_recovery_service.py
@@ -5,17 +5,14 @@ Unit tests for the takeout recovery service that handles gap-fill logic
 for recovering metadata from historical Google Takeout exports.
 """
 
-import json
 import shutil
 import tempfile
-from datetime import datetime, timezone
+from collections.abc import Generator
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Dict, Generator, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-pytestmark = pytest.mark.asyncio
 
 from chronovista.models.enums import AvailabilityStatus
 from chronovista.models.takeout.recovery import (
@@ -126,7 +123,7 @@ class TestRecoverFromHistoricalTakeouts:
 
         historical_takeout = HistoricalTakeout(
             path=temp_takeout_dir / "YouTube and YouTube Music",
-            export_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            export_date=datetime(2024, 1, 15, tzinfo=UTC),
             has_watch_history=True,
         )
 
@@ -178,7 +175,7 @@ class TestRecoverFromHistoricalTakeouts:
 
         historical_takeout = HistoricalTakeout(
             path=youtube_path,
-            export_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            export_date=datetime(2024, 1, 15, tzinfo=UTC),
             has_watch_history=True,
         )
 
@@ -189,7 +186,7 @@ class TestRecoverFromHistoricalTakeouts:
                 channel_name="RickAstleyVEVO",
                 channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
                 source_takeout=youtube_path,
-                source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+                source_date=datetime(2024, 1, 15, tzinfo=UTC),
             )
         }
 
@@ -198,7 +195,7 @@ class TestRecoverFromHistoricalTakeouts:
                 channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
                 channel_name="RickAstleyVEVO",
                 source_takeout=youtube_path,
-                source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+                source_date=datetime(2024, 1, 15, tzinfo=UTC),
             )
         }
 
@@ -260,7 +257,7 @@ class TestRecoverVideos:
                 channel_name="RickAstleyVEVO",
                 channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
                 source_takeout=Path("/takeouts/2024-01-15"),
-                source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+                source_date=datetime(2024, 1, 15, tzinfo=UTC),
             )
         }
 
@@ -296,7 +293,7 @@ class TestRecoverVideos:
                 video_id="dQw4w9WgXcQ",
                 title="Never Gonna Give You Up",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -340,7 +337,7 @@ class TestRecoverVideos:
                 channel_name="RickAstleyVEVO",
                 channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -388,7 +385,7 @@ class TestRecoverVideos:
                 channel_name="RickAstleyVEVO",
                 channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -433,7 +430,7 @@ class TestRecoverVideos:
                 channel_name="RickAstleyVEVO",
                 channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",  # This channel doesn't exist in DB
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -494,7 +491,7 @@ class TestRecoverVideos:
                 video_id="dQw4w9WgXcQ",
                 title="Never Gonna Give You Up",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -536,7 +533,7 @@ class TestRecoverChannels:
                 channel_id=valid_channel_id,
                 channel_name="Test Channel",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -570,7 +567,7 @@ class TestRecoverChannels:
                 channel_id=valid_channel_id,
                 channel_name="Real Channel Name",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -605,7 +602,7 @@ class TestRecoverChannels:
                 channel_id=valid_channel_id,
                 channel_name="Different Name",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -636,7 +633,7 @@ class TestRecoverChannels:
                 channel_id=valid_channel_id,
                 channel_name="Test Channel",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -791,7 +788,7 @@ class TestRecoveryNeverSetsDeletedFlag:
                 channel_name="RickAstleyVEVO",
                 channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
                 source_takeout=Path("/takeouts/2024-01-15"),
-                source_date=datetime(2024, 1, 15, tzinfo=timezone.utc),
+                source_date=datetime(2024, 1, 15, tzinfo=UTC),
             )
         }
 
@@ -847,7 +844,7 @@ class TestRecoveryNeverSetsDeletedFlag:
                 channel_name="HistoricalChannel",
                 channel_id="UChistorical123456789012",
                 source_takeout=Path("/takeouts/2023-06-01"),
-                source_date=datetime(2023, 6, 1, tzinfo=timezone.utc),
+                source_date=datetime(2023, 6, 1, tzinfo=UTC),
             )
         }
 
@@ -896,7 +893,7 @@ class TestRecoveryNeverSetsDeletedFlag:
                 channel_id=valid_channel_id,
                 channel_name="New Channel From Takeout",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 
@@ -943,7 +940,7 @@ class TestRecoveryNeverSetsDeletedFlag:
                 video_id="testVideo789",
                 title="Recovered Title",
                 source_takeout=Path("/takeouts/2024"),
-                source_date=datetime.now(timezone.utc),
+                source_date=datetime.now(UTC),
             )
         }
 

--- a/tests/unit/services/test_takeout_seeding_service.py
+++ b/tests/unit/services/test_takeout_seeding_service.py
@@ -7,26 +7,23 @@ dependency resolution, and orchestration.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from chronovista.models.enums import LanguageCode
 from chronovista.models.takeout.takeout_data import TakeoutSubscription
-from chronovista.services.seeding.base_seeder import ProgressCallback, SeedResult
+from chronovista.services.seeding.base_seeder import SeedResult
 from chronovista.services.seeding.orchestrator import SeedingOrchestrator
 from chronovista.services.takeout_seeding_service import TakeoutSeedingService
-from tests.factories.id_factory import TestIds, YouTubeIdFactory
+from tests.factories.id_factory import TestIds
 from tests.factories.takeout_data_factory import create_takeout_data
 from tests.factories.takeout_playlist_factory import create_takeout_playlist
 from tests.factories.takeout_playlist_item_factory import create_takeout_playlist_item
 from tests.factories.takeout_watch_entry_factory import create_takeout_watch_entry
 
 # Ensure async tests work with coverage
-pytestmark = pytest.mark.asyncio
-
 
 class TestTakeoutSeedingService:
     """Test TakeoutSeedingService with modular architecture."""
@@ -48,7 +45,7 @@ class TestTakeoutSeedingService:
                     title_url=f"https://www.youtube.com/watch?v={TestIds.NEVER_GONNA_GIVE_YOU_UP}",
                     channel_name="Rick Astley",
                     channel_id=TestIds.RICK_ASTLEY_CHANNEL,
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                 ),
                 create_takeout_watch_entry(
                     video_id=TestIds.TEST_VIDEO_1,
@@ -56,7 +53,7 @@ class TestTakeoutSeedingService:
                     title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
                     channel_name="Test Channel",
                     channel_id=TestIds.TEST_CHANNEL_2,
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                 ),
             ],
             subscriptions=[
@@ -78,7 +75,7 @@ class TestTakeoutSeedingService:
                     videos=[
                         create_takeout_playlist_item(
                             video_id=TestIds.NEVER_GONNA_GIVE_YOU_UP,
-                            creation_timestamp=datetime.now(timezone.utc),
+                            creation_timestamp=datetime.now(UTC),
                         )
                     ],
                     video_count=1,

--- a/tests/unit/services/test_takeout_service.py
+++ b/tests/unit/services/test_takeout_service.py
@@ -9,15 +9,13 @@ import csv
 import json
 import shutil
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 # Mark all async tests in this module
-pytestmark = pytest.mark.asyncio
-
 from chronovista.models.takeout import (
     ContentGap,
     PlaylistAnalysis,
@@ -180,7 +178,7 @@ class TestParseWatchHistory:
         assert first_entry.channel_url == "https://www.youtube.com/channel/UCtest123"
         assert first_entry.channel_id == "UCtest123"
         assert first_entry.watched_at == datetime(
-            2023, 1, 15, 14, 30, 0, tzinfo=timezone.utc
+            2023, 1, 15, 14, 30, 0, tzinfo=UTC
         )
 
     async def test_parse_watch_history_no_file(self, temp_takeout_dir):
@@ -836,7 +834,7 @@ class TestLoggerIntegration:
             await service.parse_watch_history()
 
         # Check that info messages were logged
-        info_calls = [call for call in mock_logger.info.call_args_list]
+        info_calls = list(mock_logger.info.call_args_list)
         assert len(info_calls) >= 2  # Should log parsing start and completion
 
         # Check specific log messages

--- a/tests/unit/services/test_topic_analytics_service.py
+++ b/tests/unit/services/test_topic_analytics_service.py
@@ -14,8 +14,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 # Mark all async tests in this module
-pytestmark = pytest.mark.asyncio
-
 from chronovista.models.topic_analytics import (
     TopicAnalyticsSummary,
     TopicDiscoveryAnalysis,
@@ -495,15 +493,14 @@ class TestTopicAnalyticsServiceGraphGeneration:
             service,
             "get_popular_topics",
             new=AsyncMock(return_value=mock_popular_topics),
+        ), patch.object(
+            service,
+            "get_topic_relationships",
+            new=AsyncMock(return_value=mock_relationships),
         ):
-            with patch.object(
-                service,
-                "get_topic_relationships",
-                new=AsyncMock(return_value=mock_relationships),
-            ):
-                result = await service.generate_topic_graph_dot(
-                    min_confidence=0.1, max_topics=50
-                )
+            result = await service.generate_topic_graph_dot(
+                min_confidence=0.1, max_topics=50
+            )
 
         assert isinstance(result, str)
         assert "digraph TopicGraph" in result
@@ -540,15 +537,14 @@ class TestTopicAnalyticsServiceGraphGeneration:
             service,
             "get_popular_topics",
             new=AsyncMock(return_value=mock_popular_topics),
+        ), patch.object(
+            service,
+            "get_topic_relationships",
+            new=AsyncMock(return_value=mock_relationships),
         ):
-            with patch.object(
-                service,
-                "get_topic_relationships",
-                new=AsyncMock(return_value=mock_relationships),
-            ):
-                result = await service.generate_topic_graph_json(
-                    min_confidence=0.1, max_topics=50
-                )
+            result = await service.generate_topic_graph_json(
+                min_confidence=0.1, max_topics=50
+            )
 
         assert isinstance(result, dict)
         assert "nodes" in result

--- a/tests/unit/services/test_topic_graph_service.py
+++ b/tests/unit/services/test_topic_graph_service.py
@@ -4,17 +4,11 @@ Tests for TopicGraphService.
 Comprehensive test coverage for topic knowledge graph building and analysis.
 """
 
-from datetime import datetime, timezone
-from typing import Dict, List, Set
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 # Mark all async tests in this module
-pytestmark = pytest.mark.asyncio
-
-from chronovista.db.models import TopicCategory as TopicCategoryDB
-from chronovista.db.models import Video as VideoDB
 from chronovista.models.topic_category import TopicCategorySearchFilters
 from chronovista.models.video_tag import VideoTagStatistics
 from chronovista.services.topic_graph_service import (
@@ -245,7 +239,7 @@ class TestTopicGraph:
         assert "/m/metal" in related_ids  # child
 
         # Check distances
-        for node, distance in related:
+        for _node, distance in related:
             assert distance <= 1
 
     def test_find_related_topics_extended_distance(self, sample_graph):

--- a/tests/unit/services/test_transcript_correction_service.py
+++ b/tests/unit/services/test_transcript_correction_service.py
@@ -28,9 +28,9 @@ References
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, call, patch
-from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -44,8 +44,6 @@ from chronovista.models.transcript_correction import TranscriptCorrectionCreate
 # CRITICAL: Module-level asyncio marker ensures async tests run properly
 # with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
 # ---------------------------------------------------------------------------
-pytestmark = pytest.mark.asyncio
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -109,7 +107,7 @@ def _make_correction_record(
     rec.corrected_text = corrected_text
     rec.corrected_by_user_id = corrected_by_user_id
     rec.correction_type = correction_type
-    rec.corrected_at = datetime.now(timezone.utc)
+    rec.corrected_at = datetime.now(UTC)
     return rec
 
 
@@ -225,7 +223,7 @@ class TestApplyCorrection:
         mock_correction_repo.get_latest_version.return_value = 0
         mock_correction_repo.create.return_value = created_record
 
-        result = await service.apply_correction(
+        await service.apply_correction(
             mock_session,
             video_id="dQw4w9WgXcQ",
             language_code="en",

--- a/tests/unit/services/test_transcript_service.py
+++ b/tests/unit/services/test_transcript_service.py
@@ -4,15 +4,11 @@ Tests for TranscriptService.
 Comprehensive test coverage for YouTube transcript downloading and processing service.
 """
 
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 # Mark all async tests in this module
-pytestmark = pytest.mark.asyncio
-
 from chronovista.models.enums import DownloadReason, LanguageCode
 from chronovista.models.transcript_source import (
     RawTranscriptData,
@@ -22,7 +18,6 @@ from chronovista.models.transcript_source import (
 from chronovista.models.video_transcript import EnhancedVideoTranscriptBase
 from chronovista.models.youtube_types import create_test_video_id
 from chronovista.services.transcript_service import (
-    TRANSCRIPT_API_AVAILABLE,
     TranscriptNotFoundError,
     TranscriptService,
     TranscriptServiceError,
@@ -70,14 +65,13 @@ class TestTranscriptServiceInitialization:
         """Test initialization when API is unavailable."""
         with patch(
             "chronovista.services.transcript_service.TRANSCRIPT_API_AVAILABLE", False
-        ):
-            with patch("chronovista.services.transcript_service.logger") as mock_logger:
-                service = TranscriptService()
-                assert service.enable_mock_fallback is False
-                assert service._api_available is False
-                mock_logger.warning.assert_called_once_with(
-                    "youtube-transcript-api not available - transcript downloads will fail"
-                )
+        ), patch("chronovista.services.transcript_service.logger") as mock_logger:
+            service = TranscriptService()
+            assert service.enable_mock_fallback is False
+            assert service._api_available is False
+            mock_logger.warning.assert_called_once_with(
+                "youtube-transcript-api not available - transcript downloads will fail"
+            )
 
     def test_init_with_mock_fallback_disabled(self):
         """Test initialization with mock fallback disabled."""
@@ -1177,7 +1171,7 @@ class _FakeSegment:
         *,
         id: int = 1,
         text: str = "original raw text",
-        corrected_text: Optional[str] = None,
+        corrected_text: str | None = None,
         has_correction: bool = False,
     ) -> None:
         self.id = id

--- a/tests/unit/services/test_transcript_service_batch.py
+++ b/tests/unit/services/test_transcript_service_batch.py
@@ -13,15 +13,13 @@ objects are replaced with MagicMock/AsyncMock stand-ins.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 # CRITICAL: Module-level asyncio marker ensures async tests execute (not skip)
 # when running under pytest-cov. See CLAUDE.md § pytest-asyncio Coverage.
-pytestmark = pytest.mark.asyncio
-
 from chronovista.models.enums import DownloadReason
 from chronovista.models.transcript_source import (
     RawTranscriptData,
@@ -35,7 +33,6 @@ from chronovista.services.transcript_service import (
     TranscriptService,
     TranscriptServiceUnavailableError,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -54,7 +51,7 @@ def _make_snippet_mock(text: str = "Hello world", start: float = 0.0, duration: 
 
 
 def _make_fetched_transcript(
-    snippets: Optional[List[MagicMock]] = None,
+    snippets: list[MagicMock] | None = None,
 ) -> MagicMock:
     """Return a mock FetchedTranscript that is iterable over snippet mocks."""
     fetched = MagicMock()
@@ -70,8 +67,8 @@ def _make_transcript_mock(
     language: str = "English",
     is_generated: bool = False,
     is_translatable: bool = True,
-    translation_languages: Optional[List[Dict[str, str]]] = None,
-    fetch_snippets: Optional[List[MagicMock]] = None,
+    translation_languages: list[dict[str, str]] | None = None,
+    fetch_snippets: list[MagicMock] | None = None,
 ) -> MagicMock:
     """Return a mock youtube-transcript-api Transcript object."""
     t = MagicMock()
@@ -84,7 +81,7 @@ def _make_transcript_mock(
     return t
 
 
-def _make_transcript_list(transcripts: List[MagicMock]) -> MagicMock:
+def _make_transcript_list(transcripts: list[MagicMock]) -> MagicMock:
     """Return a mock TranscriptList that iterates over the given transcripts."""
     tl = MagicMock()
     tl.__iter__ = MagicMock(return_value=iter(transcripts))
@@ -353,7 +350,7 @@ class TestGetTranscriptsForLanguages:
         # Mock get_transcript to return a plausible transcript for 'en' and raise for 'fr'
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             if language_codes and language_codes[0] == "en":
@@ -422,11 +419,11 @@ class TestGetTranscriptsForLanguages:
         """When _api_available is False, method falls back to per-language get_transcript() calls."""
         service = _service_without_api()
 
-        call_log: List[str] = []
+        call_log: list[str] = []
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             lang = (language_codes or ["en"])[0]
@@ -454,7 +451,7 @@ class TestGetTranscriptsForLanguages:
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             raise TranscriptNotFoundError("No transcript")
@@ -577,7 +574,7 @@ class TestGetTranscriptsForLanguages:
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             raise TranscriptNotFoundError("not available")
@@ -920,7 +917,7 @@ def _minimal_snippet_dict(
     text: str = "Hello",
     start: float = 0.0,
     duration: float = 2.0,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     return {"text": text, "start": start, "duration": duration}
 
 
@@ -1342,7 +1339,7 @@ class TestApiListIpBlockEarlyTermination:
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             nonlocal en_call_count
@@ -1358,7 +1355,7 @@ class TestApiListIpBlockEarlyTermination:
             "chronovista.services.transcript_service.YouTubeTranscriptApi",
             return_value=mock_api_instance,
         ):
-            result = await service.get_transcripts_for_languages(
+            await service.get_transcripts_for_languages(
                 video_id=VIDEO_ID,
                 language_codes=["en", "es", "fr"],
             )
@@ -1377,7 +1374,7 @@ class TestApiListIpBlockEarlyTermination:
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             raw = _build_minimal_raw_data(video_id, "en")
@@ -1412,7 +1409,7 @@ class TestApiListIpBlockEarlyTermination:
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             raise Exception("IP is still blocked")
@@ -1445,11 +1442,11 @@ class TestApiListIpBlockEarlyTermination:
             "your ip is blocked by YouTube"
         )
 
-        called_language_codes: List[str] = []
+        called_language_codes: list[str] = []
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             called_language_codes.extend(language_codes or [])
@@ -1460,12 +1457,11 @@ class TestApiListIpBlockEarlyTermination:
         with patch(
             "chronovista.services.transcript_service.YouTubeTranscriptApi",
             return_value=mock_api_instance,
-        ):
-            with pytest.raises(TranscriptServiceUnavailableError):
-                await service.get_transcripts_for_languages(
-                    video_id=VIDEO_ID,
-                    language_codes=["en", "es", "fr", "de"],
-                )
+        ), pytest.raises(TranscriptServiceUnavailableError):
+            await service.get_transcripts_for_languages(
+                video_id=VIDEO_ID,
+                language_codes=["en", "es", "fr", "de"],
+            )
 
         # Only the English last-resort call should have been attempted
         assert "es" not in called_language_codes
@@ -1483,7 +1479,7 @@ class TestApiListIpBlockEarlyTermination:
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             raise Exception("still blocked")
@@ -1522,11 +1518,11 @@ class TestApiListNonIpBlockWithConsecutiveIpBlockFallback:
         mock_api_instance = MagicMock()
         mock_api_instance.list.side_effect = RuntimeError("quota exceeded")
 
-        called_langs: List[str] = []
+        called_langs: list[str] = []
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             lang = (language_codes or ["en"])[0]
@@ -1564,11 +1560,11 @@ class TestApiListNonIpBlockWithConsecutiveIpBlockFallback:
         mock_api_instance = MagicMock()
         mock_api_instance.list.side_effect = RuntimeError("network error")
 
-        call_log: List[str] = []
+        call_log: list[str] = []
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             lang = (language_codes or ["en"])[0]
@@ -1614,11 +1610,11 @@ class TestApiListNonIpBlockWithConsecutiveIpBlockFallback:
         mock_api_instance = MagicMock()
         mock_api_instance.list.side_effect = RuntimeError("connection reset")
 
-        call_log: List[str] = []
+        call_log: list[str] = []
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             lang = (language_codes or ["en"])[0]
@@ -1663,11 +1659,11 @@ class TestApiListNonIpBlockWithConsecutiveIpBlockFallback:
         mock_api_instance = MagicMock()
         mock_api_instance.list.side_effect = RuntimeError("network failure")
 
-        call_log: List[str] = []
+        call_log: list[str] = []
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             lang = (language_codes or ["en"])[0]
@@ -1959,7 +1955,7 @@ class TestIpBlockPartialSuccessDoesNotRaise:
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             raw = _build_minimal_raw_data(video_id, "en")
@@ -2038,11 +2034,11 @@ class TestIpBlockPartialSuccessDoesNotRaise:
         mock_api_instance = MagicMock()
         mock_api_instance.list.side_effect = RuntimeError("network error")
 
-        call_log: List[str] = []
+        call_log: list[str] = []
 
         async def _mock_get_transcript(
             video_id: str,
-            language_codes: Optional[List[str]] = None,
+            language_codes: list[str] | None = None,
             download_reason: DownloadReason = DownloadReason.USER_REQUEST,
         ) -> EnhancedVideoTranscriptBase:
             lang = (language_codes or ["en"])[0]

--- a/tests/unit/services/test_user_video_seeder.py
+++ b/tests/unit/services/test_user_video_seeder.py
@@ -4,15 +4,13 @@ Tests for UserVideoSeeder - creates user-video relationships from watch history.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 # Mark all async tests in this module
-pytestmark = pytest.mark.asyncio
-
 from chronovista.models.takeout.takeout_data import TakeoutData
 from chronovista.models.user_video import UserVideoCreate
 from chronovista.repositories.user_video_repository import UserVideoRepository
@@ -85,7 +83,7 @@ class TestUserVideoSeederSeeding:
                     title="Never Gonna Give You Up",
                     title_url=f"https://www.youtube.com/watch?v={TestIds.NEVER_GONNA_GIVE_YOU_UP}",
                     channel_name="Rick Astley",
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                     video_id=TestIds.NEVER_GONNA_GIVE_YOU_UP,
                     channel_id=TestIds.RICK_ASTLEY_CHANNEL,
                 ),
@@ -93,7 +91,7 @@ class TestUserVideoSeederSeeding:
                     title="Test Video 1",
                     title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
                     channel_name="Test Channel",
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                     video_id=TestIds.TEST_VIDEO_1,
                     channel_id=TestIds.TEST_CHANNEL_1,
                 ),
@@ -101,7 +99,7 @@ class TestUserVideoSeederSeeding:
                     title="Test Video 2",
                     title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_2}",
                     channel_name="Test Channel 2",
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                     video_id=TestIds.TEST_VIDEO_2,
                     channel_id=TestIds.TEST_CHANNEL_2,
                 ),
@@ -142,7 +140,7 @@ class TestUserVideoSeederSeeding:
                 "get_by_composite_key",
                 new_callable=AsyncMock,
                 return_value=None,
-            ) as mock_get,
+            ),
             patch.object(
                 seeder.user_video_repo, "create", new_callable=AsyncMock
             ) as mock_create,
@@ -201,7 +199,7 @@ class TestUserVideoSeederSeeding:
             return_value=None,
         ):
 
-            result = await seeder.seed(mock_session, sample_takeout_data, progress)
+            await seeder.seed(mock_session, sample_takeout_data, progress)
 
             assert "user_videos" in progress_calls
 
@@ -234,7 +232,7 @@ class TestUserVideoSeederSeeding:
             title="Test Video",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -259,7 +257,7 @@ class TestUserVideoSeederSeeding:
             title="With Timestamp",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),  # Has timestamp
+            watched_at=datetime.now(UTC),  # Has timestamp
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
             channel_url=f"https://www.youtube.com/channel/{TestIds.TEST_CHANNEL_1}",
@@ -281,7 +279,7 @@ class TestUserVideoSeederSeeding:
             title="With Timestamp 2",
             title_url=f"https://www.youtube.com/watch?v={TestIds.NEVER_GONNA_GIVE_YOU_UP}",
             channel_name="Rick Astley",
-            watched_at=datetime.now(timezone.utc),  # Has timestamp
+            watched_at=datetime.now(UTC),  # Has timestamp
             video_id=TestIds.NEVER_GONNA_GIVE_YOU_UP,
             channel_id=TestIds.RICK_ASTLEY_CHANNEL,
             channel_url=f"https://www.youtube.com/channel/{TestIds.RICK_ASTLEY_CHANNEL}",
@@ -306,7 +304,7 @@ class TestUserVideoSeederSeeding:
                 "get_by_composite_key",
                 new_callable=AsyncMock,
                 return_value=None,
-            ) as mock_get,
+            ),
             patch.object(
                 seeder.user_video_repo, "create", new_callable=AsyncMock
             ) as mock_create,
@@ -354,7 +352,7 @@ class TestUserVideoSeederBatchProcessing:
                     title=f"Video {i}",
                     title_url=f"https://www.youtube.com/watch?v={YouTubeIdFactory.create_video_id(f'video_{i}')}",
                     channel_name=f"Channel {i}",
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                     video_id=YouTubeIdFactory.create_video_id(f"video_{i}"),
                     channel_id=YouTubeIdFactory.create_channel_id(f"channel_{i}"),
                 )
@@ -415,7 +413,7 @@ class TestUserVideoSeederEdgeCases:
                     title="Video Without ID",
                     title_url="https://www.youtube.com/watch?v=invalid",
                     channel_name="Test Channel",
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                     video_id=None,  # Missing video ID
                     channel_id=TestIds.TEST_CHANNEL_1,
                 ),
@@ -433,7 +431,7 @@ class TestUserVideoSeederEdgeCases:
     ) -> None:
         """Test creating user video from watch entry with edge case timestamp."""
         # Create watch entry with very old timestamp
-        old_timestamp = datetime(1990, 1, 1, tzinfo=timezone.utc)
+        old_timestamp = datetime(1990, 1, 1, tzinfo=UTC)
         watch_entry = create_takeout_watch_entry(
             title="Old Video",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
@@ -452,7 +450,7 @@ class TestUserVideoSeederEdgeCases:
         self, seeder: UserVideoSeeder, mock_session: AsyncMock
     ) -> None:
         """Test handling duplicate watches of same video at same time."""
-        same_timestamp = datetime.now(timezone.utc)
+        same_timestamp = datetime.now(UTC)
 
         data = create_takeout_data(
             takeout_path=Path("/test/takeout"),
@@ -499,7 +497,7 @@ class TestUserVideoSeederEdgeCases:
             title="Test Video",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -519,7 +517,7 @@ class TestUserVideoSeederEdgeCases:
             title="Test Video",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -528,8 +526,8 @@ class TestUserVideoSeederEdgeCases:
 
         # Check fields that actually exist in the implementation
         assert user_video_create is not None
-        assert user_video_create.liked == False  # Default value
-        assert user_video_create.saved_to_playlist == False  # Default value
+        assert not user_video_create.liked  # Default value
+        assert not user_video_create.saved_to_playlist  # Default value
 
 
 class TestUserVideoSeederDependencies:

--- a/tests/unit/services/test_video_seeder.py
+++ b/tests/unit/services/test_video_seeder.py
@@ -4,18 +4,15 @@ Tests for VideoSeeder - creates videos from watch history.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 # Mark all async tests in this module
-pytestmark = pytest.mark.asyncio
-
 from chronovista.models.enums import LanguageCode
-from chronovista.models.takeout.takeout_data import TakeoutData, TakeoutWatchEntry
+from chronovista.models.takeout.takeout_data import TakeoutData
 from chronovista.models.video import VideoCreate
 from chronovista.repositories.video_repository import VideoRepository
 from chronovista.services.seeding.base_seeder import ProgressCallback, SeedResult
@@ -87,7 +84,7 @@ class TestVideoSeederSeeding:
                 title="Never Gonna Give You Up",
                 title_url=f"https://www.youtube.com/watch?v={TestIds.NEVER_GONNA_GIVE_YOU_UP}",
                 channel_name="Rick Astley",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 video_id=TestIds.NEVER_GONNA_GIVE_YOU_UP,
                 channel_id=TestIds.RICK_ASTLEY_CHANNEL,
             ),
@@ -95,7 +92,7 @@ class TestVideoSeederSeeding:
                 title="Test Video 1",
                 title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
                 channel_name="Test Channel 1",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 video_id=TestIds.TEST_VIDEO_1,
                 channel_id=TestIds.TEST_CHANNEL_1,
             ),
@@ -103,7 +100,7 @@ class TestVideoSeederSeeding:
                 title="Test Video 2",
                 title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_2}",
                 channel_name="Test Channel 2",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 video_id=TestIds.TEST_VIDEO_2,
                 channel_id=TestIds.TEST_CHANNEL_2,
             ),
@@ -149,7 +146,7 @@ class TestVideoSeederSeeding:
                 "get_by_video_id",
                 new_callable=AsyncMock,
                 return_value=None,
-            ) as mock_get,
+            ),
             patch.object(
                 seeder.video_repo, "create", new_callable=AsyncMock
             ) as mock_create,
@@ -215,7 +212,7 @@ class TestVideoSeederSeeding:
                     title="Test Video",
                     title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
                     channel_name="Test Channel",
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                     video_id=TestIds.TEST_VIDEO_1,
                     channel_id=TestIds.TEST_CHANNEL_1,  # Has real channel_id
                 ),
@@ -276,7 +273,7 @@ class TestVideoSeederSeeding:
                     title="Test Video",
                     title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
                     channel_name="Some Channel Name",  # Has name
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                     video_id=TestIds.TEST_VIDEO_1,
                     channel_id=None,  # No channel_id
                     channel_url=None,  # No URL either - prevents model validator from extracting channel_id
@@ -335,7 +332,7 @@ class TestVideoSeederSeeding:
             return_value=None,
         ):
 
-            result = await seeder.seed(mock_session, sample_takeout_data, progress)
+            await seeder.seed(mock_session, sample_takeout_data, progress)
 
             assert "videos" in progress_calls
 
@@ -366,7 +363,7 @@ class TestVideoSeederSeeding:
             title="Test Video Title",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -390,7 +387,7 @@ class TestVideoSeederSeeding:
                 title="Same Video First Watch",
                 title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
                 channel_name="Test Channel",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 video_id=TestIds.TEST_VIDEO_1,  # Same ID
                 channel_id=TestIds.TEST_CHANNEL_1,
             ),
@@ -398,7 +395,7 @@ class TestVideoSeederSeeding:
                 title="Same Video Second Watch",
                 title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
                 channel_name="Test Channel",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 video_id=TestIds.TEST_VIDEO_1,  # Same ID again
                 channel_id=TestIds.TEST_CHANNEL_1,
             ),
@@ -406,7 +403,7 @@ class TestVideoSeederSeeding:
                 title="Different Video",
                 title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_2}",
                 channel_name="Test Channel",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 video_id=TestIds.TEST_VIDEO_2,  # Different ID
                 channel_id=TestIds.TEST_CHANNEL_1,
             ),
@@ -470,7 +467,7 @@ class TestVideoSeederBatchProcessing:
                     title=f"Video {i}",
                     title_url=f"https://www.youtube.com/watch?v={YouTubeIdFactory.create_video_id(f'video_{i}')}",
                     channel_name=f"Channel {i}",
-                    watched_at=datetime.now(timezone.utc),
+                    watched_at=datetime.now(UTC),
                     video_id=YouTubeIdFactory.create_video_id(f"video_{i}"),
                     channel_id=YouTubeIdFactory.create_channel_id(f"channel_{i}"),
                 )
@@ -528,7 +525,7 @@ class TestVideoSeederEdgeCases:
                 title="Video Without ID",
                 title_url="https://www.youtube.com/watch?v=invalid",
                 channel_name="Test Channel",
-                watched_at=datetime.now(timezone.utc),
+                watched_at=datetime.now(UTC),
                 video_id=None,  # Missing video ID
                 channel_id=TestIds.TEST_CHANNEL_1,
             ),
@@ -552,7 +549,7 @@ class TestVideoSeederEdgeCases:
             title="Video Without Channel ID",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Unknown Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=None,  # Missing channel ID
         )
@@ -570,7 +567,7 @@ class TestVideoSeederEdgeCases:
             title="",  # Empty title
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -586,7 +583,7 @@ class TestVideoSeederEdgeCases:
             title="Video with émojis 🎵 and spëcial chars!",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -604,7 +601,7 @@ class TestVideoSeederEdgeCases:
             title=long_title,
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -620,7 +617,7 @@ class TestVideoSeederEdgeCases:
             title="Test Video",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name=None,  # Missing channel name
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -673,7 +670,7 @@ class TestVideoSeederDefaultValues:
             title="Test Video",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -688,7 +685,7 @@ class TestVideoSeederDefaultValues:
             title="Test Video",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",
             channel_name="Test Channel",
-            watched_at=datetime.now(timezone.utc),
+            watched_at=datetime.now(UTC),
             video_id=TestIds.TEST_VIDEO_1,
             channel_id=TestIds.TEST_CHANNEL_1,
         )
@@ -699,7 +696,7 @@ class TestVideoSeederDefaultValues:
 
     def test_upload_date_estimation(self, seeder: VideoSeeder) -> None:
         """Test upload date estimation from watch date."""
-        watch_date = datetime.now(timezone.utc)
+        watch_date = datetime.now(UTC)
         watch_entry = create_takeout_watch_entry(
             title="Test Video",
             title_url=f"https://www.youtube.com/watch?v={TestIds.TEST_VIDEO_1}",

--- a/tests/unit/services/test_youtube_service.py
+++ b/tests/unit/services/test_youtube_service.py
@@ -7,16 +7,13 @@ typed Pydantic models instead of Dict[str, Any].
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from chronovista.exceptions import ValidationError, YouTubeAPIError
 from chronovista.services.youtube_service import YouTubeService
-
-pytestmark = pytest.mark.asyncio
 
 
 # Helper function to create valid mock API responses
@@ -300,7 +297,7 @@ class TestYouTubeService:
         """Test get_my_channel when no channel found."""
         youtube_service._service = mock_service_client
 
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
         mock_service_client.channels.return_value.list.return_value = mock_request
@@ -344,7 +341,7 @@ class TestYouTubeService:
         """Test get_channel_details when channel not found."""
         youtube_service._service = mock_service_client
 
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
         mock_service_client.channels.return_value.list.return_value = mock_request
@@ -408,7 +405,7 @@ class TestYouTubeService:
         }
 
         # Mock empty playlist response
-        mock_playlist_response: Dict[str, Any] = {"items": []}
+        mock_playlist_response: dict[str, Any] = {"items": []}
 
         mock_request1 = MagicMock()
         mock_request1.execute.return_value = mock_channel_response
@@ -456,7 +453,7 @@ class TestYouTubeService:
         """Test get_video_details with empty video list."""
         youtube_service._service = mock_service_client
 
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
         mock_service_client.videos.return_value.list.return_value = mock_request
@@ -701,7 +698,7 @@ class TestYouTubeServiceErrorHandling:
         """Test get_my_playlists with empty response."""
         youtube_service._service = mock_service_client
 
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
         mock_service_client.playlists.return_value.list.return_value = mock_request
@@ -717,7 +714,7 @@ class TestYouTubeServiceErrorHandling:
         """Test get_video_captions with empty response."""
         youtube_service._service = mock_service_client
 
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
         mock_service_client.captions.return_value.list.return_value = mock_request
@@ -733,7 +730,7 @@ class TestYouTubeServiceErrorHandling:
         """Test search_my_videos with empty query."""
         youtube_service._service = mock_service_client
 
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
         mock_service_client.search.return_value.list.return_value = mock_request
@@ -785,7 +782,7 @@ class TestYouTubeServiceEdgeCases:
             ]
         }
 
-        mock_playlist_response: Dict[str, Any] = {"items": []}
+        mock_playlist_response: dict[str, Any] = {"items": []}
 
         mock_request1 = MagicMock()
         mock_request1.execute.return_value = mock_channel_response
@@ -911,7 +908,7 @@ class TestYouTubeServiceIntegration:
                     {"contentDetails": {"relatedPlaylists": {"uploads": "UUtest123456789012345"}}}
                 ]
             }
-            mock_video_response: Dict[str, Any] = {"items": []}
+            mock_video_response: dict[str, Any] = {"items": []}
 
             # Mock the two different calls for get_channel_videos
             def mock_execute_side_effect():
@@ -955,7 +952,7 @@ class TestYouTubeServiceMissingCoverage:
         youtube_service._service = mock_service_client
 
         # Mock empty response for channel details
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
         mock_service_client.channels.return_value.list.return_value = mock_request
@@ -1031,7 +1028,7 @@ class TestYouTubeServiceMissingCoverage:
         youtube_service._service = mock_service_client
 
         # Mock empty channel response
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
         mock_service_client.channels.return_value.list.return_value = mock_request
@@ -1082,7 +1079,7 @@ class TestYouTubeServiceMissingCoverage:
         }
 
         # Mock empty playlist response
-        mock_playlist_response: Dict[str, Any] = {"items": []}
+        mock_playlist_response: dict[str, Any] = {"items": []}
 
         # Mock the channel call
         mock_request1 = MagicMock()
@@ -1215,7 +1212,7 @@ class TestYouTubeServiceMissingCoverage:
     ):
         """Test video categories when no categories found."""
         # Mock empty response
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
         mock_service_client.videoCategories.return_value.list.return_value = (
@@ -1443,7 +1440,7 @@ class TestYouTubeServicePagination:
         """Test get_my_playlists with empty results."""
         object.__setattr__(youtube_service, "_service", mock_service_client)
 
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
 
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response
@@ -1618,7 +1615,7 @@ class TestYouTubeServicePagination:
         """Test get_playlist_videos with empty results."""
         object.__setattr__(youtube_service, "_service", mock_service_client)
 
-        mock_response: Dict[str, Any] = {"items": []}
+        mock_response: dict[str, Any] = {"items": []}
 
         mock_request = MagicMock()
         mock_request.execute.return_value = mock_response

--- a/tests/unit/services/test_youtube_service_batch.py
+++ b/tests/unit/services/test_youtube_service_batch.py
@@ -18,8 +18,6 @@ import pytest
 
 from chronovista.services.youtube_service import YouTubeService
 
-pytestmark = pytest.mark.asyncio
-
 
 class TestFetchPlaylistsBatched:
     """Tests for fetch_playlists_batched method."""
@@ -38,7 +36,7 @@ class TestFetchPlaylistsBatched:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test that fetch_playlists_batched returns playlists and not_found set."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         # Mock successful API response
         mock_response: dict[str, Any] = {
@@ -97,7 +95,7 @@ class TestFetchPlaylistsBatched:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test that not_found set contains IDs not returned by API."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         # Mock response with only some playlists found
         mock_response: dict[str, Any] = {
@@ -214,7 +212,7 @@ class TestAPIErrorHandling:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test that API error in one batch doesn't stop remaining batches."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         # Simulate fetch with error handling
         playlist_ids = [f"PL{i:04d}" for i in range(100)]
@@ -228,7 +226,7 @@ class TestAPIErrorHandling:
             {"items": [{"id": "PL0050", "snippet": {"title": "Playlist 50"}}]},
         ]
 
-        for i, batch_idx in enumerate(range(0, len(playlist_ids), batch_size)):
+        for i, _batch_idx in enumerate(range(0, len(playlist_ids), batch_size)):
             try:
                 result = batch_results[i]
                 if "error" in result:
@@ -250,7 +248,7 @@ class TestAPIErrorHandling:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test that partial results are returned when some batches fail."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         # Successfully fetched before error
         successful_items = [
@@ -269,7 +267,7 @@ class TestAPIErrorHandling:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test handling of rate limit (quota exceeded) errors."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         rate_limit_error = Exception(
             "quotaExceeded: The request cannot be completed because you have exceeded your quota."
@@ -285,7 +283,7 @@ class TestAPIErrorHandling:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test handling of network errors."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         network_error = Exception("Network connection failed")
 
@@ -317,7 +315,7 @@ class TestPartialResults:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test fetching where some playlists exist and some don't."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         requested_ids = ["PLexists1", "PLexists2", "PLdeleted1", "PLprivate1"]
 
@@ -365,7 +363,6 @@ class TestPartialResults:
         """Test when no requested playlists are found (all deleted/private)."""
         requested_ids = ["PLdeleted1", "PLdeleted2", "PLdeleted3"]
 
-        mock_response: dict[str, list[Any]] = {"items": []}
 
         found_ids: set[str] = set()
         not_found = set(requested_ids) - found_ids
@@ -437,7 +434,7 @@ class TestEmptyPlaylistInput:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test that no API calls are made for empty input."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         playlist_ids: list[str] = []
         api_call_count = 0
@@ -479,7 +476,7 @@ class TestPlaylistBatchFetchIntegration:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test complete batch fetch workflow with realistic data."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         # Simulate 75 playlist IDs
         playlist_ids = [f"PLtest{i:04d}" for i in range(75)]
@@ -527,7 +524,7 @@ class TestPlaylistBatchFetchIntegration:
         self, youtube_service: YouTubeService, mock_service_client: MagicMock
     ) -> None:
         """Test batch fetch with playlists of different privacy statuses."""
-        setattr(youtube_service, "_service", mock_service_client)
+        youtube_service._service = mock_service_client  # type: ignore[assignment]
 
         mock_playlists: list[dict[str, Any]] = [
             {

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -16,17 +16,15 @@ Test Organization:
 - Async tests use pytestmark for proper coverage integration
 """
 
-import pytest
-from pathlib import Path
-from contextvars import ContextVar
 from unittest.mock import MagicMock
 
-# Module-level marker ensures all async tests work with coverage
-pytestmark = pytest.mark.asyncio
+import pytest
 
-from chronovista.container import Container, RequestContext, container
+# Module-level marker ensures all async tests work with coverage
+from chronovista.container import Container, RequestContext
 from chronovista.repositories import (
     ChannelRepository,
+    ChannelTopicRepository,
     PlaylistRepository,
     TopicCategoryRepository,
     UserVideoRepository,
@@ -34,12 +32,10 @@ from chronovista.repositories import (
     VideoRepository,
     VideoTagRepository,
     VideoTopicRepository,
-    ChannelTopicRepository,
 )
 from chronovista.repositories.playlist_membership_repository import (
     PlaylistMembershipRepository,
 )
-
 
 # =============================================================================
 # Phase 2 Completion: T013-T014 (Test Setup)

--- a/tests/unit/utils/test_fuzzy.py
+++ b/tests/unit/utils/test_fuzzy.py
@@ -9,10 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
-import pytest
-
 from chronovista.utils.fuzzy import find_similar, levenshtein_distance
-
 
 # -------------------------------------------------------------------------
 # Test: levenshtein_distance


### PR DESCRIPTION
## Summary

- Fix all 2,542 ruff lint violations across 241 test files — tests now pass `ruff check` clean
- Revert `asyncio.gather()` parallelization in settings and onboarding endpoints (PR #116) — `AsyncSession` is not safe for concurrent use, causing 500 errors on `/onboarding/status`
- Fix event loop isolation bug in `TestScanAuditFlag` that caused 7 test failures in full suite runs
- Add ruff lint check on `tests/` to CI workflow

## Key Changes

### Ruff Test Cleanup (2,542 → 0)
Same approach as PR #112 for src/: auto-fix (2,681), suppress intentional test patterns (162), remove redundant markers (153).

### asyncio.gather Revert
PR #116 parallelized COUNT queries via `asyncio.gather()` on a shared `AsyncSession`. SQLAlchemy's async session doesn't support concurrent queries — it threw `IllegalStateChangeError: Method 'close()' can't be called here`. This broke the `/onboarding/status` endpoint, causing the "Sign in to download transcripts" false alarm in the frontend. Reverted to sequential awaits.

### Event Loop Fix
`TestScanAuditFlag` used `asyncio.get_event_loop().run_until_complete()` which fails in full suite runs because pytest-asyncio closes loops from earlier tests. Replaced with `asyncio.new_event_loop()` for proper isolation.

### pytestmark Removal
Removed `pytestmark = pytest.mark.asyncio` from 153 test files. With `asyncio_mode = auto` in pytest.ini, async tests are detected automatically — the marker was redundant and caused warnings on sync test functions.

## Test plan
- [x] 7,553 tests pass (full suite)
- [x] `ruff check src/chronovista/ tests/` — All checks passed
- [x] `mypy --strict` clean
- [x] 0 asyncio marker warnings on sync tests
- [x] CI pipeline passes