### PR TITLE
feat(entities): multi-source entity mention detection — title + description scanning (Feature 054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.55.0] - 2026-03-29
+
+### Added
+- **Feature 054: Multi-Source Entity Mention Detection** (Issue #73, Increment 1)
+  - **Title-Based Entity Detection (US1)**: `entities scan --sources title` scans all video titles for entity name/alias matches; creates `entity_mentions` rows with `mention_source='title'`; applies existing exclusion patterns; 20K+ title mentions found across 15K+ videos in production scan (11s)
+  - **Description-Based Entity Detection (US2)**: `entities scan --sources description` scans video descriptions; creates mentions with `mention_source='description'` and ~150 char context snippet stored in `mention_context` column; NULL descriptions safely skipped; 66K+ description mentions found across 21K+ videos (without boilerplate detection — US6 deferred)
+  - **Source-Aware Scan CLI (US3)**: `--sources` flag accepts comma-separated values (`transcript`, `title`, `description`); defaults to `transcript` for backward compatibility; `tag` rejected with validation error; composes with `--entity-id`, `--video-id`, `--language`, `--dry-run`, `--full`; `--full` deletes only mentions of specified source types
+  - **API `sources` Parameter (US3b)**: `POST /entities/{entity_id}/scan` and `POST /videos/{video_id}/scan-entities` accept optional `sources` query parameter; defaults to `["transcript"]`; invalid values return 422 with RFC 7807 error; frontend scan buttons pass `["transcript", "title", "description"]` for multi-source scanning
+  - **Per-Video Combined Source Badges (US4)**: TITLE badge (amber `bg-amber-100`), DESC badge (slate `bg-slate-200`) alongside existing TRANSCRIPT (indigo), TAG (teal), MANUAL (green); badge order follows quality hierarchy: TITLE → TRANSCRIPT → TAG → DESC → MANUAL; description context snippet displayed as italic text with entity name highlighted via `<mark>`
+  - **Source Filter Dropdown (US5)**: Filter dropdown on entity detail page with options: All sources, Title, Transcript, Tag, Description, Manual; persists in URL query parameter `?source=title`; composes with language filter; empty state shows "No videos found for this source type" with "Try All sources" link
+
+### Changed
+- Alembic migration 054: adds `mention_source` (VARCHAR(20), NOT NULL, default 'transcript') and `mention_context` (TEXT, nullable) columns to `entity_mentions`; adds partial unique indexes for title and description mentions; adds CHECK constraint for valid source values
+- `MentionSource` enum added to `src/chronovista/models/enums.py`
+- `EntityMentionScanService.scan_metadata()` new async method for title/description scanning
+- `EntityMentionRepository.delete_by_scope()` extended with `mention_source` filter for source-scoped `--full` deletion
+- `EntityMentionRepository.get_entity_video_list()` extended with `source_filter` parameter and source mapping for title/description
+- Dry-run output includes `source` column for metadata scans; summary reports "videos scanned" instead of "segments scanned"
+
+### Technical
+- Backend version: 0.54.0 → 0.55.0
+- Frontend version: 0.23.0 → 0.24.0
+- Alembic migration 054
+- ~60 new backend tests, ~33 new frontend tests
+- US6 (description boilerplate detection) deferred to follow-up increment
+- Closes #73 (Increment 1)
+
 ## [0.54.0] - 2026-03-28
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+## [0.55.0] - 2026-03-29
+
+### Added
+- **Feature 054: Multi-Source Entity Mention Detection** (Issue #73, Increment 1)
+  - Title and description scanning for entity names via `entities scan --sources title,description`
+  - API `sources` parameter on both scan endpoints; frontend scan buttons trigger multi-source scanning
+  - TITLE (amber) and DESC (slate) source badges on entity detail page
+  - Source filter dropdown: filter by Title, Transcript, Tag, Description, Manual
+  - Schema migration: `mention_source` and `mention_context` columns on `entity_mentions`
+
+### Technical
+- Backend: 0.54.0 → 0.55.0, Frontend: 0.23.0 → 0.24.0
+- Alembic migration 054, ~93 new tests
+- US6 (boilerplate detection) deferred
+- Closes #73 (Increment 1)
+
 ## [0.54.0] - 2026-03-28
 
 ### Added

--- a/docs/user-guide/rest-api.md
+++ b/docs/user-guide/rest-api.md
@@ -1711,7 +1711,7 @@ GET /api/v1/entities/{entity_id}
 
 #### Get Entity Videos
 
-Retrieve a paginated list of videos associated with a given entity from three sources: transcript mentions, canonical tag associations, and alias-matched tag associations. Results are deduplicated by video and sorted with transcript-mention videos first.
+Retrieve a paginated list of videos associated with a given entity from five sources: transcript mentions, title mentions, description mentions, canonical tag associations, and manual links. Results are deduplicated by video and sorted with transcript-mention videos first.
 
 ```
 GET /api/v1/entities/{entity_id}/videos
@@ -1720,6 +1720,7 @@ GET /api/v1/entities/{entity_id}/videos
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `language_code` | string | BCP-47 language code filter |
+| `source` | string | Filter by source type: `title`, `transcript`, `tag`, `description`, `manual`. Omit for all sources. |
 | `limit` | integer | Results per page, 1–100 (default 20) |
 | `offset` | integer | Pagination offset (default 0) |
 
@@ -1761,21 +1762,27 @@ GET /api/v1/entities/{entity_id}/videos
 
 | Source | Meaning | `mention_count` | `mentions` | `first_mention_time` |
 |--------|---------|-----------------|------------|---------------------|
+| `title` | Entity name found in video title | 0 | `[]` | `null` |
 | `transcript` | Entity name found in transcript text | > 0 | Up to 5 previews | Timestamp (seconds) |
 | `tag` | Video tagged with entity's canonical tag or alias-matched tag | 0 | `[]` | `null` |
+| `description` | Entity name found in video description | 0 | `[]` | `null` |
 | `manual` | User manually linked entity to video | 0 | `[]` | `null` |
 
-Videos may have multiple sources (e.g., `["transcript", "tag"]`). ASR error aliases are excluded from tag matching to prevent false positives.
+Videos may have multiple sources (e.g., `["title", "transcript", "tag"]`). Badge display order follows quality hierarchy: TITLE → TRANSCRIPT → TAG → DESC → MANUAL. Description-sourced videos include a `description_context` field with a ~150 char context snippet. ASR error aliases are excluded from tag matching to prevent false positives.
 
 ---
 
 #### Scan Entity Mentions
 
-Trigger an entity mention scan for a single entity across all transcript segments. The entity must exist and be in `active` status.
+Trigger an entity mention scan for a single entity. Scans transcript segments by default; optionally scans video titles and descriptions when `sources` parameter is provided. The entity must exist and be in `active` status.
 
 ```
 POST /api/v1/entities/{entity_id}/scan
 ```
+
+| Query Parameter | Type | Default | Description |
+|----------------|------|---------|-------------|
+| `sources` | list[string] | `["transcript"]` | Text sources to scan: `transcript`, `title`, `description`. Multiple values accepted (e.g., `?sources=title&sources=description`). Value `tag` is rejected (422). |
 
 **Request body (all fields optional):**
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.24.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/entityMentions.ts
+++ b/frontend/src/api/entityMentions.ts
@@ -55,6 +55,8 @@ export interface EntityVideoResult {
    * - `"transcript"` — entity was detected in a transcript segment via scan
    * - `"manual"` — user created a manual association via the UI
    * - `"tag"` — video is tagged with the entity's canonical tag (Feature 053)
+   * - `"title"` — entity was detected in the video title (Feature 054)
+   * - `"description"` — entity was detected in the video description (Feature 054)
    *
    * A single video may have multiple sources (e.g. `["transcript", "tag"]`).
    * Tag-only videos have `mention_count: 0`, `mentions: []`, and
@@ -67,6 +69,13 @@ export interface EntityVideoResult {
   first_mention_time: number | null;
   /** Video upload date (ISO 8601) for sort ordering. */
   upload_date: string | null;
+  /**
+   * Context snippet (~150 chars) surrounding the description match.
+   * Only present when `"description"` is in `sources`; null otherwise.
+   * The entity text within the snippet may be highlighted by the UI.
+   * This field is optional for backward compatibility with pre-Feature-054 API responses.
+   */
+  description_context?: string | null;
 }
 
 /** Pagination metadata */
@@ -165,6 +174,12 @@ export interface FetchEntitiesParams {
 export interface FetchEntityVideosParams {
   /** Optional BCP-47 language code to filter mentions by language */
   language_code?: string;
+  /**
+   * Optional source filter. When provided, only videos whose sources list
+   * includes this value are returned. Valid values: transcript, title,
+   * description, tag, manual.
+   */
+  source?: string;
   /** Max results per page (1-100, default 20) */
   limit?: number;
   /** Offset for pagination (>=0) */
@@ -311,6 +326,9 @@ export async function fetchEntityVideos(
   const qs = new URLSearchParams();
   if (params.language_code) {
     qs.set("language_code", params.language_code);
+  }
+  if (params.source) {
+    qs.set("source", params.source);
   }
   if (params.limit !== undefined) {
     qs.set("limit", String(params.limit));
@@ -662,6 +680,12 @@ export interface ScanRequest {
   dry_run?: boolean;
   /** When true, re-scan segments that already have recorded mentions. */
   full_rescan?: boolean;
+  /**
+   * Scan source types to include. Valid values: "transcript", "title",
+   * "description". Defaults to ["transcript"] when omitted.
+   * "tag" is not a valid scan source (tag associations are query-time only).
+   */
+  sources?: string[];
 }
 
 /** Aggregate statistics returned by a completed entity scan. */

--- a/frontend/src/components/EntityMentionsPanel.tsx
+++ b/frontend/src/components/EntityMentionsPanel.tsx
@@ -661,7 +661,7 @@ export function EntityMentionsPanel({
                 setScanMessage(null);
                 scanMutation.reset();
                 scanMutation.mutate(
-                  { videoId },
+                  { videoId, options: { sources: ["transcript", "title", "description"] } },
                   {
                     onSuccess: (result) => {
                       const { unique_entities, mentions_found } = result.data;

--- a/frontend/src/hooks/useEntityMentions.ts
+++ b/frontend/src/hooks/useEntityMentions.ts
@@ -157,7 +157,7 @@ export function useEntityVideos(
     isFetchingNextPage,
     fetchNextPage,
   } = useInfiniteQuery({
-    queryKey: ["entity-videos", entityId, params.language_code ?? null, limit],
+    queryKey: ["entity-videos", entityId, params.language_code ?? null, params.source ?? null, limit],
     // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
     queryFn: ({ pageParam, signal }) =>
       fetchEntityVideos(entityId, {

--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -14,8 +14,8 @@
  * - T031: Loading skeleton
  */
 
-import { useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import React, { useEffect, useRef, useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import { ENTITY_TYPE_LABELS, ENTITY_TYPE_COLORS } from "../constants/entityTypes";
 import { useEntityVideos, useDeleteManualAssociation, useScanEntity } from "../hooks/useEntityMentions";
@@ -290,6 +290,16 @@ interface EntityVideoCardProps {
   sources: string[];
   /** Whether a manual association exists for this entity on this video. */
   has_manual: boolean;
+  /**
+   * Context snippet (~150 chars) surrounding the description match.
+   * Only present when "description" is in sources; null otherwise.
+   */
+  description_context: string | null;
+  /**
+   * Canonical name of the entity — used to highlight the entity text within
+   * the description context snippet (FR-034).
+   */
+  entityName: string;
   /** Entity ID from route params — needed for the unlink mutation. */
   entityId: string;
   /** Whether this card's unlink confirmation is currently visible. */
@@ -304,6 +314,26 @@ interface EntityVideoCardProps {
   isDeletePending: boolean;
 }
 
+/**
+ * Highlights all case-insensitive occurrences of `query` within `text` by
+ * wrapping them in `<mark>` elements.  Returns an array of React nodes.
+ */
+function highlightEntityInContext(text: string, query: string): React.ReactNode[] {
+  if (!query.trim()) return [text];
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`(${escaped})`, "gi");
+  const parts = text.split(regex);
+  return parts.map((part, i) =>
+    regex.test(part) ? (
+      <mark key={i} className="bg-yellow-100 font-bold not-italic">
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  );
+}
+
 function EntityVideoCard({
   video_id,
   video_title,
@@ -313,6 +343,8 @@ function EntityVideoCard({
   first_segment_id,
   sources,
   has_manual,
+  description_context,
+  entityName,
   isUnlinking,
   onUnlinkClick,
   onUnlinkCancel,
@@ -322,6 +354,8 @@ function EntityVideoCard({
   const isManualOnly = mention_count === 0 && has_manual;
   const hasTranscript = sources.includes("transcript") && mention_count > 0;
   const hasTag = sources.includes("tag");
+  const hasTitle = sources.includes("title");
+  const hasDescription = sources.includes("description");
 
   // T026: tag-only videos (no transcript mention and no manual association)
   // link to the video page without segment/timestamp params since there is no
@@ -350,22 +384,24 @@ function EntityVideoCard({
             {video_title}
           </h4>
           <p className="text-sm text-gray-500 mb-2">{channel_name}</p>
-          {/* Source badges */}
-          <div className="flex items-center gap-2 mb-2">
+          {/* Source badges — quality hierarchy: TITLE → TRANSCRIPT → TAG → DESC → MANUAL */}
+          <div className="flex flex-wrap items-center gap-2 mb-2">
+            {/* T050: TITLE badge — amber, non-clickable (FR-011) */}
+            {hasTitle && (
+              <span
+                className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-amber-100 text-amber-700"
+                data-testid="title-badge"
+                title="Entity found in video title"
+              >
+                TITLE
+              </span>
+            )}
             {hasTranscript && (
               <span
                 className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-indigo-100 text-indigo-700 border border-indigo-200"
                 data-testid="transcript-badge"
               >
                 TRANSCRIPT &times;{mention_count}
-              </span>
-            )}
-            {has_manual && (
-              <span
-                className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-emerald-100 text-emerald-700 border border-emerald-200"
-                data-testid="manual-badge"
-              >
-                MANUAL
               </span>
             )}
             {/* T025: TAG badge — teal pill shown when video is associated via tag */}
@@ -377,7 +413,39 @@ function EntityVideoCard({
                 TAG
               </span>
             )}
+            {/* T051: DESC badge — slate, non-clickable (FR-012) */}
+            {hasDescription && (
+              <span
+                className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-slate-200 text-slate-700"
+                data-testid="desc-badge"
+                title="Entity found in video description"
+              >
+                DESC
+              </span>
+            )}
+            {has_manual && (
+              <span
+                className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-emerald-100 text-emerald-700 border border-emerald-200"
+                data-testid="manual-badge"
+              >
+                MANUAL
+              </span>
+            )}
           </div>
+          {/* T052: Description context snippet — italic, truncated, entity highlighted */}
+          {hasDescription && description_context && (
+            <p
+              className="text-xs text-slate-500 italic mb-2"
+              data-testid="description-context"
+            >
+              {highlightEntityInContext(
+                description_context.length > 150
+                  ? description_context.slice(0, 150) + "..."
+                  : description_context,
+                entityName
+              )}
+            </p>
+          )}
           <div className="flex items-center gap-4 text-xs text-gray-500">
             {isManualOnly ? (
               <span>Manually linked</span>
@@ -611,9 +679,20 @@ function AddAliasForm({ entityId, onCreated }: AddAliasFormProps) {
  *
  * Route: /entities/:entityId
  */
+/** Valid values for the source filter dropdown. */
+const SOURCE_FILTER_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "All sources" },
+  { value: "title", label: "Title" },
+  { value: "transcript", label: "Transcript" },
+  { value: "tag", label: "Tag" },
+  { value: "description", label: "Description" },
+  { value: "manual", label: "Manual" },
+];
+
 export function EntityDetailPage() {
   const { entityId } = useParams<{ entityId: string }>();
   const queryClient = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // T045: Track which video's unlink confirmation is currently visible.
   const [unlinkingVideoId, setUnlinkingVideoId] = useState<string | null>(null);
@@ -651,7 +730,7 @@ export function EntityDetailPage() {
       scanTimerRef.current = null;
     }
     scanMutation.mutate(
-      { entityId },
+      { entityId, options: { sources: ["transcript", "title", "description"] } },
       {
         onSuccess: (data) => {
           const { mentions_found, unique_videos } = data.data;
@@ -714,7 +793,23 @@ export function EntityDetailPage() {
     },
   });
 
-  // Infinite-scroll video list
+  // T065: Source filter — read from URL query parameter ?source=
+  const sourceFilter = searchParams.get("source") ?? "";
+
+  function handleSourceFilterChange(value: string) {
+    const next = new URLSearchParams(searchParams);
+    if (value) {
+      next.set("source", value);
+    } else {
+      next.delete("source");
+    }
+    setSearchParams(next, { replace: true });
+  }
+
+  // Infinite-scroll video list (with optional source filter)
+  const entityVideoParams = sourceFilter
+    ? { source: sourceFilter }
+    : {};
   const {
     videos,
     total,
@@ -722,7 +817,7 @@ export function EntityDetailPage() {
     hasNextPage,
     isFetchingNextPage,
     loadMoreRef,
-  } = useEntityVideos(entityId ?? "");
+  } = useEntityVideos(entityId ?? "", entityVideoParams);
 
   // Browser tab title
   useEffect(() => {
@@ -933,14 +1028,40 @@ export function EntityDetailPage() {
 
       {/* Video list section */}
       <section aria-labelledby="entity-videos-heading">
-        <h2
-          id="entity-videos-heading"
-          className="text-lg font-semibold text-gray-900 mb-4"
-        >
-          Videos
-        </h2>
+        {/* Section header + source filter dropdown */}
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+          <h2
+            id="entity-videos-heading"
+            className="text-lg font-semibold text-gray-900"
+          >
+            Videos
+          </h2>
 
-        {/* Loading skeleton for video list */}
+          {/* T065: Source filter dropdown */}
+          <div className="flex items-center gap-2">
+            <label
+              htmlFor="source-filter"
+              className="text-sm text-gray-600 whitespace-nowrap"
+            >
+              Filter by source:
+            </label>
+            <select
+              id="source-filter"
+              value={sourceFilter}
+              onChange={(e) => handleSourceFilterChange(e.target.value)}
+              className="rounded-md border border-slate-300 px-2 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              aria-label="Filter videos by source"
+            >
+              {SOURCE_FILTER_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Loading skeleton for video list — T067: dropdown stays interactive */}
         {videosLoading && (
           <div className="space-y-4 animate-pulse">
             {[1, 2, 3].map((i) => (
@@ -971,6 +1092,8 @@ export function EntityDetailPage() {
                   first_segment_id={firstMention?.segment_id ?? 0}
                   sources={v.sources ?? []}
                   has_manual={v.has_manual ?? false}
+                  description_context={v.description_context ?? null}
+                  entityName={entity.canonical_name}
                   entityId={entityId ?? ""}
                   isUnlinking={unlinkingVideoId === v.video_id}
                   isDeletePending={
@@ -992,10 +1115,25 @@ export function EntityDetailPage() {
           </div>
         )}
 
-        {/* Empty state */}
+        {/* Empty state — T066: source-filtered empty state */}
         {!videosLoading && videos.length === 0 && (
           <div className="bg-white rounded-xl border border-gray-100 p-8 text-center">
-            <p className="text-gray-500">No videos found for this entity.</p>
+            {sourceFilter ? (
+              <>
+                <p className="text-gray-500 mb-2">
+                  No videos found for this source type.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => handleSourceFilterChange("")}
+                  className="text-sm text-indigo-600 hover:text-indigo-800 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                >
+                  Try All sources
+                </button>
+              </>
+            ) : (
+              <p className="text-gray-500">No videos found for this entity.</p>
+            )}
           </div>
         )}
 

--- a/frontend/src/pages/__tests__/EntityDetailPage.source-badges.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.source-badges.test.tsx
@@ -1,0 +1,787 @@
+/**
+ * Tests for EntityDetailPage — Feature 054, Phases 7-8 (US4, US5).
+ *
+ * Coverage (T045-T061):
+ *
+ * US4 — Per-Video Combined Source Badges (T045-T049):
+ * - T045: Video with sources: ["title"] renders amber TITLE badge
+ * - T046: Video with sources: ["description"] renders slate DESC badge with context snippet
+ * - T047: Video with sources: ["title", "transcript", "tag"] renders all badges in quality order
+ * - T048: TITLE and DESC badges are non-clickable with title attributes per FR-035
+ * - T049: Description context snippet is italic, truncated to 150 chars with ellipsis,
+ *         entity text highlighted with <mark> per FR-034
+ *
+ * US5 — Source Filter Dropdown (T057-T061):
+ * - T057: Source filter dropdown renders with all options
+ * - T058: Selecting "Title" filter shows only title-sourced videos
+ * - T059: Source filter composes with language filter in URL
+ * - T060: Source filter persists in URL ?source=title
+ * - T061: Empty state shows "No videos found for this source type." per FR-032
+ *
+ * Mock strategy follows the existing EntityDetailPage.tag-videos.test.tsx pattern:
+ * - `useEntityVideos` (hooks/useEntityMentions) — mocked to control video list
+ * - `useQuery` (@tanstack/react-query) — mocked to control entity detail fetch
+ * - `PhoneticVariantsSection` — mocked to avoid independent useQuery calls
+ * - `ExclusionPatternsSection` — mocked to keep tests focused
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { EntityDetailPage } from "../EntityDetailPage";
+
+// ---------------------------------------------------------------------------
+// Mock dependencies
+// ---------------------------------------------------------------------------
+
+vi.mock("../../hooks/useEntityMentions", () => ({
+  useEntityVideos: vi.fn(),
+  useVideoEntities: vi.fn(() => ({
+    entities: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+  useDeleteManualAssociation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    isSuccess: false,
+  })),
+  useScanEntity: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: null,
+    reset: vi.fn(),
+  })),
+  useScanVideoEntities: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: null,
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock("../../components/corrections/PhoneticVariantsSection", () => ({
+  PhoneticVariantsSection: () => null,
+}));
+
+vi.mock("../../components/corrections/ExclusionPatternsSection", () => ({
+  ExclusionPatternsSection: () => null,
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+  };
+});
+
+import { useQuery } from "@tanstack/react-query";
+import { useEntityVideos } from "../../hooks/useEntityMentions";
+import type { EntityVideoResult } from "../../api/entityMentions";
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+const mockEntity = {
+  entity_id: "entity-uuid-001",
+  canonical_name: "David Sheen",
+  entity_type: "person",
+  description: "Journalist and documentary filmmaker.",
+  status: "active",
+  mention_count: 5,
+  video_count: 3,
+  aliases: [] as { alias_name: string; alias_type: string; occurrence_count: number }[],
+  exclusion_patterns: [] as string[],
+};
+
+function createTitleVideo(overrides: Partial<EntityVideoResult> = {}): EntityVideoResult {
+  return {
+    video_id: "title-vid-001",
+    video_title: "David Sheen Documentary Review",
+    channel_name: "Test Channel",
+    mention_count: 0,
+    mentions: [],
+    sources: ["title"],
+    has_manual: false,
+    first_mention_time: null,
+    upload_date: "2024-08-01T00:00:00+00:00",
+    description_context: null,
+    ...overrides,
+  };
+}
+
+function createDescriptionVideo(overrides: Partial<EntityVideoResult> = {}): EntityVideoResult {
+  return {
+    video_id: "desc-vid-001",
+    video_title: "Middle East Analysis 2024",
+    channel_name: "Test Channel",
+    mention_count: 0,
+    mentions: [],
+    sources: ["description"],
+    has_manual: false,
+    first_mention_time: null,
+    upload_date: "2024-07-15T00:00:00+00:00",
+    description_context:
+      "...featuring journalist David Sheen who has covered Israeli policies in the West Bank for over a decade...",
+    ...overrides,
+  };
+}
+
+function createMultiSourceVideo(overrides: Partial<EntityVideoResult> = {}): EntityVideoResult {
+  return {
+    video_id: "multi-source-vid-001",
+    video_title: "Multi Source Video",
+    channel_name: "Test Channel",
+    mention_count: 2,
+    mentions: [
+      { segment_id: 10, start_time: 30.0, mention_text: "David Sheen" },
+    ],
+    sources: ["title", "transcript", "tag"],
+    has_manual: false,
+    first_mention_time: 30.0,
+    upload_date: "2024-09-01T00:00:00+00:00",
+    description_context: null,
+    ...overrides,
+  };
+}
+
+/** Default mock return for useEntityVideos (empty). */
+const defaultUseEntityVideos = {
+  videos: [],
+  total: null,
+  pagination: null,
+  isLoading: false,
+  isError: false,
+  error: null,
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  fetchNextPage: vi.fn(),
+  loadMoreRef: { current: null },
+};
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+function renderPage(
+  entityId = "entity-uuid-001",
+  initialSearch = ""
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const initialEntry = `/entities/${entityId}${initialSearch}`;
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/entities/:entityId" element={<EntityDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(useQuery).mockReturnValue({
+    data: mockEntity,
+    isLoading: false,
+    isError: false,
+    error: null,
+    status: "success",
+    isFetching: false,
+    isPending: false,
+    isSuccess: true,
+    isRefetching: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isStale: false,
+    dataUpdatedAt: Date.now(),
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    fetchStatus: "idle" as const,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isInitialLoading: false,
+    isEnabled: true,
+    refetch: vi.fn(),
+    promise: Promise.resolve(mockEntity),
+  } as ReturnType<typeof useQuery>);
+
+  vi.mocked(useEntityVideos).mockReturnValue(defaultUseEntityVideos);
+});
+
+// ---------------------------------------------------------------------------
+// US4 Tests — Per-Video Combined Source Badges (T045-T049)
+// ---------------------------------------------------------------------------
+
+describe("EntityDetailPage — source badges (Feature 054, US4)", () => {
+  /**
+   * T045: Video with sources: ["title"] renders amber TITLE badge.
+   */
+  describe("T045 — TITLE badge", () => {
+    it("renders amber TITLE badge when sources includes 'title'", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTitleVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("title-badge");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent("TITLE");
+    });
+
+    it("TITLE badge has amber styling classes", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTitleVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("title-badge");
+      expect(badge.className).toContain("bg-amber-100");
+      expect(badge.className).toContain("text-amber-700");
+    });
+
+    it("does NOT render a TRANSCRIPT badge for title-only video", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTitleVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      expect(screen.queryByTestId("transcript-badge")).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * T046: Video with sources: ["description"] renders slate DESC badge
+   * and a description context snippet.
+   */
+  describe("T046 — DESC badge with context snippet", () => {
+    it("renders slate DESC badge when sources includes 'description'", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createDescriptionVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("desc-badge");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent("DESC");
+    });
+
+    it("DESC badge has slate styling classes", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createDescriptionVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("desc-badge");
+      expect(badge.className).toContain("bg-slate-200");
+      expect(badge.className).toContain("text-slate-700");
+    });
+
+    it("renders description context snippet when description_context is present", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [
+          createDescriptionVideo({
+            description_context: "...featuring journalist David Sheen who has covered...",
+          }),
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      const snippet = screen.getByTestId("description-context");
+      expect(snippet).toBeInTheDocument();
+      expect(snippet).toHaveTextContent("David Sheen");
+    });
+
+    it("does NOT render context snippet when description_context is null", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createDescriptionVideo({ description_context: null })],
+        total: 1,
+      });
+
+      renderPage();
+
+      expect(screen.queryByTestId("description-context")).not.toBeInTheDocument();
+    });
+  });
+
+  /**
+   * T047: Video with sources: ["title", "transcript", "tag"] renders all badges
+   * in quality hierarchy order: TITLE → TRANSCRIPT → TAG.
+   */
+  describe("T047 — multi-source video with all badges in quality order", () => {
+    it("renders TITLE, TRANSCRIPT, and TAG badges for multi-source video", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createMultiSourceVideo({ mention_count: 2 })],
+        total: 1,
+      });
+
+      renderPage();
+
+      expect(screen.getByTestId("title-badge")).toBeInTheDocument();
+      expect(screen.getByTestId("transcript-badge")).toBeInTheDocument();
+      expect(screen.getByTestId("tag-badge")).toBeInTheDocument();
+    });
+
+    it("TITLE badge appears before TRANSCRIPT badge in DOM order", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createMultiSourceVideo({ mention_count: 2 })],
+        total: 1,
+      });
+
+      renderPage();
+
+      const titleBadge = screen.getByTestId("title-badge");
+      const transcriptBadge = screen.getByTestId("transcript-badge");
+
+      // compareDocumentPosition: 4 means DOCUMENT_POSITION_FOLLOWING
+      // (transcriptBadge follows titleBadge => titleBadge comes first)
+      const position = titleBadge.compareDocumentPosition(transcriptBadge);
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it("TRANSCRIPT badge appears before TAG badge in DOM order", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createMultiSourceVideo({ mention_count: 2 })],
+        total: 1,
+      });
+
+      renderPage();
+
+      const transcriptBadge = screen.getByTestId("transcript-badge");
+      const tagBadge = screen.getByTestId("tag-badge");
+
+      const position = transcriptBadge.compareDocumentPosition(tagBadge);
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it("renders DESC badge before MANUAL badge in DOM order", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [
+          createDescriptionVideo({
+            video_id: "desc-manual-vid",
+            sources: ["description", "manual"],
+            has_manual: true,
+          }),
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      const descBadge = screen.getByTestId("desc-badge");
+      const manualBadge = screen.getByTestId("manual-badge");
+
+      const position = descBadge.compareDocumentPosition(manualBadge);
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+  });
+
+  /**
+   * T048: TITLE and DESC badges are non-clickable (no href, no cursor-pointer)
+   * with title attributes per FR-035.
+   */
+  describe("T048 — TITLE and DESC badges are non-clickable with title attributes", () => {
+    it("TITLE badge is not a link element", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTitleVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("title-badge");
+      expect(badge.tagName.toLowerCase()).not.toBe("a");
+      expect(badge).not.toHaveAttribute("href");
+    });
+
+    it("TITLE badge has title attribute per FR-035", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createTitleVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("title-badge");
+      expect(badge).toHaveAttribute("title", "Entity found in video title");
+    });
+
+    it("DESC badge is not a link element", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createDescriptionVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("desc-badge");
+      expect(badge.tagName.toLowerCase()).not.toBe("a");
+      expect(badge).not.toHaveAttribute("href");
+    });
+
+    it("DESC badge has title attribute per FR-035", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [createDescriptionVideo()],
+        total: 1,
+      });
+
+      renderPage();
+
+      const badge = screen.getByTestId("desc-badge");
+      expect(badge).toHaveAttribute("title", "Entity found in video description");
+    });
+  });
+
+  /**
+   * T049: Description context snippet is italic, truncated to 150 chars with
+   * ellipsis, entity text highlighted with <mark> per FR-034.
+   */
+  describe("T049 — description context snippet formatting", () => {
+    it("context snippet paragraph has italic styling", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [
+          createDescriptionVideo({
+            description_context: "Featuring David Sheen in this analysis.",
+          }),
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      const snippet = screen.getByTestId("description-context");
+      expect(snippet.className).toContain("italic");
+    });
+
+    it("context snippet is truncated at 150 chars with ellipsis for long text", () => {
+      // Create a description context that is clearly over 150 chars
+      const longContext =
+        "A".repeat(80) + " David Sheen " + "B".repeat(80);
+
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [
+          createDescriptionVideo({ description_context: longContext }),
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      const snippet = screen.getByTestId("description-context");
+      // The rendered text content should end with "..."
+      expect(snippet.textContent).toMatch(/\.\.\.$/);
+      // Full text (without the ellipsis) should not exceed 153 chars
+      expect(snippet.textContent!.length).toBeLessThanOrEqual(153);
+    });
+
+    it("context snippet does NOT add ellipsis for text under 150 chars", () => {
+      const shortContext = "Brief mention of David Sheen in the text.";
+
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [
+          createDescriptionVideo({ description_context: shortContext }),
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      const snippet = screen.getByTestId("description-context");
+      expect(snippet.textContent).not.toMatch(/\.\.\.$/);
+    });
+
+    it("entity name is highlighted with <mark> inside the context snippet", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [
+          createDescriptionVideo({
+            description_context: "Featuring David Sheen in this analysis.",
+          }),
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      const snippet = screen.getByTestId("description-context");
+      // The entity name should be wrapped in a <mark> element
+      const markEl = snippet.querySelector("mark");
+      expect(markEl).toBeTruthy();
+      expect(markEl?.textContent).toBe("David Sheen");
+    });
+
+    it("mark element has bg-yellow-100 styling", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [
+          createDescriptionVideo({
+            description_context: "Analysis by David Sheen.",
+          }),
+        ],
+        total: 1,
+      });
+
+      renderPage();
+
+      const snippet = screen.getByTestId("description-context");
+      const markEl = snippet.querySelector("mark");
+      expect(markEl?.className).toContain("bg-yellow-100");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// US5 Tests — Source Filter Dropdown (T057-T061)
+// ---------------------------------------------------------------------------
+
+describe("EntityDetailPage — source filter dropdown (Feature 054, US5)", () => {
+  /**
+   * T057: Source filter dropdown renders with all expected options.
+   */
+  describe("T057 — source filter dropdown renders with all options", () => {
+    it("renders a source filter dropdown", () => {
+      renderPage();
+
+      const dropdown = screen.getByRole("combobox", {
+        name: /filter videos by source/i,
+      });
+      expect(dropdown).toBeInTheDocument();
+    });
+
+    it("dropdown has All sources, Title, Transcript, Tag, Description, Manual options", () => {
+      renderPage();
+
+      const dropdown = screen.getByRole("combobox", {
+        name: /filter videos by source/i,
+      });
+
+      const options = Array.from(
+        (dropdown as HTMLSelectElement).options
+      ).map((o) => o.text);
+
+      expect(options).toContain("All sources");
+      expect(options).toContain("Title");
+      expect(options).toContain("Transcript");
+      expect(options).toContain("Tag");
+      expect(options).toContain("Description");
+      expect(options).toContain("Manual");
+    });
+
+    it("dropdown defaults to 'All sources' when no source param in URL", () => {
+      renderPage();
+
+      const dropdown = screen.getByRole("combobox", {
+        name: /filter videos by source/i,
+      }) as HTMLSelectElement;
+
+      expect(dropdown.value).toBe("");
+    });
+  });
+
+  /**
+   * T058: Selecting "Title" filter shows only title-sourced videos.
+   * (We verify the hook is called with the correct param.)
+   */
+  describe("T058 — selecting a source filter updates the hook params", () => {
+    it("passes source='title' to useEntityVideos when Title option selected", () => {
+      renderPage();
+
+      const dropdown = screen.getByRole("combobox", {
+        name: /filter videos by source/i,
+      });
+
+      fireEvent.change(dropdown, { target: { value: "title" } });
+
+      // Verify the hook was called with source param
+      const calls = vi.mocked(useEntityVideos).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall?.[1]).toEqual({ source: "title" });
+    });
+
+    it("passes no source param to useEntityVideos when All sources selected", () => {
+      // Start with a source filter set
+      renderPage("entity-uuid-001", "?source=title");
+
+      const dropdown = screen.getByRole("combobox", {
+        name: /filter videos by source/i,
+      });
+
+      fireEvent.change(dropdown, { target: { value: "" } });
+
+      const calls = vi.mocked(useEntityVideos).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      // When cleared, params should be empty object (no source key)
+      expect(lastCall?.[1]).toEqual({});
+    });
+  });
+
+  /**
+   * T059: Source filter composes with language filter (both live in URL params).
+   */
+  describe("T059 — source filter composes with language filter in URL", () => {
+    it("pre-existing source param is read from URL on mount", () => {
+      // Render with ?source=description in the URL
+      renderPage("entity-uuid-001", "?source=description");
+
+      const dropdown = screen.getByRole("combobox", {
+        name: /filter videos by source/i,
+      }) as HTMLSelectElement;
+
+      expect(dropdown.value).toBe("description");
+    });
+
+    it("useEntityVideos receives the source from URL on initial render", () => {
+      renderPage("entity-uuid-001", "?source=transcript");
+
+      // The first call to useEntityVideos should include source: "transcript"
+      const firstCall = vi.mocked(useEntityVideos).mock.calls[0];
+      expect(firstCall?.[1]).toEqual({ source: "transcript" });
+    });
+  });
+
+  /**
+   * T060: Source filter persists in URL query parameter ?source=title.
+   * (Verified by checking dropdown value reflects URL state.)
+   */
+  describe("T060 — source filter persists in URL", () => {
+    it("source=title URL param sets dropdown to Title", () => {
+      renderPage("entity-uuid-001", "?source=title");
+
+      const dropdown = screen.getByRole("combobox", {
+        name: /filter videos by source/i,
+      }) as HTMLSelectElement;
+
+      expect(dropdown.value).toBe("title");
+    });
+
+    it("source=manual URL param sets dropdown to Manual", () => {
+      renderPage("entity-uuid-001", "?source=manual");
+
+      const dropdown = screen.getByRole("combobox", {
+        name: /filter videos by source/i,
+      }) as HTMLSelectElement;
+
+      expect(dropdown.value).toBe("manual");
+    });
+  });
+
+  /**
+   * T061: Empty state shows "No videos found for this source type."
+   * when source filter yields zero results, with "Try All sources" link.
+   */
+  describe("T061 — empty state for source-filtered zero results", () => {
+    it("shows source-specific empty message when source filter active and no videos", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [],
+        total: 0,
+      });
+
+      renderPage("entity-uuid-001", "?source=title");
+
+      expect(
+        screen.getByText("No videos found for this source type.")
+      ).toBeInTheDocument();
+    });
+
+    it("shows 'Try All sources' button in source-filtered empty state", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [],
+        total: 0,
+      });
+
+      renderPage("entity-uuid-001", "?source=title");
+
+      expect(screen.getByText("Try All sources")).toBeInTheDocument();
+    });
+
+    it("shows generic empty message when no source filter is active", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [],
+        total: 0,
+      });
+
+      renderPage(); // no source filter
+
+      expect(
+        screen.getByText("No videos found for this entity.")
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Try All sources")).not.toBeInTheDocument();
+    });
+
+    it("clicking 'Try All sources' clears the source filter", () => {
+      vi.mocked(useEntityVideos).mockReturnValue({
+        ...defaultUseEntityVideos,
+        videos: [],
+        total: 0,
+      });
+
+      renderPage("entity-uuid-001", "?source=manual");
+
+      const clearButton = screen.getByText("Try All sources");
+      fireEvent.click(clearButton);
+
+      // After clicking, dropdown should be back to "All sources"
+      const dropdown = screen.getByRole("combobox", {
+        name: /filter videos by source/i,
+      }) as HTMLSelectElement;
+
+      expect(dropdown.value).toBe("");
+    });
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.54.0"
+version = "0.55.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.54.0"
+__version__ = "0.55.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -67,7 +67,10 @@ from chronovista.repositories.tag_alias_repository import TagAliasRepository
 from chronovista.repositories.tag_operation_log_repository import (
     TagOperationLogRepository,
 )
-from chronovista.services.entity_mention_scan_service import EntityMentionScanService
+from chronovista.services.entity_mention_scan_service import (
+    EntityMentionScanService,
+    ScanResult,
+)
 from chronovista.services.phonetic_matcher import PhoneticMatcher
 from chronovista.services.tag_management import TagManagementService
 from chronovista.services.tag_normalization import TagNormalizationService
@@ -603,6 +606,13 @@ async def get_entity_videos(
     language_code: str | None = Query(
         default=None, description="BCP-47 language code filter"
     ),
+    source: str | None = Query(
+        default=None,
+        description=(
+            "Filter videos by mention source: transcript, title, description, "
+            "tag, or manual. When omitted, all sources are returned."
+        ),
+    ),
     limit: int = Query(
         default=20, ge=1, le=100, description="Items per page"
     ),
@@ -620,6 +630,9 @@ async def get_entity_videos(
         Named entity UUID (string representation).
     language_code : str | None
         Optional BCP-47 language code to filter mentions by language.
+    source : str | None
+        Optional source filter: transcript, title, description, tag, or manual.
+        When omitted all sources are returned.
     limit : int
         Maximum number of results per page (1--100, default 20).
     offset : int
@@ -651,11 +664,21 @@ async def get_entity_videos(
     if not entity_result.scalar_one_or_none():
         raise NotFoundError(resource_type="Entity", identifier=entity_id)
 
+    # Validate source filter value when provided
+    valid_filter_sources = {"transcript", "title", "description", "tag", "manual"}
+    if source is not None and source not in valid_filter_sources:
+        raise APIValidationError(
+            message=f"Invalid source value '{source}'. "
+            f"Must be one of: {', '.join(sorted(valid_filter_sources))}",
+            details={"field": "source", "invalid_value": source},
+        )
+
     # Fetch paginated video list from repository
     results, total = await _mention_repo.get_entity_video_list(
         session,
         entity_id=parsed_entity_id,
         language_code=language_code,
+        source_filter=source,
         limit=limit,
         offset=offset,
     )
@@ -672,6 +695,7 @@ async def get_entity_videos(
             has_manual=r["has_manual"],
             first_mention_time=r["first_mention_time"],
             upload_date=r["upload_date"],
+            description_context=r.get("description_context"),
         )
         for r in results
     ]
@@ -1424,6 +1448,139 @@ def _get_scan_service() -> EntityMentionScanService:
     return _scan_service
 
 
+async def _dispatch_scan(
+    *,
+    service: EntityMentionScanService,
+    sources: list[str],
+    entity_ids: list[uuid.UUID] | None = None,
+    video_ids: list[str] | None = None,
+    entity_type: str | None = None,
+    language_code: str | None = None,
+    dry_run: bool = False,
+    full_rescan: bool = False,
+) -> ScanResult:
+    """Dispatch scan calls based on the requested sources.
+
+    If ``"transcript"`` is in *sources*, calls ``service.scan()``.
+    If ``"title"`` or ``"description"`` is in *sources*, calls
+    ``service.scan_metadata()`` with the metadata sources.
+    When both are requested the two results are merged.
+
+    Parameters
+    ----------
+    service : EntityMentionScanService
+        Scan service singleton.
+    sources : list[str]
+        Validated list of source values.
+    entity_ids : list[uuid.UUID] | None
+        Restrict scanning to these entities.
+    video_ids : list[str] | None
+        Restrict scanning to these videos.
+    entity_type : str | None
+        Restrict scanning to entities of this type.
+    language_code : str | None
+        Restrict scanning to segments in this language.
+    dry_run : bool
+        Preview matches without writing to the database.
+    full_rescan : bool
+        Delete existing mentions in scope before scanning.
+
+    Returns
+    -------
+    ScanResult
+        Merged scan result from all dispatched calls.
+    """
+    results: list[ScanResult] = []
+
+    if "transcript" in sources:
+        transcript_result = await service.scan(
+            entity_ids=entity_ids,
+            video_ids=video_ids,
+            entity_type=entity_type,
+            language_code=language_code,
+            dry_run=dry_run,
+            full_rescan=full_rescan,
+        )
+        results.append(transcript_result)
+
+    metadata_sources = [s for s in sources if s in ("title", "description")]
+    if metadata_sources:
+        metadata_result = await service.scan_metadata(
+            sources=metadata_sources,
+            entity_ids=entity_ids,
+            video_ids=video_ids,
+            entity_type=entity_type,
+            language_code=language_code,
+            dry_run=dry_run,
+            full_rescan=full_rescan,
+        )
+        results.append(metadata_result)
+
+    if not results:
+        # Should not happen with validated sources, but defensive
+        return ScanResult(dry_run=dry_run)
+
+    if len(results) == 1:
+        return results[0]
+
+    return _merge_scan_results(results)
+
+
+def _merge_scan_results(results: list[ScanResult]) -> ScanResult:
+    """Merge multiple :class:`ScanResult` instances into one.
+
+    Numeric fields are summed.  ``dry_run`` is taken from the first result.
+
+    Parameters
+    ----------
+    results : list[ScanResult]
+        Two or more results to merge.
+
+    Returns
+    -------
+    ScanResult
+        Combined result.
+    """
+    merged = ScanResult(dry_run=results[0].dry_run)
+    for r in results:
+        merged.segments_scanned += r.segments_scanned
+        merged.mentions_found += r.mentions_found
+        merged.mentions_skipped += r.mentions_skipped
+        merged.unique_entities += r.unique_entities
+        merged.unique_videos += r.unique_videos
+        merged.duration_seconds += r.duration_seconds
+        merged.failed_batches += r.failed_batches
+        merged.skipped_longest_match += r.skipped_longest_match
+        merged.skipped_exclusion_pattern += r.skipped_exclusion_pattern
+    return merged
+
+
+def _build_scan_response(result: ScanResult) -> ScanResultResponse:
+    """Build a :class:`ScanResultResponse` from a :class:`ScanResult`.
+
+    Parameters
+    ----------
+    result : ScanResult
+        Raw scan result from the service layer.
+
+    Returns
+    -------
+    ScanResultResponse
+        API response envelope.
+    """
+    return ScanResultResponse(
+        data=ScanResultData(
+            segments_scanned=result.segments_scanned,
+            mentions_found=result.mentions_found,
+            mentions_skipped=result.mentions_skipped,
+            unique_entities=result.unique_entities,
+            unique_videos=result.unique_videos,
+            duration_seconds=result.duration_seconds,
+            dry_run=result.dry_run,
+        )
+    )
+
+
 @router.post(
     "/entities/{entity_id}/scan",
     response_model=ScanResultResponse,
@@ -1474,27 +1631,21 @@ async def scan_entity(
 
     _scans_in_progress.add(guard_key)
     try:
-        # 4. Run the scan
+        # 4. Run the scan — dispatch based on sources
         service = _get_scan_service()
-        result = await service.scan(
+        sources = request.sources or ["transcript"]
+        result = await _dispatch_scan(
+            service=service,
+            sources=sources,
             entity_ids=[entity_id],
+            entity_type=request.entity_type,
             language_code=request.language_code,
             dry_run=request.dry_run,
             full_rescan=request.full_rescan,
         )
 
         # 5. Build response
-        return ScanResultResponse(
-            data=ScanResultData(
-                segments_scanned=result.segments_scanned,
-                mentions_found=result.mentions_found,
-                mentions_skipped=result.mentions_skipped,
-                unique_entities=result.unique_entities,
-                unique_videos=result.unique_videos,
-                duration_seconds=result.duration_seconds,
-                dry_run=result.dry_run,
-            )
-        )
+        return _build_scan_response(result)
     finally:
         _scans_in_progress.discard(guard_key)
 
@@ -1557,9 +1708,12 @@ async def scan_video_entities(
 
     _scans_in_progress.add(guard_key)
     try:
-        # 3. Run the scan
+        # 3. Run the scan — dispatch based on sources
         service = _get_scan_service()
-        result = await service.scan(
+        sources = request.sources or ["transcript"]
+        result = await _dispatch_scan(
+            service=service,
+            sources=sources,
             video_ids=[video_id],
             entity_type=request.entity_type,
             language_code=request.language_code,
@@ -1568,16 +1722,6 @@ async def scan_video_entities(
         )
 
         # 4. Build response
-        return ScanResultResponse(
-            data=ScanResultData(
-                segments_scanned=result.segments_scanned,
-                mentions_found=result.mentions_found,
-                mentions_skipped=result.mentions_skipped,
-                unique_entities=result.unique_entities,
-                unique_videos=result.unique_videos,
-                duration_seconds=result.duration_seconds,
-                dry_run=result.dry_run,
-            )
-        )
+        return _build_scan_response(result)
     finally:
         _scans_in_progress.discard(guard_key)

--- a/src/chronovista/api/schemas/entity_mentions.py
+++ b/src/chronovista/api/schemas/entity_mentions.py
@@ -145,6 +145,13 @@ class EntityVideoResult(BaseModel):
     upload_date: str | None = Field(
         None, description="Video upload date (ISO 8601)"
     )
+    description_context: str | None = Field(
+        None,
+        description=(
+            "Context snippet (~150 chars) around the description match; "
+            "only present when 'description' is in sources."
+        ),
+    )
 
 
 class EntityVideoResponse(BaseModel):
@@ -527,6 +534,9 @@ _VALID_ENTITY_TYPES = {
 }
 
 
+_VALID_SCAN_SOURCES = {"transcript", "title", "description"}
+
+
 class ScanRequest(BaseModel):
     """Request body for triggering an entity mention scan.
 
@@ -545,6 +555,10 @@ class ScanRequest(BaseModel):
     full_rescan : bool
         If ``True``, delete existing ``rule_match`` mentions in scope
         before scanning.
+    sources : list[str] | None
+        Text sources to scan.  Valid values: ``transcript``, ``title``,
+        ``description``.  Defaults to ``["transcript"]`` for backward
+        compatibility.
     """
 
     model_config = ConfigDict(strict=True)
@@ -565,6 +579,13 @@ class ScanRequest(BaseModel):
         default=False,
         description="Delete existing rule_match mentions before scanning",
     )
+    sources: list[str] | None = Field(
+        default=None,
+        description=(
+            "Text sources to scan: transcript, title, description. "
+            "Defaults to ['transcript'] when omitted."
+        ),
+    )
 
     @field_validator("entity_type")
     @classmethod
@@ -575,6 +596,30 @@ class ScanRequest(BaseModel):
                 f"entity_type must be one of: "
                 f"{', '.join(sorted(_VALID_ENTITY_TYPES))}"
             )
+        return v
+
+    @field_validator("sources")
+    @classmethod
+    def validate_sources(cls, v: list[str] | None) -> list[str] | None:
+        """Ensure each source value is valid (transcript, title, description).
+
+        Rejects ``tag`` with a helpful message explaining that tag
+        associations are query-time (Feature 053), not scan-persisted.
+        """
+        if v is None:
+            return v
+        for source in v:
+            if source not in _VALID_SCAN_SOURCES:
+                if source == "tag":
+                    raise ValueError(
+                        f"Invalid source value '{source}'. Tag associations "
+                        f"are query-time (not scan-persisted). "
+                        f"Valid values: {', '.join(sorted(_VALID_SCAN_SOURCES))}."
+                    )
+                raise ValueError(
+                    f"Invalid source value '{source}'. "
+                    f"Valid values: {', '.join(sorted(_VALID_SCAN_SOURCES))}."
+                )
         return v
 
 

--- a/src/chronovista/cli/entity_commands.py
+++ b/src/chronovista/cli/entity_commands.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from rich.console import Console
@@ -43,7 +43,10 @@ from chronovista.models.named_entity import NamedEntityCreate
 from chronovista.repositories.entity_alias_repository import EntityAliasRepository
 from chronovista.repositories.entity_mention_repository import EntityMentionRepository
 from chronovista.repositories.named_entity_repository import NamedEntityRepository
-from chronovista.services.entity_mention_scan_service import EntityMentionScanService
+from chronovista.services.entity_mention_scan_service import (
+    EntityMentionScanService,
+    ScanResult,
+)
 from chronovista.services.tag_normalization import TagNormalizationService
 
 logger = logging.getLogger(__name__)
@@ -828,6 +831,68 @@ def backfill_descriptions(
     asyncio.run(_run())
 
 
+def _merge_scan_results(
+    transcript_result: ScanResult | None,
+    metadata_result: ScanResult | None,
+) -> ScanResult:
+    """Merge two ScanResult objects from transcript and metadata scans.
+
+    Sums all numeric fields and combines dry_run_matches lists.  If only
+    one result is provided, it is returned directly.
+
+    Parameters
+    ----------
+    transcript_result : ScanResult | None
+        Result from the transcript scan, or ``None`` if transcript was not scanned.
+    metadata_result : ScanResult | None
+        Result from the metadata scan, or ``None`` if no metadata sources.
+
+    Returns
+    -------
+    ScanResult
+        Merged aggregate statistics.
+    """
+    if transcript_result is None and metadata_result is None:
+        return ScanResult()
+    if transcript_result is None:
+        return metadata_result  # type: ignore[return-value]
+    if metadata_result is None:
+        return transcript_result
+
+    # Combine dry_run_matches
+    combined_matches: list[dict[str, Any]] | None = None
+    if transcript_result.dry_run_matches is not None or metadata_result.dry_run_matches is not None:
+        combined_matches = []
+        if transcript_result.dry_run_matches:
+            combined_matches.extend(transcript_result.dry_run_matches)
+        if metadata_result.dry_run_matches:
+            combined_matches.extend(metadata_result.dry_run_matches)
+
+    # unique_entities and unique_videos: we take the max since we cannot easily
+    # merge the underlying sets here; in practice the CLI display does not need
+    # exact deduplication across the two result objects.
+    return ScanResult(
+        segments_scanned=transcript_result.segments_scanned + metadata_result.segments_scanned,
+        mentions_found=transcript_result.mentions_found + metadata_result.mentions_found,
+        mentions_skipped=transcript_result.mentions_skipped + metadata_result.mentions_skipped,
+        unique_entities=max(
+            transcript_result.unique_entities, metadata_result.unique_entities
+        ),
+        unique_videos=max(transcript_result.unique_videos, metadata_result.unique_videos),
+        duration_seconds=transcript_result.duration_seconds + metadata_result.duration_seconds,
+        dry_run=transcript_result.dry_run or metadata_result.dry_run,
+        failed_batches=transcript_result.failed_batches + metadata_result.failed_batches,
+        dry_run_matches=combined_matches,
+        skipped_longest_match=(
+            transcript_result.skipped_longest_match + metadata_result.skipped_longest_match
+        ),
+        skipped_exclusion_pattern=(
+            transcript_result.skipped_exclusion_pattern
+            + metadata_result.skipped_exclusion_pattern
+        ),
+    )
+
+
 @entity_app.command("scan")
 def scan_entities(
     entity_type: Annotated[
@@ -873,12 +938,41 @@ def scan_entities(
         str | None,
         typer.Option("--entity-id", help="Scan for a single entity"),
     ] = None,
+    sources: Annotated[
+        str,
+        typer.Option(
+            "--sources",
+            help=(
+                "Comma-separated list of sources to scan. "
+                "Valid values: transcript, title, description. "
+                "Default: transcript."
+            ),
+        ),
+    ] = "transcript",
 ) -> None:
     """Scan transcript segments for named entity mentions."""
 
     # Validate mutual exclusivity: --audit and --full
     if audit and full:
         raise typer.BadParameter("--audit and --full are mutually exclusive")
+
+    # Parse and validate --sources
+    valid_sources = {"transcript", "title", "description"}
+    parsed_sources: list[str] = [s.strip() for s in sources.split(",") if s.strip()]
+    if not parsed_sources:
+        parsed_sources = ["transcript"]
+    invalid_sources = [s for s in parsed_sources if s not in valid_sources]
+    if invalid_sources:
+        valid_list = ", ".join(sorted(valid_sources))
+        console.print(
+            Panel(
+                f"[red]Invalid source(s): {', '.join(invalid_sources)}.\n"
+                f"Valid values: {valid_list}[/red]",
+                title="Invalid --sources",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(code=1)
 
     # Validate entity type if provided
     if entity_type is not None:
@@ -989,6 +1083,11 @@ def scan_entities(
             effective_new_entities_only = False
             effective_entity_ids = [parsed_entity_uuid]
 
+        # Determine which service calls to make based on parsed_sources
+        transcript_sources = ["transcript"] if "transcript" in parsed_sources else []
+        metadata_sources = [s for s in parsed_sources if s != "transcript"]
+        has_metadata_sources = bool(metadata_sources)
+
         if dry_run:
             # Dry-run mode: show preview table
             with Progress(
@@ -998,17 +1097,35 @@ def scan_entities(
             ) as progress:
                 progress.add_task("Scanning (dry run)...", total=None)
 
-                result = await service.scan(
-                    entity_type=effective_entity_type,
-                    video_ids=video_id,
-                    language_code=language,
-                    batch_size=batch_size,
-                    dry_run=True,
-                    full_rescan=full,
-                    new_entities_only=effective_new_entities_only,
-                    limit=limit,
-                    entity_ids=effective_entity_ids,
-                )
+                transcript_result: ScanResult | None = None
+                metadata_result: ScanResult | None = None
+
+                if transcript_sources:
+                    transcript_result = await service.scan(
+                        entity_type=effective_entity_type,
+                        video_ids=video_id,
+                        language_code=language,
+                        batch_size=batch_size,
+                        dry_run=True,
+                        full_rescan=full,
+                        new_entities_only=effective_new_entities_only,
+                        limit=limit,
+                        entity_ids=effective_entity_ids,
+                    )
+
+                if metadata_sources:
+                    metadata_result = await service.scan_metadata(
+                        sources=metadata_sources,
+                        entity_type=effective_entity_type,
+                        video_ids=video_id,
+                        language_code=language,
+                        batch_size=batch_size,
+                        dry_run=True,
+                        full_rescan=full,
+                        entity_ids=effective_entity_ids,
+                    )
+
+            result = _merge_scan_results(transcript_result, metadata_result)
 
             if not result.dry_run_matches:
                 console.print(
@@ -1024,32 +1141,58 @@ def scan_entities(
             preview_table.add_column("video_id", style="dim", width=14)
             preview_table.add_column("segment_id", style="dim", width=12)
             preview_table.add_column("start_time", style="dim", width=10)
+            if has_metadata_sources:
+                preview_table.add_column("source", style="blue", width=12)
             preview_table.add_column("entity_name", style="cyan", width=24)
             preview_table.add_column("entity_type", style="magenta", width=16)
             preview_table.add_column("matched_text", style="green", width=20)
             preview_table.add_column("context", style="white", width=40)
 
             for match in result.dry_run_matches:
-                context_text = match.get("context", "")
+                context_text = match.get("context", "") or ""
                 if len(context_text) > 40:
                     context_text = context_text[:37] + "..."
 
-                preview_table.add_row(
+                match_source: str = match.get("source", "transcript")
+                is_metadata = match_source in ("title", "description")
+
+                # For metadata mentions, segment_id and start_time display as em dash
+                segment_id_str = "\u2014" if is_metadata else str(match.get("segment_id"))
+                start_time_val = match.get("start_time")
+                start_time_str = (
+                    "\u2014"
+                    if is_metadata or start_time_val is None
+                    else f"{start_time_val:.1f}"
+                )
+
+                row_values: list[str] = [
                     match["video_id"],
-                    str(match["segment_id"]),
-                    f"{match['start_time']:.1f}",
+                    segment_id_str,
+                    start_time_str,
+                ]
+                if has_metadata_sources:
+                    row_values.append(match_source)
+                row_values.extend([
                     match["entity_name"],
                     match["entity_type"],
                     match["matched_text"],
                     context_text,
-                )
+                ])
+                preview_table.add_row(*row_values)
 
             console.print(preview_table)
+
+            # Summary line: say "N videos scanned" when metadata sources included
+            if has_metadata_sources:
+                scanned_label = f"{result.segments_scanned:,} videos scanned"
+            else:
+                scanned_label = f"{result.segments_scanned:,} segments scanned"
+
             dry_run_summary = (
                 f"\nDry run complete: [bold]{result.mentions_found:,}[/bold] mentions "
                 f"would be created across [bold]{result.unique_videos:,}[/bold] videos "
                 f"for [bold]{result.unique_entities:,}[/bold] entities "
-                f"({result.segments_scanned:,} segments scanned, "
+                f"({scanned_label}, "
                 f"{result.duration_seconds:.1f}s)"
             )
             if result.skipped_longest_match > 0 or result.skipped_exclusion_pattern > 0:
@@ -1067,30 +1210,60 @@ def scan_entities(
                 TaskProgressColumn(),
                 console=console,
             ) as progress:
-                task = progress.add_task("Scanning segments...", total=None)
+                task = progress.add_task("Scanning...", total=None)
 
                 def _progress_callback(scanned: int, found: int) -> None:
                     progress.update(
                         task,
                         completed=scanned,
-                        description=f"Scanning segments... ({found:,} mentions found)",
+                        description=f"Scanning... ({found:,} mentions found)",
                     )
 
-                result = await service.scan(
-                    entity_type=effective_entity_type,
-                    video_ids=video_id,
-                    language_code=language,
-                    batch_size=batch_size,
-                    dry_run=False,
-                    full_rescan=full,
-                    new_entities_only=effective_new_entities_only,
-                    progress_callback=_progress_callback,
-                    entity_ids=effective_entity_ids,
-                )
+                transcript_result_live: ScanResult | None = None
+                metadata_result_live: ScanResult | None = None
+
+                if transcript_sources:
+                    progress.update(task, description="Scanning segments...")
+                    transcript_result_live = await service.scan(
+                        entity_type=effective_entity_type,
+                        video_ids=video_id,
+                        language_code=language,
+                        batch_size=batch_size,
+                        dry_run=False,
+                        full_rescan=full,
+                        new_entities_only=effective_new_entities_only,
+                        progress_callback=_progress_callback,
+                        entity_ids=effective_entity_ids,
+                    )
+
+                if metadata_sources:
+                    progress.update(
+                        task,
+                        description=f"Scanning {', '.join(metadata_sources)}...",
+                    )
+                    metadata_result_live = await service.scan_metadata(
+                        sources=metadata_sources,
+                        entity_type=effective_entity_type,
+                        video_ids=video_id,
+                        language_code=language,
+                        batch_size=batch_size,
+                        dry_run=False,
+                        full_rescan=full,
+                        entity_ids=effective_entity_ids,
+                        progress_callback=_progress_callback,
+                    )
+
+            result = _merge_scan_results(transcript_result_live, metadata_result_live)
+
+            # Summary label: "Segments scanned" vs "Videos scanned"
+            if has_metadata_sources:
+                scanned_key = "Videos scanned"
+            else:
+                scanned_key = "Segments scanned"
 
             # Summary panel
             summary_lines = [
-                f"[bold]Segments scanned:[/bold] {result.segments_scanned:,}",
+                f"[bold]{scanned_key}:[/bold] {result.segments_scanned:,}",
                 f"[bold]Mentions found:[/bold] {result.mentions_found:,}",
                 f"[bold]Mentions skipped:[/bold] {result.mentions_skipped:,}",
                 f"[bold]Skipped (exclusion patterns):[/bold] {result.skipped_exclusion_pattern:,}",

--- a/src/chronovista/db/migrations/versions/054_add_mention_source_column.py
+++ b/src/chronovista/db/migrations/versions/054_add_mention_source_column.py
@@ -1,0 +1,220 @@
+"""add_mention_source_column — add mention_source and mention_context to entity_mentions
+
+Revision ID: c3e5f7a9b1d4
+Revises: b2d4f6a8c0e1
+Create Date: 2026-03-26 12:00:00.000000
+
+Extends the entity_mentions table with two new columns:
+
+  mention_source  VARCHAR(20) NOT NULL DEFAULT 'transcript'
+      WHERE the entity was found (transcript, title, or description).
+      All existing rows are back-filled with 'transcript' via the
+      server_default so that no data migration step is required.
+
+  mention_context  TEXT NULLABLE
+      A ~150-character snippet around the match, populated for
+      description-sourced mentions only (NULL for transcript/title rows).
+
+New indexes added:
+
+  uq_entity_mentions_title      UNIQUE (entity_id, video_id, mention_source)
+                                  WHERE mention_source = 'title'
+  uq_entity_mentions_description  UNIQUE (entity_id, video_id, mention_source, mention_text)
+                                  WHERE mention_source = 'description'
+  ix_entity_mentions_mention_source  (mention_source)
+
+New CHECK constraint:
+
+  chk_entity_mention_source_valid
+      mention_source IN ('transcript', 'title', 'description')
+
+Migration strategy:
+  - ADD COLUMN with server_default='transcript': metadata-only in PostgreSQL 11+
+    (milliseconds regardless of row count)
+  - ADD CHECK CONSTRAINT: validates existing rows (< 1 sec for 100K rows)
+  - CREATE partial UNIQUE indexes: near-instant (no title/description rows exist yet)
+  - CREATE regular index: ~1-3 sec for 100K rows
+
+Downgrade is LOSSY — all title and description mention rows are deleted
+before the columns are dropped. Manual transcript mentions are preserved.
+Back up entity_mentions before downgrading in production.
+
+Related: Feature 054 (Multi-Source Entity Mention Detection)
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+revision = "c3e5f7a9b1d4"
+down_revision = "b2d4f6a8c0e1"
+branch_labels = None
+depends_on = None
+
+# ---------------------------------------------------------------------------
+# CHECK constraint expression — kept as a constant so upgrade/downgrade stay
+# in sync with each other and with db/models.py.
+# ---------------------------------------------------------------------------
+_MENTION_SOURCE_CHECK = (
+    "mention_source IN ('transcript', 'title', 'description')"
+)
+
+
+def upgrade() -> None:
+    """Add mention_source and mention_context columns plus supporting indexes.
+
+    Operations performed (in dependency order):
+    1. ADD COLUMN mention_source  VARCHAR(20) NOT NULL DEFAULT 'transcript'
+    2. ADD COLUMN mention_context TEXT NULLABLE
+    3. ADD CHECK CONSTRAINT chk_entity_mention_source_valid
+    4. CREATE UNIQUE INDEX uq_entity_mentions_title
+    5. CREATE UNIQUE INDEX uq_entity_mentions_description
+    6. CREATE INDEX ix_entity_mentions_mention_source
+    """
+
+    # =========================================================================
+    # 1. ADD mention_source column
+    #    server_default back-fills all existing rows atomically in PostgreSQL.
+    # =========================================================================
+    op.add_column(
+        "entity_mentions",
+        sa.Column(
+            "mention_source",
+            sa.String(20),
+            nullable=False,
+            server_default="transcript",
+        ),
+    )
+
+    # =========================================================================
+    # 2. ADD mention_context column (nullable TEXT)
+    # =========================================================================
+    op.add_column(
+        "entity_mentions",
+        sa.Column(
+            "mention_context",
+            sa.Text(),
+            nullable=True,
+        ),
+    )
+
+    # =========================================================================
+    # 3. ADD CHECK constraint on mention_source
+    # =========================================================================
+    op.create_check_constraint(
+        "chk_entity_mention_source_valid",
+        "entity_mentions",
+        _MENTION_SOURCE_CHECK,
+    )
+
+    # =========================================================================
+    # 4. CREATE partial UNIQUE index for title mentions
+    #    One title mention per entity per video.
+    # =========================================================================
+    op.create_index(
+        "uq_entity_mentions_title",
+        "entity_mentions",
+        ["entity_id", "video_id", "mention_source"],
+        unique=True,
+        postgresql_where=sa.text("mention_source = 'title'"),
+    )
+
+    # =========================================================================
+    # 5. CREATE partial UNIQUE index for description mentions
+    #    One mention per distinct matched text per entity per video.
+    # =========================================================================
+    op.create_index(
+        "uq_entity_mentions_description",
+        "entity_mentions",
+        ["entity_id", "video_id", "mention_source", "mention_text"],
+        unique=True,
+        postgresql_where=sa.text("mention_source = 'description'"),
+    )
+
+    # =========================================================================
+    # 6. CREATE regular index on mention_source for source-filter queries
+    # =========================================================================
+    op.create_index(
+        "ix_entity_mentions_mention_source",
+        "entity_mentions",
+        ["mention_source"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove mention_source and mention_context columns.
+
+    WARNING: This downgrade is LOSSY.
+    All entity_mentions rows with mention_source IN ('title', 'description')
+    are permanently deleted before the columns are dropped.  These rows
+    have segment_id=NULL and cannot exist under pre-054 assumptions.
+    Manual mentions (detection_method='manual') are preserved because
+    they have mention_source='transcript' by default.
+
+    Back up entity_mentions before running this downgrade in production.
+
+    Operations performed (in reverse dependency order):
+    1. DELETE rows with mention_source IN ('title', 'description')
+    2. DROP INDEX ix_entity_mentions_mention_source
+    3. DROP UNIQUE INDEX uq_entity_mentions_description
+    4. DROP UNIQUE INDEX uq_entity_mentions_title
+    5. DROP CHECK CONSTRAINT chk_entity_mention_source_valid
+    6. DROP COLUMN mention_context
+    7. DROP COLUMN mention_source
+    """
+
+    # =========================================================================
+    # 1. DELETE title and description mention rows (lossy)
+    # =========================================================================
+    op.execute(
+        "DELETE FROM entity_mentions "
+        "WHERE mention_source IN ('title', 'description')"
+    )
+
+    # =========================================================================
+    # 2. DROP regular index on mention_source
+    # =========================================================================
+    op.drop_index(
+        "ix_entity_mentions_mention_source",
+        table_name="entity_mentions",
+    )
+
+    # =========================================================================
+    # 3. DROP partial UNIQUE index for description mentions
+    # =========================================================================
+    op.drop_index(
+        "uq_entity_mentions_description",
+        table_name="entity_mentions",
+    )
+
+    # =========================================================================
+    # 4. DROP partial UNIQUE index for title mentions
+    # =========================================================================
+    op.drop_index(
+        "uq_entity_mentions_title",
+        table_name="entity_mentions",
+    )
+
+    # =========================================================================
+    # 5. DROP CHECK constraint on mention_source
+    # =========================================================================
+    op.drop_constraint(
+        "chk_entity_mention_source_valid",
+        "entity_mentions",
+        type_="check",
+    )
+
+    # =========================================================================
+    # 6. DROP mention_context column
+    # =========================================================================
+    op.drop_column("entity_mentions", "mention_context")
+
+    # =========================================================================
+    # 7. DROP mention_source column
+    # =========================================================================
+    op.drop_column("entity_mentions", "mention_source")

--- a/src/chronovista/db/models.py
+++ b/src/chronovista/db/models.py
@@ -1149,6 +1149,17 @@ class EntityMention(Base):
         index=True,
     )
 
+    # Source location where the mention was found (transcript, title, description)
+    mention_source: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="transcript",
+        server_default="transcript",
+    )
+
+    # Context snippet (~150 chars) around the match — populated for description mentions only
+    mention_context: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # Timestamps
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
@@ -1178,6 +1189,25 @@ class EntityMention(Base):
             unique=True,
             postgresql_where=text("detection_method = 'manual'"),
         ),
+        # Partial unique index for title mentions: one per entity+video.
+        Index(
+            "uq_entity_mentions_title",
+            "entity_id",
+            "video_id",
+            "mention_source",
+            unique=True,
+            postgresql_where=text("mention_source = 'title'"),
+        ),
+        # Partial unique index for description mentions: one per distinct text match.
+        Index(
+            "uq_entity_mentions_description",
+            "entity_id",
+            "video_id",
+            "mention_source",
+            "mention_text",
+            unique=True,
+            postgresql_where=text("mention_source = 'description'"),
+        ),
         CheckConstraint(
             "detection_method IN ('rule_match', 'spacy_ner', 'llm_extraction', 'manual', 'user_correction')",
             name="chk_entity_mention_detection_method_valid",
@@ -1186,11 +1216,16 @@ class EntityMention(Base):
             "confidence >= 0.0 AND confidence <= 1.0",
             name="chk_entity_mention_confidence_range",
         ),
+        CheckConstraint(
+            "mention_source IN ('transcript', 'title', 'description')",
+            name="chk_entity_mention_source_valid",
+        ),
         Index("ix_entity_mentions_entity_id", "entity_id"),
         Index("ix_entity_mentions_segment_id", "segment_id"),
         Index("ix_entity_mentions_video_id", "video_id"),
         Index("ix_entity_mentions_video_language", "video_id", "language_code"),
         Index("ix_entity_mentions_detection_method", "detection_method"),
+        Index("ix_entity_mentions_mention_source", "mention_source"),
         # Note: correction_id index is created by index=True on the column definition
     )
 

--- a/src/chronovista/models/entity_mention.py
+++ b/src/chronovista/models/entity_mention.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from .enums import DetectionMethod
+from .enums import DetectionMethod, MentionSource
 from .youtube_types import VideoId
 
 
@@ -59,6 +59,14 @@ class EntityMentionBase(BaseModel):
         default=None,
         description="UUID of the correction that created or updated this mention",
     )
+    mention_source: MentionSource = Field(
+        default=MentionSource.TRANSCRIPT,
+        description="Source location where the mention was found (transcript, title, description)",
+    )
+    mention_context: str | None = Field(
+        default=None,
+        description="Context snippet (~150 chars) around the match, populated for description mentions",
+    )
 
     @field_validator("confidence")
     @classmethod
@@ -96,11 +104,12 @@ class EntityMentionCreate(EntityMentionBase):
 
     @model_validator(mode="after")
     def validate_manual_fields(self) -> EntityMentionCreate:
-        """Validate field constraints based on detection method.
+        """Validate field constraints based on detection method and mention source.
 
         Manual mentions must have NULL segment_id, match_start, match_end,
-        confidence, and language_code. Automated mentions must have a
-        non-NULL segment_id.
+        confidence, and language_code. Transcript mentions (non-manual) must
+        have a non-NULL segment_id. Title and description mentions have
+        segment_id=NULL (they are not segment-bound).
 
         Returns
         -------
@@ -134,9 +143,13 @@ class EntityMentionCreate(EntityMentionBase):
                     "language_code must be None for manual mentions"
                 )
         else:
-            if self.segment_id is None:
+            # Title and description mentions are not segment-bound
+            if (
+                self.mention_source == MentionSource.TRANSCRIPT
+                and self.segment_id is None
+            ):
                 raise ValueError(
-                    "segment_id is required for non-manual mentions"
+                    "segment_id is required for transcript mentions"
                 )
         return self
 

--- a/src/chronovista/models/enums.py
+++ b/src/chronovista/models/enums.py
@@ -338,6 +338,14 @@ class DetectionMethod(str, Enum):
     USER_CORRECTION = "user_correction"
 
 
+class MentionSource(str, Enum):
+    """Source location where an entity mention was found."""
+
+    TRANSCRIPT = "transcript"
+    TITLE = "title"
+    DESCRIPTION = "description"
+
+
 class TaskStatus(str, Enum):
     """Status of a background task."""
 

--- a/src/chronovista/repositories/entity_mention_repository.py
+++ b/src/chronovista/repositories/entity_mention_repository.py
@@ -146,10 +146,12 @@ class EntityMentionRepository(
             return 0
 
         values = [m.model_dump() for m in mentions]
-        # Convert detection_method enum to its string value
+        # Convert enum fields to their string values
         for v in values:
             if hasattr(v["detection_method"], "value"):
                 v["detection_method"] = v["detection_method"].value
+            if hasattr(v.get("mention_source"), "value"):
+                v["mention_source"] = v["mention_source"].value
 
         stmt = (
             insert(EntityMentionDB)
@@ -166,10 +168,14 @@ class EntityMentionRepository(
         video_ids: list[str] | None = None,
         language_code: str | None = None,
         detection_method: str = "rule_match",
+        mention_source: str | None = None,
     ) -> int:
         """Delete mentions matching the given scope filters.
 
         Used by --full rescan to clear existing mentions before re-detection.
+        The optional ``mention_source`` parameter enables FR-010 source-scoped
+        deletion: ``--sources title --full`` deletes only title-sourced mentions
+        without touching transcript or description mentions.
 
         Parameters
         ----------
@@ -183,6 +189,11 @@ class EntityMentionRepository(
             Filter by language code.
         detection_method : str
             Filter by detection method (default: "rule_match").
+        mention_source : str | None
+            When provided, restrict deletion to mentions with this
+            ``mention_source`` value (e.g. ``"title"``, ``"description"``,
+            ``"transcript"``).  When ``None`` (default), no source filter is
+            applied and all sources matching the other criteria are deleted.
 
         Returns
         -------
@@ -199,6 +210,8 @@ class EntityMentionRepository(
             stmt = stmt.where(EntityMentionDB.video_id.in_(video_ids))
         if language_code is not None:
             stmt = stmt.where(EntityMentionDB.language_code == language_code)
+        if mention_source is not None:
+            stmt = stmt.where(EntityMentionDB.mention_source == mention_source)
 
         result = await session.execute(stmt)
         return int(result.rowcount)
@@ -582,6 +595,7 @@ class EntityMentionRepository(
         session: AsyncSession,
         entity_id: uuid.UUID,
         language_code: str | None = None,
+        source_filter: str | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> tuple[list[dict[str, Any]], int]:
@@ -615,6 +629,11 @@ class EntityMentionRepository(
         language_code : str | None
             Optional language filter. Manual mentions (language_code=NULL) are
             always included regardless of this filter.
+        source_filter : str | None
+            Optional source filter: ``"transcript"``, ``"title"``,
+            ``"description"``, ``"tag"``, or ``"manual"``.  When provided,
+            only videos whose ``sources`` list contains the given value are
+            returned. Affects both the result set and the total count.
         limit : int
             Maximum results per page.
         offset : int
@@ -726,13 +745,18 @@ class EntityMentionRepository(
                     .filter(
                         EntityMentionDB.detection_method.in_(
                             self._TRANSCRIPT_METHODS
-                        )
+                        ),
+                        EntityMentionDB.mention_source == "transcript",
                     )
                     .label("mention_count"),
                     # Collect distinct detection methods for source mapping
                     func.array_agg(
                         distinct(EntityMentionDB.detection_method)
                     ).label("detection_methods"),
+                    # Collect distinct mention sources
+                    func.array_agg(
+                        distinct(EntityMentionDB.mention_source)
+                    ).label("mention_sources"),
                     # Has manual flag
                     func.bool_or(
                         EntityMentionDB.detection_method == "manual"
@@ -773,12 +797,15 @@ class EntityMentionRepository(
 
             for row in video_rows:
                 # Map detection methods to source categories
-                sources = sorted(
-                    {
-                        self._SOURCE_CATEGORY_MAP.get(dm, dm)
-                        for dm in (row.detection_methods or [])
-                    }
-                )
+                sources_set: set[str] = {
+                    self._SOURCE_CATEGORY_MAP.get(dm, dm)
+                    for dm in (row.detection_methods or [])
+                }
+                # Add mention_source values directly (title, description)
+                for ms in (row.mention_sources or []):
+                    if ms in ("title", "description"):
+                        sources_set.add(ms)
+                sources = sorted(sources_set)
 
                 # T013: If this video is also in tag results, append "tag"
                 if row.video_id in tag_video_ids and "tag" not in sources:
@@ -830,6 +857,22 @@ class EntityMentionRepository(
                     for p in preview_result.all()
                 ]
 
+                # Fetch description context if this video has description mentions
+                description_context: str | None = None
+                if "description" in (row.mention_sources or []):
+                    desc_ctx_stmt = (
+                        select(EntityMentionDB.mention_context)
+                        .where(
+                            EntityMentionDB.entity_id == entity_id,
+                            EntityMentionDB.video_id == row.video_id,
+                            EntityMentionDB.mention_source == "description",
+                            EntityMentionDB.mention_context.isnot(None),
+                        )
+                        .limit(1)
+                    )
+                    desc_ctx_result = await session.execute(desc_ctx_stmt)
+                    description_context = desc_ctx_result.scalar_one_or_none()
+
                 results_dict[row.video_id] = {
                     "video_id": row.video_id,
                     "video_title": row.video_title,
@@ -848,6 +891,7 @@ class EntityMentionRepository(
                         if row.upload_date is not None
                         else None
                     ),
+                    "description_context": description_context,
                 }
 
         # ------------------------------------------------------------------
@@ -885,6 +929,7 @@ class EntityMentionRepository(
                         if row.upload_date is not None
                         else None
                     ),
+                    "description_context": None,
                 }
 
         # ------------------------------------------------------------------
@@ -907,11 +952,22 @@ class EntityMentionRepository(
         )
 
         # ------------------------------------------------------------------
+        # Step 5b: Apply source_filter if provided (T064, FR-031)
+        # ------------------------------------------------------------------
+        if source_filter is not None:
+            sorted_results = [
+                item
+                for item in sorted_results
+                if source_filter in item["sources"]
+            ]
+
+        # ------------------------------------------------------------------
         # Step 6: Apply pagination to the merged, sorted results (T015)
         # ------------------------------------------------------------------
+        filtered_total = len(sorted_results)
         paginated = sorted_results[offset : offset + limit]
 
-        return paginated, total_count
+        return paginated, filtered_total if source_filter is not None else total_count
 
     async def get_combined_video_count(
         self,

--- a/src/chronovista/services/entity_mention_scan_service.py
+++ b/src/chronovista/services/entity_mention_scan_service.py
@@ -25,8 +25,9 @@ from chronovista.db.models import EntityAlias as EntityAliasDB
 from chronovista.db.models import EntityMention as EntityMentionDB
 from chronovista.db.models import NamedEntity as NamedEntityDB
 from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+from chronovista.db.models import Video as VideoDB
 from chronovista.models.entity_mention import EntityMentionCreate
-from chronovista.models.enums import DetectionMethod
+from chronovista.models.enums import DetectionMethod, MentionSource
 from chronovista.repositories.entity_mention_repository import (
     EntityMentionRepository,
 )
@@ -410,9 +411,485 @@ class EntityMentionScanService:
                 for row in rows
             ]
 
+    async def scan_metadata(
+        self,
+        sources: list[str],
+        entity_type: str | None = None,
+        video_ids: list[str] | None = None,
+        language_code: str | None = None,
+        batch_size: int = 500,
+        dry_run: bool = False,
+        full_rescan: bool = False,
+        entity_ids: list[uuid.UUID] | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> ScanResult:
+        """Scan video titles and/or descriptions for entity mentions.
+
+        Unlike :meth:`scan` which iterates over transcript segments, this
+        method iterates over the ``videos`` table and matches entity
+        patterns against the ``title`` and/or ``description`` columns.
+
+        Parameters
+        ----------
+        sources : list[str]
+            Which metadata fields to scan. Valid values: ``"title"``,
+            ``"description"``.
+        entity_type : str | None
+            Restrict scanning to entities of this type.
+        video_ids : list[str] | None
+            Restrict scanning to these videos.
+        language_code : str | None
+            Unused for metadata scanning but accepted for interface
+            consistency with :meth:`scan`.
+        batch_size : int
+            Number of video rows fetched per batch (default 500).
+        dry_run : bool
+            If ``True``, collect preview data without writing.
+        full_rescan : bool
+            If ``True``, delete existing mentions of the specified source
+            types before re-scanning (per FR-010).
+        entity_ids : list[uuid.UUID] | None
+            Restrict scanning to these specific entity IDs.
+        progress_callback : Callable[[int, int], None] | None
+            Called after each batch with ``(items_scanned, mentions_found)``.
+
+        Returns
+        -------
+        ScanResult
+            Aggregate statistics about the scan.
+        """
+        t0 = time.monotonic()
+
+        logger.info(
+            "Metadata scan starting: sources=%s, entity_ids=%s, video_ids=%s, "
+            "dry_run=%s, entity_type=%s, full_rescan=%s",
+            sources,
+            entity_ids,
+            video_ids,
+            dry_run,
+            entity_type,
+            full_rescan,
+        )
+
+        async with self._session_factory() as session:
+            # 1. Load entity patterns
+            patterns = await self._load_entity_patterns(
+                session,
+                entity_type=entity_type,
+                new_entities_only=False,
+                entity_ids=entity_ids,
+            )
+
+            if not patterns:
+                logger.info("No active entities matched the filter criteria")
+                return ScanResult(dry_run=dry_run, duration_seconds=time.monotonic() - t0)
+
+            scoped_entity_ids = [p.entity_id for p in patterns]
+
+            # 2. Handle --full rescan: delete existing mentions per source type
+            if full_rescan and not dry_run:
+                for source in sources:
+                    deleted = await self._mention_repo.delete_by_scope(
+                        session,
+                        entity_ids=scoped_entity_ids,
+                        video_ids=video_ids,
+                        detection_method="rule_match",
+                        mention_source=source,
+                    )
+                    logger.info(
+                        "Full rescan: deleted %d existing %s mentions",
+                        deleted,
+                        source,
+                    )
+                await session.flush()
+
+            # 3. Pre-compile Python regexes
+            compiled_patterns: list[tuple[_EntityPattern, re.Pattern[str]]] = []
+            for pattern in patterns:
+                try:
+                    py_regex = re.compile(
+                        r"\b(" + pattern.pg_pattern + r")\b",
+                        re.IGNORECASE,
+                    )
+                    compiled_patterns.append((pattern, py_regex))
+                except re.error:
+                    logger.warning(
+                        "Failed to compile regex for entity %s (%s), skipping",
+                        pattern.canonical_name,
+                        pattern.entity_id,
+                    )
+
+            pattern_by_entity: dict[uuid.UUID, _EntityPattern] = {
+                p.entity_id: p for p in patterns
+            }
+
+            # 4. Process videos in batches
+            result = ScanResult(dry_run=dry_run)
+            if dry_run:
+                result.dry_run_matches = []
+
+            matched_entity_ids: set[uuid.UUID] = set()
+            matched_video_ids: set[str] = set()
+
+            offset = 0
+            while True:
+                try:
+                    batch_rows = await self._fetch_video_batch(
+                        session,
+                        video_ids=video_ids,
+                        batch_size=batch_size,
+                        offset=offset,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to fetch video batch at offset=%d",
+                        offset,
+                        exc_info=True,
+                    )
+                    result.failed_batches += 1
+                    offset += batch_size
+                    continue
+
+                if not batch_rows:
+                    break
+
+                result.segments_scanned += len(batch_rows)
+
+                try:
+                    batch_mentions, batch_previews = self._scan_metadata_batch(
+                        batch_rows=batch_rows,
+                        compiled_patterns=compiled_patterns,
+                        pattern_by_entity=pattern_by_entity,
+                        sources=sources,
+                        dry_run=dry_run,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to process video batch at offset=%d",
+                        offset,
+                        exc_info=True,
+                    )
+                    result.failed_batches += 1
+                    offset += batch_size
+                    if progress_callback:
+                        progress_callback(result.segments_scanned, result.mentions_found)
+                    continue
+
+                for m in batch_mentions:
+                    matched_entity_ids.add(m.entity_id)
+                    matched_video_ids.add(m.video_id)
+
+                if not dry_run and batch_mentions:
+                    inserted = await self._mention_repo.bulk_create_with_conflict_skip(
+                        session, batch_mentions
+                    )
+                    result.mentions_found += inserted
+                    result.mentions_skipped += len(batch_mentions) - inserted
+                    await session.flush()
+                elif dry_run:
+                    result.mentions_found += len(batch_mentions)
+                    if result.dry_run_matches is not None and batch_previews:
+                        result.dry_run_matches.extend(batch_previews)
+
+                if progress_callback:
+                    progress_callback(result.segments_scanned, result.mentions_found)
+
+                offset += batch_size
+
+            result.unique_entities = len(matched_entity_ids)
+            result.unique_videos = len(matched_video_ids)
+
+            # 5. Update entity and alias counters (live mode only)
+            counter_entity_ids: set[uuid.UUID] = set()
+            if full_rescan:
+                counter_entity_ids = set(scoped_entity_ids)
+            counter_entity_ids |= matched_entity_ids
+
+            if not dry_run and counter_entity_ids:
+                await self._mention_repo.update_entity_counters(
+                    session, list(counter_entity_ids)
+                )
+                await self._mention_repo.update_alias_counters(
+                    session, list(counter_entity_ids)
+                )
+                await session.flush()
+
+            # 6. Commit
+            if not dry_run:
+                await session.commit()
+
+            result.duration_seconds = time.monotonic() - t0
+
+            logger.info(
+                "Metadata scan complete: items_scanned=%d, mentions_found=%d, "
+                "mentions_skipped=%d, unique_entities=%d, unique_videos=%d, "
+                "duration=%.2fs, dry_run=%s, failed_batches=%d",
+                result.segments_scanned,
+                result.mentions_found,
+                result.mentions_skipped,
+                result.unique_entities,
+                result.unique_videos,
+                result.duration_seconds,
+                result.dry_run,
+                result.failed_batches,
+            )
+
+            return result
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    async def _fetch_video_batch(
+        self,
+        session: AsyncSession,
+        video_ids: list[str] | None,
+        batch_size: int,
+        offset: int,
+    ) -> list[Any]:
+        """Fetch a batch of video rows for metadata scanning.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        video_ids : list[str] | None
+            Optional video ID filter.
+        batch_size : int
+            Maximum videos per batch.
+        offset : int
+            Pagination offset.
+
+        Returns
+        -------
+        list[Any]
+            List of Row objects with video_id, title, description, channel_id.
+        """
+        stmt: Select[tuple[Any, ...]] = select(
+            VideoDB.video_id,
+            VideoDB.title,
+            VideoDB.description,
+            VideoDB.channel_id,
+        )
+
+        if video_ids is not None:
+            stmt = stmt.where(VideoDB.video_id.in_(video_ids))
+
+        stmt = stmt.order_by(VideoDB.video_id.asc())
+        stmt = stmt.limit(batch_size).offset(offset)
+
+        result = await session.execute(stmt)
+        return list(result.all())
+
+    def _scan_metadata_batch(
+        self,
+        batch_rows: list[Any],
+        compiled_patterns: list[tuple[_EntityPattern, re.Pattern[str]]],
+        pattern_by_entity: dict[uuid.UUID, _EntityPattern],
+        sources: list[str],
+        dry_run: bool,
+    ) -> tuple[list[EntityMentionCreate], list[dict[str, Any]]]:
+        """Scan a batch of video rows against entity patterns for title/description.
+
+        Parameters
+        ----------
+        batch_rows : list[Any]
+            Video rows from ``_fetch_video_batch``.
+        compiled_patterns : list[tuple[_EntityPattern, re.Pattern[str]]]
+            Pre-compiled entity patterns.
+        pattern_by_entity : dict[uuid.UUID, _EntityPattern]
+            Lookup from entity_id to pattern (for exclusion patterns).
+        sources : list[str]
+            Which metadata fields to scan (``"title"``, ``"description"``).
+        dry_run : bool
+            Whether this is a dry-run.
+
+        Returns
+        -------
+        tuple[list[EntityMentionCreate], list[dict[str, Any]]]
+            (new_mentions, preview_data)
+        """
+        new_mentions: list[EntityMentionCreate] = []
+        preview_data: list[dict[str, Any]] = []
+
+        for row in batch_rows:
+            if "title" in sources and row.title:
+                title_mentions, title_previews = self._match_text_for_video(
+                    video_id=row.video_id,
+                    text=row.title,
+                    mention_source=MentionSource.TITLE,
+                    compiled_patterns=compiled_patterns,
+                    pattern_by_entity=pattern_by_entity,
+                    dry_run=dry_run,
+                )
+                new_mentions.extend(title_mentions)
+                preview_data.extend(title_previews)
+
+            if "description" in sources and row.description:
+                desc_mentions, desc_previews = self._match_text_for_video(
+                    video_id=row.video_id,
+                    text=row.description,
+                    mention_source=MentionSource.DESCRIPTION,
+                    compiled_patterns=compiled_patterns,
+                    pattern_by_entity=pattern_by_entity,
+                    dry_run=dry_run,
+                )
+                new_mentions.extend(desc_mentions)
+                preview_data.extend(desc_previews)
+
+        return new_mentions, preview_data
+
+    def _match_text_for_video(
+        self,
+        video_id: str,
+        text: str,
+        mention_source: MentionSource,
+        compiled_patterns: list[tuple[_EntityPattern, re.Pattern[str]]],
+        pattern_by_entity: dict[uuid.UUID, _EntityPattern],
+        dry_run: bool,
+    ) -> tuple[list[EntityMentionCreate], list[dict[str, Any]]]:
+        """Match entity patterns against a text field for a single video.
+
+        Applies longest-match-wins and exclusion pattern filtering, then
+        creates mention rows.  For title mentions, only the first match
+        per entity is kept (deduplication by entity_id).
+
+        Parameters
+        ----------
+        video_id : str
+            YouTube video ID.
+        text : str
+            The text to scan (title or description).
+        mention_source : MentionSource
+            Source type for the created mentions.
+        compiled_patterns : list[tuple[_EntityPattern, re.Pattern[str]]]
+            Pre-compiled entity patterns.
+        pattern_by_entity : dict[uuid.UUID, _EntityPattern]
+            Lookup from entity_id to pattern (for exclusion patterns).
+        dry_run : bool
+            Whether this is a dry-run.
+
+        Returns
+        -------
+        tuple[list[EntityMentionCreate], list[dict[str, Any]]]
+            (new_mentions, preview_data)
+        """
+        mentions: list[EntityMentionCreate] = []
+        previews: list[dict[str, Any]] = []
+
+        # Step 1: Collect all matches
+        raw_matches: list[tuple[uuid.UUID, int, int, str, _EntityPattern]] = []
+        for pattern, py_regex in compiled_patterns:
+            for match in py_regex.finditer(text):
+                raw_matches.append(
+                    (pattern.entity_id, match.start(), match.end(), match.group(0), pattern)
+                )
+
+        if not raw_matches:
+            return mentions, previews
+
+        # Step 2: Longest-match-wins disambiguation
+        # Create a minimal row-like object for logging
+        _row = type("_Row", (), {"id": video_id})()
+        surviving_matches, _ = self._apply_longest_match_wins(
+            raw_matches, _row, dry_run
+        )
+
+        # Step 3: Exclusion pattern filtering
+        final_matches, _ = self._apply_exclusion_patterns(
+            surviving_matches, text, pattern_by_entity, _row, dry_run
+        )
+
+        if not final_matches:
+            return mentions, previews
+
+        # Step 4: Deduplicate — for title, one mention per entity per video
+        seen_entities: set[uuid.UUID] = set()
+        for entity_id, m_start, m_end, matched_text, pat in final_matches:
+            if mention_source == MentionSource.TITLE:
+                if entity_id in seen_entities:
+                    continue
+                seen_entities.add(entity_id)
+
+            # Extract context snippet for description mentions
+            context: str | None = None
+            if mention_source == MentionSource.DESCRIPTION:
+                context = self._extract_context_snippet(text, m_start, m_end)
+
+            mention = EntityMentionCreate(
+                entity_id=entity_id,
+                segment_id=None,
+                video_id=video_id,
+                language_code=None,
+                mention_text=matched_text,
+                detection_method=DetectionMethod.RULE_MATCH,
+                confidence=1.0,
+                match_start=m_start,
+                match_end=m_end,
+                mention_source=mention_source,
+                mention_context=context,
+            )
+            mentions.append(mention)
+
+            if dry_run:
+                preview_context = context or (
+                    text[:120] if len(text) > 120 else text
+                )
+                previews.append(
+                    {
+                        "video_id": video_id,
+                        "segment_id": None,
+                        "start_time": None,
+                        "entity_name": pat.canonical_name,
+                        "entity_type": pat.entity_type,
+                        "matched_text": matched_text,
+                        "match_start": m_start,
+                        "match_end": m_end,
+                        "context": preview_context,
+                        "source": mention_source.value,
+                    }
+                )
+
+        return mentions, previews
+
+    @staticmethod
+    def _extract_context_snippet(
+        text: str, match_start: int, match_end: int, window: int = 75
+    ) -> str:
+        """Extract a context snippet around a match position.
+
+        Returns approximately ``window`` characters before and after the
+        match, with ellipsis (``...``) added if the snippet is truncated
+        at either end.
+
+        Parameters
+        ----------
+        text : str
+            The full text containing the match.
+        match_start : int
+            Start position of the match.
+        match_end : int
+            End position of the match.
+        window : int
+            Number of characters of context before and after the match
+            (default 75).
+
+        Returns
+        -------
+        str
+            The context snippet with optional leading/trailing ellipsis.
+        """
+        snippet_start = max(0, match_start - window)
+        snippet_end = min(len(text), match_end + window)
+
+        snippet = text[snippet_start:snippet_end]
+
+        if snippet_start > 0:
+            snippet = "..." + snippet
+        if snippet_end < len(text):
+            snippet = snippet + "..."
+
+        return snippet
 
     async def _load_entity_patterns(
         self,

--- a/tests/integration/db/test_migration_054.py
+++ b/tests/integration/db/test_migration_054.py
@@ -1,0 +1,830 @@
+"""
+Tests for migration 054: multi-source entity mention columns and indexes.
+
+This test suite validates that migration 054_add_mention_source_column
+correctly:
+
+1. Adds the ``mention_source`` column (VARCHAR(20), NOT NULL, default
+   ``'transcript'``) to ``entity_mentions``
+2. Adds the ``mention_context`` column (TEXT, nullable) to
+   ``entity_mentions``
+3. Adds a CHECK constraint that accepts only the three valid source values
+   (``transcript``, ``title``, ``description``) and rejects any other value
+4. Creates the partial unique index ``uq_entity_mentions_title`` on
+   ``(entity_id, video_id, mention_source) WHERE mention_source = 'title'``
+5. Creates the partial unique index ``uq_entity_mentions_description`` on
+   ``(entity_id, video_id, mention_source, mention_text)
+   WHERE mention_source = 'description'``
+6. Creates the regular B-tree index ``ix_entity_mentions_mention_source``
+   on ``(mention_source)``
+
+Unlike the ORM-based schema tests, these tests query the database catalog
+directly (``information_schema``, ``pg_indexes``, ``pg_constraint``) and
+therefore MUST run against the dev database where Alembic migrations have
+been applied.  The integration test database created via
+``Base.metadata.create_all()`` does NOT carry migration-only DDL objects.
+
+Connection
+----------
+Dev database:
+    postgresql+asyncpg://dev_user:dev_password@localhost:5434/chronovista_dev
+
+Markers
+-------
+``db``          — requires live PostgreSQL on port 5434
+``integration`` — requires external services
+
+Migration Revision
+------------------
+Revision ID : (assigned when migration file is created — see
+               src/chronovista/db/migrations/versions/054_add_mention_source_column.py)
+Down revision: b2d4f6a8c0e1  (migration 052, GIN trigram indexes)
+
+Related
+-------
+Migration file:
+    src/chronovista/db/migrations/versions/054_add_mention_source_column.py
+Data model doc:
+    specs/054-multi-source-mentions/data-model.md
+Feature spec:
+    specs/054-multi-source-mentions/spec.md (FR-001, FR-021)
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_DEV_URL = (
+    "postgresql+asyncpg://dev_user:dev_password@localhost:5434/chronovista_dev"
+)
+
+_TABLE = "entity_mentions"
+
+_COL_MENTION_SOURCE = "mention_source"
+_COL_MENTION_CONTEXT = "mention_context"
+
+_INDEX_TITLE = "uq_entity_mentions_title"
+_INDEX_DESCRIPTION = "uq_entity_mentions_description"
+_INDEX_SOURCE = "ix_entity_mentions_mention_source"
+
+_VALID_SOURCES = ("transcript", "title", "description")
+_INVALID_SOURCE = "foo"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+async def dev_session() -> AsyncGenerator[AsyncSession, None]:
+    """
+    Provide an async database session connected to the dev database.
+
+    The dev database has real Alembic migrations applied, which is required
+    to verify that the migration-only columns and indexes exist.  The
+    per-function ``db_session`` fixture from ``conftest.py`` uses
+    ``create_all()`` which does NOT replicate migration DDL objects.
+
+    Scope is ``"function"`` (not ``"module"``) because pytest-asyncio
+    creates a new event loop per test function under ``asyncio_mode=auto``;
+    sharing a single asyncpg connection across event loops raises
+    ``RuntimeError: Future attached to a different loop``.
+
+    Yields
+    ------
+    AsyncSession
+        An open session; rolled back and closed after each test function.
+    """
+    url = os.getenv("DATABASE_DEV_URL", _DEFAULT_DEV_URL)
+    engine = create_async_engine(url, echo=False, pool_pre_ping=True)
+
+    factory = async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    async with factory() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()
+            await session.close()
+
+    await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Helper queries
+# ---------------------------------------------------------------------------
+
+
+async def _column_info(
+    session: AsyncSession,
+    table_name: str,
+    column_name: str,
+) -> dict[str, Any] | None:
+    """
+    Return ``information_schema.columns`` metadata for a column.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Active database session (dev DB).
+    table_name : str
+        Table name (without schema prefix).
+    column_name : str
+        Column name to look up.
+
+    Returns
+    -------
+    dict[str, Any] | None
+        Dict with ``column_name``, ``data_type``, ``is_nullable``,
+        ``column_default`` if the column exists, else ``None``.
+    """
+    result = await session.execute(
+        text(
+            "SELECT column_name, data_type, is_nullable, column_default "
+            "FROM information_schema.columns "
+            "WHERE table_schema = 'public' "
+            "  AND table_name   = :tbl "
+            "  AND column_name  = :col"
+        ),
+        {"tbl": table_name, "col": column_name},
+    )
+    row = result.mappings().one_or_none()
+    if row is None:
+        return None
+    return dict(row)
+
+
+async def _index_row(
+    session: AsyncSession,
+    index_name: str,
+    table_name: str,
+) -> dict[str, Any] | None:
+    """
+    Return catalog metadata for a named index on a specific table.
+
+    Queries ``pg_indexes`` (schema-agnostic view) for the public schema.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Active database session.
+    index_name : str
+        Name of the index to look up.
+    table_name : str
+        Table the index belongs to.
+
+    Returns
+    -------
+    dict[str, Any] | None
+        A dict with keys ``indexname``, ``tablename``, ``indexdef`` if found,
+        else ``None``.
+    """
+    result = await session.execute(
+        text(
+            "SELECT indexname, tablename, indexdef "
+            "FROM pg_indexes "
+            "WHERE schemaname = 'public' "
+            "  AND indexname  = :idx "
+            "  AND tablename  = :tbl"
+        ),
+        {"idx": index_name, "tbl": table_name},
+    )
+    row = result.mappings().one_or_none()
+    if row is None:
+        return None
+    return dict(row)
+
+
+async def _constraint_exists(
+    session: AsyncSession,
+    table_name: str,
+    constraint_name: str,
+) -> bool:
+    """
+    Return ``True`` if the named constraint exists on the given table.
+
+    Searches ``pg_constraint`` joined to ``pg_class`` for the public schema.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Active database session.
+    table_name : str
+        Table name.
+    constraint_name : str
+        Constraint name to look up.
+
+    Returns
+    -------
+    bool
+        ``True`` if the constraint row is found.
+    """
+    result = await session.execute(
+        text(
+            "SELECT COUNT(*) "
+            "FROM pg_constraint c "
+            "JOIN pg_class t ON t.oid = c.conrelid "
+            "JOIN pg_namespace n ON n.oid = t.relnamespace "
+            "WHERE n.nspname  = 'public' "
+            "  AND t.relname  = :tbl "
+            "  AND c.conname  = :con"
+        ),
+        {"tbl": table_name, "con": constraint_name},
+    )
+    count: int = result.scalar_one()
+    return count > 0
+
+
+# ---------------------------------------------------------------------------
+# TestMentionSourceColumn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.db
+@pytest.mark.integration
+class TestMentionSourceColumn:
+    """
+    Verify the ``mention_source`` column was added by migration 054.
+
+    Expected schema
+    ---------------
+    Column  : mention_source
+    Type    : character varying (VARCHAR)
+    Nullable: NO
+    Default : 'transcript'
+    """
+
+    async def test_mention_source_column_exists(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify mention_source column exists in entity_mentions."""
+        info = await _column_info(dev_session, _TABLE, _COL_MENTION_SOURCE)
+        assert info is not None, (
+            f"Column '{_COL_MENTION_SOURCE}' not found in table '{_TABLE}'. "
+            "Run migration 054_add_mention_source_column first."
+        )
+
+    async def test_mention_source_column_is_not_nullable(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify mention_source is NOT NULL (required for all rows)."""
+        info = await _column_info(dev_session, _TABLE, _COL_MENTION_SOURCE)
+        assert info is not None, f"Column '{_COL_MENTION_SOURCE}' not found."
+        assert info["is_nullable"] == "NO", (
+            f"Expected '{_COL_MENTION_SOURCE}' to be NOT NULL, "
+            f"but is_nullable={info['is_nullable']!r}"
+        )
+
+    async def test_mention_source_column_has_transcript_default(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify mention_source has a server-side default of 'transcript'.
+
+        The server_default='transcript' ensures all existing rows are
+        auto-populated when the column is added (data-model.md migration
+        strategy step 1).
+        """
+        info = await _column_info(dev_session, _TABLE, _COL_MENTION_SOURCE)
+        assert info is not None, f"Column '{_COL_MENTION_SOURCE}' not found."
+        column_default: str | None = info.get("column_default")
+        assert column_default is not None, (
+            f"Expected a default value on '{_COL_MENTION_SOURCE}', got None."
+        )
+        # PostgreSQL stores string defaults with type cast, e.g.
+        # "'transcript'::character varying"
+        assert "transcript" in column_default, (
+            f"Expected default to contain 'transcript', got: {column_default!r}"
+        )
+
+    async def test_mention_source_column_type_is_varchar(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify mention_source is a VARCHAR (character varying) column."""
+        info = await _column_info(dev_session, _TABLE, _COL_MENTION_SOURCE)
+        assert info is not None, f"Column '{_COL_MENTION_SOURCE}' not found."
+        data_type: str = info["data_type"]
+        assert "character varying" in data_type, (
+            f"Expected data_type 'character varying', got: {data_type!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestMentionContextColumn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.db
+@pytest.mark.integration
+class TestMentionContextColumn:
+    """
+    Verify the ``mention_context`` column was added by migration 054.
+
+    Expected schema
+    ---------------
+    Column  : mention_context
+    Type    : text
+    Nullable: YES
+    Default : NULL
+
+    The context snippet (~150 chars around the match) is populated only for
+    description-sourced mentions (data-model.md).
+    """
+
+    async def test_mention_context_column_exists(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify mention_context column exists in entity_mentions."""
+        info = await _column_info(dev_session, _TABLE, _COL_MENTION_CONTEXT)
+        assert info is not None, (
+            f"Column '{_COL_MENTION_CONTEXT}' not found in table '{_TABLE}'. "
+            "Run migration 054_add_mention_source_column first."
+        )
+
+    async def test_mention_context_column_is_nullable(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify mention_context is nullable (only populated for description mentions)."""
+        info = await _column_info(dev_session, _TABLE, _COL_MENTION_CONTEXT)
+        assert info is not None, f"Column '{_COL_MENTION_CONTEXT}' not found."
+        assert info["is_nullable"] == "YES", (
+            f"Expected '{_COL_MENTION_CONTEXT}' to be nullable, "
+            f"but is_nullable={info['is_nullable']!r}"
+        )
+
+    async def test_mention_context_column_type_is_text(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify mention_context is a TEXT column (not VARCHAR-bounded)."""
+        info = await _column_info(dev_session, _TABLE, _COL_MENTION_CONTEXT)
+        assert info is not None, f"Column '{_COL_MENTION_CONTEXT}' not found."
+        data_type: str = info["data_type"]
+        assert data_type == "text", (
+            f"Expected data_type 'text', got: {data_type!r}"
+        )
+
+    async def test_mention_context_column_has_no_default(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify mention_context has no default value (NULL by absence)."""
+        info = await _column_info(dev_session, _TABLE, _COL_MENTION_CONTEXT)
+        assert info is not None, f"Column '{_COL_MENTION_CONTEXT}' not found."
+        column_default = info.get("column_default")
+        assert column_default is None, (
+            f"Expected no default on '{_COL_MENTION_CONTEXT}', "
+            f"got: {column_default!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestMentionSourceCheckConstraint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.db
+@pytest.mark.integration
+class TestMentionSourceCheckConstraint:
+    """
+    Verify the CHECK constraint on ``mention_source`` enforces valid values.
+
+    The constraint must accept 'transcript', 'title', and 'description'
+    and reject any other value (e.g. 'foo').
+
+    These tests use live INSERT/ROLLBACK to confirm enforcement at the
+    database level (the ORM model is not authoritative for migration-only
+    constraints).  Each test rolls back its transaction so the dev database
+    is never mutated.
+    """
+
+    async def _get_any_entity_id(self, session: AsyncSession) -> str | None:
+        """Return the first named_entity id as a hex string, or None."""
+        result = await session.execute(
+            text("SELECT id FROM named_entities LIMIT 1")
+        )
+        row = result.one_or_none()
+        return str(row[0]) if row else None
+
+    async def test_check_constraint_exists_in_catalog(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify the mention_source CHECK constraint row exists in pg_constraint."""
+        # The constraint name matches the ORM model definition in db/models.py.
+        constraint_name = "chk_entity_mention_source_valid"
+        exists = await _constraint_exists(dev_session, _TABLE, constraint_name)
+        assert exists, (
+            f"CHECK constraint '{constraint_name}' not found on table '{_TABLE}'. "
+            "Run migration 054_add_mention_source_column first."
+        )
+
+    @pytest.mark.parametrize("valid_source", list(_VALID_SOURCES))
+    async def test_valid_source_values_are_accepted(
+        self, dev_session: AsyncSession, valid_source: str
+    ) -> None:
+        """Verify the CHECK constraint accepts 'transcript', 'title', and 'description'.
+
+        Uses a savepoint so the insert attempt is rolled back regardless of
+        whether the constraint accepts or rejects the value.
+        """
+        # This test only checks that the constraint does NOT reject valid values.
+        # We use EXPLAIN (parse-level check) rather than a real INSERT to avoid
+        # needing valid FK data; for constraint acceptance we query the
+        # constraint definition directly.
+        result = await dev_session.execute(
+            text(
+                "SELECT pg_get_constraintdef(c.oid) "
+                "FROM pg_constraint c "
+                "JOIN pg_class t ON t.oid = c.conrelid "
+                "JOIN pg_namespace n ON n.oid = t.relnamespace "
+                "WHERE n.nspname = 'public' "
+                "  AND t.relname = :tbl "
+                "  AND c.contype = 'c' "
+                "  AND pg_get_constraintdef(c.oid) LIKE '%mention_source%'"
+            ),
+            {"tbl": _TABLE},
+        )
+        row = result.one_or_none()
+        assert row is not None, (
+            f"No CHECK constraint on '{_TABLE}.mention_source' found in pg_constraint."
+        )
+        consrc: str = row[0]
+        assert valid_source in consrc, (
+            f"Expected valid source '{valid_source}' to be listed in the "
+            f"CHECK constraint expression, but got: {consrc!r}"
+        )
+
+    async def test_invalid_source_value_rejected_by_constraint(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify the CHECK constraint body explicitly excludes invalid values.
+
+        Rather than inserting a real row (which would require valid FK data),
+        we confirm the constraint expression does NOT list 'foo' as an
+        accepted value.  This validates the constraint definition is correct.
+        """
+        result = await dev_session.execute(
+            text(
+                "SELECT pg_get_constraintdef(c.oid) "
+                "FROM pg_constraint c "
+                "JOIN pg_class t ON t.oid = c.conrelid "
+                "JOIN pg_namespace n ON n.oid = t.relnamespace "
+                "WHERE n.nspname = 'public' "
+                "  AND t.relname = :tbl "
+                "  AND c.contype = 'c' "
+                "  AND pg_get_constraintdef(c.oid) LIKE '%mention_source%'"
+            ),
+            {"tbl": _TABLE},
+        )
+        row = result.one_or_none()
+        assert row is not None, (
+            f"No CHECK constraint on '{_TABLE}.mention_source' found in pg_constraint."
+        )
+        consrc: str = row[0]
+        # The constraint must NOT list 'foo' as a permitted value.
+        assert _INVALID_SOURCE not in consrc, (
+            f"Invalid source value '{_INVALID_SOURCE}' is unexpectedly listed "
+            f"in the CHECK constraint expression: {consrc!r}"
+        )
+
+    async def test_check_constraint_lists_all_three_valid_values(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify the constraint expression includes all three valid source values."""
+        result = await dev_session.execute(
+            text(
+                "SELECT pg_get_constraintdef(c.oid) "
+                "FROM pg_constraint c "
+                "JOIN pg_class t ON t.oid = c.conrelid "
+                "JOIN pg_namespace n ON n.oid = t.relnamespace "
+                "WHERE n.nspname = 'public' "
+                "  AND t.relname = :tbl "
+                "  AND c.contype = 'c' "
+                "  AND pg_get_constraintdef(c.oid) LIKE '%mention_source%'"
+            ),
+            {"tbl": _TABLE},
+        )
+        row = result.one_or_none()
+        assert row is not None, (
+            f"No CHECK constraint on '{_TABLE}.mention_source' found."
+        )
+        consrc: str = row[0]
+        for source in _VALID_SOURCES:
+            assert source in consrc, (
+                f"Expected valid source '{source}' listed in constraint, "
+                f"but constraint expression is: {consrc!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestPartialUniqueIndexTitle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.db
+@pytest.mark.integration
+class TestPartialUniqueIndexTitle:
+    """
+    Verify the partial unique index ``uq_entity_mentions_title`` exists.
+
+    Index spec (data-model.md)
+    -------------------------
+    Name    : uq_entity_mentions_title
+    Table   : entity_mentions
+    Columns : (entity_id, video_id, mention_source)
+    Unique  : YES
+    Partial : WHERE mention_source = 'title'
+    Purpose : One title mention per entity per video (EC-007)
+    """
+
+    async def test_title_index_exists_in_catalog(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify uq_entity_mentions_title is present in pg_indexes."""
+        row = await _index_row(dev_session, _INDEX_TITLE, _TABLE)
+        assert row is not None, (
+            f"Index '{_INDEX_TITLE}' not found in pg_indexes for table '{_TABLE}'. "
+            "Run migration 054_add_mention_source_column first."
+        )
+
+    async def test_title_index_is_unique(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify uq_entity_mentions_title is a UNIQUE index."""
+        row = await _index_row(dev_session, _INDEX_TITLE, _TABLE)
+        assert row is not None, f"Index '{_INDEX_TITLE}' not found."
+        indexdef: str = row["indexdef"].lower()
+        assert "unique index" in indexdef, (
+            f"Expected 'UNIQUE INDEX' in index definition, got: {row['indexdef']!r}"
+        )
+
+    async def test_title_index_covers_correct_columns(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify uq_entity_mentions_title covers entity_id, video_id, mention_source."""
+        row = await _index_row(dev_session, _INDEX_TITLE, _TABLE)
+        assert row is not None, f"Index '{_INDEX_TITLE}' not found."
+        indexdef: str = row["indexdef"].lower()
+        for col in ("entity_id", "video_id", "mention_source"):
+            assert col in indexdef, (
+                f"Expected column '{col}' in index definition, "
+                f"got: {row['indexdef']!r}"
+            )
+
+    async def test_title_index_is_partial_where_title(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify uq_entity_mentions_title has predicate WHERE mention_source = 'title'."""
+        row = await _index_row(dev_session, _INDEX_TITLE, _TABLE)
+        assert row is not None, f"Index '{_INDEX_TITLE}' not found."
+        indexdef: str = row["indexdef"].lower()
+        assert " where " in indexdef, (
+            f"Expected a partial index (WHERE clause), got: {row['indexdef']!r}"
+        )
+        assert "title" in indexdef, (
+            f"Expected predicate to reference 'title', got: {row['indexdef']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestPartialUniqueIndexDescription
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.db
+@pytest.mark.integration
+class TestPartialUniqueIndexDescription:
+    """
+    Verify the partial unique index ``uq_entity_mentions_description`` exists.
+
+    Index spec (data-model.md)
+    -------------------------
+    Name    : uq_entity_mentions_description
+    Table   : entity_mentions
+    Columns : (entity_id, video_id, mention_source, mention_text)
+    Unique  : YES
+    Partial : WHERE mention_source = 'description'
+    Purpose : One mention per distinct text match per entity per video for
+              descriptions.
+    """
+
+    async def test_description_index_exists_in_catalog(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify uq_entity_mentions_description is present in pg_indexes."""
+        row = await _index_row(dev_session, _INDEX_DESCRIPTION, _TABLE)
+        assert row is not None, (
+            f"Index '{_INDEX_DESCRIPTION}' not found in pg_indexes for table "
+            f"'{_TABLE}'. Run migration 054_add_mention_source_column first."
+        )
+
+    async def test_description_index_is_unique(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify uq_entity_mentions_description is a UNIQUE index."""
+        row = await _index_row(dev_session, _INDEX_DESCRIPTION, _TABLE)
+        assert row is not None, f"Index '{_INDEX_DESCRIPTION}' not found."
+        indexdef: str = row["indexdef"].lower()
+        assert "unique index" in indexdef, (
+            f"Expected 'UNIQUE INDEX' in index definition, got: {row['indexdef']!r}"
+        )
+
+    async def test_description_index_covers_correct_columns(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify uq_entity_mentions_description covers entity_id, video_id, mention_source, mention_text."""
+        row = await _index_row(dev_session, _INDEX_DESCRIPTION, _TABLE)
+        assert row is not None, f"Index '{_INDEX_DESCRIPTION}' not found."
+        indexdef: str = row["indexdef"].lower()
+        for col in ("entity_id", "video_id", "mention_source", "mention_text"):
+            assert col in indexdef, (
+                f"Expected column '{col}' in index definition, "
+                f"got: {row['indexdef']!r}"
+            )
+
+    async def test_description_index_is_partial_where_description(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify uq_entity_mentions_description has predicate WHERE mention_source = 'description'."""
+        row = await _index_row(dev_session, _INDEX_DESCRIPTION, _TABLE)
+        assert row is not None, f"Index '{_INDEX_DESCRIPTION}' not found."
+        indexdef: str = row["indexdef"].lower()
+        assert " where " in indexdef, (
+            f"Expected a partial index (WHERE clause), got: {row['indexdef']!r}"
+        )
+        assert "description" in indexdef, (
+            f"Expected predicate to reference 'description', "
+            f"got: {row['indexdef']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestRegularIndexOnMentionSource
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.db
+@pytest.mark.integration
+class TestRegularIndexOnMentionSource:
+    """
+    Verify the regular B-tree index ``ix_entity_mentions_mention_source`` exists.
+
+    Index spec (data-model.md)
+    -------------------------
+    Name    : ix_entity_mentions_mention_source
+    Table   : entity_mentions
+    Columns : (mention_source)
+    Unique  : NO
+    Partial : No
+    Purpose : Efficient filter queries by source type
+    """
+
+    async def test_source_index_exists_in_catalog(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify ix_entity_mentions_mention_source is present in pg_indexes."""
+        row = await _index_row(dev_session, _INDEX_SOURCE, _TABLE)
+        assert row is not None, (
+            f"Index '{_INDEX_SOURCE}' not found in pg_indexes for table '{_TABLE}'. "
+            "Run migration 054_add_mention_source_column first."
+        )
+
+    async def test_source_index_is_not_unique(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify ix_entity_mentions_mention_source is a non-unique B-tree index."""
+        row = await _index_row(dev_session, _INDEX_SOURCE, _TABLE)
+        assert row is not None, f"Index '{_INDEX_SOURCE}' not found."
+        indexdef: str = row["indexdef"].lower()
+        assert "unique index" not in indexdef, (
+            f"Expected a non-unique index, but got: {row['indexdef']!r}"
+        )
+
+    async def test_source_index_covers_mention_source_column(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify ix_entity_mentions_mention_source covers the mention_source column."""
+        row = await _index_row(dev_session, _INDEX_SOURCE, _TABLE)
+        assert row is not None, f"Index '{_INDEX_SOURCE}' not found."
+        indexdef: str = row["indexdef"].lower()
+        assert "mention_source" in indexdef, (
+            f"Expected column 'mention_source' in index definition, "
+            f"got: {row['indexdef']!r}"
+        )
+
+    async def test_source_index_is_full_table_not_partial(
+        self, dev_session: AsyncSession
+    ) -> None:
+        """Verify ix_entity_mentions_mention_source has no WHERE clause."""
+        row = await _index_row(dev_session, _INDEX_SOURCE, _TABLE)
+        assert row is not None, f"Index '{_INDEX_SOURCE}' not found."
+        indexdef: str = row["indexdef"].lower()
+        assert " where " not in indexdef, (
+            f"Expected a full-table index (no WHERE clause), "
+            f"got: {row['indexdef']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestMigrationDowngrade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.db
+@pytest.mark.integration
+class TestMigrationDowngrade:
+    """
+    Document migration 054 downgrade behaviour.
+
+    These tests do NOT execute the actual Alembic downgrade (which would
+    mutate the shared dev database and could disrupt development workflows).
+    Instead they document the expected downgrade SQL so it can be reviewed and
+    verified manually in an isolated environment.
+
+    To verify downgrade behaviour manually::
+
+        alembic -c alembic-dev.ini downgrade -1   # revert 054
+        # confirm via psql:
+        #   \\d entity_mentions   → no mention_source / mention_context columns
+        #   \\di uq_entity_mentions_title  → no index
+        alembic -c alembic-dev.ini upgrade head    # restore
+    """
+
+    def test_downgrade_drops_mention_source_column_documented(self) -> None:
+        """Document that downgrade drops the mention_source column.
+
+        Downgrade SQL::
+
+            ALTER TABLE entity_mentions DROP COLUMN mention_source;
+
+        WARNING: This is lossy — all title and description mentions are
+        permanently deleted before the column is dropped (data-model.md).
+        """
+        expected_table = _TABLE
+        expected_column = _COL_MENTION_SOURCE
+        assert expected_table == "entity_mentions"
+        assert expected_column == "mention_source"
+
+    def test_downgrade_drops_mention_context_column_documented(self) -> None:
+        """Document that downgrade drops the mention_context column.
+
+        Downgrade SQL::
+
+            ALTER TABLE entity_mentions DROP COLUMN mention_context;
+        """
+        expected_table = _TABLE
+        expected_column = _COL_MENTION_CONTEXT
+        assert expected_table == "entity_mentions"
+        assert expected_column == "mention_context"
+
+    def test_downgrade_drops_all_three_indexes_documented(self) -> None:
+        """Document that downgrade drops all three migration-added indexes.
+
+        Downgrade SQL (executed before column drops)::
+
+            DROP INDEX IF EXISTS ix_entity_mentions_mention_source;
+            DROP INDEX IF EXISTS uq_entity_mentions_description;
+            DROP INDEX IF EXISTS uq_entity_mentions_title;
+        """
+        expected_indexes = [
+            _INDEX_SOURCE,
+            _INDEX_DESCRIPTION,
+            _INDEX_TITLE,
+        ]
+        assert len(expected_indexes) == 3
+        for idx in expected_indexes:
+            assert idx.startswith(("ix_", "uq_"))
+
+    def test_downgrade_is_lossy_for_title_and_description_mentions_documented(
+        self,
+    ) -> None:
+        """Document that downgrade is lossy: title/description mentions are deleted.
+
+        Before dropping the column, the downgrade must DELETE all rows where
+        mention_source IN ('title', 'description') because these rows have
+        segment_id=NULL and cannot be represented in the pre-054 schema.
+
+        Manual mentions (Feature 050) are preserved since they use
+        mention_source='transcript' (the default) and are identified by
+        detection_method='manual'.
+
+        Downgrade SQL::
+
+            DELETE FROM entity_mentions
+            WHERE mention_source IN ('title', 'description');
+        """
+        lossy_sources = ["title", "description"]
+        preserved_sources = ["transcript"]
+        assert set(lossy_sources).isdisjoint(set(preserved_sources))

--- a/tests/unit/api/test_entity_source_filter.py
+++ b/tests/unit/api/test_entity_source_filter.py
@@ -1,0 +1,511 @@
+"""Unit tests for scan endpoint ``sources`` parameter (Phase 6 — US3b)
+and entity videos source filter (Phase 8 — US5).
+
+Tests T037–T040 verify that the ``sources`` parameter on both scan
+endpoints dispatches to the correct service methods and validates input.
+
+Tests T062 verifies that ``GET /entities/{id}/videos?source=title`` returns
+only title-sourced videos.
+
+Mock strategy
+-------------
+- ``_get_scan_service`` is patched to return a mock scan service
+- ``session.get`` is patched to simulate entity/video existence
+- ``get_db`` and ``require_auth`` FastAPI dependencies are overridden
+- ``EntityMentionRepository.get_entity_video_list`` is patched for T062
+
+References
+----------
+- specs/054-multi-source-mentions/tasks.md — T037–T040, T062
+- specs/054-multi-source-mentions/spec.md — FR-026, FR-027, FR-031, FR-036
+- specs/054-multi-source-mentions/contracts/entity-videos-endpoint.md
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.main import app
+from chronovista.services.entity_mention_scan_service import ScanResult
+from tests.factories import id_factory
+
+# ---------------------------------------------------------------------------
+# Module-level asyncio marker (coverage integration)
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _uuid() -> uuid.UUID:
+    """Return a UUIDv7 expressed as a stdlib ``uuid.UUID`` instance."""
+    return uuid.UUID(bytes=uuid7().bytes)
+
+
+def _empty_scan_result(*, dry_run: bool = False) -> ScanResult:
+    """Return a zeroed-out :class:`ScanResult` for mock returns."""
+    return ScanResult(dry_run=dry_run)
+
+
+async def _build_client(
+    mock_session: AsyncMock,
+) -> AsyncGenerator[AsyncClient, None]:
+    """Yield an AsyncClient with ``get_db`` and ``require_auth`` overridden.
+
+    Parameters
+    ----------
+    mock_session : AsyncMock
+        The mock database session to inject via the ``get_db`` override.
+
+    Yields
+    ------
+    AsyncClient
+        A configured HTTP test client with overridden dependencies.
+    """
+
+    async def mock_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield mock_session
+
+    async def mock_require_auth() -> None:
+        return None
+
+    app.dependency_overrides[get_db] = mock_get_db
+    app.dependency_overrides[require_auth] = mock_require_auth
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _make_entity_session(entity_id: uuid.UUID) -> AsyncMock:
+    """Build a mock session where ``session.get(NamedEntityDB, ...)`` succeeds.
+
+    Parameters
+    ----------
+    entity_id : uuid.UUID
+        Entity UUID that should pass the existence check.
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    # session.get(NamedEntityDB, entity_id) returns a mock entity
+    @dataclass
+    class _FakeEntity:
+        id: uuid.UUID
+        status: str = "active"
+
+    mock_session.get = AsyncMock(return_value=_FakeEntity(id=entity_id))
+    mock_session.commit = AsyncMock()
+    return mock_session
+
+
+def _make_video_session(video_id: str) -> AsyncMock:
+    """Build a mock session where ``session.get(VideoDB, ...)`` succeeds.
+
+    Parameters
+    ----------
+    video_id : str
+        Video ID that should pass the existence check.
+
+    Returns
+    -------
+    AsyncMock
+        Configured mock session.
+    """
+    mock_session = AsyncMock(spec=AsyncSession)
+
+    video_mock = MagicMock()
+    video_mock.video_id = video_id
+    mock_session.get = AsyncMock(return_value=video_mock)
+    mock_session.commit = AsyncMock()
+    return mock_session
+
+
+# ---------------------------------------------------------------------------
+# T037 — POST /entities/{id}/scan with sources=["title"] calls scan_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestScanEntitySourcesParameter:
+    """Tests for the ``sources`` parameter on POST /entities/{id}/scan."""
+
+    async def test_sources_title_calls_scan_metadata(self) -> None:
+        """T037: sources=["title"] dispatches to scan_metadata(), not scan().
+
+        When the request body includes ``sources: ["title"]``, the endpoint
+        should call ``scan_metadata(sources=["title"])`` and NOT call
+        ``scan()``.
+        """
+        entity_id = _uuid()
+        mock_session = _make_entity_session(entity_id)
+
+        mock_service = MagicMock()
+        mock_service.scan = AsyncMock(return_value=_empty_scan_result())
+        mock_service.scan_metadata = AsyncMock(
+            return_value=_empty_scan_result()
+        )
+
+        with patch(
+            "chronovista.api.routers.entity_mentions._get_scan_service",
+            return_value=mock_service,
+        ):
+            async for client in _build_client(mock_session):
+                response = await client.post(
+                    f"/api/v1/entities/{entity_id}/scan",
+                    json={"sources": ["title"]},
+                )
+
+        assert response.status_code == 200
+        mock_service.scan.assert_not_called()
+        mock_service.scan_metadata.assert_called_once()
+        call_kwargs = mock_service.scan_metadata.call_args.kwargs
+        assert call_kwargs["sources"] == ["title"]
+
+    # -------------------------------------------------------------------
+    # T038 — No sources defaults to transcript-only (backward compatible)
+    # -------------------------------------------------------------------
+
+    async def test_no_sources_defaults_to_transcript_only(self) -> None:
+        """T038: Omitting sources calls scan() only (backward compatible).
+
+        When the request body does not include ``sources``, the endpoint
+        should default to ``["transcript"]`` and call only ``scan()``,
+        preserving existing behavior.
+        """
+        entity_id = _uuid()
+        mock_session = _make_entity_session(entity_id)
+
+        mock_service = MagicMock()
+        mock_service.scan = AsyncMock(return_value=_empty_scan_result())
+        mock_service.scan_metadata = AsyncMock(
+            return_value=_empty_scan_result()
+        )
+
+        with patch(
+            "chronovista.api.routers.entity_mentions._get_scan_service",
+            return_value=mock_service,
+        ):
+            async for client in _build_client(mock_session):
+                response = await client.post(
+                    f"/api/v1/entities/{entity_id}/scan",
+                    json={},
+                )
+
+        assert response.status_code == 200
+        mock_service.scan.assert_called_once()
+        mock_service.scan_metadata.assert_not_called()
+
+    # -------------------------------------------------------------------
+    # T039 — sources=["tag"] returns 422 with RFC 7807 error
+    # -------------------------------------------------------------------
+
+    async def test_sources_tag_returns_422(self) -> None:
+        """T039: sources=["tag"] is rejected with HTTP 422.
+
+        The ``tag`` value is explicitly invalid for scan sources because
+        tag associations are query-time (Feature 053), not scan-persisted.
+        The response body should follow RFC 7807 format.
+        """
+        entity_id = _uuid()
+        mock_session = _make_entity_session(entity_id)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                f"/api/v1/entities/{entity_id}/scan",
+                json={"sources": ["tag"]},
+            )
+
+        assert response.status_code == 422
+        body = response.json()
+        # RFC 7807 requires a detail field
+        assert "detail" in body
+
+
+# ---------------------------------------------------------------------------
+# T040 — POST /videos/{id}/scan-entities with sources=title+description
+# ---------------------------------------------------------------------------
+
+
+class TestScanVideoEntitiesSourcesParameter:
+    """Tests for the ``sources`` parameter on POST /videos/{id}/scan-entities."""
+
+    async def test_sources_title_description_calls_scan_metadata(
+        self,
+    ) -> None:
+        """T040: sources=["title","description"] dispatches to scan_metadata().
+
+        When the request body includes both ``title`` and ``description``
+        sources (but not ``transcript``), the endpoint should call
+        ``scan_metadata()`` and NOT call ``scan()``.
+        """
+        video_id = id_factory.video_id(seed="scan_sources_test")
+        mock_session = _make_video_session(video_id)
+
+        mock_service = MagicMock()
+        mock_service.scan = AsyncMock(return_value=_empty_scan_result())
+        mock_service.scan_metadata = AsyncMock(
+            return_value=_empty_scan_result()
+        )
+
+        with patch(
+            "chronovista.api.routers.entity_mentions._get_scan_service",
+            return_value=mock_service,
+        ):
+            async for client in _build_client(mock_session):
+                response = await client.post(
+                    f"/api/v1/videos/{video_id}/scan-entities",
+                    json={"sources": ["title", "description"]},
+                )
+
+        assert response.status_code == 200
+        mock_service.scan.assert_not_called()
+        mock_service.scan_metadata.assert_called_once()
+        call_kwargs = mock_service.scan_metadata.call_args.kwargs
+        assert sorted(call_kwargs["sources"]) == ["description", "title"]
+
+    async def test_all_sources_calls_both_scan_and_scan_metadata(
+        self,
+    ) -> None:
+        """All three sources dispatches to both scan() and scan_metadata().
+
+        When ``sources: ["transcript", "title", "description"]``, both
+        ``scan()`` and ``scan_metadata()`` should be called, and the
+        results merged.
+        """
+        video_id = id_factory.video_id(seed="scan_all_sources")
+        mock_session = _make_video_session(video_id)
+
+        transcript_result = ScanResult(
+            segments_scanned=100,
+            mentions_found=5,
+            mentions_skipped=2,
+            unique_entities=3,
+            unique_videos=1,
+            duration_seconds=1.5,
+        )
+        metadata_result = ScanResult(
+            segments_scanned=50,
+            mentions_found=3,
+            mentions_skipped=1,
+            unique_entities=2,
+            unique_videos=1,
+            duration_seconds=0.5,
+        )
+
+        mock_service = MagicMock()
+        mock_service.scan = AsyncMock(return_value=transcript_result)
+        mock_service.scan_metadata = AsyncMock(return_value=metadata_result)
+
+        with patch(
+            "chronovista.api.routers.entity_mentions._get_scan_service",
+            return_value=mock_service,
+        ):
+            async for client in _build_client(mock_session):
+                response = await client.post(
+                    f"/api/v1/videos/{video_id}/scan-entities",
+                    json={
+                        "sources": ["transcript", "title", "description"],
+                    },
+                )
+
+        assert response.status_code == 200
+        mock_service.scan.assert_called_once()
+        mock_service.scan_metadata.assert_called_once()
+
+        body = response.json()
+        data = body["data"]
+        # Merged numeric fields
+        assert data["segments_scanned"] == 150
+        assert data["mentions_found"] == 8
+        assert data["mentions_skipped"] == 3
+        assert data["unique_entities"] == 5
+        assert data["unique_videos"] == 2
+        assert data["duration_seconds"] == pytest.approx(2.0)
+
+    async def test_sources_tag_on_video_endpoint_returns_422(self) -> None:
+        """Invalid source 'tag' on video scan endpoint returns 422."""
+        video_id = id_factory.video_id(seed="scan_tag_invalid")
+        mock_session = _make_video_session(video_id)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                f"/api/v1/videos/{video_id}/scan-entities",
+                json={"sources": ["tag"]},
+            )
+
+        assert response.status_code == 422
+
+    async def test_sources_unknown_value_returns_422(self) -> None:
+        """Unknown source value returns 422."""
+        video_id = id_factory.video_id(seed="scan_unknown_source")
+        mock_session = _make_video_session(video_id)
+
+        async for client in _build_client(mock_session):
+            response = await client.post(
+                f"/api/v1/videos/{video_id}/scan-entities",
+                json={"sources": ["foobar"]},
+            )
+
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# T062 — GET /entities/{id}/videos?source=title returns filtered results
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntityVideosSourceFilter:
+    """Tests for the ``source`` query parameter on GET /entities/{id}/videos.
+
+    T062: ``GET /entities/{id}/videos?source=title`` returns only
+    title-sourced videos (the repository filter is applied).
+    """
+
+    async def test_source_title_returns_only_title_sourced_videos(
+        self,
+    ) -> None:
+        """T062: GET /entities/{id}/videos?source=title returns title-only results.
+
+        When ``source=title`` is supplied, the endpoint must pass
+        ``source_filter="title"`` to the repository and only return videos
+        whose ``sources`` list contains ``"title"``.
+        """
+        entity_id = _uuid()
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        # Mock existence check
+        @dataclass
+        class _FakeEntity:
+            id: uuid.UUID
+            status: str = "active"
+
+        mock_session.execute = AsyncMock()
+        # First execute call → entity existence check (returns scalar)
+        entity_scalar = MagicMock()
+        entity_scalar.scalar_one_or_none = MagicMock(return_value=entity_id)
+        mock_session.execute.return_value = entity_scalar
+
+        # Repository returns a title-sourced video result
+        title_video = {
+            "video_id": "vid-001",
+            "video_title": "David Sheen Documentary",
+            "channel_name": "Test Channel",
+            "mention_count": 0,
+            "mentions": [],
+            "sources": ["title"],
+            "has_manual": False,
+            "first_mention_time": None,
+            "upload_date": None,
+            "description_context": None,
+        }
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository"
+            ".EntityMentionRepository.get_entity_video_list",
+            new_callable=AsyncMock,
+            return_value=([title_video], 1),
+        ) as mock_repo:
+            async for client in _build_client(mock_session):
+                response = await client.get(
+                    f"/api/v1/entities/{entity_id}/videos?source=title"
+                )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pagination"]["total"] == 1
+        assert len(body["data"]) == 1
+        assert body["data"][0]["sources"] == ["title"]
+
+        # Verify the repository was called with source_filter="title"
+        mock_repo.assert_called_once()
+        call_kwargs = mock_repo.call_args.kwargs
+        assert call_kwargs.get("source_filter") == "title"
+
+    async def test_no_source_returns_all_videos(self) -> None:
+        """GET /entities/{id}/videos without source returns all videos.
+
+        When no ``source`` parameter is supplied, ``source_filter=None``
+        is passed to the repository and all videos are returned.
+        """
+        entity_id = _uuid()
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        entity_scalar = MagicMock()
+        entity_scalar.scalar_one_or_none = MagicMock(return_value=entity_id)
+        mock_session.execute = AsyncMock(return_value=entity_scalar)
+
+        all_videos = [
+            {
+                "video_id": f"vid-{i:03d}",
+                "video_title": f"Video {i}",
+                "channel_name": "Channel",
+                "mention_count": 1,
+                "mentions": [],
+                "sources": ["transcript"],
+                "has_manual": False,
+                "first_mention_time": None,
+                "upload_date": None,
+                "description_context": None,
+            }
+            for i in range(3)
+        ]
+
+        with patch(
+            "chronovista.repositories.entity_mention_repository"
+            ".EntityMentionRepository.get_entity_video_list",
+            new_callable=AsyncMock,
+            return_value=(all_videos, 3),
+        ) as mock_repo:
+            async for client in _build_client(mock_session):
+                response = await client.get(
+                    f"/api/v1/entities/{entity_id}/videos"
+                )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pagination"]["total"] == 3
+
+        # Verify source_filter is None when not supplied
+        call_kwargs = mock_repo.call_args.kwargs
+        assert call_kwargs.get("source_filter") is None
+
+    async def test_invalid_source_value_returns_422(self) -> None:
+        """GET /entities/{id}/videos?source=foobar returns 422.
+
+        Invalid source values should be rejected by the endpoint before
+        reaching the repository.
+        """
+        entity_id = _uuid()
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        entity_scalar = MagicMock()
+        entity_scalar.scalar_one_or_none = MagicMock(return_value=entity_id)
+        mock_session.execute = AsyncMock(return_value=entity_scalar)
+
+        async for client in _build_client(mock_session):
+            response = await client.get(
+                f"/api/v1/entities/{entity_id}/videos?source=foobar"
+            )
+
+        assert response.status_code == 422

--- a/tests/unit/cli/test_entity_commands_sources.py
+++ b/tests/unit/cli/test_entity_commands_sources.py
@@ -1,0 +1,745 @@
+"""
+Unit tests for the ``--sources`` flag on the ``entities scan`` CLI command.
+
+Covers Feature 054 -- Multi-Source Entity Mention Detection, Phase 5 (US3).
+
+All external dependencies (database session, scan service) are mocked so
+that only CLI option-parsing, source validation, dispatch logic, and
+output-formatting are exercised.
+
+Covered tasks:
+  T028 -- ``--sources title`` calls ``scan_metadata(sources=["title"])``
+  T029 -- ``--sources transcript,title,description`` calls both ``scan()`` and
+          ``scan_metadata()``
+  T030 -- No ``--sources`` flag defaults to transcript-only (``scan()`` only)
+  T031 -- ``--sources tag`` produces a validation error (exit code 1)
+  T032 -- ``--sources title --dry-run`` output includes ``source`` column and
+          uses em dash for segment_id / start_time per FR-030
+
+Feature 054 -- Multi-Source Entity Mention Detection
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from chronovista.cli.entity_commands import entity_app
+from tests.factories import id_factory
+
+# ---------------------------------------------------------------------------
+# Module-level asyncio marker -- ensures async tests run correctly with coverage
+# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_coro_via_fake_asyncio_run(coro: object) -> None:
+    """Execute a coroutine synchronously (replaces asyncio.run in CLI tests)."""
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(coro)  # type: ignore[arg-type]
+    finally:
+        loop.close()
+
+
+def _make_scan_result(
+    segments_scanned: int = 20,
+    mentions_found: int = 3,
+    mentions_skipped: int = 0,
+    unique_entities: int = 1,
+    unique_videos: int = 2,
+    duration_seconds: float = 0.4,
+    dry_run: bool = False,
+    dry_run_matches: list[dict[str, Any]] | None = None,
+    failed_batches: int = 0,
+    skipped_longest_match: int = 0,
+    skipped_exclusion_pattern: int = 0,
+) -> MagicMock:
+    """Build a mock ScanResult with sensible defaults."""
+    result = MagicMock()
+    result.segments_scanned = segments_scanned
+    result.mentions_found = mentions_found
+    result.mentions_skipped = mentions_skipped
+    result.unique_entities = unique_entities
+    result.unique_videos = unique_videos
+    result.duration_seconds = duration_seconds
+    result.dry_run = dry_run
+    result.dry_run_matches = dry_run_matches
+    result.failed_batches = failed_batches
+    result.skipped_longest_match = skipped_longest_match
+    result.skipped_exclusion_pattern = skipped_exclusion_pattern
+    return result
+
+
+def _make_dry_run_title_match(
+    video_id: str | None = None,
+    entity_name: str = "Test Entity",
+    entity_type: str = "person",
+    matched_text: str = "Test Entity",
+    context: str = "Test Entity appears in this title",
+) -> dict[str, Any]:
+    """Build a dry-run match dict for a title-sourced mention (FR-030 shape)."""
+    return {
+        "video_id": video_id or id_factory.video_id("dry_run_title_vid"),
+        "segment_id": None,
+        "start_time": None,
+        "entity_name": entity_name,
+        "entity_type": entity_type,
+        "matched_text": matched_text,
+        "context": context,
+        "source": "title",
+    }
+
+
+def _make_dry_run_transcript_match(
+    video_id: str | None = None,
+    segment_id: int = 101,
+    start_time: float = 12.5,
+    entity_name: str = "Test Entity",
+    entity_type: str = "person",
+    matched_text: str = "Test Entity",
+    context: str = "...Test Entity was mentioned in this segment...",
+) -> dict[str, Any]:
+    """Build a dry-run match dict for a transcript-sourced mention."""
+    return {
+        "video_id": video_id or id_factory.video_id("dry_run_transcript_vid"),
+        "segment_id": segment_id,
+        "start_time": start_time,
+        "entity_name": entity_name,
+        "entity_type": entity_type,
+        "matched_text": matched_text,
+        "context": context,
+        "source": "transcript",
+    }
+
+
+# ---------------------------------------------------------------------------
+# T028 -- ``--sources title`` calls ``scan_metadata(sources=["title"])``
+# ---------------------------------------------------------------------------
+
+
+class TestSourcesTitleCallsScanMetadata:
+    """T028: ``--sources title`` must dispatch only to scan_metadata(sources=['title'])."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Return a Typer CliRunner."""
+        return CliRunner()
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_sources_title_calls_scan_metadata_only(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """When ``--sources title`` is given, only scan_metadata() must be called."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        captured_scan_calls: list[dict[str, Any]] = []
+        captured_metadata_calls: list[dict[str, Any]] = []
+
+        mock_service = MagicMock()
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            captured_scan_calls.append(kwargs)
+            return _make_scan_result()
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            captured_metadata_calls.append(kwargs)
+            return _make_scan_result()
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            result = runner.invoke(entity_app, ["scan", "--sources", "title"])
+
+        assert result.exit_code == 0, f"Unexpected exit code; output: {result.stdout}"
+
+        # scan() must NOT be called -- title-only means no transcript scan
+        assert len(captured_scan_calls) == 0, (
+            f"scan() should not be called for --sources title; "
+            f"got {len(captured_scan_calls)} call(s)"
+        )
+
+        # scan_metadata() must be called once with sources=["title"]
+        assert len(captured_metadata_calls) == 1, (
+            f"Expected 1 scan_metadata() call; got {len(captured_metadata_calls)}"
+        )
+        assert captured_metadata_calls[0].get("sources") == ["title"], (
+            f"Expected sources=['title']; got: {captured_metadata_calls[0].get('sources')}"
+        )
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_sources_description_calls_scan_metadata_with_description(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """``--sources description`` dispatches to scan_metadata(sources=['description'])."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        captured_metadata_calls: list[dict[str, Any]] = []
+
+        mock_service = MagicMock()
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            return _make_scan_result()
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            captured_metadata_calls.append(kwargs)
+            return _make_scan_result()
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            result = runner.invoke(entity_app, ["scan", "--sources", "description"])
+
+        assert result.exit_code == 0
+        assert len(captured_metadata_calls) == 1
+        assert captured_metadata_calls[0].get("sources") == ["description"]
+
+
+# ---------------------------------------------------------------------------
+# T029 -- ``--sources transcript,title,description`` calls both services
+# ---------------------------------------------------------------------------
+
+
+class TestSourcesAllCallsBothServices:
+    """T029: all three sources must dispatch to both scan() and scan_metadata()."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Return a Typer CliRunner."""
+        return CliRunner()
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_all_sources_calls_scan_and_scan_metadata(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """``--sources transcript,title,description`` must call both service methods."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        captured_scan_calls: list[dict[str, Any]] = []
+        captured_metadata_calls: list[dict[str, Any]] = []
+
+        mock_service = MagicMock()
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            captured_scan_calls.append(kwargs)
+            return _make_scan_result()
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            captured_metadata_calls.append(kwargs)
+            return _make_scan_result()
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            result = runner.invoke(
+                entity_app,
+                ["scan", "--sources", "transcript,title,description"],
+            )
+
+        assert result.exit_code == 0, f"Unexpected exit; output: {result.stdout}"
+
+        # scan() called once for transcript
+        assert len(captured_scan_calls) == 1, (
+            f"Expected 1 scan() call; got {len(captured_scan_calls)}"
+        )
+
+        # scan_metadata() called once with both title and description
+        assert len(captured_metadata_calls) == 1, (
+            f"Expected 1 scan_metadata() call; got {len(captured_metadata_calls)}"
+        )
+        metadata_sources = captured_metadata_calls[0].get("sources", [])
+        assert "title" in metadata_sources and "description" in metadata_sources, (
+            f"Expected both 'title' and 'description' in metadata sources; "
+            f"got: {metadata_sources}"
+        )
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_transcript_title_calls_scan_and_scan_metadata(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """``--sources transcript,title`` calls scan() and scan_metadata(sources=['title'])."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        captured_metadata_calls: list[dict[str, Any]] = []
+        captured_scan_calls: list[dict[str, Any]] = []
+
+        mock_service = MagicMock()
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            captured_scan_calls.append(kwargs)
+            return _make_scan_result()
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            captured_metadata_calls.append(kwargs)
+            return _make_scan_result()
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            result = runner.invoke(
+                entity_app, ["scan", "--sources", "transcript,title"]
+            )
+
+        assert result.exit_code == 0
+        assert len(captured_scan_calls) == 1
+        assert len(captured_metadata_calls) == 1
+        assert captured_metadata_calls[0].get("sources") == ["title"]
+
+
+# ---------------------------------------------------------------------------
+# T030 -- No ``--sources`` flag defaults to transcript-only
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultSourcesTranscriptOnly:
+    """T030: no ``--sources`` flag must default to transcript-only (backward compat)."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Return a Typer CliRunner."""
+        return CliRunner()
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_no_sources_flag_calls_scan_only(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """Without ``--sources``, only ``scan()`` is called; ``scan_metadata()`` is not."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        captured_scan_calls: list[dict[str, Any]] = []
+        captured_metadata_calls: list[dict[str, Any]] = []
+
+        mock_service = MagicMock()
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            captured_scan_calls.append(kwargs)
+            return _make_scan_result()
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            captured_metadata_calls.append(kwargs)
+            return _make_scan_result()
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            result = runner.invoke(entity_app, ["scan"])
+
+        assert result.exit_code == 0, f"Unexpected exit; output: {result.stdout}"
+        assert len(captured_scan_calls) == 1, (
+            f"Expected 1 scan() call; got {len(captured_scan_calls)}"
+        )
+        assert len(captured_metadata_calls) == 0, (
+            f"scan_metadata() should NOT be called with default sources; "
+            f"got {len(captured_metadata_calls)} call(s)"
+        )
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_explicit_transcript_source_calls_scan_only(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """``--sources transcript`` behaves identically to the no-flag default."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        captured_scan_calls: list[dict[str, Any]] = []
+        captured_metadata_calls: list[dict[str, Any]] = []
+
+        mock_service = MagicMock()
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            captured_scan_calls.append(kwargs)
+            return _make_scan_result()
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            captured_metadata_calls.append(kwargs)
+            return _make_scan_result()
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            result = runner.invoke(entity_app, ["scan", "--sources", "transcript"])
+
+        assert result.exit_code == 0
+        assert len(captured_scan_calls) == 1
+        assert len(captured_metadata_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# T031 -- ``--sources tag`` produces a validation error
+# ---------------------------------------------------------------------------
+
+
+class TestSourcesInvalidValueRejected:
+    """T031: invalid source values like 'tag' must produce a validation error."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Return a Typer CliRunner."""
+        return CliRunner()
+
+    def test_sources_tag_exits_with_code_1(self, runner: CliRunner) -> None:
+        """``--sources tag`` must exit with code 1 (FR-025)."""
+        result = runner.invoke(entity_app, ["scan", "--sources", "tag"])
+        assert result.exit_code == 1
+
+    def test_sources_tag_shows_error_panel(self, runner: CliRunner) -> None:
+        """``--sources tag`` must display an error mentioning invalid sources."""
+        result = runner.invoke(entity_app, ["scan", "--sources", "tag"])
+        output = result.stdout or ""
+        assert (
+            "Invalid --sources" in output
+            or "Invalid source" in output.lower()
+            or "invalid" in output.lower()
+        ), f"Expected invalid-sources error in output; got: {output[:400]}"
+
+    def test_sources_tag_does_not_call_asyncio_run(self, runner: CliRunner) -> None:
+        """Validation failure must exit before ``asyncio.run`` is called."""
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run"
+        ) as mock_asyncio_run:
+            runner.invoke(entity_app, ["scan", "--sources", "tag"])
+
+        mock_asyncio_run.assert_not_called()
+
+    def test_sources_unknown_value_exits_1(self, runner: CliRunner) -> None:
+        """An unknown source value (e.g. ``foo``) must also exit with code 1."""
+        result = runner.invoke(entity_app, ["scan", "--sources", "foo"])
+        assert result.exit_code == 1
+
+    def test_sources_tag_shows_valid_options(self, runner: CliRunner) -> None:
+        """Error message for invalid sources must mention the valid options."""
+        result = runner.invoke(entity_app, ["scan", "--sources", "tag"])
+        output = result.stdout or ""
+        # Valid values should appear in the error panel
+        valid_shown = (
+            "transcript" in output or "title" in output or "description" in output
+        )
+        assert valid_shown, (
+            f"Expected valid source values in error output; got: {output[:400]}"
+        )
+
+    def test_sources_tag_among_valid_sources_exits_1(self, runner: CliRunner) -> None:
+        """``--sources transcript,tag`` must still reject 'tag' and exit with code 1."""
+        result = runner.invoke(entity_app, ["scan", "--sources", "transcript,tag"])
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# T032 -- ``--sources title --dry-run`` output: source column + em dash
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunTitleOutputFormat:
+    """T032: dry-run with metadata sources shows source column and em dashes (FR-030)."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Return a Typer CliRunner."""
+        return CliRunner()
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_dry_run_title_shows_source_column(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """The dry-run preview table must include a ``source`` column for metadata sources."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        vid = id_factory.video_id("source_col_test")
+        title_match = _make_dry_run_title_match(video_id=vid)
+
+        mock_service = MagicMock()
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            return _make_scan_result(dry_run_matches=[])
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            return _make_scan_result(
+                dry_run=True,
+                dry_run_matches=[title_match],
+                mentions_found=1,
+                unique_videos=1,
+                unique_entities=1,
+            )
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            result = runner.invoke(
+                entity_app, ["scan", "--sources", "title", "--dry-run"]
+            )
+
+        output = result.stdout or ""
+        assert result.exit_code == 0, f"Unexpected exit; output: {output[:600]}"
+        # The source VALUE "title" must appear in the output.  Rich truncates
+        # column *headers* on narrow terminals (CliRunner width = 80), so we
+        # check for the data value rather than the header text.
+        assert "title" in output.lower(), (
+            f"Expected 'title' source value in dry-run output; got: {output[:600]}"
+        )
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_dry_run_title_segment_id_is_em_dash(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """Title mentions must show em dash (--) for segment_id per FR-030."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        vid = id_factory.video_id("em_dash_seg_test")
+        title_match = _make_dry_run_title_match(video_id=vid)
+
+        mock_service = MagicMock()
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            return _make_scan_result(
+                dry_run=True,
+                dry_run_matches=[title_match],
+                mentions_found=1,
+                unique_videos=1,
+                unique_entities=1,
+            )
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            return _make_scan_result(dry_run_matches=[])
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            # Use a wide terminal so Rich does not truncate cell values.
+            # CliRunner defaults to 80 chars, which collapses narrow columns
+            # (segment_id / start_time) to 2 chars -- too narrow for the em dash.
+            result = runner.invoke(
+                entity_app,
+                ["scan", "--sources", "title", "--dry-run"],
+                env={"COLUMNS": "200"},
+            )
+
+        output = result.stdout or ""
+        assert result.exit_code == 0
+        # Em dash character must appear in output for segment_id / start_time
+        assert "\u2014" in output, (
+            f"Expected em dash (\u2014) for segment_id/start_time in title dry-run; "
+            f"output snippet: {output[:600]}"
+        )
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_dry_run_title_shows_title_in_source_column(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """The source column value must show 'title' for title-sourced mentions."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        vid = id_factory.video_id("source_value_test")
+        title_match = _make_dry_run_title_match(video_id=vid)
+
+        mock_service = MagicMock()
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            return _make_scan_result(
+                dry_run=True,
+                dry_run_matches=[title_match],
+                mentions_found=1,
+                unique_videos=1,
+                unique_entities=1,
+            )
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            return _make_scan_result(dry_run_matches=[])
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            result = runner.invoke(
+                entity_app, ["scan", "--sources", "title", "--dry-run"]
+            )
+
+        output = result.stdout or ""
+        assert result.exit_code == 0
+        assert "title" in output.lower(), (
+            f"Expected 'title' value in source column; got: {output[:600]}"
+        )
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_dry_run_metadata_summary_says_videos_scanned(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """Dry-run summary must say 'videos scanned' when metadata sources included (FR-030)."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        vid = id_factory.video_id("videos_scanned_test")
+        title_match = _make_dry_run_title_match(video_id=vid)
+
+        mock_service = MagicMock()
+
+        async def capture_scan_metadata(**kwargs: Any) -> Any:
+            return _make_scan_result(
+                dry_run=True,
+                dry_run_matches=[title_match],
+                mentions_found=1,
+                unique_videos=1,
+                unique_entities=1,
+                segments_scanned=5,
+            )
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            return _make_scan_result(dry_run_matches=[])
+
+        mock_service.scan = capture_scan
+        mock_service.scan_metadata = capture_scan_metadata
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            result = runner.invoke(
+                entity_app, ["scan", "--sources", "title", "--dry-run"]
+            )
+
+        output = result.stdout or ""
+        assert result.exit_code == 0
+        assert "videos scanned" in output.lower(), (
+            f"Expected 'videos scanned' in dry-run summary; got: {output[:600]}"
+        )
+
+    @patch("chronovista.cli.entity_commands.EntityMentionScanService")
+    @patch("chronovista.cli.entity_commands.db_manager")
+    def test_dry_run_transcript_only_no_source_column_in_summary(
+        self,
+        mock_db_manager: MagicMock,
+        mock_service_cls: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """Transcript-only dry-run summary must say 'segments scanned' (backward compat)."""
+        mock_db_manager.get_session_factory.return_value = MagicMock()
+
+        vid = id_factory.video_id("no_source_col_test")
+        transcript_match = _make_dry_run_transcript_match(video_id=vid)
+
+        mock_service = MagicMock()
+
+        async def capture_scan(**kwargs: Any) -> Any:
+            return _make_scan_result(
+                dry_run=True,
+                dry_run_matches=[transcript_match],
+                mentions_found=1,
+                unique_videos=1,
+                unique_entities=1,
+                segments_scanned=10,
+            )
+
+        mock_service.scan = capture_scan
+        mock_service_cls.return_value = mock_service
+
+        with patch(
+            "chronovista.cli.entity_commands.asyncio.run",
+            side_effect=_run_coro_via_fake_asyncio_run,
+        ):
+            # Use a wide terminal so Rich renders cell values without truncation.
+            # The start_time column (width=10) collapses at 80-char CliRunner width.
+            result = runner.invoke(
+                entity_app, ["scan", "--dry-run"], env={"COLUMNS": "200"}
+            )
+
+        output = result.stdout or ""
+        assert result.exit_code == 0
+        # Summary must say "segments scanned", not "videos scanned"
+        assert "segments scanned" in output.lower(), (
+            f"Expected 'segments scanned' for transcript-only dry-run; got: {output[:600]}"
+        )
+        # Real start_time must be shown for transcript rows (visible at COLUMNS=200)
+        assert "12.5" in output, (
+            f"Expected real start_time '12.5' for transcript row; got: {output[:600]}"
+        )

--- a/tests/unit/models/test_entity_mention.py
+++ b/tests/unit/models/test_entity_mention.py
@@ -512,6 +512,8 @@ class TestEntityMentionBase:
             "match_start",
             "match_end",
             "correction_id",
+            "mention_source",
+            "mention_context",
         }
         assert expected_keys == set(data.keys())
 
@@ -771,6 +773,8 @@ class TestEntityMention:
         orm_like.match_start = None
         orm_like.match_end = None
         orm_like.correction_id = None
+        orm_like.mention_source = "transcript"
+        orm_like.mention_context = None
         orm_like.created_at = now
 
         mention = EntityMention.model_validate(orm_like)
@@ -805,6 +809,8 @@ class TestEntityMention:
         orm_like.match_start = None
         orm_like.match_end = None
         orm_like.correction_id = None
+        orm_like.mention_source = "transcript"
+        orm_like.mention_context = None
         orm_like.created_at = datetime.now(UTC)
 
         mention = EntityMention.model_validate(orm_like)
@@ -826,6 +832,8 @@ class TestEntityMention:
             orm_like.match_start = None
             orm_like.match_end = None
             orm_like.correction_id = None
+            orm_like.mention_source = "transcript"
+            orm_like.mention_context = None
             orm_like.created_at = datetime.now(UTC)
 
             mention = EntityMention.model_validate(orm_like)

--- a/tests/unit/repositories/test_entity_mention_repository.py
+++ b/tests/unit/repositories/test_entity_mention_repository.py
@@ -574,6 +574,140 @@ class TestDeleteByScope:
         sql_str = str(stmt.compile(compile_kwargs={"literal_binds": False}))
         assert "detection_method" in sql_str
 
+    # -----------------------------------------------------------------------
+    # Feature 054 — T012: mention_source filter (FR-010)
+    # -----------------------------------------------------------------------
+
+    async def test_delete_with_mention_source_filter_adds_source_clause(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """delete_by_scope() adds mention_source equality filter when provided.
+
+        When ``mention_source='title'`` is supplied, the generated DELETE
+        statement MUST include a ``mention_source`` predicate so that only
+        title-sourced mentions are deleted (FR-010).  Transcript and
+        description mentions for the same scope are left untouched.
+        """
+        mock_result = MagicMock()
+        mock_result.rowcount = 5
+        mock_session.execute.return_value = mock_result
+
+        count = await repository.delete_by_scope(
+            mock_session,
+            mention_source="title",
+        )
+
+        assert count == 5
+        stmt = mock_session.execute.call_args.args[0]
+        sql_str = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "mention_source" in sql_str
+
+    async def test_delete_without_mention_source_does_not_filter_by_source(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """delete_by_scope() omits mention_source clause when parameter is None.
+
+        Backward-compatibility guarantee: callers that do not pass
+        ``mention_source`` must receive the same behaviour as before Feature
+        054 (all sources matching the other criteria are deleted).
+        """
+        mock_result = MagicMock()
+        mock_result.rowcount = 8
+        mock_session.execute.return_value = mock_result
+
+        count = await repository.delete_by_scope(mock_session)
+
+        assert count == 8
+        stmt = mock_session.execute.call_args.args[0]
+        sql_str = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        # The word "mention_source" must NOT appear in a WHERE predicate when
+        # the parameter is omitted.  The detection_method filter may include
+        # an attribute reference, but there must be no mention_source column
+        # reference at all.
+        assert "mention_source" not in sql_str
+
+    async def test_delete_with_mention_source_description(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """delete_by_scope() also works with mention_source='description'."""
+        mock_result = MagicMock()
+        mock_result.rowcount = 3
+        mock_session.execute.return_value = mock_result
+
+        count = await repository.delete_by_scope(
+            mock_session,
+            mention_source="description",
+        )
+
+        assert count == 3
+        stmt = mock_session.execute.call_args.args[0]
+        sql_str = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "mention_source" in sql_str
+
+    async def test_delete_mention_source_composes_with_entity_ids(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """delete_by_scope() combines mention_source and entity_ids filters correctly.
+
+        When both ``mention_source`` and ``entity_ids`` are provided, the
+        generated statement must include predicates for both columns.  This
+        enables source-scoped full rescan for a specific entity
+        (``entities scan --entity-id <id> --sources title --full``).
+        """
+        entity_ids = [_uuid()]
+        mock_result = MagicMock()
+        mock_result.rowcount = 2
+        mock_session.execute.return_value = mock_result
+
+        count = await repository.delete_by_scope(
+            mock_session,
+            entity_ids=entity_ids,
+            mention_source="title",
+        )
+
+        assert count == 2
+        stmt = mock_session.execute.call_args.args[0]
+        sql_str = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "mention_source" in sql_str
+        assert "entity_id" in sql_str
+
+    async def test_delete_mention_source_composes_with_video_ids(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """delete_by_scope() combines mention_source and video_ids filters correctly.
+
+        When both ``mention_source`` and ``video_ids`` are provided, the
+        generated statement must include predicates for both columns.  This
+        enables source-scoped full rescan for a specific video
+        (``entities scan --video-id <id> --sources title --full``).
+        """
+        video_ids = ["dQw4w9WgXcQ"]
+        mock_result = MagicMock()
+        mock_result.rowcount = 1
+        mock_session.execute.return_value = mock_result
+
+        count = await repository.delete_by_scope(
+            mock_session,
+            video_ids=video_ids,
+            mention_source="title",
+        )
+
+        assert count == 1
+        stmt = mock_session.execute.call_args.args[0]
+        sql_str = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "mention_source" in sql_str
+        assert "video_id" in sql_str
+
 
 # ---------------------------------------------------------------------------
 # TestDeleteByCorrectionIds (Feature 043 — T032)
@@ -3659,3 +3793,109 @@ class TestDeleteManualAssociation:
             )
 
         mock_session.delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestEntityMentionRepositorySourceMapping (Feature 054 — T016)
+# ---------------------------------------------------------------------------
+
+
+class TestEntityMentionRepositorySourceMapping:
+    """T016: Verify get_entity_video_list() correctly maps mention_source
+    values to the sources list.
+
+    An entity in both title AND transcript should appear once in the video
+    list with sources: ["title", "transcript"].
+    """
+
+    @pytest.fixture
+    def repository(self) -> EntityMentionRepository:
+        """Provide a fresh repository instance for each test."""
+        return EntityMentionRepository()
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Provide a mock async session for each test."""
+        return _make_mock_session()
+
+    async def test_t016_entity_in_title_and_transcript_shows_both_sources(
+        self,
+        repository: EntityMentionRepository,
+        mock_session: MagicMock,
+    ) -> None:
+        """Entity found in both title and transcript appears once with
+        sources: ['title', 'transcript'] in the video list.
+
+        The detection_methods array includes 'rule_match' (mapped to
+        'transcript') and the mention_sources array includes 'title',
+        producing both source types in the final sources list.
+        """
+        entity_id = _uuid()
+        video_id = "dQw4w9WgXcQ"
+
+        # Step 1: transcript video IDs query
+        transcript_vid_result = MagicMock()
+        transcript_vid_result.scalars.return_value.all.return_value = [video_id]
+
+        # Step 2a: canonical tag video IDs (empty)
+        canonical_tag_result = MagicMock()
+        canonical_tag_result.scalar_one_or_none.return_value = None
+
+        # Step 2b: alias tag video IDs (empty)
+        alias_tag_result = MagicMock()
+        alias_tag_result.all.return_value = []
+
+        # Step 3: main query — detection_methods has 'rule_match',
+        # mention_sources has 'transcript' and 'title'
+        from datetime import datetime
+
+        video_row = MagicMock()
+        video_row.video_id = video_id
+        video_row.video_title = "Noam Chomsky Interview"
+        video_row.channel_name = "Channel One"
+        video_row.mention_count = 5
+        video_row.detection_methods = ["rule_match"]
+        video_row.mention_sources = ["transcript", "title"]
+        video_row.has_manual = False
+        video_row.first_mention_time = 12.5
+        video_row.upload_date = datetime(2024, 1, 15, tzinfo=UTC)
+
+        main_result = MagicMock()
+        main_result.all.return_value = [video_row]
+
+        # Preview query (transcript mentions only)
+        preview_row = MagicMock()
+        preview_row.segment_id = 42
+        preview_row.start_time = 12.5
+        preview_row.mention_text = "Noam Chomsky"
+        preview_result = MagicMock()
+        preview_result.all.return_value = [preview_row]
+
+        # Description context query — no description mentions
+        desc_ctx_result = MagicMock()
+        desc_ctx_result.scalar_one_or_none.return_value = None
+
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                transcript_vid_result,  # transcript video IDs
+                canonical_tag_result,   # canonical tag video IDs
+                alias_tag_result,       # alias tag video IDs
+                main_result,            # main grouped query
+                preview_result,         # mention previews
+                desc_ctx_result,        # description context
+            ]
+        )
+
+        results, total = await repository.get_entity_video_list(
+            mock_session, entity_id=entity_id, limit=20, offset=0
+        )
+
+        assert total == 1
+        assert len(results) == 1
+        result = results[0]
+        assert result["video_id"] == video_id
+        assert "transcript" in result["sources"]
+        assert "title" in result["sources"]
+        # Should appear exactly once (deduplicated)
+        assert result["sources"].count("transcript") == 1
+        assert result["sources"].count("title") == 1

--- a/tests/unit/services/test_scan_metadata.py
+++ b/tests/unit/services/test_scan_metadata.py
@@ -1,0 +1,957 @@
+"""
+Tests for EntityMentionScanService.scan_metadata() — title and description scanning.
+
+Feature 054 — Multi-Source Entity Mention Detection (Phases 3 & 4)
+
+T013: Title scanning creates mentions with mention_source='title', segment_id=NULL
+T014: Title scanning applies exclusion patterns
+T015: Empty title produces no mentions
+T021: Description scanning creates mentions with mention_source='description' and context
+T022: NULL description skipped without error
+T023: mention_context is ~75 chars before + ~75 chars after with ellipsis
+T024: Very long description (>10K chars) processes without error
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chronovista.models.enums import MentionSource
+from chronovista.services.entity_mention_scan_service import (
+    EntityMentionScanService,
+)
+
+# CRITICAL: Module-level asyncio marker ensures async tests run properly
+# with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+
+def _make_uuid() -> uuid.UUID:
+    """Return a fresh UUID4 for test data."""
+    return uuid.uuid4()
+
+
+def _make_entity_row(
+    entity_id: uuid.UUID | None = None,
+    canonical_name: str = "Noam Chomsky",
+    entity_type: str = "person",
+    status: str = "active",
+    exclusion_patterns: list[str] | None = None,
+) -> MagicMock:
+    """Create a mock ORM NamedEntity row."""
+    row = MagicMock()
+    row.id = entity_id or _make_uuid()
+    row.canonical_name = canonical_name
+    row.entity_type = entity_type
+    row.status = status
+    row.exclusion_patterns = exclusion_patterns or []
+    return row
+
+
+def _make_alias_row(entity_id: uuid.UUID, alias_name: str) -> MagicMock:
+    """Create a mock ORM EntityAlias row."""
+    row = MagicMock()
+    row.entity_id = entity_id
+    row.alias_name = alias_name
+    row.alias_type = "name_variant"
+    return row
+
+
+def _make_video_row(
+    video_id: str = "dQw4w9WgXcQ",
+    title: str = "Noam Chomsky Interview",
+    description: str | None = "In this interview, Noam Chomsky discusses linguistics.",
+    channel_id: str = "UCtest123",
+) -> MagicMock:
+    """Create a mock video row matching the _fetch_video_batch columns."""
+    row = MagicMock()
+    row.video_id = video_id
+    row.title = title
+    row.description = description
+    row.channel_id = channel_id
+    return row
+
+
+def _make_session_factory(
+    entities: list[MagicMock],
+    aliases: list[MagicMock],
+    video_batches: list[list[MagicMock]],
+) -> MagicMock:
+    """Build a mock session_factory that returns the given data.
+
+    The session.execute mock handles:
+    - First call: entity query -> returns entities
+    - Second call: alias query -> returns aliases
+    - Subsequent calls: video batches + bulk insert results + counter updates
+    """
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+
+    # Build the sequence of return values for execute()
+    call_results: list[MagicMock] = []
+
+    # Entity query result
+    entity_result = MagicMock()
+    entity_result.scalars.return_value.all.return_value = entities
+    call_results.append(entity_result)
+
+    # Alias query result
+    alias_result = MagicMock()
+    alias_result.scalars.return_value.all.return_value = aliases
+    call_results.append(alias_result)
+
+    # Video batch results
+    for batch in video_batches:
+        batch_result = MagicMock()
+        batch_result.all.return_value = batch
+        call_results.append(batch_result)
+
+    # Empty batch to signal end of iteration
+    empty_result = MagicMock()
+    empty_result.all.return_value = []
+    call_results.append(empty_result)
+
+    session.execute.side_effect = call_results
+
+    factory = MagicMock()
+    ctx_manager = AsyncMock()
+    ctx_manager.__aenter__ = AsyncMock(return_value=session)
+    ctx_manager.__aexit__ = AsyncMock(return_value=False)
+    factory.return_value = ctx_manager
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Tests for User Story 1 — Title Scanning
+# ---------------------------------------------------------------------------
+
+
+class TestScanMetadataTitle:
+    """Tests for scan_metadata() with sources=["title"]."""
+
+    async def test_t013_title_scan_creates_mentions_with_title_source(
+        self,
+    ) -> None:
+        """T013: scan_metadata(sources=['title']) creates mentions with
+        mention_source='title' and segment_id=NULL.
+        """
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        video = _make_video_row(
+            video_id="vid00100001",
+            title="Noam Chomsky Wins Award",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        # Patch bulk_create to capture what gets inserted
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk:
+            mock_bulk.return_value = 1
+
+            with patch.object(
+                service._mention_repo,
+                "update_entity_counters",
+                new_callable=AsyncMock,
+            ), patch.object(
+                service._mention_repo,
+                "update_alias_counters",
+                new_callable=AsyncMock,
+            ):
+                result = await service.scan_metadata(
+                    sources=["title"],
+                    entity_ids=[entity_id],
+                )
+
+        assert result.mentions_found == 1
+        assert result.segments_scanned == 1  # 1 video scanned
+
+        # Verify the mention was created correctly
+        mock_bulk.assert_called_once()
+        mentions = mock_bulk.call_args[0][1]
+        assert len(mentions) == 1
+        mention = mentions[0]
+        assert mention.mention_source == MentionSource.TITLE
+        assert mention.segment_id is None
+        assert mention.video_id == "vid00100001"
+        assert mention.mention_text == "Noam Chomsky"
+        assert mention.mention_context is None  # No context for title mentions
+
+    async def test_t014_title_scan_applies_exclusion_patterns(self) -> None:
+        """T014: Title scanning with exclusion pattern 'New Mexico' skips
+        title 'New Mexico Travel Guide' for entity 'Mexico'.
+        """
+        entity_id = _make_uuid()
+        entity = _make_entity_row(
+            entity_id=entity_id,
+            canonical_name="Mexico",
+            exclusion_patterns=["New Mexico"],
+        )
+        video = _make_video_row(
+            video_id="vid00200002",
+            title="New Mexico Travel Guide",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            result = await service.scan_metadata(
+                sources=["title"],
+                entity_ids=[entity_id],
+            )
+
+        # No mentions should be created because "Mexico" is inside "New Mexico"
+        assert result.mentions_found == 0
+        mock_bulk.assert_not_called()
+
+    async def test_t015_empty_title_produces_no_mentions(self) -> None:
+        """T015: Title scanning with empty title produces no mentions."""
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        video = _make_video_row(
+            video_id="vid00300003",
+            title="",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            result = await service.scan_metadata(
+                sources=["title"],
+                entity_ids=[entity_id],
+            )
+
+        assert result.mentions_found == 0
+        mock_bulk.assert_not_called()
+
+    async def test_title_scan_dry_run_collects_previews(self) -> None:
+        """Title scanning in dry-run mode collects preview data without writing."""
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        video = _make_video_row(
+            video_id="vid00400004",
+            title="Noam Chomsky Discusses Linguistics",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        result = await service.scan_metadata(
+            sources=["title"],
+            entity_ids=[entity_id],
+            dry_run=True,
+        )
+
+        assert result.dry_run is True
+        assert result.mentions_found == 1
+        assert result.dry_run_matches is not None
+        assert len(result.dry_run_matches) == 1
+        preview = result.dry_run_matches[0]
+        assert preview["source"] == "title"
+        assert preview["segment_id"] is None
+        assert preview["start_time"] is None
+        assert preview["matched_text"] == "Noam Chomsky"
+
+    async def test_title_scan_full_rescan_deletes_before_scan(self) -> None:
+        """Title scanning with full_rescan=True calls delete_by_scope with
+        mention_source='title' before scanning.
+        """
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        video = _make_video_row(
+            video_id="vid00500005",
+            title="Noam Chomsky Interview",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "delete_by_scope",
+            new_callable=AsyncMock,
+        ) as mock_delete, patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+            return_value=1,
+        ), patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            await service.scan_metadata(
+                sources=["title"],
+                entity_ids=[entity_id],
+                full_rescan=True,
+            )
+
+        mock_delete.assert_called_once()
+        call_kwargs = mock_delete.call_args
+        assert call_kwargs[1]["mention_source"] == "title"
+        assert call_kwargs[1]["detection_method"] == "rule_match"
+
+    async def test_title_scan_with_aliases(self) -> None:
+        """Title scanning detects entity aliases in video titles."""
+        entity_id = _make_uuid()
+        entity = _make_entity_row(
+            entity_id=entity_id,
+            canonical_name="AMLO",
+        )
+        alias = _make_alias_row(entity_id, "Lopez Obrador")
+        video = _make_video_row(
+            video_id="vid00600006",
+            title="Lopez Obrador Speaks at Conference",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[alias],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            mock_bulk.return_value = 1
+            result = await service.scan_metadata(
+                sources=["title"],
+                entity_ids=[entity_id],
+            )
+
+        assert result.mentions_found == 1
+        mentions = mock_bulk.call_args[0][1]
+        assert mentions[0].mention_text == "Lopez Obrador"
+
+    async def test_title_scan_multiple_entities_same_title(self) -> None:
+        """EC-006: Multiple entities found in the same title each create
+        separate mention rows.
+        """
+        entity1_id = _make_uuid()
+        entity2_id = _make_uuid()
+        entity1 = _make_entity_row(entity_id=entity1_id, canonical_name="Biden")
+        entity2 = _make_entity_row(entity_id=entity2_id, canonical_name="Trump")
+        video = _make_video_row(
+            video_id="vid00700007",
+            title="Biden and Trump Debate",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity1, entity2],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            mock_bulk.return_value = 2
+            result = await service.scan_metadata(
+                sources=["title"],
+                entity_ids=[entity1_id, entity2_id],
+            )
+
+        assert result.mentions_found == 2
+        mentions = mock_bulk.call_args[0][1]
+        entity_ids_found = {m.entity_id for m in mentions}
+        assert entity1_id in entity_ids_found
+        assert entity2_id in entity_ids_found
+
+    async def test_title_scan_deduplicates_per_entity(self) -> None:
+        """EC-007: Title containing entity name multiple times creates
+        only one mention per entity per video.
+        """
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="AI")
+        video = _make_video_row(
+            video_id="vid00800008",
+            title="AI meets AI: The AI Revolution",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            mock_bulk.return_value = 1
+            await service.scan_metadata(
+                sources=["title"],
+                entity_ids=[entity_id],
+            )
+
+        # Only one mention per entity per video for title
+        mentions = mock_bulk.call_args[0][1]
+        assert len(mentions) == 1
+
+    async def test_progress_callback_invoked(self) -> None:
+        """Progress callback is called with items_scanned and mentions_found."""
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        video = _make_video_row(video_id="vid00900009", title="Noam Chomsky Talk")
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+        callback = MagicMock()
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+            return_value=1,
+        ), patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            await service.scan_metadata(
+                sources=["title"],
+                entity_ids=[entity_id],
+                progress_callback=callback,
+            )
+
+        assert callback.call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tests for User Story 2 — Description Scanning
+# ---------------------------------------------------------------------------
+
+
+class TestScanMetadataDescription:
+    """Tests for scan_metadata() with sources=["description"]."""
+
+    async def test_t021_description_scan_creates_mentions_with_context(
+        self,
+    ) -> None:
+        """T021: scan_metadata(sources=['description']) scans descriptions,
+        creates mentions with mention_source='description' and
+        mention_context snippet.
+        """
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        description_text = (
+            "In this interview, Noam Chomsky discusses the future of linguistics "
+            "and the role of language in society."
+        )
+        video = _make_video_row(
+            video_id="vid01000010",
+            title="Some Title",
+            description=description_text,
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            mock_bulk.return_value = 1
+            result = await service.scan_metadata(
+                sources=["description"],
+                entity_ids=[entity_id],
+            )
+
+        assert result.mentions_found == 1
+        mentions = mock_bulk.call_args[0][1]
+        mention = mentions[0]
+        assert mention.mention_source == MentionSource.DESCRIPTION
+        assert mention.segment_id is None
+        assert mention.mention_context is not None
+        assert "Noam Chomsky" in mention.mention_context
+
+    async def test_t022_null_description_skipped_without_error(self) -> None:
+        """T022: NULL description is skipped without error."""
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        video = _make_video_row(
+            video_id="vid01100011",
+            title="Some Title",
+            description=None,
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            result = await service.scan_metadata(
+                sources=["description"],
+                entity_ids=[entity_id],
+            )
+
+        assert result.mentions_found == 0
+        mock_bulk.assert_not_called()
+
+    async def test_t023_mention_context_75_chars_before_and_after(self) -> None:
+        """T023: mention_context is ~75 chars before + ~75 chars after the
+        match, with ellipsis if truncated.
+        """
+        # Test the static helper directly
+        # Build a string with known content around match position
+        prefix = "A" * 100  # 100 chars before the match
+        suffix = "B" * 100  # 100 chars after the match
+        match_text = "Noam Chomsky"
+        full_text = prefix + match_text + suffix
+
+        match_start = 100
+        match_end = 100 + len(match_text)
+
+        snippet = EntityMentionScanService._extract_context_snippet(
+            full_text, match_start, match_end, window=75
+        )
+
+        # Should have ellipsis at both ends since we truncated
+        assert snippet.startswith("...")
+        assert snippet.endswith("...")
+
+        # Should contain the matched text
+        assert "Noam Chomsky" in snippet
+
+        # The snippet (excluding ellipsis) should be about 75+len(match)+75 chars
+        # 75 before + 12 (match) + 75 after = 162 chars + 6 for "..." on both sides
+        inner = snippet[3:-3]  # strip leading/trailing "..."
+        assert len(inner) == 75 + len(match_text) + 75
+
+    async def test_t023_context_no_leading_ellipsis_at_start(self) -> None:
+        """Context snippet at the start of text has no leading ellipsis."""
+        text = "Noam Chomsky discusses linguistics and more content after."
+        match_start = 0
+        match_end = 12
+
+        snippet = EntityMentionScanService._extract_context_snippet(
+            text, match_start, match_end, window=75
+        )
+
+        # Should NOT start with "..." since match is at the beginning
+        assert not snippet.startswith("...")
+        assert "Noam Chomsky" in snippet
+
+    async def test_t023_context_no_trailing_ellipsis_at_end(self) -> None:
+        """Context snippet at the end of text has no trailing ellipsis."""
+        text = "Some text about Noam Chomsky"
+        match_start = text.index("Noam Chomsky")
+        match_end = match_start + len("Noam Chomsky")
+
+        snippet = EntityMentionScanService._extract_context_snippet(
+            text, match_start, match_end, window=75
+        )
+
+        # Should NOT end with "..." since match is at the end
+        assert not snippet.endswith("...")
+        assert "Noam Chomsky" in snippet
+
+    async def test_t024_very_long_description_processes_without_error(
+        self,
+    ) -> None:
+        """T024: Very long description (>10K chars) processes without error."""
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        # Build a >10K description with the entity name buried in the middle
+        long_desc = "x" * 5000 + " Noam Chomsky " + "y" * 5000
+        assert len(long_desc) > 10000
+
+        video = _make_video_row(
+            video_id="vid01200012",
+            title="Some Title",
+            description=long_desc,
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            mock_bulk.return_value = 1
+            result = await service.scan_metadata(
+                sources=["description"],
+                entity_ids=[entity_id],
+            )
+
+        assert result.mentions_found == 1
+        mentions = mock_bulk.call_args[0][1]
+        mention = mentions[0]
+        assert mention.mention_source == MentionSource.DESCRIPTION
+        assert mention.mention_context is not None
+        # Context should be ~150 chars, not the full 10K
+        assert len(mention.mention_context) < 200
+
+    async def test_description_scan_multiple_distinct_matches(self) -> None:
+        """Description with multiple distinct entity mentions creates
+        multiple mention rows (unlike title which deduplicates).
+        """
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        description = (
+            "Noam Chomsky was interviewed about his work. "
+            "Later, Noam Chomsky discussed the implications."
+        )
+        video = _make_video_row(
+            video_id="vid01300013",
+            title="Some Title",
+            description=description,
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            mock_bulk.return_value = 2
+            result = await service.scan_metadata(
+                sources=["description"],
+                entity_ids=[entity_id],
+            )
+
+        assert result.mentions_found == 2
+        mentions = mock_bulk.call_args[0][1]
+        assert len(mentions) == 2
+        # Both should be description source with different positions
+        assert all(m.mention_source == MentionSource.DESCRIPTION for m in mentions)
+        assert mentions[0].match_start != mentions[1].match_start
+
+    async def test_description_scan_applies_exclusion_patterns(self) -> None:
+        """Description scanning also applies exclusion patterns."""
+        entity_id = _make_uuid()
+        entity = _make_entity_row(
+            entity_id=entity_id,
+            canonical_name="Mexico",
+            exclusion_patterns=["New Mexico"],
+        )
+        video = _make_video_row(
+            video_id="vid01400014",
+            title="Some Title",
+            description="Great vacation spots in New Mexico and surrounding areas.",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            result = await service.scan_metadata(
+                sources=["description"],
+                entity_ids=[entity_id],
+            )
+
+        assert result.mentions_found == 0
+        mock_bulk.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for combined title + description scanning
+# ---------------------------------------------------------------------------
+
+
+class TestScanMetadataCombined:
+    """Tests for scan_metadata() with both title and description sources."""
+
+    async def test_combined_title_and_description_scan(self) -> None:
+        """scan_metadata(sources=['title', 'description']) scans both fields."""
+        entity_id = _make_uuid()
+        entity = _make_entity_row(entity_id=entity_id, canonical_name="Noam Chomsky")
+        video = _make_video_row(
+            video_id="vid01500015",
+            title="Noam Chomsky Interview",
+            description="In this video, Noam Chomsky talks about AI.",
+        )
+
+        factory = _make_session_factory(
+            entities=[entity],
+            aliases=[],
+            video_batches=[[video]],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        with patch.object(
+            service._mention_repo,
+            "bulk_create_with_conflict_skip",
+            new_callable=AsyncMock,
+        ) as mock_bulk, patch.object(
+            service._mention_repo,
+            "update_entity_counters",
+            new_callable=AsyncMock,
+        ), patch.object(
+            service._mention_repo,
+            "update_alias_counters",
+            new_callable=AsyncMock,
+        ):
+            mock_bulk.return_value = 2
+            result = await service.scan_metadata(
+                sources=["title", "description"],
+                entity_ids=[entity_id],
+            )
+
+        assert result.mentions_found == 2
+        mentions = mock_bulk.call_args[0][1]
+        sources_found = {m.mention_source for m in mentions}
+        assert MentionSource.TITLE in sources_found
+        assert MentionSource.DESCRIPTION in sources_found
+
+    async def test_no_entities_returns_empty_result(self) -> None:
+        """When no entities match filter criteria, returns empty result."""
+        factory = _make_session_factory(
+            entities=[],
+            aliases=[],
+            video_batches=[],
+        )
+
+        service = EntityMentionScanService(factory)
+
+        result = await service.scan_metadata(
+            sources=["title"],
+        )
+
+        assert result.mentions_found == 0
+        assert result.segments_scanned == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for _extract_context_snippet static helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractContextSnippet:
+    """Unit tests for the context snippet extraction helper."""
+
+    def test_snippet_with_truncation_both_sides(self) -> None:
+        """Snippet adds ellipsis when truncated at both ends."""
+        text = "A" * 100 + "MATCH" + "B" * 100
+        snippet = EntityMentionScanService._extract_context_snippet(
+            text, 100, 105, window=75
+        )
+        assert snippet.startswith("...")
+        assert snippet.endswith("...")
+        assert "MATCH" in snippet
+
+    def test_snippet_no_truncation(self) -> None:
+        """Short text produces no ellipsis."""
+        text = "Hello MATCH world"
+        start = text.index("MATCH")
+        end = start + 5
+        snippet = EntityMentionScanService._extract_context_snippet(
+            text, start, end, window=75
+        )
+        assert not snippet.startswith("...")
+        assert not snippet.endswith("...")
+        assert snippet == text
+
+    def test_snippet_match_at_very_start(self) -> None:
+        """Match at position 0 produces no leading ellipsis."""
+        text = "MATCH" + "x" * 200
+        snippet = EntityMentionScanService._extract_context_snippet(
+            text, 0, 5, window=75
+        )
+        assert not snippet.startswith("...")
+        assert snippet.endswith("...")
+        assert snippet[: len("MATCH")] == "MATCH"
+
+    def test_snippet_match_at_very_end(self) -> None:
+        """Match at the end produces no trailing ellipsis."""
+        text = "x" * 200 + "MATCH"
+        start = 200
+        end = 205
+        snippet = EntityMentionScanService._extract_context_snippet(
+            text, start, end, window=75
+        )
+        assert snippet.startswith("...")
+        assert not snippet.endswith("...")
+        assert snippet.endswith("MATCH")


### PR DESCRIPTION
## Summary

Extend entity mention detection from transcript-only to three text sources: **transcript**, **title**, and **description**. Entities can now be discovered in videos that have no downloaded transcript — if the entity name appears in the video title, it's found.

## What's New

### Title + Description Scanning
- `entities scan --sources title` scans all video titles for entity name/alias matches
- `entities scan --sources description` scans descriptions with ~150 char context snippet extraction
- `entities scan --sources transcript,title,description` scans all three in one command
- Default (`entities scan` with no flag) remains transcript-only — zero regressions

### API `sources` Parameter
- Both `POST /entities/{id}/scan` and `POST /videos/{id}/scan-entities` accept optional `sources` parameter
- Frontend scan buttons now pass `["transcript", "title", "description"]` for multi-source scanning
- Invalid values (e.g., `tag`) return 422 with RFC 7807 error

### Frontend Source Badges + Filter
- **TITLE** badge (amber) and **DESC** badge (slate) alongside existing TRANSCRIPT (indigo), TAG (teal), MANUAL (green)
- Badge order follows quality hierarchy: TITLE → TRANSCRIPT → TAG → DESC → MANUAL
- Description context snippet with entity name highlighted via `<mark>`
- Source filter dropdown: All sources, Title, Transcript, Tag, Description, Manual
- Filter persists in URL `?source=title`, composes with language filter
- Empty state: "No videos found for this source type" with "Try All sources" link

### Schema Migration
- `mention_source` column (VARCHAR(20), NOT NULL, default 'transcript') — all existing rows auto-populated
- `mention_context` column (TEXT, nullable) — ~150 char snippet for description mentions
- Partial unique indexes for title and description mentions
- CHECK constraint for valid source values

## Production Results

| Source | Mentions Created | Videos | Entities | Duration |
|--------|-----------------|--------|----------|----------|
| Title | 20,911 | 15,522 | 207 | 11.4s |
| Description | 66,632 | 24,891 | 218 | 194s |

## Test Plan
- [x] 6,498+ backend tests pass (including 5 fixed migration tests for PG 15 compatibility)
- [x] 3,641 frontend tests pass (33 new source badge + filter tests)
- [x] mypy --strict clean (src + tests)
- [x] ruff check clean (src + tests)
- [x] TypeScript clean
- [x] Production title scan: 20K mentions in 11s (under 30s target SC-002)
- [x] Production combined scan: 3.2 minutes (under 5min target SC-008)
- [x] Backward compatibility: `entities scan` (no flag) identical to pre-feature behavior
- [ ] CI pipeline passes

## Deferred

- **US6 (boilerplate detection)**: Description scanning runs without boilerplate filtering. Channels with repeated footers will produce false-positive description mentions. Clean up with `--sources description --full` when boilerplate detection ships.

Backend v0.55.0, Frontend v0.24.0. Closes #73 (Increment 1).