### PR TITLE
fix(transcripts): allow zero-duration segments in transcript download

### DIFF
--- a/src/chronovista/models/transcript_source.py
+++ b/src/chronovista/models/transcript_source.py
@@ -98,7 +98,7 @@ class TranscriptSnippet(BaseModel):
 
     text: str = Field(..., min_length=1, description="Transcript text content")
     start: float = Field(..., ge=0.0, description="Start time in seconds")
-    duration: float = Field(..., gt=0.0, description="Duration in seconds")
+    duration: float = Field(..., ge=0.0, description="Duration in seconds")
 
     @property
     def end(self) -> float:


### PR DESCRIPTION
## Summary

Relax `TranscriptSnippet.duration` validation from `gt=0` to `ge=0`. YouTube auto-generated captions occasionally produce segments with `duration: 0.0` (typically ASR stuttering), causing the entire transcript download to fail validation.

## Root Cause

A single zero-duration segment (e.g., `"spe spe spe spe..."` at a word boundary) triggers a Pydantic validation error that rejects the entire transcript. The DB constraint already allows `duration >= 0` — only the Pydantic model was overly strict.

## Test plan
- [x] Verified: video `dxjus5Gg30w` now downloads successfully (previously failed)
- [x] Confirmed zero-duration segment exists in DB: `start_time=3134.8, duration=0, text="spe spe spe..."`
- [x] 52 transcript segment tests pass
- [x] ruff + mypy clean
- [x] CI passes

Fixes #121