### PR TITLE
feat(tags): add --link-entity option to tags classify (#127)

### DIFF
--- a/src/chronovista/cli/tag_commands.py
+++ b/src/chronovista/cli/tag_commands.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -1277,6 +1278,12 @@ def classify_tag(
         is_flag=True,
         help="Skip auto-title-casing of the canonical form.",
     ),
+    link_entity: str | None = typer.Option(
+        None,
+        "--link-entity",
+        help="Link to an existing entity by name or UUID instead of creating a new one. "
+        "When used, --type is optional (inferred from the entity).",
+    ),
 ) -> None:
     """Classify a canonical tag with an entity type, or list top unclassified tags."""
 
@@ -1303,21 +1310,39 @@ def classify_tag(
         )
         raise typer.Exit(code=2)
 
-    if normalized_form is not None and entity_type is None:
+    if normalized_form is not None and entity_type is None and link_entity is None:
         console.print(
             Panel(
                 "[red]--type is required when classifying a tag. "
                 "Valid values: person, organization, place, event, work, "
-                "technical_term, concept, other, topic, descriptor.[/red]",
+                "technical_term, concept, other, topic, descriptor. "
+                "Or use --link-entity to infer the type from an existing entity.[/red]",
                 title="Missing --type",
                 border_style="red",
             )
         )
         raise typer.Exit(code=2)
 
+    if link_entity is not None and description is not None:
+        console.print(
+            Panel(
+                "[red]--description and --link-entity are mutually exclusive. "
+                "--description applies to new entity creation.[/red]",
+                title="Invalid Usage",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(code=2)
+
     async def _run() -> None:
+        from sqlalchemy import select
+
+        from chronovista.db.models import NamedEntity as NamedEntityDB
         from chronovista.models.enums import EntityType
         from chronovista.services.tag_management import ClassifyResult
+        from chronovista.services.tag_normalization import (
+            TagNormalizationService,
+        )
 
         service = _create_tag_management_service()
 
@@ -1367,16 +1392,71 @@ def classify_tag(
                 console.print(classify_table)
             else:
                 assert normalized_form is not None  # type narrowing
-                assert entity_type is not None  # type narrowing
+
+                # Resolve --link-entity to a UUID and infer type
+                resolved_entity_id: uuid.UUID | None = None
+                effective_entity_type = entity_type
+                if link_entity is not None:
+                    # Try UUID first
+                    try:
+                        resolved_entity_id = uuid.UUID(link_entity)
+                    except ValueError:
+                        # Look up by canonical name (normalized)
+                        normalizer = TagNormalizationService()
+                        search_norm = normalizer.normalize(link_entity)
+                        if search_norm:
+                            entity_result = await session.execute(
+                                select(NamedEntityDB).where(
+                                    NamedEntityDB.canonical_name_normalized
+                                    == search_norm,
+                                    NamedEntityDB.status == "active",
+                                )
+                            )
+                            found_entity = entity_result.scalar_one_or_none()
+                            if found_entity is not None:
+                                resolved_entity_id = found_entity.id
+
+                    if resolved_entity_id is None:
+                        console.print(
+                            Panel(
+                                f"[red]Entity '{link_entity}' not found. "
+                                "Provide a valid entity name or UUID.[/red]",
+                                title="Entity Not Found",
+                                border_style="red",
+                            )
+                        )
+                        raise typer.Exit(code=1)
+
+                    # Infer entity_type from the resolved entity if not given
+                    if effective_entity_type is None:
+                        entity_row = await session.execute(
+                            select(NamedEntityDB).where(
+                                NamedEntityDB.id == resolved_entity_id
+                            )
+                        )
+                        found = entity_row.scalar_one_or_none()
+                        if found is not None:
+                            effective_entity_type = found.entity_type
+
+                if effective_entity_type is None:
+                    console.print(
+                        Panel(
+                            "[red]Could not determine entity type. "
+                            "Provide --type explicitly.[/red]",
+                            title="Missing --type",
+                            border_style="red",
+                        )
+                    )
+                    raise typer.Exit(code=2)
 
                 # Parse entity type string to enum
                 try:
-                    parsed_type = EntityType(entity_type)
+                    parsed_type = EntityType(effective_entity_type)
                 except ValueError:
                     valid_types = ", ".join(t.value for t in EntityType)
                     console.print(
                         Panel(
-                            f"[red]Invalid entity type '{entity_type}'. "
+                            f"[red]Invalid entity type '{effective_entity_type}'. "
                             f"Valid values: {valid_types}[/red]",
                             title="Invalid --type",
                             border_style="red",
@@ -1393,6 +1473,7 @@ def classify_tag(
                         reason=reason,
                         description=description,
                         auto_case=not no_auto_case,
+                        link_entity_id=resolved_entity_id,
                     )
                     await session.commit()
 

--- a/src/chronovista/services/tag_management.py
+++ b/src/chronovista/services/tag_management.py
@@ -833,6 +833,7 @@ class TagManagementService:
         reason: str | None = None,
         description: str | None = None,
         auto_case: bool = True,
+        link_entity_id: uuid.UUID | None = None,
     ) -> ClassifyResult:
         """
         Classify a canonical tag with an entity type.
@@ -936,39 +937,57 @@ class TagManagementService:
                 tag.canonical_form = tag.canonical_form.title()
                 session.add(tag)
 
-            # 4. Check if a named_entity already exists with same name and type
-            existing_entity_result = await session.execute(
-                select(NamedEntityDB).where(
-                    NamedEntityDB.canonical_name_normalized
-                    == tag.normalized_form,
-                    NamedEntityDB.entity_type == entity_type.value,
+            # 3c. --link-entity: link to a specific existing entity by ID
+            if link_entity_id is not None:
+                target_entity = await self._named_entity_repo.get(
+                    session, link_entity_id
                 )
-            )
-            existing_entity = existing_entity_result.scalar_one_or_none()
-
-            if existing_entity is not None:
-                # Link to existing entity
+                if target_entity is None:
+                    raise ValueError(
+                        f"Entity '{link_entity_id}' not found."
+                    )
+                if target_entity.status != "active":
+                    raise ValueError(
+                        f"Entity '{target_entity.canonical_name}' is not active "
+                        f"(status: {target_entity.status})."
+                    )
                 tag.entity_type = entity_type.value
-                tag.entity_id = existing_entity.id
-                linked_existing_entity_id = existing_entity.id
+                tag.entity_id = target_entity.id
+                linked_existing_entity_id = target_entity.id
             else:
-                # Create new NamedEntity
-                entity_description = description or reason
-                entity_create = NamedEntityCreate(
-                    canonical_name=tag.canonical_form,
-                    canonical_name_normalized=tag.normalized_form,
-                    entity_type=entity_type,
-                    description=entity_description,
-                    discovery_method=DiscoveryMethod.USER_CREATED,
-                    confidence=1.0,
+                # 4. Check if a named_entity already exists with same name/type
+                existing_entity_result = await session.execute(
+                    select(NamedEntityDB).where(
+                        NamedEntityDB.canonical_name_normalized
+                        == tag.normalized_form,
+                        NamedEntityDB.entity_type == entity_type.value,
+                    )
                 )
-                new_entity = await self._named_entity_repo.create(
-                    session, obj_in=entity_create
-                )
-                tag.entity_type = entity_type.value
-                tag.entity_id = new_entity.id
-                created_entity_id = new_entity.id
-                entity_created = True
+                existing_entity = existing_entity_result.scalar_one_or_none()
+
+                if existing_entity is not None:
+                    # Link to existing entity by name match
+                    tag.entity_type = entity_type.value
+                    tag.entity_id = existing_entity.id
+                    linked_existing_entity_id = existing_entity.id
+                else:
+                    # Create new NamedEntity
+                    entity_description = description or reason
+                    entity_create = NamedEntityCreate(
+                        canonical_name=tag.canonical_form,
+                        canonical_name_normalized=tag.normalized_form,
+                        entity_type=entity_type,
+                        description=entity_description,
+                        discovery_method=DiscoveryMethod.USER_CREATED,
+                        confidence=1.0,
+                    )
+                    new_entity = await self._named_entity_repo.create(
+                        session, obj_in=entity_create
+                    )
+                    tag.entity_type = entity_type.value
+                    tag.entity_id = new_entity.id
+                    created_entity_id = new_entity.id
+                    entity_created = True
 
             # Create self-alias (canonical form as name_variant).
             # Tag aliases are NOT copied — they represent YouTube tag

--- a/tests/unit/cli/test_tag_commands_incremental.py
+++ b/tests/unit/cli/test_tag_commands_incremental.py
@@ -577,3 +577,95 @@ class TestSkipNormalizeFlag:
         result = runner.invoke(enrich_app, ["run", "--help"])
         assert result.exit_code == 0
         assert "normalization" in result.output.lower()
+
+
+# ===========================================================================
+# T-LinkEntity — ``tags classify --link-entity`` CLI validation
+# ===========================================================================
+
+
+class TestClassifyLinkEntityCli:
+    """
+    CLI-level tests for the ``--link-entity`` option added to
+    ``tags classify`` (Feature 127).
+
+    These tests exercise the argument-parsing and early-exit validation
+    logic inside ``classify_tag`` without touching the database.
+
+    Covers:
+    - T-LE01: ``--link-entity`` appears in ``tags classify --help``.
+    - T-LE02: ``--description`` and ``--link-entity`` together → exit 2,
+      "mutually exclusive" message.
+    - T-LE03: Missing ``--type`` when ``--link-entity`` is also absent → exit 2
+      (unchanged behaviour).
+    - T-LE04: Missing ``--type`` when ``--link-entity`` IS present → does NOT
+      exit early with "Missing --type" (type is inferred from entity).
+    """
+
+    def test_link_entity_appears_in_classify_help(
+        self,
+        runner: CliRunner,
+    ) -> None:
+        """T-LE01: ``--link-entity`` is documented in ``tags classify --help``."""
+        result = runner.invoke(tag_app, ["classify", "--help"])
+        assert result.exit_code == 0
+        assert "--link-entity" in result.output
+
+    def test_description_and_link_entity_are_mutually_exclusive(
+        self,
+        runner: CliRunner,
+    ) -> None:
+        """T-LE02: Providing both ``--description`` and ``--link-entity`` exits with code 2.
+
+        The CLI must print an error panel containing "mutually exclusive"
+        before any database operation takes place.
+        """
+        result = runner.invoke(
+            tag_app,
+            [
+                "classify",
+                "destiny",
+                "--type", "person",
+                "--description", "A streamer",
+                "--link-entity", "Steven Bonnell",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_missing_type_without_link_entity_exits_code_2(
+        self,
+        runner: CliRunner,
+    ) -> None:
+        """T-LE03: Omitting ``--type`` without ``--link-entity`` still exits with code 2.
+
+        This validates that the existing "Missing --type" guard was not
+        accidentally removed by the --link-entity refactor.
+        """
+        result = runner.invoke(
+            tag_app,
+            ["classify", "destiny"],
+        )
+        assert result.exit_code == 2
+        assert "type" in result.output.lower()
+
+    @patch("chronovista.cli.tag_commands.asyncio.run")
+    def test_missing_type_with_link_entity_does_not_exit_early(
+        self,
+        mock_asyncio_run: MagicMock,
+        runner: CliRunner,
+    ) -> None:
+        """T-LE04: Omitting ``--type`` when ``--link-entity`` is given must NOT
+        trigger the early "Missing --type" exit.
+
+        The command should proceed past the guard (asyncio.run is reached)
+        because the type will be inferred from the entity at runtime.
+        """
+        result = runner.invoke(
+            tag_app,
+            ["classify", "destiny", "--link-entity", "Steven Bonnell"],
+        )
+        # asyncio.run being called means we passed all early-exit guards
+        mock_asyncio_run.assert_called_once()
+        # Must NOT print the "Missing --type" panel
+        assert "missing --type" not in result.output.lower()

--- a/tests/unit/services/test_tag_management.py
+++ b/tests/unit/services/test_tag_management.py
@@ -3852,3 +3852,188 @@ class TestClassifyDescriptionAndAutoCase:
             "auto_case must have no effect for tag-only types such as TOPIC"
         )
         mock_named_entity_repo.create.assert_not_called()
+
+
+# ===========================================================================
+# TestClassifyLinkEntity
+# ===========================================================================
+
+
+class TestClassifyLinkEntity:
+    """
+    Tests for the ``link_entity_id`` parameter added to
+    ``TagManagementService.classify``.
+
+    Covers:
+    - Happy path: active entity found by ID → tag linked, no new entity created.
+    - Entity not found by ID → ``ValueError`` raised.
+    - Entity found but status is not "active" → ``ValueError`` raised.
+    """
+
+    async def test_classify_link_entity_links_existing_entity(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_entity_alias_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When ``link_entity_id`` is provided and the entity is active, the tag
+        must be linked to that entity without creating a new NamedEntity.
+
+        Expected behaviour:
+        - ``named_entity_repo.get`` is called with the given UUID.
+        - ``named_entity_repo.create`` is NOT called.
+        - ``tag.entity_id`` is set to the target entity's id.
+        - ``tag.entity_type`` is set to the entity type value.
+        - ``ClassifyResult.entity_created`` is ``False``.
+        """
+        from chronovista.models.enums import EntityType
+        from chronovista.services.tag_management import ClassifyResult
+
+        tag = _make_canonical_tag(
+            normalized_form="destiny",
+            canonical_form="Destiny",
+            status="active",
+        )
+        tag.entity_type = None
+        tag.entity_id = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        # The existing entity (e.g. "Steven Bonnell") that the tag should link to
+        target_entity = _make_named_entity(
+            normalized_form="steven bonnell",
+            entity_type="person",
+            discovery_method="user_created",
+        )
+        target_entity.status = "active"
+        target_entity.canonical_name = "Steven Bonnell"
+
+        entity_uuid = target_entity.id
+        mock_named_entity_repo.get.return_value = target_entity
+
+        ea = _make_entity_alias(entity_id=entity_uuid)
+        mock_entity_alias_repo.create.return_value = ea
+
+        op_id = uuid.uuid4()
+        log_entry = _make_operation_log(operation_type="create")
+        log_entry.id = op_id
+        mock_operation_log_repo.create.return_value = log_entry
+
+        # Only the self-alias existence check fires (no existing-entity SELECT
+        # because we skip straight to link_entity_id branch)
+        mock_session.execute = AsyncMock(
+            side_effect=[
+                MagicMock(**{"scalar_one_or_none.return_value": None}),  # self-alias check
+            ]
+        )
+        mock_session.add = MagicMock()
+
+        result = await service.classify(
+            mock_session,
+            normalized_form="destiny",
+            entity_type=EntityType.PERSON,
+            link_entity_id=entity_uuid,
+        )
+
+        assert isinstance(result, ClassifyResult)
+        assert result.entity_created is False
+        assert result.entity_type == "person"
+        assert tag.entity_id == entity_uuid
+        assert tag.entity_type == "person"
+        mock_named_entity_repo.create.assert_not_called()
+        mock_named_entity_repo.get.assert_called_once_with(mock_session, entity_uuid)
+
+    async def test_classify_link_entity_not_found_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When ``link_entity_id`` is provided but the entity does not exist,
+        ``classify`` must raise ``ValueError`` with a message containing the UUID.
+
+        Expected behaviour:
+        - ``named_entity_repo.get`` returns ``None``.
+        - ``ValueError`` is raised immediately (no entity created, no log written).
+        """
+        from chronovista.models.enums import EntityType
+
+        tag = _make_canonical_tag(
+            normalized_form="destiny",
+            canonical_form="Destiny",
+            status="active",
+        )
+        tag.entity_type = None
+        tag.entity_id = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        missing_uuid = uuid.uuid4()
+        mock_named_entity_repo.get.return_value = None
+        mock_session.add = MagicMock()
+
+        with pytest.raises(ValueError, match=str(missing_uuid)):
+            await service.classify(
+                mock_session,
+                normalized_form="destiny",
+                entity_type=EntityType.PERSON,
+                link_entity_id=missing_uuid,
+            )
+
+        mock_named_entity_repo.create.assert_not_called()
+        mock_operation_log_repo.create.assert_not_called()
+
+    async def test_classify_link_entity_inactive_raises(
+        self,
+        service: TagManagementService,
+        mock_canonical_tag_repo: AsyncMock,
+        mock_named_entity_repo: AsyncMock,
+        mock_operation_log_repo: AsyncMock,
+        mock_session: AsyncMock,
+    ) -> None:
+        """
+        When ``link_entity_id`` resolves to a non-active entity (e.g. merged),
+        ``classify`` must raise ``ValueError`` mentioning the entity name and status.
+
+        Expected behaviour:
+        - ``named_entity_repo.get`` returns an entity with status ``"merged"``.
+        - ``ValueError`` is raised with a message containing ``"merged"`` and the
+          entity's canonical name.
+        """
+        from chronovista.models.enums import EntityType
+
+        tag = _make_canonical_tag(
+            normalized_form="destiny",
+            canonical_form="Destiny",
+            status="active",
+        )
+        tag.entity_type = None
+        tag.entity_id = None
+        mock_canonical_tag_repo.get_by_normalized_form.return_value = tag
+
+        inactive_entity = _make_named_entity(
+            normalized_form="old entity",
+            entity_type="person",
+            discovery_method="user_created",
+        )
+        inactive_entity.status = "merged"
+        inactive_entity.canonical_name = "Old Entity"
+
+        mock_named_entity_repo.get.return_value = inactive_entity
+        mock_session.add = MagicMock()
+
+        with pytest.raises(ValueError, match="not active"):
+            await service.classify(
+                mock_session,
+                normalized_form="destiny",
+                entity_type=EntityType.PERSON,
+                link_entity_id=inactive_entity.id,
+            )
+
+        mock_named_entity_repo.create.assert_not_called()
+        mock_operation_log_repo.create.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `--link-entity` option to `tags classify` that links a canonical tag to an existing entity by name or UUID
- `--type` is optional when `--link-entity` is used — inferred from the entity
- `--description` and `--link-entity` are mutually exclusive
- Entity lookup supports both UUID and normalized name matching

## Test plan

- [x] `tags classify "river" --link-entity "Peter Naur"` links tag to entity, infers type as person
- [x] mypy --strict clean (src + tests)
- [x] ruff clean
- [x] 7,714 backend tests pass
- [x] Production validation: both tags ("River", "Peter Naur") linked to entity, videos visible via TAG associations

Closes #127