### PR TITLE
fix(frontend): resolve intermittent navigation failures and virtualizer warnings

### DIFF
--- a/frontend/src/components/batch/ResultSummary.tsx
+++ b/frontend/src/components/batch/ResultSummary.tsx
@@ -17,6 +17,8 @@
  * @see T026 in batch corrections spec
  */
 
+import { Link } from 'react-router-dom';
+
 import type { BatchApplyResult } from '../../types/batchCorrections';
 
 // ---------------------------------------------------------------------------
@@ -234,8 +236,8 @@ export function ResultSummary({
                 <ul className="space-y-1">
                   {affected_video_ids.map((videoId) => (
                     <li key={videoId}>
-                      <a
-                        href={`/videos/${videoId}`}
+                      <Link
+                        to={`/videos/${videoId}`}
                         className={[
                           'inline-flex items-center gap-1.5 text-sm',
                           'min-h-[44px] min-w-[44px]',
@@ -258,7 +260,7 @@ export function ResultSummary({
                           <path d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                         </svg>
                         Video <span className="font-mono text-xs">{videoId}</span>
-                      </a>
+                      </Link>
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/components/transcript/TranscriptSegments.tsx
+++ b/frontend/src/components/transcript/TranscriptSegments.tsx
@@ -619,6 +619,7 @@ function VirtualizedSegmentList({
         return (
           <div
             key={virtualItem.key}
+            data-index={virtualItem.index}
             // NFR-003: ref callback so the virtualizer re-measures on edit mode toggle
             ref={(el) => {
               if (el) virtualizer.measureElement(el);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -31,7 +31,7 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} future={{ v7_startTransition: true }} />
+      <RouterProvider router={router} />
     </QueryClientProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary

- **Remove `v7_startTransition: true`** from RouterProvider — this flag deferred route commits in React 19, causing the URL to update while the old page stayed visible. Root cause of intermittent "click does nothing" navigation failures across sidebar, entity badges, and other links.
- **Replace `<a href>` with `<Link to>`** in ResultSummary — batch correction video links were causing full page reloads instead of client-side navigation
- **Add missing `data-index` attribute** on virtualizer items in TranscriptSegments — fixes `@tanstack/virtual-core` measurement warnings and enables proper dynamic height re-measurement for edit/history/revert states

## Root Cause Analysis

`v7_startTransition: true` wraps route transitions in React's `startTransition`, which suppresses Suspense fallbacks and keeps the old page visible during lazy chunk loads. Combined with React 19's more aggressive concurrent scheduler, this caused unpredictable delays where the URL updated but the component tree was never committed — appearing as "stuck" navigation. Confirmed independently by two specialist agents.

## Test plan

- [x] 3,641 frontend tests pass
- [x] TypeScript strict — no errors
- [x] Manual verification: sidebar navigation, entity badge clicks, video links all navigate immediately
- [x] `data-index` console warning eliminated