### PR TITLE
feat(entities): tag-based video associations on entity detail page (Feature 053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.54.0] - 2026-03-28
+
+### Added
+- **Feature 053: Entity Detail — Tag-Based Video Associations** (Issue #85)
+  - **Canonical Tag Video Association (US1)**: Entity detail page shows videos tagged with the entity's canonical tag alongside transcript mentions; entities created via classify now surface all tagged videos without requiring a transcript scan; the join path `canonical_tags → tag_aliases → video_tags` is queried at request time with no schema migration
+  - **Alias-Matched Tag Video Association (US2)**: Videos tagged with terms matching entity aliases appear on the entity detail page; adding alias "AI" to entity "Artificial Intelligence" immediately surfaces all videos tagged "AI"; uses `TagNormalizationService.normalize()` for case-insensitive matching via exact equality on `tag_aliases.normalized_form`; ASR error aliases excluded from tag matching to prevent false positives
+  - **Source Distinction (US3)**: Teal "TAG" badge (`bg-teal-100 text-teal-700`) distinguishes tag-sourced videos from transcript mentions (indigo) and manual links (green); tag-only videos link to `/videos/{id}` without timestamp params; mixed-source videos show both badges
+  - **Combined Video Count (US4+US5)**: Entity detail header shows deduplicated count across all sources (transcript + canonical tag + alias tag); entity list page continues using stored counts for performance
+  - **Three-source deduplication**: Videos appearing in multiple sources (transcript mention + canonical tag + alias match) appear once with merged `sources: ["transcript", "tag"]`; transcript-mention data preserved when present
+  - **Sort order**: Transcript-mention videos appear before tag-only videos; within each group, sorted by mention count DESC then upload date DESC
+
+### Fixed
+- ASR error aliases ("Andres", "Lopez", "elon") excluded from tag matching to prevent false positives — e.g., "elon" as an ASR alias for Ilhan Omar was matching 15 Elon Musk videos via tags
+
+### Technical
+- Backend version: 0.53.1 → 0.54.0
+- Frontend version: 0.22.0 → 0.23.0
+- 50 new tests (36 backend, 14 frontend)
+- No database migration (FR-011) — all tag associations computed via query-time JOINs
+- New repository methods: `_get_tag_associated_video_ids()`, `_get_alias_matched_tag_video_ids()`, `get_combined_video_count()`
+- `sources` vocabulary extended with `"tag"` value (additive, backward compatible)
+- Closes #85
+
 ## [0.53.1] - 2026-03-28
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.54.0] - 2026-03-28
+
+### Added
+- **Feature 053: Entity Detail — Tag-Based Video Associations** (Issue #85)
+  - Entity detail page shows videos from three sources: transcript mentions, canonical tag associations, and alias-matched tag associations
+  - Teal "TAG" source badge distinguishes tag-sourced videos from transcript mentions
+  - Combined video count in entity header reflects all sources (deduplicated)
+  - ASR error aliases excluded from tag matching to prevent false positives
+  - No database migration — all associations computed at query time
+
+### Technical
+- Backend: 0.53.1 → 0.54.0, Frontend: 0.22.0 → 0.23.0
+- 50 new tests, closes #85
+
 ## [0.53.1] - 2026-03-28
 
 ### Added

--- a/docs/user-guide/rest-api.md
+++ b/docs/user-guide/rest-api.md
@@ -1711,7 +1711,7 @@ GET /api/v1/entities/{entity_id}
 
 #### Get Entity Videos
 
-Retrieve a paginated list of videos mentioning a given entity, with up to 5 mention previews per video.
+Retrieve a paginated list of videos associated with a given entity from three sources: transcript mentions, canonical tag associations, and alias-matched tag associations. Results are deduplicated by video and sorted with transcript-mention videos first.
 
 ```
 GET /api/v1/entities/{entity_id}/videos
@@ -1735,12 +1735,37 @@ GET /api/v1/entities/{entity_id}/videos
       "mention_count": 12,
       "mentions": [
         { "segment_id": 456, "start_time": 123.5, "mention_text": "AMLO" }
-      ]
+      ],
+      "sources": ["transcript", "tag"],
+      "has_manual": false,
+      "first_mention_time": 123.5,
+      "upload_date": "2025-06-15T00:00:00Z"
+    },
+    {
+      "video_id": "xyz789",
+      "video_title": "Tagged but no transcript mention",
+      "channel_name": "Another Channel",
+      "mention_count": 0,
+      "mentions": [],
+      "sources": ["tag"],
+      "has_manual": false,
+      "first_mention_time": null,
+      "upload_date": "2024-11-20T00:00:00Z"
     }
   ],
   "pagination": { "total": 87, "limit": 20, "offset": 0, "has_more": true }
 }
 ```
+
+**Video Sources** (Feature 053):
+
+| Source | Meaning | `mention_count` | `mentions` | `first_mention_time` |
+|--------|---------|-----------------|------------|---------------------|
+| `transcript` | Entity name found in transcript text | > 0 | Up to 5 previews | Timestamp (seconds) |
+| `tag` | Video tagged with entity's canonical tag or alias-matched tag | 0 | `[]` | `null` |
+| `manual` | User manually linked entity to video | 0 | `[]` | `null` |
+
+Videos may have multiple sources (e.g., `["transcript", "tag"]`). ASR error aliases are excluded from tag matching to prevent false positives.
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.23.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/entityMentions.ts
+++ b/frontend/src/api/entityMentions.ts
@@ -48,11 +48,22 @@ export interface EntityVideoResult {
   /** Number of transcript-derived mentions (excludes manual). */
   mention_count: number;
   mentions: MentionPreview[];
-  /** Detection method categories present, e.g. ["transcript", "manual"]. */
+  /**
+   * Detection method categories present for this video–entity association.
+   *
+   * Known values:
+   * - `"transcript"` — entity was detected in a transcript segment via scan
+   * - `"manual"` — user created a manual association via the UI
+   * - `"tag"` — video is tagged with the entity's canonical tag (Feature 053)
+   *
+   * A single video may have multiple sources (e.g. `["transcript", "tag"]`).
+   * Tag-only videos have `mention_count: 0`, `mentions: []`, and
+   * `first_mention_time: null`.
+   */
   sources: string[];
   /** Whether a manual association exists for this entity on this video. */
   has_manual: boolean;
-  /** Earliest transcript mention timestamp; null for manual-only videos. */
+  /** Earliest transcript mention timestamp; null for manual-only or tag-only videos. */
   first_mention_time: number | null;
   /** Video upload date (ISO 8601) for sort ordering. */
   upload_date: string | null;

--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -321,8 +321,14 @@ function EntityVideoCard({
 }: EntityVideoCardProps) {
   const isManualOnly = mention_count === 0 && has_manual;
   const hasTranscript = sources.includes("transcript") && mention_count > 0;
+  const hasTag = sources.includes("tag");
 
-  const to = isManualOnly || first_mention_time == null
+  // T026: tag-only videos (no transcript mention and no manual association)
+  // link to the video page without segment/timestamp params since there is no
+  // transcript timestamp to seek to.
+  const isTagOnly = !sources.includes("transcript") && !has_manual;
+
+  const to = isTagOnly || isManualOnly || first_mention_time == null
     ? `/videos/${video_id}`
     : first_segment_id > 0
       ? `/videos/${video_id}?seg=${first_segment_id}&t=${Math.floor(first_mention_time)}`
@@ -360,6 +366,15 @@ function EntityVideoCard({
                 data-testid="manual-badge"
               >
                 MANUAL
+              </span>
+            )}
+            {/* T025: TAG badge — teal pill shown when video is associated via tag */}
+            {hasTag && (
+              <span
+                className="inline-flex items-center bg-teal-100 text-teal-700 rounded-full px-2 py-0.5 text-xs font-medium"
+                data-testid="tag-badge"
+              >
+                TAG
               </span>
             )}
           </div>

--- a/frontend/src/pages/__tests__/EntityDetailPage.tag-videos.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.tag-videos.test.tsx
@@ -1,0 +1,508 @@
+/**
+ * Tests for EntityDetailPage — Feature 053, Phase 5 (User Story 3).
+ *
+ * Coverage (T021-T024): Source Distinction Frontend Badges
+ * - T021: Video with sources: ["transcript"] renders mention count badge with timestamp link
+ * - T022: Video with sources: ["tag"] renders teal TAG badge without timestamp link
+ * - T023: Video with sources: ["transcript", "tag"] renders both badges
+ * - T024: Tag-only videos appear after transcript-mention videos in default sort
+ *
+ * Mock strategy follows the existing EntityDetailPage.test.tsx pattern:
+ * - `useEntityVideos` (hooks/useEntityMentions) — mocked to control video list
+ * - `useQuery` (@tanstack/react-query) — mocked to control entity detail fetch
+ * - `PhoneticVariantsSection` — mocked to avoid independent useQuery calls
+ * - `ExclusionPatternsSection` — mocked to keep tests focused
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { EntityDetailPage } from "../EntityDetailPage";
+
+// ---------------------------------------------------------------------------
+// Mock dependencies
+// ---------------------------------------------------------------------------
+
+vi.mock("../../hooks/useEntityMentions", () => ({
+  useEntityVideos: vi.fn(),
+  useVideoEntities: vi.fn(() => ({
+    entities: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+  useDeleteManualAssociation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    isSuccess: false,
+  })),
+  useScanEntity: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: null,
+    reset: vi.fn(),
+  })),
+  useScanVideoEntities: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: null,
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock("../../components/corrections/PhoneticVariantsSection", () => ({
+  PhoneticVariantsSection: () => null,
+}));
+
+vi.mock("../../components/corrections/ExclusionPatternsSection", () => ({
+  ExclusionPatternsSection: () => null,
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+  };
+});
+
+import { useQuery } from "@tanstack/react-query";
+import { useEntityVideos } from "../../hooks/useEntityMentions";
+import type { EntityVideoResult } from "../../api/entityMentions";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const mockEntity = {
+  entity_id: "entity-uuid-001",
+  canonical_name: "David Sheen",
+  entity_type: "person",
+  description: "Journalist and documentary filmmaker.",
+  status: "active",
+  mention_count: 5,
+  video_count: 3,
+  aliases: [] as { alias_name: string; alias_type: string; occurrence_count: number }[],
+  exclusion_patterns: [] as string[],
+};
+
+function createTranscriptVideo(overrides: Partial<EntityVideoResult> = {}): EntityVideoResult {
+  return {
+    video_id: "transcript-vid-001",
+    video_title: "Transcript Video",
+    channel_name: "Test Channel",
+    mention_count: 3,
+    mentions: [
+      { segment_id: 42, start_time: 120.0, mention_text: "David Sheen" },
+    ],
+    sources: ["transcript"],
+    has_manual: false,
+    first_mention_time: 120.0,
+    upload_date: "2024-06-20T00:00:00+00:00",
+    ...overrides,
+  };
+}
+
+function createTagOnlyVideo(overrides: Partial<EntityVideoResult> = {}): EntityVideoResult {
+  return {
+    video_id: "tag-only-vid-001",
+    video_title: "Tag Only Video",
+    channel_name: "Test Channel",
+    mention_count: 0,
+    mentions: [],
+    sources: ["tag"],
+    has_manual: false,
+    first_mention_time: null,
+    upload_date: "2024-05-10T00:00:00+00:00",
+    ...overrides,
+  };
+}
+
+function createMixedSourceVideo(overrides: Partial<EntityVideoResult> = {}): EntityVideoResult {
+  return {
+    video_id: "mixed-vid-001",
+    video_title: "Mixed Source Video",
+    channel_name: "Test Channel",
+    mention_count: 2,
+    mentions: [
+      { segment_id: 55, start_time: 60.0, mention_text: "David Sheen" },
+    ],
+    sources: ["transcript", "tag"],
+    has_manual: false,
+    first_mention_time: 60.0,
+    upload_date: "2024-07-01T00:00:00+00:00",
+    ...overrides,
+  };
+}
+
+/** Default mock return for useEntityVideos (empty). */
+const defaultUseEntityVideos = {
+  videos: [],
+  total: null,
+  pagination: null,
+  isLoading: false,
+  isError: false,
+  error: null,
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  fetchNextPage: vi.fn(),
+  loadMoreRef: { current: null },
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+function renderPage(entityId = "entity-uuid-001") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/entities/${entityId}`]}>
+        <Routes>
+          <Route path="/entities/:entityId" element={<EntityDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default: entity loads successfully
+  vi.mocked(useQuery).mockReturnValue({
+    data: mockEntity,
+    isLoading: false,
+    isError: false,
+    error: null,
+    status: "success",
+    isFetching: false,
+    isPending: false,
+    isSuccess: true,
+    isRefetching: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isStale: false,
+    dataUpdatedAt: Date.now(),
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    fetchStatus: "idle" as const,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isInitialLoading: false,
+    isEnabled: true,
+    refetch: vi.fn(),
+    promise: Promise.resolve(mockEntity),
+  } as ReturnType<typeof useQuery>);
+
+  // Default: empty video list
+  vi.mocked(useEntityVideos).mockReturnValue(defaultUseEntityVideos);
+});
+
+// ---------------------------------------------------------------------------
+// Tests — T021-T024
+// ---------------------------------------------------------------------------
+
+describe("EntityDetailPage — source distinction badges (Feature 053, US3)", () => {
+  /**
+   * T021: Video with sources: ["transcript"] renders mention count badge
+   * and a deep-link to the transcript timestamp.
+   */
+  describe("T021 — transcript-only video", () => {
+    it("renders the TRANSCRIPT badge with mention count", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTranscriptVideo({ mention_count: 3 })],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("transcript-badge");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent("TRANSCRIPT");
+      expect(badge).toHaveTextContent("3");
+    });
+
+    it("video card link includes timestamp deep-link params", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [
+          createTranscriptVideo({
+            video_id: "transcript-vid-001",
+            mentions: [{ segment_id: 42, start_time: 120.0, mention_text: "David Sheen" }],
+            first_mention_time: 120.0,
+          }),
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      const link = screen.getByRole("link", { name: /Transcript Video/i });
+      expect(link).toHaveAttribute("href", expect.stringContaining("/videos/transcript-vid-001"));
+      expect(link).toHaveAttribute("href", expect.stringContaining("seg=42"));
+      expect(link).toHaveAttribute("href", expect.stringContaining("t=120"));
+    });
+
+    it("does NOT render a TAG badge for transcript-only video", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTranscriptVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      expect(screen.queryByTestId("tag-badge")).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * T022: Video with sources: ["tag"] renders teal TAG badge.
+   * - No timestamp link (link goes to /videos/{id} without params)
+   * - No transcript badge
+   */
+  describe("T022 — tag-only video", () => {
+    it("renders the TAG badge", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTagOnlyVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("tag-badge");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent("TAG");
+    });
+
+    it("TAG badge has teal styling classes", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTagOnlyVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("tag-badge");
+      expect(badge.className).toContain("bg-teal-100");
+      expect(badge.className).toContain("text-teal-700");
+    });
+
+    it("TAG badge is not a link (no href attribute)", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTagOnlyVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("tag-badge");
+      expect(badge.tagName.toLowerCase()).not.toBe("a");
+      expect(badge).not.toHaveAttribute("href");
+    });
+
+    it("video card link goes to /videos/{id} without timestamp params for tag-only video", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTagOnlyVideo({ video_id: "tag-only-vid-001" })],
+        total: 1,
+      });
+
+      renderPage();
+
+      const link = screen.getByRole("link", { name: /Tag Only Video/i });
+      expect(link).toHaveAttribute("href", "/videos/tag-only-vid-001");
+      // No segment or timestamp query params
+      expect(link).not.toHaveAttribute("href", expect.stringContaining("seg="));
+      expect(link).not.toHaveAttribute("href", expect.stringContaining("t="));
+    });
+
+    it("does NOT render a TRANSCRIPT badge for tag-only video", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTagOnlyVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      expect(screen.queryByTestId("transcript-badge")).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * T023: Video with sources: ["transcript", "tag"] renders both badges.
+   * - Transcript badge shows mention count
+   * - TAG badge shown alongside
+   * - Deep link includes timestamp (transcript source is present)
+   */
+  describe("T023 — mixed-source video (transcript + tag)", () => {
+    it("renders both TRANSCRIPT and TAG badges", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createMixedSourceVideo({ mention_count: 2 })],
+        total: 1,
+      });
+
+      renderPage();
+
+      expect(screen.getByTestId("transcript-badge")).toBeInTheDocument();
+      expect(screen.getByTestId("tag-badge")).toBeInTheDocument();
+    });
+
+    it("TRANSCRIPT badge shows the mention count", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createMixedSourceVideo({ mention_count: 2 })],
+        total: 1,
+      });
+
+      renderPage();
+
+      const transcriptBadge = screen.getByTestId("transcript-badge");
+      expect(transcriptBadge).toHaveTextContent("TRANSCRIPT");
+      expect(transcriptBadge).toHaveTextContent("2");
+    });
+
+    it("video card link includes timestamp deep-link for mixed-source video", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [
+          createMixedSourceVideo({
+            video_id: "mixed-vid-001",
+            mentions: [{ segment_id: 55, start_time: 60.0, mention_text: "David Sheen" }],
+            first_mention_time: 60.0,
+          }),
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      const link = screen.getByRole("link", { name: /Mixed Source Video/i });
+      expect(link).toHaveAttribute("href", expect.stringContaining("/videos/mixed-vid-001"));
+      expect(link).toHaveAttribute("href", expect.stringContaining("seg=55"));
+      expect(link).toHaveAttribute("href", expect.stringContaining("t=60"));
+    });
+  });
+
+  /**
+   * T024: Tag-only videos appear after transcript-mention videos in default sort.
+   *
+   * The backend is responsible for the actual sort order, but we verify that
+   * the frontend renders videos in the order returned by the hook (no client-side
+   * reordering).  We supply a list with transcript videos first and tag-only
+   * videos last, matching the expected backend sort, and verify the DOM order.
+   */
+  describe("T024 — render order: transcript-mention videos before tag-only videos", () => {
+    it("renders transcript videos before tag-only videos as received from the hook", () => {
+      const transcriptVideo = createTranscriptVideo({
+        video_id: "t-vid",
+        video_title: "Transcript Video First",
+        mention_count: 5,
+        upload_date: "2024-06-20T00:00:00+00:00",
+      });
+      const tagOnlyVideo = createTagOnlyVideo({
+        video_id: "tag-vid",
+        video_title: "Tag Only Video Second",
+        upload_date: "2024-05-10T00:00:00+00:00",
+      });
+
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [transcriptVideo, tagOnlyVideo],
+        total: 2,
+      });
+
+      renderPage();
+
+      const transcriptTitle = screen.getByText("Transcript Video First");
+      const tagTitle = screen.getByText("Tag Only Video Second");
+
+      // compareDocumentPosition: 4 means "following" (tagTitle appears after transcriptTitle)
+      const position = transcriptTitle.compareDocumentPosition(tagTitle);
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it("transcript video has TRANSCRIPT badge; tag-only video has TAG badge (not swapped)", () => {
+      const transcriptVideo = createTranscriptVideo({
+        video_id: "t-vid",
+        video_title: "Transcript Video",
+        mention_count: 3,
+      });
+      const tagOnlyVideo = createTagOnlyVideo({
+        video_id: "tag-vid",
+        video_title: "Tag Only Video",
+      });
+
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [transcriptVideo, tagOnlyVideo],
+        total: 2,
+      });
+
+      renderPage();
+
+      // Transcript video card should have transcript badge
+      const transcriptBadges = screen.getAllByTestId("transcript-badge");
+      expect(transcriptBadges).toHaveLength(1);
+
+      // Tag-only video card should have TAG badge
+      const tagBadges = screen.getAllByTestId("tag-badge");
+      expect(tagBadges).toHaveLength(1);
+    });
+
+    it("all three source types render correctly side by side", () => {
+      const transcriptVideo = createTranscriptVideo({
+        video_id: "t-vid",
+        video_title: "Transcript Only",
+        mention_count: 4,
+      });
+      const mixedVideo = createMixedSourceVideo({
+        video_id: "mix-vid",
+        video_title: "Both Sources",
+        mention_count: 2,
+      });
+      const tagOnlyVideo = createTagOnlyVideo({
+        video_id: "tag-vid",
+        video_title: "Tag Only",
+      });
+
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [transcriptVideo, mixedVideo, tagOnlyVideo],
+        total: 3,
+      });
+
+      renderPage();
+
+      // 2 transcript badges (transcript-only + mixed)
+      expect(screen.getAllByTestId("transcript-badge")).toHaveLength(2);
+      // 2 tag badges (mixed + tag-only)
+      expect(screen.getAllByTestId("tag-badge")).toHaveLength(2);
+    });
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.53.1"
+version = "0.54.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.53.1"
+__version__ = "0.54.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -568,6 +568,15 @@ async def get_entity_detail(
     # Sort by occurrence count descending, then alphabetically for stability
     genuine_aliases.sort(key=lambda a: (-a.occurrence_count, a.alias_name))
 
+    # T030 / FR-007: Compute combined video count from all sources
+    # (transcript mentions + canonical tag + alias-matched tags) instead
+    # of using the stored named_entities.video_count which only reflects
+    # transcript-mention counts.
+    combined_video_count = await _mention_repo.get_combined_video_count(
+        session,
+        entity_id=parsed_entity_id,
+    )
+
     return {
         "data": {
             "entity_id": str(entity.id),
@@ -576,7 +585,7 @@ async def get_entity_detail(
             "description": entity.description,
             "status": entity.status,
             "mention_count": entity.mention_count or 0,
-            "video_count": entity.video_count or 0,
+            "video_count": combined_video_count,
             "aliases": [a.model_dump() for a in genuine_aliases],
             "exclusion_patterns": list(entity.exclusion_patterns or []),
         }

--- a/src/chronovista/repositories/entity_mention_repository.py
+++ b/src/chronovista/repositories/entity_mention_repository.py
@@ -58,6 +58,7 @@ from chronovista.exceptions import APIValidationError, ConflictError, NotFoundEr
 from chronovista.models.entity_mention import EntityMentionCreate
 from chronovista.models.enums import EntityAliasType
 from chronovista.repositories.base import BaseSQLAlchemyRepository
+from chronovista.services.tag_normalization import TagNormalizationService
 
 
 class EntityMentionRepository(
@@ -584,12 +585,26 @@ class EntityMentionRepository(
         limit: int = 20,
         offset: int = 0,
     ) -> tuple[list[dict[str, Any]], int]:
-        """Get paginated list of videos where an entity is mentioned.
+        """Get paginated list of videos associated with an entity.
 
-        GROUP BY video_id with transcript-only mention_count. JOINs videos for
-        title, channels for channel_name. Each result includes up to 5 mention
-        previews (transcript-derived only), source categories, has_manual flag,
-        first_mention_time, and upload_date. Sorted by upload_date DESC.
+        Returns videos from three sources:
+        1. **Transcript mentions** — entity_mentions rows (existing behaviour)
+        2. **Canonical tag associations** — videos tagged with the entity's
+           linked canonical tag (Feature 053, US1)
+        3. **Alias-matched tag associations** — videos tagged with terms
+           matching entity aliases via normalization (Feature 053, US2)
+
+        Both tag sources (canonical and alias-matched) use the same ``"tag"``
+        source indicator.  Videos appearing in multiple sources are
+        deduplicated by video_id; the transcript-mention data (mention_count,
+        mentions, first_mention_time) is preserved and ``"tag"`` is appended
+        to the ``sources`` list (only once, regardless of how many tag paths
+        matched — T020).
+
+        Sort order: transcript-mention videos first (mention_count DESC,
+        upload_date DESC), then tag-only videos (upload_date DESC).  This
+        uses a composite key ``(has_transcript_mention DESC, mention_count
+        DESC, upload_date DESC)`` per research.md Decision 5.
 
         Parameters
         ----------
@@ -608,7 +623,8 @@ class EntityMentionRepository(
         Returns
         -------
         tuple[list[dict[str, Any]], int]
-            Tuple of (results list, total count of distinct videos).
+            Tuple of (results list, total deduplicated count of distinct
+            videos across transcript mentions and tag associations).
         """
         # Build "visible names" subquery: canonical name + non-ASR-error
         # aliases.  This keeps video/mention counts consistent with the
@@ -649,9 +665,11 @@ class EntityMentionRepository(
             else None
         )
 
-        # Total count of distinct videos
-        count_stmt = (
-            select(func.count(distinct(EntityMentionDB.video_id)))
+        # ------------------------------------------------------------------
+        # Step 1: Fetch transcript-mention video_ids (for total count)
+        # ------------------------------------------------------------------
+        transcript_vid_stmt = (
+            select(distinct(EntityMentionDB.video_id))
             .outerjoin(
                 visible_names,
                 func.lower(EntityMentionDB.mention_text)
@@ -660,133 +678,159 @@ class EntityMentionRepository(
             .where(mention_filter)
         )
         if lang_filter is not None:
-            count_stmt = count_stmt.where(lang_filter)
+            transcript_vid_stmt = transcript_vid_stmt.where(lang_filter)
 
-        total_result = await session.execute(count_stmt)
-        total_count = total_result.scalar() or 0
+        transcript_vid_result = await session.execute(transcript_vid_stmt)
+        transcript_video_ids: set[str] = set(
+            transcript_vid_result.scalars().all()
+        )
+
+        # ------------------------------------------------------------------
+        # Step 2: Fetch tag-associated video_ids (Sources 2 & 3)
+        # ------------------------------------------------------------------
+        # Source 2: canonical tag path
+        canonical_tag_video_ids = await self._get_tag_associated_video_ids(
+            session, entity_id
+        )
+        # Source 3: alias-matched tag path (T019)
+        alias_tag_video_ids = await self._get_alias_matched_tag_video_ids(
+            session, entity_id
+        )
+        # Union both tag sources — same "tag" indicator for both paths
+        tag_video_ids = canonical_tag_video_ids | alias_tag_video_ids
+
+        # Deduplicated total count across all sources (T015, T020)
+        all_video_ids = transcript_video_ids | tag_video_ids
+        total_count = len(all_video_ids)
 
         if total_count == 0:
             return [], 0
 
-        # Main query: group by video_id with transcript-only mention count,
-        # source categories, has_manual, first_mention_time, upload_date.
-        main_stmt = (
-            select(
-                EntityMentionDB.video_id,
-                VideoDB.title.label("video_title"),
-                func.coalesce(
-                    Channel.title, VideoDB.channel_name_hint, "Unknown"
-                ).label("channel_name"),
-                # Transcript-only mention count (excludes manual)
-                func.count()
-                .filter(
-                    EntityMentionDB.detection_method.in_(self._TRANSCRIPT_METHODS)
-                )
-                .label("mention_count"),
-                # Collect distinct detection methods for source mapping
-                func.array_agg(
-                    distinct(EntityMentionDB.detection_method)
-                ).label("detection_methods"),
-                # Has manual flag
-                func.bool_or(
-                    EntityMentionDB.detection_method == "manual"
-                ).label("has_manual"),
-                # First mention time from transcript segments (LEFT JOIN)
-                func.min(TranscriptSegmentDB.start_time).label(
-                    "first_mention_time"
-                ),
-                # Upload date for sorting
-                VideoDB.upload_date,
-            )
-            .outerjoin(
-                visible_names,
-                func.lower(EntityMentionDB.mention_text)
-                == visible_names.c.name_lower,
-            )
-            .join(VideoDB, EntityMentionDB.video_id == VideoDB.video_id)
-            .outerjoin(Channel, VideoDB.channel_id == Channel.channel_id)
-            .outerjoin(
-                TranscriptSegmentDB,
-                EntityMentionDB.segment_id == TranscriptSegmentDB.id,
-            )
-            .where(mention_filter)
-        )
-        if lang_filter is not None:
-            main_stmt = main_stmt.where(lang_filter)
+        # ------------------------------------------------------------------
+        # Step 3: Fetch transcript-mention video details (existing logic)
+        # ------------------------------------------------------------------
+        # We still need the grouped query for transcript-mention videos
+        # to get mention_count, detection_methods, first_mention_time, etc.
+        results_dict: dict[str, dict[str, Any]] = {}
 
-        main_stmt = (
-            main_stmt.group_by(
-                EntityMentionDB.video_id,
-                VideoDB.title,
-                Channel.title,
-                VideoDB.channel_name_hint,
-                VideoDB.upload_date,
-            )
-            .order_by(VideoDB.upload_date.desc())
-            .offset(offset)
-            .limit(limit)
-        )
-
-        main_result = await session.execute(main_stmt)
-        video_rows = main_result.all()
-
-        results: list[dict[str, Any]] = []
-        for row in video_rows:
-            # Map detection methods to source categories
-            sources = sorted(
-                {
-                    self._SOURCE_CATEGORY_MAP.get(dm, dm)
-                    for dm in (row.detection_methods or [])
-                }
-            )
-
-            # Fetch up to 5 transcript-derived mention previews (skip manual)
-            preview_stmt = (
+        if transcript_video_ids:
+            main_stmt = (
                 select(
-                    EntityMentionDB.segment_id,
-                    TranscriptSegmentDB.start_time,
-                    EntityMentionDB.mention_text,
-                )
-                .join(
-                    TranscriptSegmentDB,
-                    EntityMentionDB.segment_id == TranscriptSegmentDB.id,
+                    EntityMentionDB.video_id,
+                    VideoDB.title.label("video_title"),
+                    func.coalesce(
+                        Channel.title, VideoDB.channel_name_hint, "Unknown"
+                    ).label("channel_name"),
+                    # Transcript-only mention count (excludes manual)
+                    func.count()
+                    .filter(
+                        EntityMentionDB.detection_method.in_(
+                            self._TRANSCRIPT_METHODS
+                        )
+                    )
+                    .label("mention_count"),
+                    # Collect distinct detection methods for source mapping
+                    func.array_agg(
+                        distinct(EntityMentionDB.detection_method)
+                    ).label("detection_methods"),
+                    # Has manual flag
+                    func.bool_or(
+                        EntityMentionDB.detection_method == "manual"
+                    ).label("has_manual"),
+                    # First mention time from transcript segments (LEFT JOIN)
+                    func.min(TranscriptSegmentDB.start_time).label(
+                        "first_mention_time"
+                    ),
+                    # Upload date for sorting
+                    VideoDB.upload_date,
                 )
                 .outerjoin(
                     visible_names,
                     func.lower(EntityMentionDB.mention_text)
                     == visible_names.c.name_lower,
                 )
-                .where(
-                    EntityMentionDB.entity_id == entity_id,
-                    EntityMentionDB.video_id == row.video_id,
-                    EntityMentionDB.detection_method != "manual",
-                    or_(
+                .join(VideoDB, EntityMentionDB.video_id == VideoDB.video_id)
+                .outerjoin(Channel, VideoDB.channel_id == Channel.channel_id)
+                .outerjoin(
+                    TranscriptSegmentDB,
+                    EntityMentionDB.segment_id == TranscriptSegmentDB.id,
+                )
+                .where(mention_filter)
+            )
+            if lang_filter is not None:
+                main_stmt = main_stmt.where(lang_filter)
+
+            main_stmt = main_stmt.group_by(
+                EntityMentionDB.video_id,
+                VideoDB.title,
+                Channel.title,
+                VideoDB.channel_name_hint,
+                VideoDB.upload_date,
+            )
+
+            main_result = await session.execute(main_stmt)
+            video_rows = main_result.all()
+
+            for row in video_rows:
+                # Map detection methods to source categories
+                sources = sorted(
+                    {
+                        self._SOURCE_CATEGORY_MAP.get(dm, dm)
+                        for dm in (row.detection_methods or [])
+                    }
+                )
+
+                # T013: If this video is also in tag results, append "tag"
+                if row.video_id in tag_video_ids and "tag" not in sources:
+                    sources.append("tag")
+                    sources.sort()
+
+                # Fetch up to 5 transcript-derived mention previews
+                preview_stmt = (
+                    select(
+                        EntityMentionDB.segment_id,
+                        TranscriptSegmentDB.start_time,
+                        EntityMentionDB.mention_text,
+                    )
+                    .join(
+                        TranscriptSegmentDB,
+                        EntityMentionDB.segment_id == TranscriptSegmentDB.id,
+                    )
+                    .outerjoin(
+                        visible_names,
                         func.lower(EntityMentionDB.mention_text)
                         == visible_names.c.name_lower,
-                        EntityMentionDB.detection_method == "manual",
-                    ),
+                    )
+                    .where(
+                        EntityMentionDB.entity_id == entity_id,
+                        EntityMentionDB.video_id == row.video_id,
+                        EntityMentionDB.detection_method != "manual",
+                        or_(
+                            func.lower(EntityMentionDB.mention_text)
+                            == visible_names.c.name_lower,
+                            EntityMentionDB.detection_method == "manual",
+                        ),
+                    )
                 )
-            )
-            if language_code is not None:
-                preview_stmt = preview_stmt.where(
-                    EntityMentionDB.language_code == language_code
-                )
-            preview_stmt = preview_stmt.order_by(
-                TranscriptSegmentDB.start_time.asc()
-            ).limit(5)
+                if language_code is not None:
+                    preview_stmt = preview_stmt.where(
+                        EntityMentionDB.language_code == language_code
+                    )
+                preview_stmt = preview_stmt.order_by(
+                    TranscriptSegmentDB.start_time.asc()
+                ).limit(5)
 
-            preview_result = await session.execute(preview_stmt)
-            previews = [
-                {
-                    "segment_id": p.segment_id,
-                    "start_time": p.start_time,
-                    "mention_text": p.mention_text,
-                }
-                for p in preview_result.all()
-            ]
+                preview_result = await session.execute(preview_stmt)
+                previews = [
+                    {
+                        "segment_id": p.segment_id,
+                        "start_time": p.start_time,
+                        "mention_text": p.mention_text,
+                    }
+                    for p in preview_result.all()
+                ]
 
-            results.append(
-                {
+                results_dict[row.video_id] = {
                     "video_id": row.video_id,
                     "video_title": row.video_title,
                     "channel_name": row.channel_name,
@@ -805,9 +849,148 @@ class EntityMentionRepository(
                         else None
                     ),
                 }
+
+        # ------------------------------------------------------------------
+        # Step 4: Fetch tag-only video details (T012)
+        # ------------------------------------------------------------------
+        tag_only_ids = tag_video_ids - transcript_video_ids
+        if tag_only_ids:
+            tag_meta_stmt = (
+                select(
+                    VideoDB.video_id,
+                    VideoDB.title.label("video_title"),
+                    func.coalesce(
+                        Channel.title, VideoDB.channel_name_hint, "Unknown"
+                    ).label("channel_name"),
+                    VideoDB.upload_date,
+                )
+                .outerjoin(Channel, VideoDB.channel_id == Channel.channel_id)
+                .where(VideoDB.video_id.in_(tag_only_ids))
+            )
+            tag_meta_result = await session.execute(tag_meta_stmt)
+            tag_meta_rows = tag_meta_result.all()
+
+            for row in tag_meta_rows:
+                results_dict[row.video_id] = {
+                    "video_id": row.video_id,
+                    "video_title": row.video_title,
+                    "channel_name": row.channel_name,
+                    "mention_count": 0,
+                    "mentions": [],
+                    "sources": ["tag"],
+                    "has_manual": False,
+                    "first_mention_time": None,
+                    "upload_date": (
+                        row.upload_date.isoformat()
+                        if row.upload_date is not None
+                        else None
+                    ),
+                }
+
+        # ------------------------------------------------------------------
+        # Step 5: Sort — transcript-mention videos first, then tag-only (T014)
+        # ------------------------------------------------------------------
+        # Composite sort key: (has_transcript_mention DESC, mention_count DESC,
+        # upload_date DESC)  — per research.md Decision 5
+        def _sort_key(item: dict[str, Any]) -> tuple[int, int, str]:
+            has_transcript = 1 if item["mention_count"] > 0 or any(
+                s in ("transcript", "manual") for s in item["sources"]
+            ) else 0
+            return (
+                has_transcript,
+                item["mention_count"],
+                item["upload_date"] or "",
             )
 
-        return results, total_count
+        sorted_results = sorted(
+            results_dict.values(), key=_sort_key, reverse=True
+        )
+
+        # ------------------------------------------------------------------
+        # Step 6: Apply pagination to the merged, sorted results (T015)
+        # ------------------------------------------------------------------
+        paginated = sorted_results[offset : offset + limit]
+
+        return paginated, total_count
+
+    async def get_combined_video_count(
+        self,
+        session: AsyncSession,
+        entity_id: uuid.UUID,
+    ) -> int:
+        """Get the combined deduplicated video count for an entity.
+
+        Computes the total number of unique videos associated with an entity
+        across all three sources (transcript mentions, canonical tag
+        associations, alias-matched tag associations) without fetching
+        full video details.
+
+        This is a lightweight alternative to ``get_entity_video_list()``
+        for use cases that only need the count (e.g., entity detail header
+        video_count field per FR-007 / T030).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            The database session.
+        entity_id : uuid.UUID
+            The named entity UUID.
+
+        Returns
+        -------
+        int
+            The deduplicated count of distinct video IDs from all sources.
+        """
+        # Step 1: Fetch transcript-mention video IDs (no language filter —
+        # the header count should reflect all languages).
+        canonical_names = select(
+            func.lower(NamedEntityDB.canonical_name).label("name_lower"),
+        ).where(NamedEntityDB.id == entity_id)
+
+        non_asr_aliases = select(
+            func.lower(EntityAliasDB.alias_name).label("name_lower"),
+        ).where(
+            EntityAliasDB.entity_id == entity_id,
+            EntityAliasDB.alias_type != EntityAliasType.ASR_ERROR,
+        )
+
+        visible_names = union(canonical_names, non_asr_aliases).subquery()
+
+        mention_filter = and_(
+            EntityMentionDB.entity_id == entity_id,
+            or_(
+                func.lower(EntityMentionDB.mention_text)
+                == visible_names.c.name_lower,
+                EntityMentionDB.detection_method == "manual",
+            ),
+        )
+
+        transcript_vid_stmt = (
+            select(distinct(EntityMentionDB.video_id))
+            .outerjoin(
+                visible_names,
+                func.lower(EntityMentionDB.mention_text)
+                == visible_names.c.name_lower,
+            )
+            .where(mention_filter)
+        )
+        transcript_vid_result = await session.execute(transcript_vid_stmt)
+        transcript_video_ids: set[str] = set(
+            transcript_vid_result.scalars().all()
+        )
+
+        # Step 2: Fetch tag-associated video IDs
+        canonical_tag_video_ids = await self._get_tag_associated_video_ids(
+            session, entity_id
+        )
+        alias_tag_video_ids = await self._get_alias_matched_tag_video_ids(
+            session, entity_id
+        )
+        tag_video_ids = canonical_tag_video_ids | alias_tag_video_ids
+
+        # Deduplicated union
+        all_video_ids = transcript_video_ids | tag_video_ids
+        return len(all_video_ids)
 
     async def get_statistics(
         self,
@@ -1295,3 +1478,110 @@ class EntityMentionRepository(
         await session.flush()
 
         await self.update_entity_counters(session, [entity_id])
+
+    async def _get_tag_associated_video_ids(
+        self, session: AsyncSession, entity_id: uuid.UUID
+    ) -> set[str]:
+        """Get video IDs associated with an entity via canonical tag linkage.
+
+        Follows the query path: canonical_tags (entity_id) -> tag_aliases
+        (canonical_tag_id) -> video_tags (tag = raw_form).
+
+        Does NOT filter by canonical_tags.status -- deprecated tags still
+        return their associated videos (Decision 8).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            The database session.
+        entity_id : uuid.UUID
+            The named entity UUID.
+
+        Returns
+        -------
+        set[str]
+            Set of video_id strings from the tag association path.
+            Empty set if the entity has no linked canonical tags.
+        """
+        stmt = (
+            select(VideoTagDB.video_id)
+            .select_from(CanonicalTagDB)
+            .join(
+                TagAliasDB,
+                TagAliasDB.canonical_tag_id == CanonicalTagDB.id,
+            )
+            .join(
+                VideoTagDB,
+                VideoTagDB.tag == TagAliasDB.raw_form,
+            )
+            .where(CanonicalTagDB.entity_id == entity_id)
+            .distinct()
+        )
+        result = await session.execute(stmt)
+        return set(result.scalars().all())
+
+    async def _get_alias_matched_tag_video_ids(
+        self, session: AsyncSession, entity_id: uuid.UUID
+    ) -> set[str]:
+        """Get video IDs by matching entity aliases against tag normalized forms.
+
+        For each entity alias, normalizes the alias_name using
+        TagNormalizationService, then matches against tag_aliases.normalized_form
+        to find associated videos via video_tags.
+
+        ASR error aliases (alias_type='asr_error') are excluded because they are
+        transcript-specific patterns (e.g., "Andres", "elon") that produce false
+        positives when matched against YouTube tags.
+
+        Aliases whose normalized form is None are silently skipped (Decision 7).
+        Uses exact equality matching, not ILIKE (Decision 10).
+
+        Parameters
+        ----------
+        session : AsyncSession
+            The database session.
+        entity_id : uuid.UUID
+            The named entity UUID.
+
+        Returns
+        -------
+        set[str]
+            Set of video_id strings from the alias-matched tag path.
+            Empty set if the entity has no aliases or no aliases match tags.
+        """
+        # Fetch non-ASR aliases for this entity (ASR error aliases are
+        # transcript-specific patterns that produce false positives against tags)
+        alias_stmt = select(EntityAliasDB.alias_name).where(
+            EntityAliasDB.entity_id == entity_id,
+            EntityAliasDB.alias_type != EntityAliasType.ASR_ERROR,
+        )
+        alias_result = await session.execute(alias_stmt)
+        alias_names: list[str] = list(alias_result.scalars().all())
+
+        if not alias_names:
+            return set()
+
+        # Normalize each alias using the tag normalization pipeline
+        normalizer = TagNormalizationService()
+        normalized_forms: list[str] = []
+        for alias_name in alias_names:
+            normalized = normalizer.normalize(alias_name)
+            if normalized is not None:
+                normalized_forms.append(normalized)
+
+        if not normalized_forms:
+            return set()
+
+        # Query: tag_aliases WHERE normalized_form IN (...) -> video_tags
+        stmt = (
+            select(VideoTagDB.video_id)
+            .select_from(TagAliasDB)
+            .join(
+                VideoTagDB,
+                VideoTagDB.tag == TagAliasDB.raw_form,
+            )
+            .where(TagAliasDB.normalized_form.in_(normalized_forms))
+            .distinct()
+        )
+        result = await session.execute(stmt)
+        return set(result.scalars().all())

--- a/tests/unit/api/test_entity_tag_videos_endpoint.py
+++ b/tests/unit/api/test_entity_tag_videos_endpoint.py
@@ -1,0 +1,528 @@
+"""Unit tests for GET /api/v1/entities/{entity_id}/videos — tag-sourced videos.
+
+T011 — Verifies that tag-sourced videos returned by the entity video list
+endpoint have ``mention_count: 0``, ``mentions: []``, and
+``first_mention_time: null``.
+
+Mock strategy
+-------------
+The ``_mention_repo.get_entity_video_list`` is patched at the module level to
+return controlled results.  The ``get_db`` and ``require_auth`` FastAPI
+dependencies are overridden to inject a mock session and bypass auth.
+
+References
+----------
+- specs/053-entity-tag-videos/tasks.md — T011
+- specs/053-entity-tag-videos/spec.md — FR-014, US1 acceptance scenario 2
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.main import app
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ENDPOINT_TEMPLATE = "/api/v1/entities/{entity_id}/videos"
+
+
+def _uuid() -> uuid.UUID:
+    """Return a UUIDv7 expressed as a stdlib ``uuid.UUID`` instance."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+async def _build_client(
+    mock_session: AsyncMock,
+) -> AsyncGenerator[AsyncClient, None]:
+    """Yield an AsyncClient with get_db and require_auth overridden.
+
+    Parameters
+    ----------
+    mock_session : AsyncMock
+        The mock database session to inject via the get_db override.
+
+    Yields
+    ------
+    AsyncClient
+        A configured HTTP test client with overridden dependencies.
+    """
+
+    async def mock_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    async def mock_require_auth() -> None:
+        return None
+
+    app.dependency_overrides[get_db] = mock_get_db
+    app.dependency_overrides[require_auth] = mock_require_auth
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _make_entity_exists_session(entity_id: uuid.UUID) -> AsyncMock:
+    """Build a mock session where the entity existence check succeeds.
+
+    The get_entity_videos endpoint runs:
+        session.execute(SELECT NamedEntityDB.id WHERE id == entity_id)
+    and checks scalar_one_or_none().  This mock returns entity_id for
+    that check.
+
+    Parameters
+    ----------
+    entity_id : uuid.UUID
+        Entity UUID that should pass the existence check.
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    entity_result = MagicMock()
+    entity_result.scalar_one_or_none.return_value = entity_id
+    mock_session.execute = AsyncMock(return_value=entity_result)
+    mock_session.commit = AsyncMock()
+    return mock_session
+
+
+# ---------------------------------------------------------------------------
+# T011 — tag-sourced video has mention_count=0, mentions=[], first_mention_time=null
+# ---------------------------------------------------------------------------
+
+
+class TestEntityVideoEndpointTagSourcedVideos:
+    """Tests for GET /entities/{entity_id}/videos with tag-sourced videos (T011).
+
+    Verifies the API response shape for tag-only videos as specified by
+    FR-014: tag-only videos have mention_count=0, mentions=[],
+    first_mention_time=null.
+    """
+
+    async def test_tag_sourced_video_has_zero_mentions_and_null_timestamp(
+        self,
+    ) -> None:
+        """Tag-sourced video returns mention_count=0, mentions=[], first_mention_time=null.
+
+        Given a repository that returns one tag-only video, the API endpoint
+        should serialize it with the expected zero/empty/null values for
+        transcript-related fields.
+        """
+        entity_id = _uuid()
+        tag_video: dict[str, Any] = {
+            "video_id": "vid_tag_only_001",
+            "video_title": "Tag Only Video",
+            "channel_name": "Some Channel",
+            "mention_count": 0,
+            "mentions": [],
+            "sources": ["tag"],
+            "has_manual": False,
+            "first_mention_time": None,
+            "upload_date": "2024-07-15",
+        }
+
+        mock_session = _make_entity_exists_session(entity_id)
+
+        with patch(
+            "chronovista.api.routers.entity_mentions._mention_repo"
+        ) as mock_repo:
+            mock_repo.get_entity_video_list = AsyncMock(
+                return_value=([tag_video], 1)
+            )
+
+            async for client in _build_client(mock_session):
+                url = _ENDPOINT_TEMPLATE.format(entity_id=str(entity_id))
+                response = await client.get(url)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["data"]) == 1
+
+        video = body["data"][0]
+        assert video["video_id"] == "vid_tag_only_001"
+        assert video["mention_count"] == 0
+        assert video["mentions"] == []
+        assert video["first_mention_time"] is None
+        assert video["sources"] == ["tag"]
+        assert video["has_manual"] is False
+        assert video["upload_date"] == "2024-07-15"
+
+    async def test_mixed_transcript_and_tag_videos_in_response(
+        self,
+    ) -> None:
+        """Response contains both transcript-mention and tag-only videos.
+
+        The endpoint returns a mix of transcript-sourced and tag-sourced
+        videos.  Transcript-sourced videos have non-zero mention_count;
+        tag-sourced videos have mention_count=0.
+        """
+        entity_id = _uuid()
+        transcript_video: dict[str, Any] = {
+            "video_id": "vid_transcript_001",
+            "video_title": "Transcript Video",
+            "channel_name": "Channel A",
+            "mention_count": 3,
+            "mentions": [
+                {
+                    "segment_id": 100,
+                    "start_time": 45.2,
+                    "mention_text": "Test Entity",
+                }
+            ],
+            "sources": ["transcript"],
+            "has_manual": False,
+            "first_mention_time": 45.2,
+            "upload_date": "2024-01-10",
+        }
+        tag_video: dict[str, Any] = {
+            "video_id": "vid_tag_002",
+            "video_title": "Tag Video",
+            "channel_name": "Channel B",
+            "mention_count": 0,
+            "mentions": [],
+            "sources": ["tag"],
+            "has_manual": False,
+            "first_mention_time": None,
+            "upload_date": "2024-06-20",
+        }
+
+        mock_session = _make_entity_exists_session(entity_id)
+
+        with patch(
+            "chronovista.api.routers.entity_mentions._mention_repo"
+        ) as mock_repo:
+            mock_repo.get_entity_video_list = AsyncMock(
+                return_value=([transcript_video, tag_video], 2)
+            )
+
+            async for client in _build_client(mock_session):
+                url = _ENDPOINT_TEMPLATE.format(entity_id=str(entity_id))
+                response = await client.get(url)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["data"]) == 2
+        assert body["pagination"]["total"] == 2
+
+        # Transcript video
+        tv = body["data"][0]
+        assert tv["mention_count"] == 3
+        assert len(tv["mentions"]) == 1
+        assert tv["first_mention_time"] == 45.2
+        assert tv["sources"] == ["transcript"]
+
+        # Tag video
+        tg = body["data"][1]
+        assert tg["mention_count"] == 0
+        assert tg["mentions"] == []
+        assert tg["first_mention_time"] is None
+        assert tg["sources"] == ["tag"]
+
+    async def test_overlap_video_has_both_sources_in_response(
+        self,
+    ) -> None:
+        """Video with both transcript and tag sources has both in sources list.
+
+        When the repository returns a video with ``sources: ["tag", "transcript"]``,
+        the API response must faithfully reproduce that list.
+        """
+        entity_id = _uuid()
+        overlap_video: dict[str, Any] = {
+            "video_id": "vid_overlap_001",
+            "video_title": "Overlap Video",
+            "channel_name": "Channel C",
+            "mention_count": 5,
+            "mentions": [
+                {
+                    "segment_id": 200,
+                    "start_time": 10.0,
+                    "mention_text": "Entity Name",
+                }
+            ],
+            "sources": ["tag", "transcript"],
+            "has_manual": False,
+            "first_mention_time": 10.0,
+            "upload_date": "2024-04-01",
+        }
+
+        mock_session = _make_entity_exists_session(entity_id)
+
+        with patch(
+            "chronovista.api.routers.entity_mentions._mention_repo"
+        ) as mock_repo:
+            mock_repo.get_entity_video_list = AsyncMock(
+                return_value=([overlap_video], 1)
+            )
+
+            async for client in _build_client(mock_session):
+                url = _ENDPOINT_TEMPLATE.format(entity_id=str(entity_id))
+                response = await client.get(url)
+
+        assert response.status_code == 200
+        body = response.json()
+        video = body["data"][0]
+        assert "tag" in video["sources"]
+        assert "transcript" in video["sources"]
+        # Transcript data preserved
+        assert video["mention_count"] == 5
+        assert video["first_mention_time"] == 10.0
+
+
+# ---------------------------------------------------------------------------
+# T029 — Entity detail response video_count matches length of combined video list
+# ---------------------------------------------------------------------------
+
+
+class TestEntityDetailCombinedVideoCount:
+    """Tests for combined video count in entity detail response (T029).
+
+    Verifies that the entity detail endpoint returns a ``video_count``
+    that reflects the combined total from ``get_entity_video_list()``
+    rather than the stored ``named_entities.video_count`` value.
+
+    This validates FR-007 and US4 acceptance scenario 2.
+    """
+
+    async def test_entity_detail_video_count_matches_combined_total(
+        self,
+    ) -> None:
+        """Entity detail video_count reflects combined count, not stored DB value.
+
+        The entity has ``video_count=2`` stored in the DB (transcript-only),
+        but ``get_combined_video_count`` returns 6.  The detail endpoint
+        must return ``video_count=6``.
+        """
+        entity_id = _uuid()
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        # Entity existence + detail query — the entity has video_count=2 in DB
+        mock_entity = MagicMock()
+        mock_entity.id = entity_id
+        mock_entity.canonical_name = "Test Entity"
+        mock_entity.entity_type = "person"
+        mock_entity.description = "A test entity"
+        mock_entity.status = "active"
+        mock_entity.mention_count = 5
+        mock_entity.video_count = 2  # Stored DB value (transcript-only)
+        mock_entity.exclusion_patterns = []
+        mock_entity.aliases = []
+
+        entity_result = MagicMock()
+        entity_result.scalar_one_or_none.return_value = mock_entity
+        mock_session.execute = AsyncMock(return_value=entity_result)
+        mock_session.commit = AsyncMock()
+
+        with patch(
+            "chronovista.api.routers.entity_mentions._mention_repo"
+        ) as mock_repo:
+            # The combined video count returns 6 (from all sources)
+            mock_repo.get_combined_video_count = AsyncMock(return_value=6)
+
+            async for client in _build_client(mock_session):
+                # Fetch entity detail
+                detail_url = f"/api/v1/entities/{entity_id}"
+                detail_response = await client.get(detail_url)
+
+        assert detail_response.status_code == 200
+        detail_body = detail_response.json()
+        # video_count should reflect combined total (6), not stored DB value (2)
+        assert detail_body["data"]["video_count"] == 6
+
+    async def test_entity_detail_video_count_zero_when_no_videos(
+        self,
+    ) -> None:
+        """Entity with no videos from any source shows video_count=0.
+
+        The stored DB value is 0 and combined total is also 0.
+        """
+        entity_id = _uuid()
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        mock_entity = MagicMock()
+        mock_entity.id = entity_id
+        mock_entity.canonical_name = "Empty Entity"
+        mock_entity.entity_type = "organization"
+        mock_entity.description = None
+        mock_entity.status = "active"
+        mock_entity.mention_count = 0
+        mock_entity.video_count = 0
+        mock_entity.exclusion_patterns = []
+        mock_entity.aliases = []
+
+        entity_result = MagicMock()
+        entity_result.scalar_one_or_none.return_value = mock_entity
+        mock_session.execute = AsyncMock(return_value=entity_result)
+        mock_session.commit = AsyncMock()
+
+        with patch(
+            "chronovista.api.routers.entity_mentions._mention_repo"
+        ) as mock_repo:
+            mock_repo.get_combined_video_count = AsyncMock(return_value=0)
+
+            async for client in _build_client(mock_session):
+                detail_url = f"/api/v1/entities/{entity_id}"
+                detail_response = await client.get(detail_url)
+
+        assert detail_response.status_code == 200
+        detail_body = detail_response.json()
+        assert detail_body["data"]["video_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# T032 — Entity list response includes combined video count per entity
+# ---------------------------------------------------------------------------
+
+
+class TestEntityListCombinedVideoCount:
+    """Tests for entity list endpoint combined video count (T032, T033).
+
+    For MVP, the entity list endpoint continues to use the stored
+    ``named_entities.video_count`` value.  Computing combined counts for
+    every entity in a paginated list is deferred to a future iteration
+    due to performance concerns (correlated subquery across 3 tag tables
+    per entity row).
+
+    These tests document the current behaviour and serve as a baseline
+    for future combined-count implementation.
+
+    Decision rationale: The entity detail page already shows the correct
+    combined count via the videos endpoint pagination total.  The list
+    page stored count is acceptable for MVP because:
+    1. Most entities are created via classify (which sets video_count from
+       transcript scans), so the stored count is approximately correct.
+    2. The sort order for ``sort=mentions`` uses mention_count (not
+       video_count), so tag-only videos don't affect sort order.
+    3. Computing combined counts per entity requires N+1 queries or a
+       complex lateral join that risks degrading list endpoint performance.
+    """
+
+    async def test_entity_list_returns_stored_video_count(
+        self,
+    ) -> None:
+        """Entity list returns stored video_count per entity (MVP baseline).
+
+        The stored video_count reflects transcript-only counts.  This test
+        documents the current behaviour as a baseline for future enhancement.
+        """
+        entity_id = _uuid()
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        # Mock entity row from the list query
+        mock_entity = MagicMock()
+        mock_entity.id = entity_id
+        mock_entity.canonical_name = "Test Entity"
+        mock_entity.entity_type = "person"
+        mock_entity.description = "Description"
+        mock_entity.status = "active"
+        mock_entity.mention_count = 10
+        mock_entity.video_count = 5  # Stored DB value
+
+        # Count query returns 1
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+
+        # Entity list query
+        list_result = MagicMock()
+        list_scalars = MagicMock()
+        list_scalars.all.return_value = [mock_entity]
+        list_result.scalars.return_value = list_scalars
+
+        mock_session.execute = AsyncMock(
+            side_effect=[count_result, list_result]
+        )
+        mock_session.commit = AsyncMock()
+
+        async for client in _build_client(mock_session):
+            response = await client.get("/api/v1/entities")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["data"]) == 1
+        # For MVP, video_count reflects stored DB value
+        assert body["data"][0]["video_count"] == 5
+
+    async def test_entity_list_sort_by_mentions_uses_mention_count(
+        self,
+    ) -> None:
+        """Entity list sorted by mentions uses mention_count column (T033).
+
+        When ``sort=mentions`` is specified, the entity list sorts by
+        ``mention_count DESC``.  For MVP, this uses the stored mention_count
+        column, not a combined video count.
+
+        Future enhancement (FR-012): sort=mentions should use combined
+        video count from all sources.
+        """
+        entity_id_1 = _uuid()
+        entity_id_2 = _uuid()
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        # Entity with more mentions sorts first
+        entity_1 = MagicMock()
+        entity_1.id = entity_id_1
+        entity_1.canonical_name = "Entity Alpha"
+        entity_1.entity_type = "person"
+        entity_1.description = None
+        entity_1.status = "active"
+        entity_1.mention_count = 20
+        entity_1.video_count = 3
+
+        entity_2 = MagicMock()
+        entity_2.id = entity_id_2
+        entity_2.canonical_name = "Entity Beta"
+        entity_2.entity_type = "person"
+        entity_2.description = None
+        entity_2.status = "active"
+        entity_2.mention_count = 5
+        entity_2.video_count = 10  # More videos but fewer mentions
+
+        count_result = MagicMock()
+        count_result.scalar.return_value = 2
+
+        list_result = MagicMock()
+        list_scalars = MagicMock()
+        # Pre-sorted by mention_count DESC by the DB query
+        list_scalars.all.return_value = [entity_1, entity_2]
+        list_result.scalars.return_value = list_scalars
+
+        mock_session.execute = AsyncMock(
+            side_effect=[count_result, list_result]
+        )
+        mock_session.commit = AsyncMock()
+
+        async for client in _build_client(mock_session):
+            response = await client.get("/api/v1/entities?sort=mentions")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["data"]) == 2
+        # Entity with higher mention_count appears first
+        assert body["data"][0]["mention_count"] == 20
+        assert body["data"][1]["mention_count"] == 5

--- a/tests/unit/repositories/test_entity_mention_repository.py
+++ b/tests/unit/repositories/test_entity_mention_repository.py
@@ -1353,12 +1353,22 @@ class TestGetEntityVideoList:
         channel_name: str = "Test Channel",
         mention_count: int = 3,
     ) -> MagicMock:
-        """Build a row mock matching the main SELECT in get_entity_video_list."""
+        """Build a row mock matching the main SELECT in get_entity_video_list.
+
+        Includes detection_methods, has_manual, first_mention_time, and
+        upload_date so the new multi-source sort logic does not raise TypeError.
+        """
+        from datetime import datetime as dt
+
         row = MagicMock()
         row.video_id = video_id
         row.video_title = video_title
         row.channel_name = channel_name
         row.mention_count = mention_count
+        row.detection_methods = ["rule_match"]
+        row.has_manual = False
+        row.first_mention_time = None
+        row.upload_date = dt(2024, 1, 1, tzinfo=UTC)
         return row
 
     def _make_preview_row(
@@ -1385,17 +1395,20 @@ class TestGetEntityVideoList:
         The count query fires first; when it returns 0 the method must skip the
         main and preview queries and return ([], 0).
         """
-        count_result = MagicMock()
-        count_result.scalar.return_value = 0
-        mock_session.execute.return_value = count_result
+        # New API: first execute returns SELECT DISTINCT video_ids via .scalars().all()
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = []
+        mock_session.execute.return_value = transcript_vid_result
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=_uuid()
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=_uuid()
+            )
 
         assert results == []
         assert total == 0
-        # Only the count query should have fired
+        # Only the transcript-vid-ids query should have fired (no main/preview)
         mock_session.execute.assert_called_once()
 
     async def test_returns_paginated_results_with_total_count(
@@ -1412,8 +1425,12 @@ class TestGetEntityVideoList:
         video_row = self._make_video_row(video_id="dQw4w9WgXcQ", mention_count=4)
         preview_row = self._make_preview_row()
 
-        count_result = MagicMock()
-        count_result.scalar.return_value = 5  # 5 total videos across all pages
+        # New API: execute 1 returns SELECT DISTINCT video_ids via scalars().all()
+        # 5 total video IDs so total_count==5; only 1 returned by main query (page 1)
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = [
+            "dQw4w9WgXcQ", "vid2", "vid3", "vid4", "vid5"
+        ]
 
         main_result = MagicMock()
         main_result.all.return_value = [video_row]
@@ -1421,12 +1438,14 @@ class TestGetEntityVideoList:
         preview_result = MagicMock()
         preview_result.all.return_value = [preview_row]
 
-        # count → main → preview (one per video row)
-        mock_session.execute.side_effect = [count_result, main_result, preview_result]
+        # transcript_vid → main → preview (one per video row)
+        mock_session.execute.side_effect = [transcript_vid_result, main_result, preview_result]
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id, limit=1, offset=0
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id, limit=1, offset=0
+            )
 
         assert total == 5
         assert len(results) == 1
@@ -1441,8 +1460,9 @@ class TestGetEntityVideoList:
         """Each result dict must contain video_id, video_title, channel_name, mention_count, mentions."""
         entity_id = _uuid()
 
-        count_result = MagicMock()
-        count_result.scalar.return_value = 1
+        # New API: execute 1 returns SELECT DISTINCT video_ids
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = ["dQw4w9WgXcQ"]
 
         video_row = self._make_video_row()
         main_result = MagicMock()
@@ -1451,11 +1471,13 @@ class TestGetEntityVideoList:
         preview_result = MagicMock()
         preview_result.all.return_value = []
 
-        mock_session.execute.side_effect = [count_result, main_result, preview_result]
+        mock_session.execute.side_effect = [transcript_vid_result, main_result, preview_result]
 
-        results, _ = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, _ = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert len(results) == 1
         item = results[0]
@@ -1475,8 +1497,9 @@ class TestGetEntityVideoList:
         entity_id = _uuid()
         video_row = self._make_video_row()
 
-        count_result = MagicMock()
-        count_result.scalar.return_value = 1
+        # New API: execute 1 returns SELECT DISTINCT video_ids
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = ["dQw4w9WgXcQ"]
 
         main_result = MagicMock()
         main_result.all.return_value = [video_row]
@@ -1486,15 +1509,19 @@ class TestGetEntityVideoList:
         preview_result = MagicMock()
         preview_result.all.return_value = preview_rows
 
-        mock_session.execute.side_effect = [count_result, main_result, preview_result]
+        # transcript_vid → main → preview
+        mock_session.execute.side_effect = [transcript_vid_result, main_result, preview_result]
 
-        results, _ = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, _ = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert len(results[0]["mentions"]) == 3
 
         # Check the preview statement has the LIMIT 5 clause
+        # call_args_list[2] = third execute = preview query (index 0=transcript_vid, 1=main, 2=preview)
         preview_stmt = mock_session.execute.call_args_list[2].args[0]
         preview_sql = str(preview_stmt.compile(compile_kwargs={"literal_binds": True}))
         assert "5" in preview_sql, (
@@ -1510,8 +1537,9 @@ class TestGetEntityVideoList:
         entity_id = _uuid()
         video_row = self._make_video_row()
 
-        count_result = MagicMock()
-        count_result.scalar.return_value = 1
+        # New API: execute 1 = SELECT DISTINCT video_ids, execute 2 = main, execute 3 = preview
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = ["dQw4w9WgXcQ"]
 
         main_result = MagicMock()
         main_result.all.return_value = [video_row]
@@ -1519,11 +1547,13 @@ class TestGetEntityVideoList:
         preview_result = MagicMock()
         preview_result.all.return_value = []
 
-        mock_session.execute.side_effect = [count_result, main_result, preview_result]
+        mock_session.execute.side_effect = [transcript_vid_result, main_result, preview_result]
 
-        await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id, language_code="fr"
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id, language_code="fr"
+            )
 
         assert mock_session.execute.call_count == 3
         for i, call_args in enumerate(mock_session.execute.call_args_list):
@@ -1541,23 +1571,28 @@ class TestGetEntityVideoList:
         """The OFFSET and LIMIT values are applied to the main video-list query."""
         entity_id = _uuid()
 
-        count_result = MagicMock()
-        count_result.scalar.return_value = 10
+        # New API: transcript_vid query first, then main (pagination is Python-side)
+        # 10 transcript video IDs → total_count=10; main returns 0 rows for this page
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = [
+            f"vid{i}" for i in range(10)
+        ]
 
         main_result = MagicMock()
         main_result.all.return_value = []
 
-        mock_session.execute.side_effect = [count_result, main_result]
+        mock_session.execute.side_effect = [transcript_vid_result, main_result]
 
-        await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id, limit=5, offset=10
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id, limit=5, offset=10
+            )
 
-        main_stmt = mock_session.execute.call_args_list[1].args[0]
-        sql_str = str(main_stmt.compile(compile_kwargs={"literal_binds": True}))
-        assert "10" in sql_str and "5" in sql_str, (
-            f"Expected LIMIT 5 and OFFSET 10 in main SQL; got: {sql_str}"
-        )
+        # Verify total reflects all video IDs
+        assert total == 10
+        # Pagination applied: offset=10 on 0 main rows → empty page
+        assert results == []
 
     async def test_multiple_videos_each_get_preview_query(
         self,
@@ -1571,8 +1606,11 @@ class TestGetEntityVideoList:
             self._make_video_row(video_id="9bZkp7q19f0"),
         ]
 
-        count_result = MagicMock()
-        count_result.scalar.return_value = 2
+        # New API: transcript_vid_result first, then main, then 2 preview queries
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = [
+            "dQw4w9WgXcQ", "9bZkp7q19f0"
+        ]
 
         main_result = MagicMock()
         main_result.all.return_value = video_rows
@@ -1583,17 +1621,19 @@ class TestGetEntityVideoList:
         preview_result_2.all.return_value = []
 
         mock_session.execute.side_effect = [
-            count_result,
+            transcript_vid_result,
             main_result,
             preview_result_1,
             preview_result_2,
         ]
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
-        # 1 count + 1 main + 2 previews = 4 execute() calls
+        # 1 transcript_vid + 1 main + 2 previews = 4 execute() calls
         assert mock_session.execute.call_count == 4
         assert total == 2
         assert len(results) == 2
@@ -1649,7 +1689,9 @@ class TestGetEntityVideoList:
         count_result.scalar.return_value = 0
         mock_session.execute.return_value = count_result
 
-        await repository.get_entity_video_list(mock_session, entity_id=entity_id)
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            await repository.get_entity_video_list(mock_session, entity_id=entity_id)
 
         # Only the count query should have been issued (total=0 short-circuits)
         mock_session.execute.assert_called_once()
@@ -1706,8 +1748,9 @@ class TestGetEntityVideoList:
         """
         entity_id = _uuid()
 
-        count_result = MagicMock()
-        count_result.scalar.return_value = 1  # non-zero so main query runs
+        # New API: execute 1 = transcript_vid (non-empty so main query runs)
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = ["dQw4w9WgXcQ"]
 
         video_row = self._make_video_row()
         main_result = MagicMock()
@@ -1716,11 +1759,13 @@ class TestGetEntityVideoList:
         preview_result = MagicMock()
         preview_result.all.return_value = []
 
-        mock_session.execute.side_effect = [count_result, main_result, preview_result]
+        mock_session.execute.side_effect = [transcript_vid_result, main_result, preview_result]
 
-        await repository.get_entity_video_list(mock_session, entity_id=entity_id)
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            await repository.get_entity_video_list(mock_session, entity_id=entity_id)
 
-        # count=0, main=1, preview=2
+        # transcript_vid=0, main=1, preview=2
         assert mock_session.execute.call_count == 3
         main_stmt = mock_session.execute.call_args_list[1].args[0]
         sql_str = self._compile_pg_sql(main_stmt)
@@ -1743,8 +1788,9 @@ class TestGetEntityVideoList:
         """
         entity_id = _uuid()
 
-        count_result = MagicMock()
-        count_result.scalar.return_value = 1
+        # New API: execute 1 = transcript_vid, execute 2 = main, execute 3 = preview
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = ["dQw4w9WgXcQ"]
 
         video_row = self._make_video_row()
         main_result = MagicMock()
@@ -1754,10 +1800,13 @@ class TestGetEntityVideoList:
         preview_result = MagicMock()
         preview_result.all.return_value = [preview_row]
 
-        mock_session.execute.side_effect = [count_result, main_result, preview_result]
+        mock_session.execute.side_effect = [transcript_vid_result, main_result, preview_result]
 
-        await repository.get_entity_video_list(mock_session, entity_id=entity_id)
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            await repository.get_entity_video_list(mock_session, entity_id=entity_id)
 
+        # transcript_vid=0, main=1, preview=2
         preview_stmt = mock_session.execute.call_args_list[2].args[0]
         sql_str = self._compile_pg_sql(preview_stmt)
 
@@ -1787,9 +1836,11 @@ class TestGetEntityVideoList:
         count_result.scalar.return_value = 0
         mock_session.execute.return_value = count_result
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert results == [], "No videos should be returned when count is zero"
         assert total == 0
@@ -3010,9 +3061,20 @@ class TestGetEntityVideoListMultiSource:
 
     @staticmethod
     def _make_count_result(count: int) -> MagicMock:
-        """Create a mock scalar result for the count query."""
+        """Create a mock scalar result for the count query (legacy helper)."""
         mock = MagicMock()
         mock.scalar.return_value = count
+        return mock
+
+    @staticmethod
+    def _make_transcript_vid_result(video_ids: list[str]) -> MagicMock:
+        """Create a mock result for the SELECT DISTINCT video_id transcript query.
+
+        The new get_entity_video_list() API replaced the COUNT query with a
+        SELECT DISTINCT video_id query consumed via .scalars().all().
+        """
+        mock = MagicMock()
+        mock.scalars.return_value.all.return_value = video_ids
         return mock
 
     @staticmethod
@@ -3079,14 +3141,16 @@ class TestGetEntityVideoListMultiSource:
         )
 
         mock_session.execute.side_effect = [
-            self._make_count_result(1),     # count query
-            self._make_main_result([row]),   # main query
-            self._make_preview_result(),     # preview query
+            self._make_transcript_vid_result(["vid001"]),  # SELECT DISTINCT video_ids
+            self._make_main_result([row]),                  # main grouped query
+            self._make_preview_result(),                    # preview query
         ]
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert total == 1
         assert len(results) == 1
@@ -3110,14 +3174,16 @@ class TestGetEntityVideoListMultiSource:
         )
 
         mock_session.execute.side_effect = [
-            self._make_count_result(1),
+            self._make_transcript_vid_result(["vid001"]),  # manual mentions included in transcript_vid
             self._make_main_result([row]),
             self._make_preview_result([]),  # no transcript previews
         ]
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert total == 1
         assert len(results) == 1
@@ -3142,14 +3208,16 @@ class TestGetEntityVideoListMultiSource:
         )
 
         mock_session.execute.side_effect = [
-            self._make_count_result(1),
+            self._make_transcript_vid_result(["vid001"]),
             self._make_main_result([row]),
             self._make_preview_result([{"segment_id": 1, "start_time": 5.0, "mention_text": "Elon"}]),
         ]
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert total == 1
         assert len(results) == 1
@@ -3175,14 +3243,16 @@ class TestGetEntityVideoListMultiSource:
         )
 
         mock_session.execute.side_effect = [
-            self._make_count_result(1),
+            self._make_transcript_vid_result(["vid_dedup"]),
             self._make_main_result([row]),
             self._make_preview_result(),
         ]
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert total == 1
         assert len(results) == 1
@@ -3197,16 +3267,18 @@ class TestGetEntityVideoListMultiSource:
         entity_id = _uuid()
 
         mock_session.execute.side_effect = [
-            self._make_count_result(0),  # count query returns 0, early exit
+            self._make_transcript_vid_result([]),  # empty → early exit
         ]
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert total == 0
         assert results == []
-        # Verify the count query was called
+        # Verify the transcript-vid query was the only execute call (early exit)
         mock_session.execute.assert_called_once()
 
     async def test_pagination(
@@ -3221,15 +3293,17 @@ class TestGetEntityVideoListMultiSource:
         row2 = self._make_video_row(video_id="vid_b", detection_methods=["manual"], has_manual=True, mention_count=0)
 
         mock_session.execute.side_effect = [
-            self._make_count_result(5),       # total=5
+            self._make_transcript_vid_result(["vid_a", "vid_b", "vid_c", "vid_d", "vid_e"]),  # total=5
             self._make_main_result([row1, row2]),
             self._make_preview_result(),      # previews for vid_a
             self._make_preview_result([]),    # previews for vid_b
         ]
 
-        results, total = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id, limit=2, offset=0
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id, limit=2, offset=0
+            )
 
         assert total == 5
         assert len(results) == 2
@@ -3251,14 +3325,16 @@ class TestGetEntityVideoListMultiSource:
         )
 
         mock_session.execute.side_effect = [
-            self._make_count_result(1),
+            self._make_transcript_vid_result(["vid001"]),
             self._make_main_result([row]),
             self._make_preview_result(),
         ]
 
-        results, _ = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, _ = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert results[0]["upload_date"] is not None
         assert "2024-12-25" in results[0]["upload_date"]
@@ -3279,14 +3355,16 @@ class TestGetEntityVideoListMultiSource:
         )
 
         mock_session.execute.side_effect = [
-            self._make_count_result(1),
+            self._make_transcript_vid_result(["vid001"]),
             self._make_main_result([row]),
             self._make_preview_result([]),  # No transcript previews
         ]
 
-        results, _ = await repository.get_entity_video_list(
-            mock_session, entity_id=entity_id
-        )
+        with patch.object(repository, "_get_tag_associated_video_ids", new=AsyncMock(return_value=set())), \
+             patch.object(repository, "_get_alias_matched_tag_video_ids", new=AsyncMock(return_value=set())):
+            results, _ = await repository.get_entity_video_list(
+                mock_session, entity_id=entity_id
+            )
 
         assert results[0]["mentions"] == []
         assert results[0]["has_manual"] is True

--- a/tests/unit/repositories/test_entity_tag_videos.py
+++ b/tests/unit/repositories/test_entity_tag_videos.py
@@ -1,0 +1,1749 @@
+"""
+Tests for EntityMentionRepository private helpers introduced in Feature 053
+(entity-tag-videos): T006 and T007.
+
+T006 — _get_tag_associated_video_ids()
+    Source 2 query path: canonical_tags (entity_id FK) → tag_aliases
+    (canonical_tag_id) → video_tags (tag = raw_form) → set[str] of video_ids.
+
+T007 — _get_alias_matched_tag_video_ids()
+    Source 3 query path: entity_aliases (entity_id) → normalize(alias_name)
+    via TagNormalizationService → tag_aliases (normalized_form IN (...)) →
+    video_tags (tag = raw_form) → set[str] of video_ids.
+
+Mock strategy
+-------------
+Both private methods are tested via MagicMock(spec=AsyncSession) with an
+AsyncMock execute attribute — the same pattern used throughout the project
+(see test_entity_mention_repository.py).
+
+For _get_tag_associated_video_ids: one execute() call is made; the mock
+returns a result whose .scalars().all() yields the video IDs.
+
+For _get_alias_matched_tag_video_ids: the method makes *two* execute() calls
+in sequence:
+  1. Fetch alias_name values from entity_aliases.
+  2. Fetch video_id values from tag_aliases → video_tags (only if there are
+     aliases with non-None normalized forms).
+session.execute is configured as AsyncMock with side_effect to return
+different mock results per call.
+
+TagNormalizationService is patched at the module level so that normalize()
+returns predictable values without running the full 9-step pipeline.
+
+References
+----------
+- specs/053-entity-tag-videos/research.md — Decisions 7, 8, 9, 10
+- specs/053-entity-tag-videos/spec.md — EC-001, EC-002, EC-007, EC-008,
+  EC-010, EC-012
+- src/chronovista/repositories/entity_mention_repository.py — lines 1300-1399
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.repositories.entity_mention_repository import EntityMentionRepository
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _uuid() -> uuid.UUID:
+    """Return a UUIDv7 expressed as a stdlib ``uuid.UUID`` instance."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+
+def _make_mock_session() -> MagicMock:
+    """Create a MagicMock AsyncSession with an AsyncMock execute attribute.
+
+    Returns
+    -------
+    MagicMock
+        Mock session compatible with the AsyncSession interface.
+    """
+    session = MagicMock(spec=AsyncSession)
+    session.execute = AsyncMock()
+    return session
+
+
+def _scalars_result(values: list[str]) -> MagicMock:
+    """Build a mock execute() result whose .scalars().all() returns *values*.
+
+    Parameters
+    ----------
+    values : list[str]
+        The list that .scalars().all() should return.
+
+    Returns
+    -------
+    MagicMock
+        Mock compatible with SQLAlchemy CursorResult.scalars().all() chain.
+    """
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = values
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalars
+    return mock_result
+
+
+# ---------------------------------------------------------------------------
+# T006 — _get_tag_associated_video_ids()
+# ---------------------------------------------------------------------------
+
+
+class TestGetTagAssociatedVideoIds:
+    """Tests for _get_tag_associated_video_ids() (T006).
+
+    The method runs the query path:
+        canonical_tags WHERE entity_id = ?
+          JOIN tag_aliases ON tag_aliases.canonical_tag_id = canonical_tags.id
+          JOIN video_tags  ON video_tags.tag = tag_aliases.raw_form
+        SELECT DISTINCT video_tags.video_id
+
+    It issues exactly one session.execute() call and returns the result as
+    a set[str].  It does NOT filter by canonical_tags.status (Decision 8).
+    """
+
+    @pytest.fixture
+    def repository(self) -> EntityMentionRepository:
+        """Provide a fresh EntityMentionRepository for each test."""
+        return EntityMentionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    # ------------------------------------------------------------------
+    # T006-1: canonical tag path returns video_ids
+    # ------------------------------------------------------------------
+
+    async def test_canonical_tag_path_returns_video_ids(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Entity linked to a canonical tag — associated video_ids are returned.
+
+        When the database returns video IDs via the canonical_tags →
+        tag_aliases → video_tags join path, the method must return all of
+        them as a set[str].
+        """
+        entity_id = _uuid()
+        expected_ids = ["dQw4w9WgXcQ", "9bZkp7q19f0", "jNQXAC9IVRw"]
+
+        mock_session.execute.return_value = _scalars_result(expected_ids)
+
+        result = await repository._get_tag_associated_video_ids(
+            mock_session, entity_id
+        )
+
+        assert result == set(expected_ids)
+        mock_session.execute.assert_called_once()
+
+    async def test_canonical_tag_path_returns_set_type(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Return type is always set[str], even for a single video ID."""
+        entity_id = _uuid()
+
+        mock_session.execute.return_value = _scalars_result(["abc123"])
+
+        result = await repository._get_tag_associated_video_ids(
+            mock_session, entity_id
+        )
+
+        assert isinstance(result, set)
+        assert result == {"abc123"}
+
+    # ------------------------------------------------------------------
+    # T006-2: no canonical tag link returns empty set (EC-001)
+    # ------------------------------------------------------------------
+
+    async def test_no_canonical_tag_link_returns_empty_set(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Entity with no canonical_tags.entity_id link returns an empty set.
+
+        Corresponds to EC-001: entities created manually (not via classify)
+        have no canonical tag link.  The query produces zero rows, and the
+        method must return set() without raising an error.
+        """
+        entity_id = _uuid()
+
+        mock_session.execute.return_value = _scalars_result([])
+
+        result = await repository._get_tag_associated_video_ids(
+            mock_session, entity_id
+        )
+
+        assert result == set()
+        mock_session.execute.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # T006-3: deprecated canonical tag still returns videos (Decision 8 / EC-002)
+    # ------------------------------------------------------------------
+
+    async def test_deprecated_canonical_tag_still_returns_videos(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Deprecated canonical tag MUST still contribute its video IDs.
+
+        Research Decision 8: the query path does NOT filter by
+        canonical_tags.status.  Even if status='deprecated' or status='merged',
+        the entity_id FK link is the relevant criterion, and the method must
+        return the associated video IDs unchanged.
+
+        EC-002: deprecation/merging affects tag management operations, not
+        read-only queries.
+        """
+        entity_id = _uuid()
+        # Simulate the DB returning videos even for a deprecated canonical tag
+        video_ids = ["3tmd-ClpJxA", "hT_nvWreIhg"]
+
+        mock_session.execute.return_value = _scalars_result(video_ids)
+
+        result = await repository._get_tag_associated_video_ids(
+            mock_session, entity_id
+        )
+
+        # Method returns whatever the DB produces — status is NOT filtered
+        assert result == set(video_ids)
+
+        # Verify the SQL does NOT include a status filter: compile the statement
+        # that was passed to execute() and check it contains no status clause
+        stmt = mock_session.execute.call_args.args[0]
+        sql_str = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "status" not in sql_str.lower(), (
+            "Query must NOT filter by canonical_tags.status (Decision 8 / EC-002)"
+        )
+
+    # ------------------------------------------------------------------
+    # T006-4: tag-sourced videos — no availability_status filtering (EC-012/A-006)
+    # ------------------------------------------------------------------
+
+    async def test_no_availability_status_filter_applied(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Tag-sourced videos are NOT filtered by availability_status.
+
+        Research Decision 9 / A-006: the existing get_entity_video_list() does
+        NOT filter by videos.availability_status, and this method must match
+        that behaviour for consistency.  All local videos are returned regardless
+        of their availability status.
+
+        Verified by inspecting the compiled SQL for absence of
+        'availability_status'.
+        """
+        entity_id = _uuid()
+        mock_session.execute.return_value = _scalars_result(["vid_deleted_01"])
+
+        await repository._get_tag_associated_video_ids(mock_session, entity_id)
+
+        stmt = mock_session.execute.call_args.args[0]
+        sql_str = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "availability_status" not in sql_str.lower(), (
+            "Query must NOT filter by availability_status (Decision 9 / EC-012)"
+        )
+
+    # ------------------------------------------------------------------
+    # T006-5: orphaned canonical tag — no tag_aliases rows (EC-010)
+    # ------------------------------------------------------------------
+
+    async def test_orphaned_canonical_tag_returns_empty_set(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Canonical tag with no tag_aliases rows returns empty set.
+
+        EC-010: if canonical_tags row exists but has zero tag_aliases rows,
+        the JOINs produce no rows.  The method must return set() silently
+        without raising an error.
+        """
+        entity_id = _uuid()
+
+        # Simulate DB returning zero rows (orphaned canonical tag → no aliases)
+        mock_session.execute.return_value = _scalars_result([])
+
+        result = await repository._get_tag_associated_video_ids(
+            mock_session, entity_id
+        )
+
+        assert result == set()
+
+    # ------------------------------------------------------------------
+    # T006-6: duplicate video_ids in DB result are deduplicated by set()
+    # ------------------------------------------------------------------
+
+    async def test_duplicate_video_ids_are_deduplicated(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Return type is set[str] — any duplicates from the DB are eliminated.
+
+        The SQL uses DISTINCT, but even if duplicates were returned the method
+        must guarantee uniqueness via Python set conversion.
+        """
+        entity_id = _uuid()
+        # Deliberately supply a list with a repeated ID
+        raw_result = ["dQw4w9WgXcQ", "dQw4w9WgXcQ", "9bZkp7q19f0"]
+
+        mock_session.execute.return_value = _scalars_result(raw_result)
+
+        result = await repository._get_tag_associated_video_ids(
+            mock_session, entity_id
+        )
+
+        assert isinstance(result, set)
+        assert len(result) == 2
+        assert "dQw4w9WgXcQ" in result
+        assert "9bZkp7q19f0" in result
+
+    # ------------------------------------------------------------------
+    # T006-7: SQL selects from correct tables (structural correctness)
+    # ------------------------------------------------------------------
+
+    async def test_query_joins_canonical_tags_tag_aliases_video_tags(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The compiled SQL references canonical_tags, tag_aliases, and video_tags.
+
+        Verifies that the method constructs the correct three-table join path
+        described in data-model.md Source 2.
+        """
+        entity_id = _uuid()
+        mock_session.execute.return_value = _scalars_result([])
+
+        await repository._get_tag_associated_video_ids(mock_session, entity_id)
+
+        stmt = mock_session.execute.call_args.args[0]
+        sql_str = str(stmt.compile(compile_kwargs={"literal_binds": False})).lower()
+
+        assert "canonical_tags" in sql_str, "Query must reference canonical_tags table"
+        assert "tag_aliases" in sql_str, "Query must reference tag_aliases table"
+        assert "video_tags" in sql_str, "Query must reference video_tags table"
+
+
+# ---------------------------------------------------------------------------
+# T007 — _get_alias_matched_tag_video_ids()
+# ---------------------------------------------------------------------------
+
+
+class TestGetAliasMatchedTagVideoIds:
+    """Tests for _get_alias_matched_tag_video_ids() (T007).
+
+    The method runs two execute() calls in sequence:
+
+    Call 1 — Fetch entity aliases:
+        SELECT alias_name FROM entity_aliases WHERE entity_id = ?
+        → list[str] of alias_name values
+
+    Call 2 (only if aliases exist with non-None normalized forms):
+        SELECT DISTINCT video_tags.video_id
+        FROM tag_aliases
+        JOIN video_tags ON video_tags.tag = tag_aliases.raw_form
+        WHERE tag_aliases.normalized_form IN (<normalized_aliases>)
+
+    TagNormalizationService is patched for deterministic normalization.
+
+    Key behaviours:
+    - Zero aliases → immediate empty set (no second execute)
+    - All aliases normalize to None → empty set (no second execute)
+    - Non-None normalized forms → exact-match IN query (Decision 10)
+    - Results converted to set[str] for deduplication
+    """
+
+    @pytest.fixture
+    def repository(self) -> EntityMentionRepository:
+        """Provide a fresh EntityMentionRepository for each test."""
+        return EntityMentionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    # ------------------------------------------------------------------
+    # T007-1: alias matching — alias normalizes to form that matches tag
+    # ------------------------------------------------------------------
+
+    async def test_alias_matching_returns_video_ids(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Entity alias normalizes to a form matching tag_aliases.normalized_form.
+
+        Given alias_name="AI" that normalizes to "ai", and tag_aliases has a
+        row with normalized_form="ai" pointing to video_tags with video_ids,
+        the method must return those video_ids.
+        """
+        entity_id = _uuid()
+        expected_ids = ["vid_ai_001", "vid_ai_002"]
+
+        # Call 1: returns alias names
+        # Call 2: returns matched video IDs
+        mock_session.execute.side_effect = [
+            _scalars_result(["AI"]),
+            _scalars_result(expected_ids),
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ) as mock_normalizer_cls:
+            mock_normalizer = MagicMock()
+            mock_normalizer.normalize.side_effect = lambda name: name.lower()
+            mock_normalizer_cls.return_value = mock_normalizer
+
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert result == set(expected_ids)
+        assert mock_session.execute.call_count == 2
+
+    # ------------------------------------------------------------------
+    # T007-2: case-insensitive normalization matches tag
+    # ------------------------------------------------------------------
+
+    async def test_case_insensitive_normalization_matches_tag(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Alias 'MACHINE LEARNING' normalizes to 'machine learning' matching tag.
+
+        Research Decision 2: TagNormalizationService.normalize() produces a
+        casefolded form.  The method must pass the normalized form (not the raw
+        alias) to the SQL IN clause, enabling case-insensitive matching against
+        tag_aliases.normalized_form.
+        """
+        entity_id = _uuid()
+        expected_ids = ["vid_ml_001"]
+
+        mock_session.execute.side_effect = [
+            _scalars_result(["MACHINE LEARNING"]),
+            _scalars_result(expected_ids),
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ) as mock_normalizer_cls:
+            mock_normalizer = MagicMock()
+            # Simulate the casefold step of the normalization pipeline
+            mock_normalizer.normalize.side_effect = lambda name: name.casefold()
+            mock_normalizer_cls.return_value = mock_normalizer
+
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert result == set(expected_ids)
+
+        # Verify normalize() was called with the original alias_name
+        mock_normalizer.normalize.assert_called_once_with("MACHINE LEARNING")
+
+        # Verify the second SQL uses the normalized form, not the raw alias
+        second_call_stmt = mock_session.execute.call_args_list[1].args[0]
+        sql_str = str(
+            second_call_stmt.compile(compile_kwargs={"literal_binds": True})
+        ).lower()
+        assert "machine learning" in sql_str, (
+            "SQL must use normalized form 'machine learning' in the IN clause"
+        )
+
+    # ------------------------------------------------------------------
+    # T007-3: None-normalized alias is skipped (Decision 7 / EC-008)
+    # ------------------------------------------------------------------
+
+    async def test_none_normalized_alias_is_skipped(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Alias whose normalize() returns None is silently skipped.
+
+        Research Decision 7 / EC-008: TagNormalizationService.normalize()
+        returns None for whitespace-only or empty input.  Such aliases MUST
+        be skipped and MUST NOT contribute to the SQL IN clause.  When ALL
+        aliases normalize to None, the method returns an empty set without
+        issuing the second execute() call.
+        """
+        entity_id = _uuid()
+
+        # One alias present but it has whitespace-only name → normalize → None
+        mock_session.execute.side_effect = [
+            _scalars_result(["   "]),  # Call 1: one alias, whitespace only
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ) as mock_normalizer_cls:
+            mock_normalizer = MagicMock()
+            # Whitespace-only → normalize returns None
+            mock_normalizer.normalize.return_value = None
+            mock_normalizer_cls.return_value = mock_normalizer
+
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert result == set()
+        # Only one execute() call — the second query must NOT be issued
+        assert mock_session.execute.call_count == 1, (
+            "Second execute() must NOT be called when all aliases normalize to None"
+        )
+
+    # ------------------------------------------------------------------
+    # T007-3b: asr_error aliases are excluded from tag matching
+    # ------------------------------------------------------------------
+
+    async def test_asr_error_alias_excluded_from_tag_matching(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Alias with alias_type='asr_error' is excluded from tag matching.
+
+        ASR error aliases (e.g., 'Andres', 'elon') are transcript-specific
+        patterns that produce false positives when matched against YouTube
+        tags.  The first SQL query must include a WHERE clause that filters
+        out alias_type = 'asr_error', so these aliases never reach the
+        normalization or tag-matching stages.
+        """
+        entity_id = _uuid()
+
+        # The mock returns zero aliases because the only alias is asr_error
+        # and should be filtered out by the WHERE clause
+        mock_session.execute.side_effect = [
+            _scalars_result([]),  # Call 1: no aliases after asr_error filter
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ):
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert result == set()
+        assert mock_session.execute.call_count == 1
+
+        # Verify the SQL excludes asr_error aliases
+        first_stmt = mock_session.execute.call_args_list[0].args[0]
+        sql_str = str(
+            first_stmt.compile(compile_kwargs={"literal_binds": True})
+        ).lower()
+        assert "alias_type" in sql_str, (
+            "Query must filter by alias_type to exclude asr_error aliases"
+        )
+        assert "asr_error" in sql_str, (
+            "Query must explicitly reference 'asr_error' in the WHERE clause"
+        )
+
+    async def test_asr_error_alias_with_valid_normalized_form_still_excluded(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """ASR error alias with a valid normalized form is still excluded.
+
+        Even when an asr_error alias (e.g., 'elon') would produce a valid
+        normalized form that matches tags, it must be excluded at the SQL
+        level.  The alias never reaches TagNormalizationService.normalize().
+
+        This test verifies the fix for the false-positive bug where ASR
+        patterns like 'Andres', 'Lopez', 'elon' matched real YouTube tags.
+        """
+        entity_id = _uuid()
+        expected_ids = ["vid_real_001"]
+
+        # Call 1 returns only the non-ASR alias (DB filtered out 'elon')
+        # Call 2 returns video IDs for the valid alias
+        mock_session.execute.side_effect = [
+            _scalars_result(["Elon Musk"]),  # Only the name_variant alias
+            _scalars_result(expected_ids),
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ) as mock_normalizer_cls:
+            mock_normalizer = MagicMock()
+            mock_normalizer.normalize.side_effect = lambda name: name.lower()
+            mock_normalizer_cls.return_value = mock_normalizer
+
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert result == set(expected_ids)
+        # normalize() should only be called for the non-ASR alias
+        mock_normalizer.normalize.assert_called_once_with("Elon Musk")
+
+    async def test_mixed_none_and_valid_normalized_aliases(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Only non-None normalized forms are included in the SQL IN clause.
+
+        When some aliases normalize to None and others to valid strings, only
+        the valid normalized forms must appear in the query.  The None aliases
+        are silently skipped.
+        """
+        entity_id = _uuid()
+        expected_ids = ["vid_valid_001"]
+
+        mock_session.execute.side_effect = [
+            _scalars_result(["  ", "AI"]),  # Two aliases: one whitespace, one valid
+            _scalars_result(expected_ids),
+        ]
+
+        normalize_map = {"  ": None, "AI": "ai"}
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ) as mock_normalizer_cls:
+            mock_normalizer = MagicMock()
+            mock_normalizer.normalize.side_effect = lambda name: normalize_map.get(
+                name
+            )
+            mock_normalizer_cls.return_value = mock_normalizer
+
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert result == set(expected_ids)
+        assert mock_session.execute.call_count == 2
+
+        # Verify only "ai" appears in the second query
+        second_stmt = mock_session.execute.call_args_list[1].args[0]
+        sql_str = str(
+            second_stmt.compile(compile_kwargs={"literal_binds": True})
+        ).lower()
+        assert "ai" in sql_str
+        # The whitespace alias should not appear (it was skipped)
+        # We can't check for absence of whitespace in SQL easily, but we can
+        # confirm normalize was called for both aliases
+        assert mock_normalizer.normalize.call_count == 2
+
+    # ------------------------------------------------------------------
+    # T007-4: zero aliases returns empty set immediately (EC-007)
+    # ------------------------------------------------------------------
+
+    async def test_zero_aliases_returns_empty_set(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Entity with no aliases returns an empty set without a second query.
+
+        EC-007: when an entity has zero aliases (e.g., a newly created entity),
+        no alias-to-tag matching can be performed.  The method must return set()
+        after the first execute() call and MUST NOT issue a second execute().
+        """
+        entity_id = _uuid()
+
+        mock_session.execute.side_effect = [
+            _scalars_result([]),  # Call 1: no aliases found
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ):
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert result == set()
+        # Only one execute call — no second query for videos
+        assert mock_session.execute.call_count == 1, (
+            "Second execute() must NOT be called when entity has no aliases"
+        )
+
+    # ------------------------------------------------------------------
+    # T007-5: multiple aliases matching same video are deduplicated
+    # ------------------------------------------------------------------
+
+    async def test_multiple_aliases_matching_same_video_are_deduplicated(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Two different aliases both matching the same video → video_id once.
+
+        EC-006 / EC-009: when multiple aliases resolve to the same video_id
+        (either because both aliases' normalized forms map to the same tag, or
+        because the SQL DISTINCT collapses them), the returned set must contain
+        that video_id exactly once.
+        """
+        entity_id = _uuid()
+
+        # The second execute() returns the same video_id twice (simulating
+        # UNION ALL or duplicate rows before DISTINCT is applied)
+        mock_session.execute.side_effect = [
+            _scalars_result(["AI", "Artificial Intelligence"]),
+            _scalars_result(["shared_video_01", "shared_video_01"]),
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ) as mock_normalizer_cls:
+            mock_normalizer = MagicMock()
+            alias_map = {"AI": "ai", "Artificial Intelligence": "artificial intelligence"}
+            mock_normalizer.normalize.side_effect = lambda name: alias_map.get(
+                name, name.lower()
+            )
+            mock_normalizer_cls.return_value = mock_normalizer
+
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert isinstance(result, set)
+        assert len(result) == 1
+        assert "shared_video_01" in result
+
+    # ------------------------------------------------------------------
+    # T007-6: multiple aliases matching different videos — union of all
+    # ------------------------------------------------------------------
+
+    async def test_multiple_aliases_matching_different_videos(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Multiple aliases matching different video_ids — all are returned.
+
+        When aliases "AI" and "ML" each match different sets of videos via
+        tag_aliases.normalized_form, the method must return the union of all
+        matched video_ids as a single set.
+        """
+        entity_id = _uuid()
+
+        mock_session.execute.side_effect = [
+            _scalars_result(["AI", "ML"]),
+            # The IN query covers both normalized forms; DB returns union of videos
+            _scalars_result(["vid_ai_001", "vid_ai_002", "vid_ml_001"]),
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ) as mock_normalizer_cls:
+            mock_normalizer = MagicMock()
+            alias_map = {"AI": "ai", "ML": "ml"}
+            mock_normalizer.normalize.side_effect = lambda name: alias_map.get(
+                name, name.lower()
+            )
+            mock_normalizer_cls.return_value = mock_normalizer
+
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert result == {"vid_ai_001", "vid_ai_002", "vid_ml_001"}
+        assert mock_session.execute.call_count == 2
+
+    # ------------------------------------------------------------------
+    # T007-7: SQL uses exact equality (IN), not ILIKE (Decision 10)
+    # ------------------------------------------------------------------
+
+    async def test_sql_uses_exact_equality_not_ilike(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """The second SQL query uses exact IN match, NOT ILIKE or LIKE.
+
+        Research Decision 10: all alias-to-tag matching uses exact equality
+        on normalized forms.  No fuzzy or substring matching is used.
+        This is verified by inspecting the compiled SQL for ILIKE/LIKE clauses.
+        """
+        entity_id = _uuid()
+
+        mock_session.execute.side_effect = [
+            _scalars_result(["AI"]),
+            _scalars_result([]),
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ) as mock_normalizer_cls:
+            mock_normalizer = MagicMock()
+            mock_normalizer.normalize.return_value = "ai"
+            mock_normalizer_cls.return_value = mock_normalizer
+
+            await repository._get_alias_matched_tag_video_ids(mock_session, entity_id)
+
+        second_stmt = mock_session.execute.call_args_list[1].args[0]
+        sql_str = str(
+            second_stmt.compile(compile_kwargs={"literal_binds": False})
+        ).upper()
+        assert "ILIKE" not in sql_str, "Query must NOT use ILIKE (Decision 10)"
+        assert "LIKE" not in sql_str, "Query must NOT use LIKE (Decision 10)"
+        # Must use IN clause
+        assert " IN " in sql_str, "Query must use exact IN clause (Decision 10)"
+
+    # ------------------------------------------------------------------
+    # T007-8: return type is always set[str]
+    # ------------------------------------------------------------------
+
+    async def test_return_type_is_set_of_strings(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Method always returns set[str], never a list or other collection."""
+        entity_id = _uuid()
+
+        mock_session.execute.side_effect = [
+            _scalars_result(["alias1"]),
+            _scalars_result(["vidA", "vidB"]),
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository.TagNormalizationService"
+        ) as mock_normalizer_cls:
+            mock_normalizer = MagicMock()
+            mock_normalizer.normalize.return_value = "alias1"
+            mock_normalizer_cls.return_value = mock_normalizer
+
+            result = await repository._get_alias_matched_tag_video_ids(
+                mock_session, entity_id
+            )
+
+        assert isinstance(result, set)
+        for item in result:
+            assert isinstance(item, str)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for get_entity_video_list tests (T008-T010)
+# ---------------------------------------------------------------------------
+
+
+def _row_result(rows: list[Any]) -> MagicMock:
+    """Build a mock execute() result whose .all() returns *rows*.
+
+    Parameters
+    ----------
+    rows : list[Any]
+        The list of row-like objects that .all() should return.
+
+    Returns
+    -------
+    MagicMock
+        Mock compatible with SQLAlchemy CursorResult.all() chain.
+    """
+    mock_result = MagicMock()
+    mock_result.all.return_value = rows
+    return mock_result
+
+
+def _make_video_row(
+    *,
+    video_id: str,
+    video_title: str = "Test Video",
+    channel_name: str = "Test Channel",
+    mention_count: int = 1,
+    detection_methods: list[str] | None = None,
+    has_manual: bool = False,
+    first_mention_time: float | None = 10.0,
+    upload_date: Any = None,
+) -> MagicMock:
+    """Create a mock row representing a transcript-mention video result.
+
+    Parameters
+    ----------
+    video_id : str
+        YouTube video ID.
+    video_title : str
+        Video title.
+    channel_name : str
+        Channel name.
+    mention_count : int
+        Number of transcript mentions.
+    detection_methods : list[str] | None
+        Detection methods from the GROUP BY query.
+    has_manual : bool
+        Whether the video has a manual mention.
+    first_mention_time : float | None
+        Earliest transcript mention timestamp.
+    upload_date : Any
+        Upload date (should have .isoformat() for real use).
+
+    Returns
+    -------
+    MagicMock
+        Mock row object with attribute access for each column.
+    """
+    if detection_methods is None:
+        detection_methods = ["rule_match"]
+    row = MagicMock()
+    row.video_id = video_id
+    row.video_title = video_title
+    row.channel_name = channel_name
+    row.mention_count = mention_count
+    row.detection_methods = detection_methods
+    row.has_manual = has_manual
+    row.first_mention_time = first_mention_time
+    row.upload_date = upload_date
+    return row
+
+
+def _make_tag_meta_row(
+    *,
+    video_id: str,
+    video_title: str = "Tagged Video",
+    channel_name: str = "Tag Channel",
+    upload_date: Any = None,
+) -> MagicMock:
+    """Create a mock row for tag-only video metadata.
+
+    Parameters
+    ----------
+    video_id : str
+        YouTube video ID.
+    video_title : str
+        Video title.
+    channel_name : str
+        Channel name.
+    upload_date : Any
+        Upload date mock.
+
+    Returns
+    -------
+    MagicMock
+        Mock row with attribute access for video/channel metadata.
+    """
+    row = MagicMock()
+    row.video_id = video_id
+    row.video_title = video_title
+    row.channel_name = channel_name
+    row.upload_date = upload_date
+    return row
+
+
+class _MockUploadDate:
+    """Mock upload_date with isoformat() method."""
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def isoformat(self) -> str:
+        return self._value
+
+
+# ---------------------------------------------------------------------------
+# T008 — entity with tagged + transcript mention videos returns all unique
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntityVideoListTagIntegration:
+    """Tests for get_entity_video_list() with canonical tag associations (T008-T010).
+
+    These tests verify the integration of _get_tag_associated_video_ids()
+    into get_entity_video_list(), including deduplication, source merging,
+    sort order, and pagination count.
+    """
+
+    @pytest.fixture
+    def repository(self) -> EntityMentionRepository:
+        """Provide a fresh EntityMentionRepository for each test."""
+        return EntityMentionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    # ------------------------------------------------------------------
+    # T008: entity with 5 tagged + 1 transcript mention = 6 unique videos
+    # ------------------------------------------------------------------
+
+    async def test_tagged_plus_transcript_returns_all_unique_videos(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Entity with 5 tagged videos and 1 transcript mention returns 6 unique videos.
+
+        The tagged videos do not overlap with the transcript mention video.
+        Total count should be 6, and all 6 videos should appear in the results.
+        Tag-only videos have mention_count=0, mentions=[], sources=["tag"].
+        """
+        entity_id = _uuid()
+        transcript_vid = "vid_transcript_001"
+        tag_vids = [f"vid_tag_{i:03d}" for i in range(1, 6)]
+
+        # Mock _get_tag_associated_video_ids to return 5 tag video IDs
+        # Mock _get_alias_matched_tag_video_ids to return empty set — Phase 3
+        # tests focus on canonical tag behaviour, not alias matching.
+        with patch.object(
+            repository,
+            "_get_tag_associated_video_ids",
+            return_value=set(tag_vids),
+        ), patch.object(
+            repository,
+            "_get_alias_matched_tag_video_ids",
+            return_value=set(),
+        ):
+            # Call sequence for get_entity_video_list:
+            # 1. transcript_vid_stmt — distinct transcript video IDs
+            # 2. main_stmt — grouped transcript mention rows
+            # 3. preview_stmt — mention previews for the transcript video
+            # 4. tag_meta_stmt — metadata for tag-only videos
+            upload_date = _MockUploadDate("2024-01-15")
+            mock_session.execute.side_effect = [
+                _scalars_result([transcript_vid]),  # transcript video IDs
+                _row_result([  # main grouped query
+                    _make_video_row(
+                        video_id=transcript_vid,
+                        mention_count=3,
+                        upload_date=upload_date,
+                    ),
+                ]),
+                _row_result([]),  # preview query (empty for simplicity)
+                _row_result([  # tag-only video metadata
+                    _make_tag_meta_row(
+                        video_id=tv, upload_date=upload_date
+                    )
+                    for tv in tag_vids
+                ]),
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        assert total == 6
+        assert len(results) == 6
+
+        result_ids = {r["video_id"] for r in results}
+        assert transcript_vid in result_ids
+        for tv in tag_vids:
+            assert tv in result_ids
+
+        # Verify tag-only videos have correct fields
+        for r in results:
+            if r["video_id"] in tag_vids:
+                assert r["mention_count"] == 0
+                assert r["mentions"] == []
+                assert r["sources"] == ["tag"]
+                assert r["has_manual"] is False
+                assert r["first_mention_time"] is None
+
+    # ------------------------------------------------------------------
+    # T009: entity with 0 mentions but 3 tagged videos returns 3
+    # ------------------------------------------------------------------
+
+    async def test_no_mentions_but_tagged_videos_returns_tagged(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Entity with no transcript mentions but 3 tagged videos returns 3 videos.
+
+        This is the key scenario for tag-only entities: transcript mentions
+        are empty, but the entity's canonical tag links to tagged videos.
+        The result must NOT be empty.
+        """
+        entity_id = _uuid()
+        tag_vids = ["vid_tag_a", "vid_tag_b", "vid_tag_c"]
+        upload_date = _MockUploadDate("2024-06-01")
+
+        with patch.object(
+            repository,
+            "_get_tag_associated_video_ids",
+            return_value=set(tag_vids),
+        ), patch.object(
+            repository,
+            "_get_alias_matched_tag_video_ids",
+            return_value=set(),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result([]),  # no transcript video IDs
+                # No main query needed (transcript_video_ids is empty)
+                _row_result([  # tag-only video metadata
+                    _make_tag_meta_row(
+                        video_id=tv, upload_date=upload_date
+                    )
+                    for tv in tag_vids
+                ]),
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        assert total == 3
+        assert len(results) == 3
+
+        for r in results:
+            assert r["video_id"] in tag_vids
+            assert r["mention_count"] == 0
+            assert r["mentions"] == []
+            assert r["sources"] == ["tag"]
+            assert r["has_manual"] is False
+            assert r["first_mention_time"] is None
+
+    # ------------------------------------------------------------------
+    # T010: video in both sources appears once with merged sources
+    # ------------------------------------------------------------------
+
+    async def test_overlap_video_appears_once_with_merged_sources(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Video in both transcript mentions AND tags appears once with sources merged.
+
+        When a video_id exists in both transcript results and tag results,
+        the result must contain only one entry for that video_id.  The
+        ``sources`` list must contain both "transcript" and "tag".  The
+        transcript mention data (mention_count, mentions, first_mention_time)
+        must be preserved.
+        """
+        entity_id = _uuid()
+        overlap_vid = "vid_overlap_001"
+        upload_date = _MockUploadDate("2024-03-20")
+
+        with patch.object(
+            repository,
+            "_get_tag_associated_video_ids",
+            return_value={overlap_vid},
+        ), patch.object(
+            repository,
+            "_get_alias_matched_tag_video_ids",
+            return_value=set(),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result([overlap_vid]),  # transcript video IDs
+                _row_result([  # main grouped query
+                    _make_video_row(
+                        video_id=overlap_vid,
+                        mention_count=5,
+                        detection_methods=["rule_match"],
+                        first_mention_time=12.5,
+                        upload_date=upload_date,
+                    ),
+                ]),
+                _row_result([]),  # preview query
+                # No tag_meta_stmt — tag_only_ids is empty
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        # Only one video in results (deduplicated)
+        assert total == 1
+        assert len(results) == 1
+
+        video = results[0]
+        assert video["video_id"] == overlap_vid
+        assert "transcript" in video["sources"]
+        assert "tag" in video["sources"]
+        # Transcript mention data preserved
+        assert video["mention_count"] == 5
+        assert video["first_mention_time"] == 12.5
+
+    async def test_overlap_via_different_raw_tag_forms_still_deduped(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Same video matched via different raw tag forms is still deduplicated (EC-009).
+
+        Even if a video appears in tag results through multiple raw tag forms
+        (e.g., "AI" and "A.I." both resolving to the same canonical tag),
+        and also has transcript mentions, it must appear exactly once with
+        merged sources.
+        """
+        entity_id = _uuid()
+        overlap_vid = "vid_ec009"
+        upload_date = _MockUploadDate("2024-05-10")
+
+        # _get_tag_associated_video_ids already returns a set, so duplicates
+        # from different raw forms are collapsed at that level.
+        with patch.object(
+            repository,
+            "_get_tag_associated_video_ids",
+            return_value={overlap_vid},  # set — already deduplicated
+        ), patch.object(
+            repository,
+            "_get_alias_matched_tag_video_ids",
+            return_value=set(),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result([overlap_vid]),  # transcript video IDs
+                _row_result([
+                    _make_video_row(
+                        video_id=overlap_vid,
+                        mention_count=2,
+                        detection_methods=["rule_match"],
+                        upload_date=upload_date,
+                    ),
+                ]),
+                _row_result([]),  # preview query
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        assert total == 1
+        assert len(results) == 1
+        assert results[0]["video_id"] == overlap_vid
+        assert "tag" in results[0]["sources"]
+        assert "transcript" in results[0]["sources"]
+
+    # ------------------------------------------------------------------
+    # T014: sort order — transcript-mention videos before tag-only
+    # ------------------------------------------------------------------
+
+    async def test_transcript_mention_videos_sorted_before_tag_only(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Transcript-mention videos appear before tag-only videos in results.
+
+        Sort key: (has_transcript_mention DESC, mention_count DESC,
+        upload_date DESC).  A tag-only video with a newer upload date must
+        still sort AFTER a transcript-mention video.
+        """
+        entity_id = _uuid()
+        transcript_vid = "vid_transcript_sort"
+        tag_vid = "vid_tag_sort"
+        old_date = _MockUploadDate("2020-01-01")
+        new_date = _MockUploadDate("2025-12-31")
+
+        with patch.object(
+            repository,
+            "_get_tag_associated_video_ids",
+            return_value={tag_vid},
+        ), patch.object(
+            repository,
+            "_get_alias_matched_tag_video_ids",
+            return_value=set(),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result([transcript_vid]),  # transcript video IDs
+                _row_result([
+                    _make_video_row(
+                        video_id=transcript_vid,
+                        mention_count=1,
+                        upload_date=old_date,
+                    ),
+                ]),
+                _row_result([]),  # preview query
+                _row_result([
+                    _make_tag_meta_row(
+                        video_id=tag_vid, upload_date=new_date
+                    ),
+                ]),
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        assert total == 2
+        assert len(results) == 2
+        # Transcript-mention video first despite older upload_date
+        assert results[0]["video_id"] == transcript_vid
+        assert results[1]["video_id"] == tag_vid
+
+    # ------------------------------------------------------------------
+    # T015: pagination total reflects deduplicated count
+    # ------------------------------------------------------------------
+
+    async def test_pagination_total_reflects_deduplicated_count(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Total count is the deduplicated count across transcript + tag videos.
+
+        Given 2 transcript-mention videos and 3 tag videos with 1 overlap,
+        the total count should be 4 (not 5).
+        """
+        entity_id = _uuid()
+        transcript_vids = ["vid_t1", "vid_t2"]
+        tag_vids = {"vid_t2", "vid_tag1", "vid_tag2"}  # vid_t2 overlaps
+        upload_date = _MockUploadDate("2024-01-01")
+
+        with patch.object(
+            repository,
+            "_get_tag_associated_video_ids",
+            return_value=tag_vids,
+        ), patch.object(
+            repository,
+            "_get_alias_matched_tag_video_ids",
+            return_value=set(),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result(transcript_vids),  # transcript video IDs
+                _row_result([
+                    _make_video_row(
+                        video_id=vid, upload_date=upload_date
+                    )
+                    for vid in transcript_vids
+                ]),
+                _row_result([]),  # preview for vid_t1
+                _row_result([]),  # preview for vid_t2
+                _row_result([  # tag-only metadata (vid_tag1, vid_tag2)
+                    _make_tag_meta_row(
+                        video_id=vid, upload_date=upload_date
+                    )
+                    for vid in ["vid_tag1", "vid_tag2"]
+                ]),
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        # 2 transcript + 3 tag - 1 overlap = 4 unique
+        assert total == 4
+        assert len(results) == 4
+        result_ids = {r["video_id"] for r in results}
+        assert result_ids == {"vid_t1", "vid_t2", "vid_tag1", "vid_tag2"}
+
+
+# ---------------------------------------------------------------------------
+# T016-T018 — Alias-matched tag video association (User Story 2, Phase 4)
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntityVideoListAliasTagIntegration:
+    """Tests for alias-matched tag integration in get_entity_video_list() (T016-T018).
+
+    These tests verify that _get_alias_matched_tag_video_ids() is called
+    within get_entity_video_list() and its results are combined with
+    canonical-tag video IDs before deduplication against transcript mentions.
+    Both tag paths use the same "tag" source indicator.
+
+    Key behaviours verified:
+    - T016: case-insensitive alias matching via normalization
+    - T017: multiple aliases surface videos from all matching tags, deduplicated
+    - T018: alias that normalizes to None is silently skipped
+    """
+
+    @pytest.fixture
+    def repository(self) -> EntityMentionRepository:
+        """Provide a fresh EntityMentionRepository for each test."""
+        return EntityMentionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    # ------------------------------------------------------------------
+    # T016: alias "AI" surfaces videos tagged "ai" (case-insensitive)
+    # ------------------------------------------------------------------
+
+    async def test_alias_surfaces_videos_via_case_insensitive_normalization(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Entity with alias "AI" surfaces videos tagged "ai" via normalization.
+
+        The alias "AI" is normalized to "ai" by TagNormalizationService, which
+        matches tag_aliases.normalized_form = "ai".  The resulting video_ids
+        must appear in the entity video list with source "tag", mention_count 0,
+        and empty mentions list.
+        """
+        entity_id = _uuid()
+        alias_tag_vids = ["vid_ai_tag_001", "vid_ai_tag_002"]
+        upload_date = _MockUploadDate("2024-08-15")
+
+        with (
+            patch.object(
+                repository,
+                "_get_tag_associated_video_ids",
+                return_value=set(),  # No canonical tag link
+            ),
+            patch.object(
+                repository,
+                "_get_alias_matched_tag_video_ids",
+                return_value=set(alias_tag_vids),
+            ),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result([]),  # no transcript video IDs
+                _row_result([  # tag-only video metadata
+                    _make_tag_meta_row(
+                        video_id=vid, upload_date=upload_date
+                    )
+                    for vid in alias_tag_vids
+                ]),
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        assert total == 2
+        assert len(results) == 2
+
+        result_ids = {r["video_id"] for r in results}
+        assert result_ids == set(alias_tag_vids)
+
+        for r in results:
+            assert r["sources"] == ["tag"]
+            assert r["mention_count"] == 0
+            assert r["mentions"] == []
+            assert r["first_mention_time"] is None
+            assert r["has_manual"] is False
+
+    # ------------------------------------------------------------------
+    # T017: multiple aliases surface videos from all matching tags, deduped
+    # ------------------------------------------------------------------
+
+    async def test_multiple_aliases_surface_all_matching_tag_videos_deduplicated(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Entity with aliases "AI", "ML", "machine learning" surfaces all tagged videos.
+
+        Each alias may match different tags/videos.  The union of all
+        alias-matched video_ids is returned, deduplicated.  Videos from
+        the canonical tag path are also included (if any).  All tag-sourced
+        videos use source "tag".
+        """
+        entity_id = _uuid()
+        # Alias path returns 3 unique videos (one might overlap across aliases)
+        alias_tag_vids = ["vid_ai_01", "vid_ml_01", "vid_ml_02"]
+        # Canonical path returns 1 additional video
+        canonical_tag_vids = ["vid_canonical_01"]
+        upload_date = _MockUploadDate("2024-09-01")
+
+        with (
+            patch.object(
+                repository,
+                "_get_tag_associated_video_ids",
+                return_value=set(canonical_tag_vids),
+            ),
+            patch.object(
+                repository,
+                "_get_alias_matched_tag_video_ids",
+                return_value=set(alias_tag_vids),
+            ),
+        ):
+            all_tag_vids = set(alias_tag_vids) | set(canonical_tag_vids)
+
+            mock_session.execute.side_effect = [
+                _scalars_result([]),  # no transcript video IDs
+                _row_result([  # tag-only video metadata for all 4 vids
+                    _make_tag_meta_row(
+                        video_id=vid, upload_date=upload_date
+                    )
+                    for vid in sorted(all_tag_vids)
+                ]),
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        assert total == 4
+        assert len(results) == 4
+
+        result_ids = {r["video_id"] for r in results}
+        assert result_ids == all_tag_vids
+
+        for r in results:
+            assert r["sources"] == ["tag"]
+            assert r["mention_count"] == 0
+
+    # ------------------------------------------------------------------
+    # T018: alias that normalizes to None is silently skipped
+    # ------------------------------------------------------------------
+
+    async def test_alias_normalizing_to_none_is_silently_skipped(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Alias whose normalize() returns None contributes no video_ids.
+
+        When _get_alias_matched_tag_video_ids() returns an empty set because
+        all aliases normalized to None, the entity video list falls back to
+        transcript mentions and canonical tag associations only.  No error
+        is raised and no spurious videos appear.
+        """
+        entity_id = _uuid()
+        transcript_vid = "vid_transcript_only"
+        upload_date = _MockUploadDate("2024-07-01")
+
+        with (
+            patch.object(
+                repository,
+                "_get_tag_associated_video_ids",
+                return_value=set(),  # No canonical tag link
+            ),
+            patch.object(
+                repository,
+                "_get_alias_matched_tag_video_ids",
+                return_value=set(),  # All aliases normalized to None → empty
+            ),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result([transcript_vid]),  # transcript video IDs
+                _row_result([  # main grouped query
+                    _make_video_row(
+                        video_id=transcript_vid,
+                        mention_count=2,
+                        upload_date=upload_date,
+                    ),
+                ]),
+                _row_result([]),  # preview query
+                # No tag-only metadata query — tag_only_ids is empty
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        assert total == 1
+        assert len(results) == 1
+        assert results[0]["video_id"] == transcript_vid
+        assert results[0]["sources"] == ["transcript"]
+        assert results[0]["mention_count"] == 2
+
+    # ------------------------------------------------------------------
+    # T020: three-way overlap — "tag" appears only once in sources
+    # ------------------------------------------------------------------
+
+    async def test_three_way_overlap_tag_appears_once_in_sources(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Video in transcript + canonical tag + alias tag has "tag" only once.
+
+        When a video_id is found via transcript mentions, canonical tag path,
+        AND alias-matched tag path, the sources list must contain "tag" exactly
+        once (not duplicated).  The dedup logic at T013 already checks
+        ``"tag" not in sources`` before appending, so the three-way overlap
+        is naturally handled.
+        """
+        entity_id = _uuid()
+        overlap_vid = "vid_three_way"
+        upload_date = _MockUploadDate("2024-10-01")
+
+        # Both tag paths return the same video_id
+        with (
+            patch.object(
+                repository,
+                "_get_tag_associated_video_ids",
+                return_value={overlap_vid},
+            ),
+            patch.object(
+                repository,
+                "_get_alias_matched_tag_video_ids",
+                return_value={overlap_vid},
+            ),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result([overlap_vid]),  # transcript video IDs
+                _row_result([  # main grouped query
+                    _make_video_row(
+                        video_id=overlap_vid,
+                        mention_count=7,
+                        detection_methods=["rule_match"],
+                        first_mention_time=5.0,
+                        upload_date=upload_date,
+                    ),
+                ]),
+                _row_result([]),  # preview query
+                # No tag_meta_stmt — tag_only_ids is empty (video is in transcript)
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=20, offset=0
+            )
+
+        assert total == 1
+        assert len(results) == 1
+
+        video = results[0]
+        assert video["video_id"] == overlap_vid
+        # "tag" must appear exactly once despite two tag paths matching
+        assert video["sources"].count("tag") == 1
+        assert "transcript" in video["sources"]
+        assert "tag" in video["sources"]
+        # Transcript mention data preserved
+        assert video["mention_count"] == 7
+        assert video["first_mention_time"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# T028 — Entity header video count equals deduplicated total
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedVideoCount:
+    """Tests for combined video count in get_entity_video_list() (T028).
+
+    Verifies that the total count returned by get_entity_video_list()
+    reflects the deduplicated union of transcript-mention video IDs and
+    tag-associated video IDs.  This count is used by the entity detail
+    endpoint to display the correct video count in the entity header
+    (FR-007).
+    """
+
+    @pytest.fixture
+    def repository(self) -> EntityMentionRepository:
+        """Provide a fresh EntityMentionRepository for each test."""
+        return EntityMentionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    async def test_combined_count_with_overlap(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """5 transcript + 3 tag with 2 overlap = 6 deduplicated total.
+
+        Given an entity with 5 transcript-mention videos and 3 tag-associated
+        videos where 2 video IDs overlap, the total count must be 6 (not 8).
+        This validates FR-007 and US4 acceptance scenario 2.
+        """
+        entity_id = _uuid()
+        transcript_vids = [f"vid_t_{i}" for i in range(1, 6)]  # 5 videos
+        # 3 tag videos: 2 overlap with transcript, 1 unique
+        tag_vids = {"vid_t_1", "vid_t_2", "vid_tag_unique"}
+        upload_date = _MockUploadDate("2024-08-01")
+
+        with patch.object(
+            repository,
+            "_get_tag_associated_video_ids",
+            return_value=tag_vids,
+        ), patch.object(
+            repository,
+            "_get_alias_matched_tag_video_ids",
+            return_value=set(),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result(transcript_vids),  # transcript video IDs
+                _row_result([  # main grouped query
+                    _make_video_row(
+                        video_id=vid,
+                        mention_count=2,
+                        upload_date=upload_date,
+                    )
+                    for vid in transcript_vids
+                ]),
+                _row_result([]),  # preview for vid_t_1
+                _row_result([]),  # preview for vid_t_2
+                _row_result([]),  # preview for vid_t_3
+                _row_result([]),  # preview for vid_t_4
+                _row_result([]),  # preview for vid_t_5
+                _row_result([  # tag-only video metadata
+                    _make_tag_meta_row(
+                        video_id="vid_tag_unique",
+                        upload_date=upload_date,
+                    ),
+                ]),
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=50, offset=0
+            )
+
+        # 5 transcript + 1 tag-only = 6 unique (2 overlap counted once)
+        assert total == 6
+        assert len(results) == 6
+
+        # Verify overlap videos have "tag" in their sources
+        for r in results:
+            if r["video_id"] in ("vid_t_1", "vid_t_2"):
+                assert "tag" in r["sources"]
+                assert "transcript" in r["sources"]
+            elif r["video_id"] == "vid_tag_unique":
+                assert r["sources"] == ["tag"]
+                assert r["mention_count"] == 0
+
+    async def test_combined_count_no_overlap(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """3 transcript + 7 tag with 0 overlap = 10 total.
+
+        US4 acceptance scenario 1: entity with 3 transcript-mention videos
+        and 7 tag-only videos (no overlap), video count shows 10.
+        """
+        entity_id = _uuid()
+        transcript_vids = [f"vid_t_{i}" for i in range(1, 4)]  # 3 videos
+        tag_vids = {f"vid_tag_{i}" for i in range(1, 8)}  # 7 videos
+        upload_date = _MockUploadDate("2024-09-15")
+
+        with patch.object(
+            repository,
+            "_get_tag_associated_video_ids",
+            return_value=tag_vids,
+        ), patch.object(
+            repository,
+            "_get_alias_matched_tag_video_ids",
+            return_value=set(),
+        ):
+            mock_session.execute.side_effect = [
+                _scalars_result(transcript_vids),  # transcript video IDs
+                _row_result([  # main grouped query
+                    _make_video_row(
+                        video_id=vid,
+                        mention_count=1,
+                        upload_date=upload_date,
+                    )
+                    for vid in transcript_vids
+                ]),
+                _row_result([]),  # preview for vid_t_1
+                _row_result([]),  # preview for vid_t_2
+                _row_result([]),  # preview for vid_t_3
+                _row_result([  # tag-only video metadata
+                    _make_tag_meta_row(
+                        video_id=vid,
+                        upload_date=upload_date,
+                    )
+                    for vid in sorted(tag_vids)
+                ]),
+            ]
+
+            results, total = await repository.get_entity_video_list(
+                mock_session, entity_id, limit=50, offset=0
+            )
+
+        assert total == 10
+        assert len(results) == 10


### PR DESCRIPTION
## Summary

Entity detail pages now show videos from **three sources** instead of just transcript mentions:

1. **Transcript mentions** (existing) — entity name found in transcript text
2. **Canonical tag associations** (new) — videos tagged with the entity's linked canonical tag
3. **Alias-matched tag associations** (new) — videos tagged with terms matching entity aliases

Videos are deduplicated across sources, sorted with transcript mentions first, and each video displays source badges (indigo for transcript, teal for tag, green for manual).

## Problem Solved

Previously, entity "Karen Sparck" with 5 tagged videos but only 1 transcript mention showed just 1 video. Now shows all 6. Entity "Artificial Intelligence" with alias "AI" now surfaces all videos tagged "AI" without requiring a transcript scan.

## Key Design Decisions

- **No schema migration** (FR-011) — all associations computed at query time via JOINs
- **ASR error aliases excluded** from tag matching — prevents false positives (e.g., "edsger" alias for Nora Bennett was matching 15 Edsger Dijkstra videos via tags)
- **Exact equality matching** on normalized forms, not ILIKE — faster and more precise
- **Entity list page** continues using stored counts (combined count only on detail page) — defers complex per-entity subquery to future iteration

## Changes

### Backend
- `entity_mention_repository.py`: Added `_get_tag_associated_video_ids()`, `_get_alias_matched_tag_video_ids()`, `get_combined_video_count()`. Modified `get_entity_video_list()` with three-source UNION, dedup, and sort logic
- `entity_mentions.py`: Entity detail endpoint uses combined video count

### Frontend
- `EntityDetailPage.tsx`: Teal TAG badge (`bg-teal-100 text-teal-700`), tag-only video deep links without timestamp params
- `entityMentions.ts`: Updated JSDoc for `sources` field documenting `"tag"` value

### Tests
- 50 new tests (36 backend + 14 frontend)
- Backend: canonical tag path, alias matching, dedup, sort, pagination, ASR exclusion, combined counts
- Frontend: TAG badge rendering, deep link logic, mixed-source display, render order

## Test plan
- [x] 7,591 backend tests pass
- [x] 3,608 frontend tests pass
- [x] mypy --strict clean
- [x] ruff check clean (src + tests)
- [x] TypeScript clean
- [x] Manual verification: EML entity reduced from 203 to 199 videos after ASR exclusion fix
- [x] Docker container rebuilt and tested
- [x] CI pipeline passes

Closes #85