### PR TITLE
fix(entities): async entity mention scan (fixes false "Scan failed")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+### Fixed
+- **Entity mention scans no longer report a false "Scan failed."** The entity and video scan endpoints (`POST /entities/{id}/scan`, `POST /videos/{id}/scan-entities`) now run asynchronously — they return `202` with a `job_id`, and the frontend polls `GET /api/v1/scan-jobs/{job_id}` for progress and result. Previously the scan blocked for minutes and tripped the client timeout (reporting failure) even though the backend completed and committed the mentions.
+
 ## [0.57.0] - 2026-07-20
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+### Fixed
+- **Entity mention scans no longer report a false "Scan failed."** The entity and video scan endpoints (`POST /entities/{id}/scan`, `POST /videos/{id}/scan-entities`) now run asynchronously — they return `202` with a `job_id`, and the frontend polls `GET /api/v1/scan-jobs/{job_id}` for progress and result. Previously the scan blocked for minutes and tripped the client timeout (reporting failure) even though the backend completed and committed the mentions.
+
 ## [0.57.0] - 2026-07-20
 
 ### Added

--- a/docs/user-guide/rest-api.md
+++ b/docs/user-guide/rest-api.md
@@ -1879,7 +1879,9 @@ Videos may have multiple sources (e.g., `["title", "transcript", "tag"]`). Badge
 
 #### Scan Entity Mentions
 
-Trigger an entity mention scan for a single entity. Scans transcript segments by default; optionally scans video titles and descriptions when `sources` parameter is provided. The entity must exist and be in `active` status.
+Start an entity mention scan for a single entity. Scans transcript segments by default; optionally scans video titles and descriptions when `sources` parameter is provided. The entity must exist and be in `active` status.
+
+The scan runs **asynchronously** — on a large corpus it can take minutes. This endpoint validates the request, starts the scan as a background job, and returns `202` with a `job_id`. Poll [`GET /api/v1/scan-jobs/{job_id}`](#get-scan-job-status) for progress and the final result.
 
 ```
 POST /api/v1/entities/{entity_id}/scan
@@ -1905,24 +1907,26 @@ POST /api/v1/entities/{entity_id}/scan
 | `dry_run` | boolean | false | Preview mode — no writes, no counter updates |
 | `full_rescan` | boolean | false | Delete existing `rule_match` mentions for this entity before scanning |
 
-**Response (200):**
+**Response (202):**
 
 ```json
 {
   "data": {
-    "segments_scanned": 12450,
-    "mentions_found": 42,
-    "mentions_skipped": 3,
-    "unique_entities": 1,
-    "unique_videos": 12,
-    "duration_seconds": 8.2,
-    "dry_run": false
+    "job_id": "018f9c2a-1b3d-7e4f-a0b1-2c3d4e5f6a7b",
+    "kind": "entity",
+    "target_id": "5f2e...",
+    "status": "running",
+    "result": null,
+    "error": null,
+    "started_at": "2026-07-20T21:39:10Z",
+    "finished_at": null
   }
 }
 ```
 
 | Status | Description |
 |--------|-------------|
+| 202 | Scan accepted and started; poll `GET /scan-jobs/{job_id}` for the result |
 | 400 | Entity is not in an active state (status: merged/deprecated) |
 | 404 | Entity not found |
 | 409 | A scan is already in progress for this entity |
@@ -1931,7 +1935,7 @@ POST /api/v1/entities/{entity_id}/scan
 
 #### Scan Video for Entity Mentions
 
-Trigger an entity mention scan for a single video, checking all active entity patterns against that video's transcript segments.
+Start an entity mention scan for a single video, checking all active entity patterns against that video's transcript segments. Like the entity scan, this runs **asynchronously** and returns `202` with a `job_id`; poll [`GET /api/v1/scan-jobs/{job_id}`](#get-scan-job-status) for the result.
 
 ```
 POST /api/v1/videos/{video_id}/scan-entities
@@ -1955,28 +1959,64 @@ POST /api/v1/videos/{video_id}/scan-entities
 | `dry_run` | boolean | false | Preview mode — no writes, no counter updates |
 | `full_rescan` | boolean | false | Delete existing `rule_match` mentions in scope before scanning |
 
-**Response (200):**
+**Response (202):**
 
 ```json
 {
   "data": {
-    "segments_scanned": 156,
-    "mentions_found": 23,
-    "mentions_skipped": 0,
-    "unique_entities": 8,
-    "unique_videos": 1,
-    "duration_seconds": 1.4,
-    "dry_run": false
+    "job_id": "018f9c2a-1b3d-7e4f-a0b1-2c3d4e5f6a7b",
+    "kind": "video",
+    "target_id": "dQw4w9WgXcQ",
+    "status": "running",
+    "result": null,
+    "error": null,
+    "started_at": "2026-07-20T21:39:10Z",
+    "finished_at": null
   }
 }
 ```
 
-A video with no transcripts returns 200 with all counts at zero.
+| Status | Description |
+|--------|-------------|
+| 202 | Scan accepted and started; poll `GET /scan-jobs/{job_id}` for the result |
+| 404 | Video not found |
+| 409 | A scan is already in progress for this video |
+
+---
+
+#### Get Scan Job Status
+
+Poll the status and result of an asynchronous scan job started by the entity or video scan endpoints.
+
+```
+GET /api/v1/scan-jobs/{job_id}
+```
+
+**Response (200) — while running:**
+
+```json
+{
+  "data": {
+    "job_id": "018f9c2a-1b3d-7e4f-a0b1-2c3d4e5f6a7b",
+    "kind": "entity",
+    "target_id": "5f2e...",
+    "status": "running",
+    "result": null,
+    "error": null,
+    "started_at": "2026-07-20T21:39:10Z",
+    "finished_at": null
+  }
+}
+```
+
+**Response (200) — succeeded:** `status` is `"succeeded"` and `result` holds the scan metrics (`segments_scanned`, `mentions_found`, `mentions_skipped`, `unique_entities`, `unique_videos`, `duration_seconds`, `dry_run`). On failure, `status` is `"failed"` and `error` holds the message.
 
 | Status | Description |
 |--------|-------------|
-| 404 | Video not found |
-| 409 | A scan is already in progress for this video |
+| 404 | Unknown job id. Jobs are in-memory and ephemeral — an id is not found after a server restart. |
+
+!!! note "Ephemeral jobs"
+    Scan jobs are tracked in memory and do not survive a server restart. Poll shortly after launching; a lost job simply means re-running the scan.
 
 ---
 

--- a/frontend/src/api/__tests__/entityMentions.scan.test.ts
+++ b/frontend/src/api/__tests__/entityMentions.scan.test.ts
@@ -1,23 +1,30 @@
 /**
- * Tests for scanEntity and scanVideoEntities in api/entityMentions.ts (Feature 052).
+ * Tests for scanEntity, scanVideoEntities, and getScanJob in
+ * api/entityMentions.ts (Feature: async entity scan).
  *
  * Coverage:
  * - scanEntity: correct endpoint URL construction with entity ID
  * - scanEntity: sends POST with JSON body (empty object when no options)
  * - scanEntity: forwards options fields in request body
- * - scanEntity: returns ScanResultResponse on success
- * - scanEntity: propagates ApiError on failure
+ * - scanEntity: no longer overrides the request timeout (launch is fast now)
+ * - scanEntity: returns the unwrapped ScanJob (not the envelope) on success
+ * - scanEntity: propagates ApiError on failure (404, 409)
  * - scanVideoEntities: correct endpoint URL construction with video ID
  * - scanVideoEntities: sends POST with JSON body (empty object when no options)
  * - scanVideoEntities: forwards entity_type option in request body
- * - scanVideoEntities: returns ScanResultResponse on success
+ * - scanVideoEntities: no longer overrides the request timeout
+ * - scanVideoEntities: returns the unwrapped ScanJob on success
  * - scanVideoEntities: propagates ApiError on failure
+ * - getScanJob: correct endpoint URL construction with job ID
+ * - getScanJob: forwards an external AbortSignal
+ * - getScanJob: returns the unwrapped ScanJob for running/succeeded/failed states
+ * - getScanJob: propagates ApiError (404) for an unknown job
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { apiFetch, SCAN_TIMEOUT } from "../config";
-import { scanEntity, scanVideoEntities } from "../entityMentions";
-import type { ScanResultResponse } from "../entityMentions";
+import { apiFetch } from "../config";
+import { scanEntity, scanVideoEntities, getScanJob } from "../entityMentions";
+import type { ScanJob, ScanJobResponse } from "../entityMentions";
 
 vi.mock("../config", async () => {
   const actual = await vi.importActual<typeof import("../config")>("../config");
@@ -35,22 +42,26 @@ const mockedApiFetch = vi.mocked(apiFetch);
 
 const ENTITY_ID = "3f4a7b2c-1d9e-4f6a-b8c2-9e0d1f2a3b4c";
 const VIDEO_ID = "dQw4w9WgXcQ";
+const JOB_ID = "job-uuid-1234";
 
-function makeScanResultResponse(
-  overrides: Partial<ScanResultResponse["data"]> = {}
-): ScanResultResponse {
+function makeScanJob(overrides: Partial<ScanJob> = {}): ScanJob {
   return {
-    data: {
-      segments_scanned: 150,
-      mentions_found: 8,
-      mentions_skipped: 2,
-      unique_entities: 3,
-      unique_videos: 1,
-      duration_seconds: 0.42,
-      dry_run: false,
-      ...overrides,
-    },
+    job_id: JOB_ID,
+    kind: "entity",
+    target_id: ENTITY_ID,
+    status: "running",
+    result: null,
+    error: null,
+    started_at: "2026-07-19T12:00:00Z",
+    finished_at: null,
+    ...overrides,
   };
+}
+
+function makeScanJobResponse(
+  overrides: Partial<ScanJob> = {}
+): ScanJobResponse {
+  return { data: makeScanJob(overrides) };
 }
 
 // ===========================================================================
@@ -63,7 +74,7 @@ describe("scanEntity", () => {
   });
 
   it("calls apiFetch with POST method on the correct entity scan endpoint", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanEntity(ENTITY_ID);
 
@@ -74,18 +85,18 @@ describe("scanEntity", () => {
     );
   });
 
-  it("uses a 5-minute timeout to accommodate large corpus scans", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+  it("does not set a timeout override — the launch request is fast", async () => {
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanEntity(ENTITY_ID);
 
     const callArgs = mockedApiFetch.mock.calls[0];
     const options = callArgs?.[1] as Record<string, unknown> | undefined;
-    expect(options?.timeout).toBe(SCAN_TIMEOUT);
+    expect(options?.timeout).toBeUndefined();
   });
 
   it("sends an empty JSON object as the body when no options are provided", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanEntity(ENTITY_ID);
 
@@ -95,7 +106,7 @@ describe("scanEntity", () => {
   });
 
   it("sends an empty JSON object as the body when options is explicitly undefined", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanEntity(ENTITY_ID, undefined);
 
@@ -105,7 +116,7 @@ describe("scanEntity", () => {
   });
 
   it("serializes language_code option in the request body", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanEntity(ENTITY_ID, { language_code: "en" });
 
@@ -115,7 +126,7 @@ describe("scanEntity", () => {
   });
 
   it("serializes dry_run option in the request body", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse({ dry_run: true }));
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanEntity(ENTITY_ID, { dry_run: true });
 
@@ -125,7 +136,7 @@ describe("scanEntity", () => {
   });
 
   it("serializes full_rescan option in the request body", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanEntity(ENTITY_ID, { full_rescan: true });
 
@@ -135,7 +146,7 @@ describe("scanEntity", () => {
   });
 
   it("serializes all options fields together in the request body", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanEntity(ENTITY_ID, {
       language_code: "es",
@@ -156,22 +167,20 @@ describe("scanEntity", () => {
     );
   });
 
-  it("returns the ScanResultResponse from the server on success", async () => {
-    const expected = makeScanResultResponse({
-      mentions_found: 12,
-      unique_videos: 4,
-    });
-    mockedApiFetch.mockResolvedValueOnce(expected);
+  it("returns the unwrapped ScanJob (status running) on success", async () => {
+    const response = makeScanJobResponse({ status: "running" });
+    mockedApiFetch.mockResolvedValueOnce(response);
 
     const result = await scanEntity(ENTITY_ID);
 
-    expect(result).toEqual(expected);
-    expect(result.data.mentions_found).toBe(12);
-    expect(result.data.unique_videos).toBe(4);
+    expect(result).toEqual(response.data);
+    expect(result.status).toBe("running");
+    expect(result.job_id).toBe(JOB_ID);
+    expect(result.result).toBeNull();
   });
 
   it("correctly interpolates entity_id into the endpoint URL", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     const customEntityId = "aabbccdd-1111-2222-3333-444455556666";
     await scanEntity(customEntityId);
@@ -182,32 +191,22 @@ describe("scanEntity", () => {
     );
   });
 
-  it("propagates an ApiError thrown by apiFetch", async () => {
+  it("propagates a 404 ApiError thrown by apiFetch", async () => {
     const apiError = { type: "server", message: "Entity not found", status: 404 };
     mockedApiFetch.mockRejectedValueOnce(apiError);
 
     await expect(scanEntity(ENTITY_ID)).rejects.toEqual(apiError);
   });
 
-  it("propagates a 503 service unavailable error", async () => {
+  it("propagates a 409 ApiError (scan already in progress)", async () => {
     const apiError = {
       type: "server",
-      message: "Scan service unavailable",
-      status: 503,
+      message: "A scan is already in progress for this entity",
+      status: 409,
     };
     mockedApiFetch.mockRejectedValueOnce(apiError);
 
     await expect(scanEntity(ENTITY_ID)).rejects.toEqual(apiError);
-  });
-
-  it("returns scan result with dry_run=true when dry_run option was set", async () => {
-    const expected = makeScanResultResponse({ dry_run: true, mentions_found: 5 });
-    mockedApiFetch.mockResolvedValueOnce(expected);
-
-    const result = await scanEntity(ENTITY_ID, { dry_run: true });
-
-    expect(result.data.dry_run).toBe(true);
-    expect(result.data.mentions_found).toBe(5);
   });
 });
 
@@ -221,7 +220,9 @@ describe("scanVideoEntities", () => {
   });
 
   it("calls apiFetch with POST method on the correct video scan endpoint", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(
+      makeScanJobResponse({ kind: "video", target_id: VIDEO_ID })
+    );
 
     await scanVideoEntities(VIDEO_ID);
 
@@ -232,18 +233,18 @@ describe("scanVideoEntities", () => {
     );
   });
 
-  it("uses a 5-minute timeout to accommodate large corpus scans", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+  it("does not set a timeout override — the launch request is fast", async () => {
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanVideoEntities(VIDEO_ID);
 
     const callArgs = mockedApiFetch.mock.calls[0];
     const options = callArgs?.[1] as Record<string, unknown> | undefined;
-    expect(options?.timeout).toBe(SCAN_TIMEOUT);
+    expect(options?.timeout).toBeUndefined();
   });
 
   it("sends an empty JSON object as the body when no options are provided", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanVideoEntities(VIDEO_ID);
 
@@ -253,7 +254,7 @@ describe("scanVideoEntities", () => {
   });
 
   it("sends an empty JSON object as the body when options is explicitly undefined", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanVideoEntities(VIDEO_ID, undefined);
 
@@ -263,7 +264,7 @@ describe("scanVideoEntities", () => {
   });
 
   it("serializes entity_type option in the request body", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanVideoEntities(VIDEO_ID, { entity_type: "person" });
 
@@ -273,7 +274,7 @@ describe("scanVideoEntities", () => {
   });
 
   it("serializes language_code option in the request body", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanVideoEntities(VIDEO_ID, { language_code: "fr" });
 
@@ -283,7 +284,7 @@ describe("scanVideoEntities", () => {
   });
 
   it("serializes dry_run option in the request body", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse({ dry_run: true }));
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanVideoEntities(VIDEO_ID, { dry_run: true });
 
@@ -293,7 +294,7 @@ describe("scanVideoEntities", () => {
   });
 
   it("serializes full_rescan option in the request body", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanVideoEntities(VIDEO_ID, { full_rescan: true });
 
@@ -303,7 +304,7 @@ describe("scanVideoEntities", () => {
   });
 
   it("serializes all options fields together in the request body", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     await scanVideoEntities(VIDEO_ID, {
       language_code: "de",
@@ -324,23 +325,19 @@ describe("scanVideoEntities", () => {
     );
   });
 
-  it("returns the ScanResultResponse from the server on success", async () => {
-    const expected = makeScanResultResponse({
-      segments_scanned: 200,
-      unique_entities: 7,
-      mentions_found: 25,
-    });
-    mockedApiFetch.mockResolvedValueOnce(expected);
+  it("returns the unwrapped ScanJob (kind video) on success", async () => {
+    const response = makeScanJobResponse({ kind: "video", target_id: VIDEO_ID });
+    mockedApiFetch.mockResolvedValueOnce(response);
 
     const result = await scanVideoEntities(VIDEO_ID);
 
-    expect(result).toEqual(expected);
-    expect(result.data.segments_scanned).toBe(200);
-    expect(result.data.unique_entities).toBe(7);
+    expect(result).toEqual(response.data);
+    expect(result.kind).toBe("video");
+    expect(result.target_id).toBe(VIDEO_ID);
   });
 
   it("correctly interpolates video_id into the endpoint URL", async () => {
-    mockedApiFetch.mockResolvedValueOnce(makeScanResultResponse());
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
 
     const customVideoId = "abc123XYZ";
     await scanVideoEntities(customVideoId);
@@ -351,34 +348,120 @@ describe("scanVideoEntities", () => {
     );
   });
 
-  it("propagates an ApiError thrown by apiFetch", async () => {
+  it("propagates a 404 ApiError thrown by apiFetch", async () => {
     const apiError = { type: "server", message: "Video not found", status: 404 };
     mockedApiFetch.mockRejectedValueOnce(apiError);
 
     await expect(scanVideoEntities(VIDEO_ID)).rejects.toEqual(apiError);
   });
 
-  it("propagates a 500 internal server error", async () => {
+  it("propagates a 409 ApiError (scan already in progress)", async () => {
     const apiError = {
       type: "server",
-      message: "Internal server error",
-      status: 500,
+      message: "A scan is already in progress for this video",
+      status: 409,
     };
     mockedApiFetch.mockRejectedValueOnce(apiError);
 
     await expect(scanVideoEntities(VIDEO_ID)).rejects.toEqual(apiError);
   });
+});
 
-  it("returns zero mentions when no entities were found in the video", async () => {
-    const expected = makeScanResultResponse({
-      mentions_found: 0,
-      unique_entities: 0,
+// ===========================================================================
+// getScanJob
+// ===========================================================================
+
+describe("getScanJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls apiFetch on the correct scan-job status endpoint", async () => {
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
+
+    await getScanJob(JOB_ID);
+
+    expect(mockedApiFetch).toHaveBeenCalledOnce();
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/scan-jobs/${JOB_ID}`,
+      expect.any(Object)
+    );
+  });
+
+  it("forwards an external AbortSignal when provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
+    const controller = new AbortController();
+
+    await getScanJob(JOB_ID, controller.signal);
+
+    const callArgs = mockedApiFetch.mock.calls[0];
+    const options = callArgs?.[1] as Record<string, unknown> | undefined;
+    expect(options?.externalSignal).toBe(controller.signal);
+  });
+
+  it("omits externalSignal when no signal is provided", async () => {
+    mockedApiFetch.mockResolvedValueOnce(makeScanJobResponse());
+
+    await getScanJob(JOB_ID);
+
+    const callArgs = mockedApiFetch.mock.calls[0];
+    const options = callArgs?.[1] as Record<string, unknown> | undefined;
+    expect(options?.externalSignal).toBeUndefined();
+  });
+
+  it("returns the unwrapped ScanJob while running (result null)", async () => {
+    const response = makeScanJobResponse({ status: "running" });
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const result = await getScanJob(JOB_ID);
+
+    expect(result.status).toBe("running");
+    expect(result.result).toBeNull();
+    expect(result.error).toBeNull();
+  });
+
+  it("returns the unwrapped ScanJob with result metrics when succeeded", async () => {
+    const response = makeScanJobResponse({
+      status: "succeeded",
+      finished_at: "2026-07-19T12:03:00Z",
+      result: {
+        segments_scanned: 150,
+        mentions_found: 8,
+        mentions_skipped: 2,
+        unique_entities: 3,
+        unique_videos: 1,
+        duration_seconds: 120.4,
+        dry_run: false,
+      },
     });
-    mockedApiFetch.mockResolvedValueOnce(expected);
+    mockedApiFetch.mockResolvedValueOnce(response);
 
-    const result = await scanVideoEntities(VIDEO_ID);
+    const result = await getScanJob(JOB_ID);
 
-    expect(result.data.mentions_found).toBe(0);
-    expect(result.data.unique_entities).toBe(0);
+    expect(result.status).toBe("succeeded");
+    expect(result.result?.mentions_found).toBe(8);
+    expect(result.finished_at).toBe("2026-07-19T12:03:00Z");
+  });
+
+  it("returns the unwrapped ScanJob with an error message when failed", async () => {
+    const response = makeScanJobResponse({
+      status: "failed",
+      finished_at: "2026-07-19T12:01:00Z",
+      error: "Database connection lost during scan",
+    });
+    mockedApiFetch.mockResolvedValueOnce(response);
+
+    const result = await getScanJob(JOB_ID);
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("Database connection lost during scan");
+    expect(result.result).toBeNull();
+  });
+
+  it("propagates a 404 ApiError for an unknown job id", async () => {
+    const apiError = { type: "server", message: "Scan job not found", status: 404 };
+    mockedApiFetch.mockRejectedValueOnce(apiError);
+
+    await expect(getScanJob("unknown-job-id")).rejects.toEqual(apiError);
   });
 });

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -36,12 +36,6 @@ export const BATCH_PREVIEW_TIMEOUT = 30000;
 export const TRANSCRIPT_DOWNLOAD_TIMEOUT = 120000;
 
 /**
- * Timeout for entity/video scan requests in milliseconds.
- * Scans can process 1M+ segments and take 2-3 minutes on large corpora.
- */
-export const SCAN_TIMEOUT = 300000;
-
-/**
  * Classifies an error into a specific error type.
  *
  * FR-001: HTTP 401/403 responses are classified as "auth" — distinct from

--- a/frontend/src/api/entityMentions.ts
+++ b/frontend/src/api/entityMentions.ts
@@ -6,7 +6,7 @@
  * - GET /api/v1/entities/{entity_id}/videos — entity-to-videos lookup
  */
 
-import { apiFetch, SCAN_TIMEOUT } from "./config";
+import { apiFetch } from "./config";
 import type { PhoneticMatch } from "../types/corrections";
 
 // ---------------------------------------------------------------------------
@@ -705,44 +705,123 @@ export interface ScanResultResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Scan job types (for the async fire-and-poll scan flow)
+//
+// Scan endpoints now launch a background job (202) instead of blocking for
+// the scan's full duration (which can exceed the client request timeout on
+// large corpora). Callers poll GET /scan-jobs/{job_id} until the job reaches
+// a terminal status.
+// ---------------------------------------------------------------------------
+
+/** What a scan job targets. */
+export type ScanJobKind = "entity" | "video";
+
+/** Lifecycle status of an asynchronous scan job. */
+export type ScanJobStatus = "running" | "succeeded" | "failed";
+
+/**
+ * State of an asynchronous entity-mention scan job, as returned both when a
+ * scan is launched (202) and when polled via GET /scan-jobs/{job_id}.
+ *
+ * Jobs are tracked in an in-memory registry on the backend — ephemeral, does
+ * not survive a server restart.
+ */
+export interface ScanJob {
+  job_id: string;
+  kind: ScanJobKind;
+  /** Entity UUID or video ID being scanned. */
+  target_id: string;
+  status: ScanJobStatus;
+  /** Scan metrics, populated once the job has succeeded. */
+  result: ScanResultData | null;
+  /** Error message if the job failed. */
+  error: string | null;
+  started_at: string;
+  /** When the job reached a terminal state, if it has. */
+  finished_at: string | null;
+}
+
+/** Response envelope for scan-job launch (202) and status endpoints. */
+export interface ScanJobResponse {
+  data: ScanJob;
+}
+
+// ---------------------------------------------------------------------------
 // Entity scan fetchers
 // ---------------------------------------------------------------------------
 
 /**
- * Triggers a transcript scan for a single named entity across all videos.
+ * Launches an asynchronous transcript scan for a single named entity across
+ * all videos.
+ *
+ * The backend runs the scan as a background job and returns immediately
+ * (202) with the job's initial "running" state. Poll `getScanJob(job_id)`
+ * for progress and the final result.
  *
  * @param entityId - UUID of the named entity to scan for
  * @param options - Optional scan parameters (language filter, dry_run, full_rescan)
- * @returns ScanResultResponse with aggregate mention statistics
- * @throws ApiError with status 404 if the entity is not found
+ * @returns The newly created ScanJob (status "running")
+ * @throws ApiError with status 404 if the entity is not found, 409 if a scan
+ *   is already in progress for this entity
  */
 export async function scanEntity(
   entityId: string,
   options?: ScanRequest
-): Promise<ScanResultResponse> {
-  return apiFetch<ScanResultResponse>(`/entities/${entityId}/scan`, {
+): Promise<ScanJob> {
+  const res = await apiFetch<ScanJobResponse>(`/entities/${entityId}/scan`, {
     method: "POST",
     body: JSON.stringify(options ?? {}),
-    timeout: SCAN_TIMEOUT,
   });
+  return res.data;
 }
 
 /**
- * Triggers an entity scan across all known entities for a single video's
- * transcripts.
+ * Launches an asynchronous entity scan across all known entities for a
+ * single video's transcripts.
+ *
+ * The backend runs the scan as a background job and returns immediately
+ * (202) with the job's initial "running" state. Poll `getScanJob(job_id)`
+ * for progress and the final result.
  *
  * @param videoId - YouTube video ID whose transcripts should be scanned
  * @param options - Optional scan parameters (language filter, dry_run, full_rescan)
- * @returns ScanResultResponse with aggregate mention statistics
- * @throws ApiError with status 404 if the video is not found
+ * @returns The newly created ScanJob (status "running")
+ * @throws ApiError with status 404 if the video is not found, 409 if a scan
+ *   is already in progress for this video
  */
 export async function scanVideoEntities(
   videoId: string,
   options?: ScanRequest
-): Promise<ScanResultResponse> {
-  return apiFetch<ScanResultResponse>(`/videos/${videoId}/scan-entities`, {
-    method: "POST",
-    body: JSON.stringify(options ?? {}),
-    timeout: SCAN_TIMEOUT,
+): Promise<ScanJob> {
+  const res = await apiFetch<ScanJobResponse>(
+    `/videos/${videoId}/scan-entities`,
+    {
+      method: "POST",
+      body: JSON.stringify(options ?? {}),
+    }
+  );
+  return res.data;
+}
+
+/**
+ * Fetches the current state of an asynchronous scan job.
+ *
+ * While the job is running, `status` is "running" and `result` is null. On
+ * completion it becomes "succeeded" (with `result` metrics) or "failed"
+ * (with `error`).
+ *
+ * @param jobId - Scan job identifier returned by scanEntity/scanVideoEntities
+ * @param signal - Optional AbortSignal for cancellation (FR-005)
+ * @returns The current ScanJob state
+ * @throws ApiError with status 404 if the job is unknown (including after a
+ *   server restart, since jobs are in-memory only)
+ */
+export async function getScanJob(
+  jobId: string,
+  signal?: AbortSignal
+): Promise<ScanJob> {
+  const res = await apiFetch<ScanJobResponse>(`/scan-jobs/${jobId}`, {
+    ...(signal !== undefined ? { externalSignal: signal } : {}),
   });
+  return res.data;
 }

--- a/frontend/src/components/EntityMentionsPanel.tsx
+++ b/frontend/src/components/EntityMentionsPanel.tsx
@@ -677,10 +677,12 @@ export function EntityMentionsPanel({
                       }
                     },
                     onError: (err) => {
-                      setScanMessage({
-                        text: (err as { message?: string }).message ?? "Scan failed. Please try again.",
-                        kind: "error",
-                      });
+                      const status = (err as { status?: number } | null)?.status;
+                      const text =
+                        status === 409
+                          ? "A scan is already running for this video."
+                          : err.message || "Scan failed. Please try again.";
+                      setScanMessage({ text, kind: "error" });
                     },
                   }
                 );
@@ -702,6 +704,18 @@ export function EntityMentionsPanel({
               )}
             </button>
           </span>
+
+          {/* In-progress announcement — separate from the button so screen
+              readers not focused on the button still hear it via aria-live. */}
+          {scanMutation.isPending && (
+            <p
+              role="status"
+              aria-live="polite"
+              className="text-sm font-medium text-gray-500"
+            >
+              Scanning… (this can take a few minutes)
+            </p>
+          )}
 
           {/* Inline result message */}
           {scanMessage !== null && (

--- a/frontend/src/components/__tests__/EntityMentionsPanel.test.tsx
+++ b/frontend/src/components/__tests__/EntityMentionsPanel.test.tsx
@@ -560,5 +560,64 @@ describe("EntityMentionsPanel", () => {
 
       vi.useRealTimers();
     });
+
+    it("shows a distinct 'already running' message on a 409 launch conflict", () => {
+      const mockMutate = vi.fn().mockImplementation((_vars, callbacks) => {
+        callbacks?.onError?.({ status: 409, message: "A scan is already in progress for this video" });
+      });
+
+      (useScanVideoEntities as Mock).mockReturnValue({
+        mutate: mockMutate,
+        isPending: false,
+        isError: false,
+        error: null,
+        data: null,
+        reset: vi.fn(),
+      });
+
+      renderPanel({ entities: [], hasTranscript: true });
+
+      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+
+      expect(screen.getByRole("alert")).toHaveTextContent(/already running/i);
+    });
+
+    it("shows the job's real failure reason when the async scan job fails", () => {
+      const mockMutate = vi.fn().mockImplementation((_vars, callbacks) => {
+        callbacks?.onError?.({ message: "Transcript fetch timed out" });
+      });
+
+      (useScanVideoEntities as Mock).mockReturnValue({
+        mutate: mockMutate,
+        isPending: false,
+        isError: false,
+        error: null,
+        data: null,
+        reset: vi.fn(),
+      });
+
+      renderPanel({ entities: [], hasTranscript: true });
+
+      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+
+      expect(screen.getByRole("alert")).toHaveTextContent("Transcript fetch timed out");
+    });
+
+    it("shows a 'Scanning… (this can take a few minutes)' status message while the job is running", () => {
+      (useScanVideoEntities as Mock).mockReturnValue({
+        mutate: vi.fn(),
+        isPending: true,
+        isError: false,
+        error: null,
+        data: null,
+        reset: vi.fn(),
+      });
+
+      renderPanel({ entities: [], hasTranscript: true });
+
+      expect(
+        screen.getByText(/scanning.*this can take a few minutes/i)
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/hooks/__tests__/useScanHooks.test.tsx
+++ b/frontend/src/hooks/__tests__/useScanHooks.test.tsx
@@ -1,19 +1,26 @@
 /**
- * Tests for useScanEntity and useScanVideoEntities mutation hooks
- * in hooks/useEntityMentions.ts (Feature 052).
+ * Tests for useScanEntity and useScanVideoEntities launch→poll hooks
+ * in hooks/useEntityMentions.ts (async entity-mention scan flow).
+ *
+ * The scan endpoints now launch a background job (202) instead of blocking
+ * for the scan's full duration. These hooks POST to launch the job, then
+ * poll GET /scan-jobs/{job_id} every 2s while it's running, and resolve via
+ * onSuccess/onError callbacks once the job reaches a terminal status.
  *
  * Coverage:
- * - useScanEntity: calls scanEntity() API with correct entityId and options
- * - useScanEntity: transitions through isPending → isSuccess states
- * - useScanEntity: transitions through isPending → isError states
- * - useScanEntity: invalidates ["entity-detail", entityId] on success
- * - useScanEntity: invalidates ["entity-videos", entityId] on success
- * - useScanEntity: does NOT invalidate on failure
- * - useScanVideoEntities: calls scanVideoEntities() API with correct videoId and options
- * - useScanVideoEntities: transitions through isPending → isSuccess states
- * - useScanVideoEntities: transitions through isPending → isError states
- * - useScanVideoEntities: invalidates ["video-entities", videoId] on success
- * - useScanVideoEntities: does NOT invalidate on failure
+ * - useScanEntity: launches via scanEntity() with correct entityId/options
+ * - useScanEntity: launch→poll→succeeded — isPending true until terminal,
+ *   then isSuccess, data.data exposes the result, onSuccess callback fires
+ * - useScanEntity: launch→poll→failed — onError fires with the job's real
+ *   error message (not a generic message)
+ * - useScanEntity: 409 on launch (already in progress) — onError fires
+ *   immediately with status 409, no polling occurs
+ * - useScanEntity: polls getScanJob every 2s while running, stops once terminal
+ * - useScanEntity: invalidates ["entity-detail", entityId] and
+ *   ["entity-videos", entityId] only on success, never on failure
+ * - useScanVideoEntities: launches via scanVideoEntities() with correct videoId/options
+ * - useScanVideoEntities: launch→poll→succeeded / failed / 409 (mirrors useScanEntity)
+ * - useScanVideoEntities: invalidates only ["video-entities", videoId] on success
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -21,9 +28,9 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 
-import { scanEntity, scanVideoEntities } from "../../api/entityMentions";
+import { scanEntity, scanVideoEntities, getScanJob } from "../../api/entityMentions";
 import { useScanEntity, useScanVideoEntities } from "../useEntityMentions";
-import type { ScanResultResponse } from "../../api/entityMentions";
+import type { ScanJob } from "../../api/entityMentions";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -32,6 +39,7 @@ import type { ScanResultResponse } from "../../api/entityMentions";
 vi.mock("../../api/entityMentions", () => ({
   scanEntity: vi.fn(),
   scanVideoEntities: vi.fn(),
+  getScanJob: vi.fn(),
   // Stub all other exports that useEntityMentions imports transitively.
   fetchVideoEntities: vi.fn(),
   fetchEntityVideos: vi.fn(),
@@ -51,6 +59,7 @@ vi.mock("../../api/entityMentions", () => ({
 
 const mockedScanEntity = vi.mocked(scanEntity);
 const mockedScanVideoEntities = vi.mocked(scanVideoEntities);
+const mockedGetScanJob = vi.mocked(getScanJob);
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -77,29 +86,57 @@ function createWrapper(queryClient: QueryClient) {
 
 const ENTITY_ID = "entity-uuid-abc123";
 const VIDEO_ID = "dQw4w9WgXcQ";
+const JOB_ID = "scan-job-xyz";
 
-function makeScanResultResponse(
-  overrides: Partial<ScanResultResponse["data"]> = {}
-): ScanResultResponse {
+function makeJob(overrides: Partial<ScanJob> = {}): ScanJob {
   return {
-    data: {
+    job_id: JOB_ID,
+    kind: "entity",
+    target_id: ENTITY_ID,
+    status: "running",
+    result: null,
+    error: null,
+    started_at: "2026-07-19T12:00:00Z",
+    finished_at: null,
+    ...overrides,
+  };
+}
+
+function makeSucceededJob(
+  resultOverrides: Partial<NonNullable<ScanJob["result"]>> = {},
+  jobOverrides: Partial<ScanJob> = {}
+): ScanJob {
+  return makeJob({
+    status: "succeeded",
+    finished_at: "2026-07-19T12:03:00Z",
+    result: {
       segments_scanned: 100,
       mentions_found: 5,
       mentions_skipped: 0,
       unique_entities: 2,
       unique_videos: 1,
-      duration_seconds: 0.3,
+      duration_seconds: 120.3,
       dry_run: false,
-      ...overrides,
+      ...resultOverrides,
     },
-  };
+    ...jobOverrides,
+  });
+}
+
+function makeFailedJob(error: string, jobOverrides: Partial<ScanJob> = {}): ScanJob {
+  return makeJob({
+    status: "failed",
+    finished_at: "2026-07-19T12:01:00Z",
+    error,
+    ...jobOverrides,
+  });
 }
 
 // ===========================================================================
 // useScanEntity
 // ===========================================================================
 
-describe("useScanEntity — mutation execution", () => {
+describe("useScanEntity — launch and terminal states", () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {
@@ -107,25 +144,20 @@ describe("useScanEntity — mutation execution", () => {
     vi.clearAllMocks();
   });
 
-  it("calls scanEntity with the provided entityId when mutate is invoked", async () => {
-    mockedScanEntity.mockResolvedValueOnce(makeScanResultResponse());
-
+  it("starts in idle state with no data", () => {
     const { result } = renderHook(() => useScanEntity(), {
       wrapper: createWrapper(queryClient),
     });
 
-    await act(async () => {
-      result.current.mutate({ entityId: ENTITY_ID });
-    });
-
-    await waitFor(() => result.current.isSuccess);
-
-    expect(mockedScanEntity).toHaveBeenCalledOnce();
-    expect(mockedScanEntity).toHaveBeenCalledWith(ENTITY_ID, undefined);
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toBeUndefined();
   });
 
-  it("calls scanEntity with options when options are provided", async () => {
-    mockedScanEntity.mockResolvedValueOnce(makeScanResultResponse({ dry_run: true }));
+  it("calls scanEntity with the provided entityId and options to launch the scan", async () => {
+    mockedScanEntity.mockResolvedValueOnce(makeJob());
+    mockedGetScanJob.mockResolvedValueOnce(makeSucceededJob());
 
     const { result } = renderHook(() => useScanEntity(), {
       wrapper: createWrapper(queryClient),
@@ -134,21 +166,48 @@ describe("useScanEntity — mutation execution", () => {
     await act(async () => {
       result.current.mutate({
         entityId: ENTITY_ID,
-        options: { dry_run: true, language_code: "en" },
+        options: { sources: ["transcript", "title"] },
       });
     });
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockedScanEntity).toHaveBeenCalledWith(ENTITY_ID, {
-      dry_run: true,
-      language_code: "en",
+      sources: ["transcript", "title"],
     });
   });
 
-  it("transitions to isSuccess and exposes response data", async () => {
-    const response = makeScanResultResponse({ mentions_found: 10, unique_videos: 3 });
-    mockedScanEntity.mockResolvedValueOnce(response);
+  it("isPending is true immediately after launch and while the job is running", async () => {
+    let resolveJob!: (job: ScanJob) => void;
+    mockedScanEntity.mockResolvedValueOnce(makeJob());
+    mockedGetScanJob.mockReturnValueOnce(
+      new Promise<ScanJob>((resolve) => {
+        resolveJob = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useScanEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate({ entityId: ENTITY_ID });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+
+    // Resolve the poll so the test doesn't leave a dangling promise.
+    await act(async () => {
+      resolveJob(makeSucceededJob());
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("transitions to isSuccess with data.data exposing the result once the job succeeds", async () => {
+    mockedScanEntity.mockResolvedValueOnce(makeJob());
+    mockedGetScanJob.mockResolvedValueOnce(
+      makeSucceededJob({ mentions_found: 12, unique_videos: 4 })
+    );
 
     const { result } = renderHook(() => useScanEntity(), {
       wrapper: createWrapper(queryClient),
@@ -158,15 +217,90 @@ describe("useScanEntity — mutation execution", () => {
       result.current.mutate({ entityId: ENTITY_ID });
     });
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.isPending).toBe(false);
     expect(result.current.isError).toBe(false);
-    expect(result.current.data?.data.mentions_found).toBe(10);
-    expect(result.current.data?.data.unique_videos).toBe(3);
+    expect(result.current.data?.data.mentions_found).toBe(12);
+    expect(result.current.data?.data.unique_videos).toBe(4);
   });
 
-  it("transitions to isError when scanEntity throws", async () => {
+  it("fires the onSuccess callback with the terminal result once the job succeeds", async () => {
+    mockedScanEntity.mockResolvedValueOnce(makeJob());
+    mockedGetScanJob.mockResolvedValueOnce(
+      makeSucceededJob({ mentions_found: 7, unique_videos: 3 })
+    );
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useScanEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ entityId: ENTITY_ID }, { onSuccess, onError });
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
+
+    expect(onSuccess).toHaveBeenCalledWith({
+      data: expect.objectContaining({ mentions_found: 7, unique_videos: 3 }),
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("fires onError with the job's real failure reason when the job fails", async () => {
+    mockedScanEntity.mockResolvedValueOnce(makeJob());
+    mockedGetScanJob.mockResolvedValueOnce(
+      makeFailedJob("Database connection lost during scan")
+    );
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useScanEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ entityId: ENTITY_ID }, { onSuccess, onError });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Database connection lost during scan" })
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(result.current.error?.message).toBe("Database connection lost during scan");
+  });
+
+  it("fires onError immediately with status 409 when a scan is already in progress", async () => {
+    mockedScanEntity.mockRejectedValueOnce({
+      type: "server",
+      message: "A scan is already in progress for this entity",
+      status: 409,
+    });
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useScanEntity(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ entityId: ENTITY_ID }, { onError });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 409 })
+    );
+    // No polling should occur — the scan never launched a job.
+    expect(mockedGetScanJob).not.toHaveBeenCalled();
+  });
+
+  it("does not poll further once a 404 launch error occurs", async () => {
     mockedScanEntity.mockRejectedValueOnce({
       type: "server",
       message: "Entity not found",
@@ -181,26 +315,15 @@ describe("useScanEntity — mutation execution", () => {
       result.current.mutate({ entityId: ENTITY_ID });
     });
 
-    await waitFor(() => result.current.isError);
+    await waitFor(() => expect(result.current.isError).toBe(true));
 
-    expect(result.current.isError).toBe(true);
-    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.error?.status).toBe(404);
+    expect(mockedGetScanJob).not.toHaveBeenCalled();
   });
 
-  it("starts in idle state with no data", () => {
-    const { result } = renderHook(() => useScanEntity(), {
-      wrapper: createWrapper(queryClient),
-    });
-
-    expect(result.current.isPending).toBe(false);
-    expect(result.current.isSuccess).toBe(false);
-    expect(result.current.isError).toBe(false);
-    expect(result.current.data).toBeUndefined();
-  });
-
-  it("exposes zero-result scan data when mentions_found is 0", async () => {
-    const response = makeScanResultResponse({ mentions_found: 0, unique_videos: 0 });
-    mockedScanEntity.mockResolvedValueOnce(response);
+  it("reset() clears the flow back to idle state", async () => {
+    mockedScanEntity.mockResolvedValueOnce(makeJob());
+    mockedGetScanJob.mockResolvedValueOnce(makeSucceededJob());
 
     const { result } = renderHook(() => useScanEntity(), {
       wrapper: createWrapper(queryClient),
@@ -210,14 +333,19 @@ describe("useScanEntity — mutation execution", () => {
       result.current.mutate({ entityId: ENTITY_ID });
     });
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data?.data.mentions_found).toBe(0);
-    expect(result.current.data?.data.unique_videos).toBe(0);
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.data).toBeUndefined();
   });
 });
 
-describe("useScanEntity — onSuccess cache invalidation", () => {
+describe("useScanEntity — polling behaviour", () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {
@@ -225,10 +353,15 @@ describe("useScanEntity — onSuccess cache invalidation", () => {
     vi.clearAllMocks();
   });
 
-  it("invalidates ['entity-detail', entityId] after a successful scan", async () => {
-    mockedScanEntity.mockResolvedValueOnce(makeScanResultResponse());
-
-    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  it("polls getScanJob again while the job is still running, and stops once terminal", async () => {
+    // Verifies the launch→poll→poll→terminal sequence without asserting on
+    // exact interval timing (TanStack's refetchInterval scheduling is
+    // exercised generically for this same pattern in useOnboarding.test.ts).
+    mockedScanEntity.mockResolvedValueOnce(makeJob());
+    mockedGetScanJob
+      .mockResolvedValueOnce(makeJob({ status: "running" }))
+      .mockResolvedValueOnce(makeJob({ status: "running" }))
+      .mockResolvedValueOnce(makeSucceededJob());
 
     const { result } = renderHook(() => useScanEntity(), {
       wrapper: createWrapper(queryClient),
@@ -238,15 +371,38 @@ describe("useScanEntity — onSuccess cache invalidation", () => {
       result.current.mutate({ entityId: ENTITY_ID });
     });
 
-    await waitFor(() => result.current.isSuccess);
+    // Still running after the first poll resolves.
+    await waitFor(() => expect(mockedGetScanJob).toHaveBeenCalledTimes(1));
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.isSuccess).toBe(false);
 
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ["entity-detail", ENTITY_ID] })
-    );
+    // Manually trigger the next poll (bypassing the real 2s interval) by
+    // invalidating the scan-job query — mirrors what refetchInterval does.
+    await act(async () => {
+      await queryClient.refetchQueries({ queryKey: ["scan-job"], exact: false });
+    });
+    await waitFor(() => expect(mockedGetScanJob).toHaveBeenCalledTimes(2));
+    expect(result.current.isPending).toBe(true);
+
+    await act(async () => {
+      await queryClient.refetchQueries({ queryKey: ["scan-job"], exact: false });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedGetScanJob).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("useScanEntity — cache invalidation", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createQueryClient();
+    vi.clearAllMocks();
   });
 
-  it("invalidates ['entity-videos', entityId] after a successful scan", async () => {
-    mockedScanEntity.mockResolvedValueOnce(makeScanResultResponse());
+  it("invalidates ['entity-detail', entityId] and ['entity-videos', entityId] once the job succeeds", async () => {
+    mockedScanEntity.mockResolvedValueOnce(makeJob());
+    mockedGetScanJob.mockResolvedValueOnce(makeSucceededJob());
 
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -258,66 +414,39 @@ describe("useScanEntity — onSuccess cache invalidation", () => {
       result.current.mutate({ entityId: ENTITY_ID });
     });
 
-    await waitFor(() => result.current.isSuccess);
-
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ["entity-videos", ENTITY_ID] })
-    );
-  });
-
-  it("invalidates both entity-detail and entity-videos on a single success", async () => {
-    mockedScanEntity.mockResolvedValueOnce(makeScanResultResponse());
-
-    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const { result } = renderHook(() => useScanEntity(), {
-      wrapper: createWrapper(queryClient),
-    });
-
-    await act(async () => {
-      result.current.mutate({ entityId: ENTITY_ID });
-    });
-
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const invalidatedKeys = invalidateSpy.mock.calls.map(
       (call) => (call[0] as { queryKey: unknown[] }).queryKey
     );
-
     expect(invalidatedKeys).toContainEqual(["entity-detail", ENTITY_ID]);
     expect(invalidatedKeys).toContainEqual(["entity-videos", ENTITY_ID]);
   });
 
-  it("uses the correct entityId in cache keys — not a different entity's ID", async () => {
-    mockedScanEntity.mockResolvedValueOnce(makeScanResultResponse());
+  it("does NOT invalidate any caches when the job fails", async () => {
+    mockedScanEntity.mockResolvedValueOnce(makeJob());
+    mockedGetScanJob.mockResolvedValueOnce(makeFailedJob("boom"));
 
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const SPECIFIC_ENTITY_ID = "specific-entity-xyz";
 
     const { result } = renderHook(() => useScanEntity(), {
       wrapper: createWrapper(queryClient),
     });
 
     await act(async () => {
-      result.current.mutate({ entityId: SPECIFIC_ENTITY_ID });
+      result.current.mutate({ entityId: ENTITY_ID });
     });
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isError).toBe(true));
 
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ["entity-detail", SPECIFIC_ENTITY_ID] })
-    );
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ["entity-videos", SPECIFIC_ENTITY_ID] })
-    );
+    expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
-  it("does NOT invalidate caches when the scan mutation fails", async () => {
+  it("does NOT invalidate any caches on a 409 launch failure", async () => {
     mockedScanEntity.mockRejectedValueOnce({
       type: "server",
-      message: "Internal server error",
-      status: 500,
+      message: "already running",
+      status: 409,
     });
 
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -330,7 +459,7 @@ describe("useScanEntity — onSuccess cache invalidation", () => {
       result.current.mutate({ entityId: ENTITY_ID });
     });
 
-    await waitFor(() => result.current.isError);
+    await waitFor(() => expect(result.current.isError).toBe(true));
 
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
@@ -340,95 +469,12 @@ describe("useScanEntity — onSuccess cache invalidation", () => {
 // useScanVideoEntities
 // ===========================================================================
 
-describe("useScanVideoEntities — mutation execution", () => {
+describe("useScanVideoEntities — launch and terminal states", () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {
     queryClient = createQueryClient();
     vi.clearAllMocks();
-  });
-
-  it("calls scanVideoEntities with the provided videoId when mutate is invoked", async () => {
-    mockedScanVideoEntities.mockResolvedValueOnce(makeScanResultResponse());
-
-    const { result } = renderHook(() => useScanVideoEntities(), {
-      wrapper: createWrapper(queryClient),
-    });
-
-    await act(async () => {
-      result.current.mutate({ videoId: VIDEO_ID });
-    });
-
-    await waitFor(() => result.current.isSuccess);
-
-    expect(mockedScanVideoEntities).toHaveBeenCalledOnce();
-    expect(mockedScanVideoEntities).toHaveBeenCalledWith(VIDEO_ID, undefined);
-  });
-
-  it("calls scanVideoEntities with options when options are provided", async () => {
-    mockedScanVideoEntities.mockResolvedValueOnce(makeScanResultResponse());
-
-    const { result } = renderHook(() => useScanVideoEntities(), {
-      wrapper: createWrapper(queryClient),
-    });
-
-    await act(async () => {
-      result.current.mutate({
-        videoId: VIDEO_ID,
-        options: { entity_type: "person", language_code: "fr" },
-      });
-    });
-
-    await waitFor(() => result.current.isSuccess);
-
-    expect(mockedScanVideoEntities).toHaveBeenCalledWith(VIDEO_ID, {
-      entity_type: "person",
-      language_code: "fr",
-    });
-  });
-
-  it("transitions to isSuccess and exposes response data", async () => {
-    const response = makeScanResultResponse({
-      unique_entities: 5,
-      mentions_found: 18,
-    });
-    mockedScanVideoEntities.mockResolvedValueOnce(response);
-
-    const { result } = renderHook(() => useScanVideoEntities(), {
-      wrapper: createWrapper(queryClient),
-    });
-
-    await act(async () => {
-      result.current.mutate({ videoId: VIDEO_ID });
-    });
-
-    await waitFor(() => result.current.isSuccess);
-
-    expect(result.current.isSuccess).toBe(true);
-    expect(result.current.isError).toBe(false);
-    expect(result.current.data?.data.unique_entities).toBe(5);
-    expect(result.current.data?.data.mentions_found).toBe(18);
-  });
-
-  it("transitions to isError when scanVideoEntities throws", async () => {
-    mockedScanVideoEntities.mockRejectedValueOnce({
-      type: "server",
-      message: "Video not found",
-      status: 404,
-    });
-
-    const { result } = renderHook(() => useScanVideoEntities(), {
-      wrapper: createWrapper(queryClient),
-    });
-
-    await act(async () => {
-      result.current.mutate({ videoId: VIDEO_ID });
-    });
-
-    await waitFor(() => result.current.isError);
-
-    expect(result.current.isError).toBe(true);
-    expect(result.current.isSuccess).toBe(false);
   });
 
   it("starts in idle state with no data", () => {
@@ -442,12 +488,42 @@ describe("useScanVideoEntities — mutation execution", () => {
     expect(result.current.data).toBeUndefined();
   });
 
-  it("exposes zero-result scan data when no entities were found in the video", async () => {
-    const response = makeScanResultResponse({
-      mentions_found: 0,
-      unique_entities: 0,
+  it("calls scanVideoEntities with the provided videoId and options to launch the scan", async () => {
+    mockedScanVideoEntities.mockResolvedValueOnce(
+      makeJob({ kind: "video", target_id: VIDEO_ID })
+    );
+    mockedGetScanJob.mockResolvedValueOnce(
+      makeSucceededJob({}, { kind: "video", target_id: VIDEO_ID })
+    );
+
+    const { result } = renderHook(() => useScanVideoEntities(), {
+      wrapper: createWrapper(queryClient),
     });
-    mockedScanVideoEntities.mockResolvedValueOnce(response);
+
+    await act(async () => {
+      result.current.mutate({
+        videoId: VIDEO_ID,
+        options: { entity_type: "person" },
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedScanVideoEntities).toHaveBeenCalledWith(VIDEO_ID, {
+      entity_type: "person",
+    });
+  });
+
+  it("transitions to isSuccess and exposes the result once the job succeeds", async () => {
+    mockedScanVideoEntities.mockResolvedValueOnce(
+      makeJob({ kind: "video", target_id: VIDEO_ID })
+    );
+    mockedGetScanJob.mockResolvedValueOnce(
+      makeSucceededJob(
+        { unique_entities: 5, mentions_found: 18 },
+        { kind: "video", target_id: VIDEO_ID }
+      )
+    );
 
     const { result } = renderHook(() => useScanVideoEntities(), {
       wrapper: createWrapper(queryClient),
@@ -457,14 +533,63 @@ describe("useScanVideoEntities — mutation execution", () => {
       result.current.mutate({ videoId: VIDEO_ID });
     });
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data?.data.mentions_found).toBe(0);
-    expect(result.current.data?.data.unique_entities).toBe(0);
+    expect(result.current.data?.data.unique_entities).toBe(5);
+    expect(result.current.data?.data.mentions_found).toBe(18);
+  });
+
+  it("fires onError with the job's real failure reason when the job fails", async () => {
+    mockedScanVideoEntities.mockResolvedValueOnce(
+      makeJob({ kind: "video", target_id: VIDEO_ID })
+    );
+    mockedGetScanJob.mockResolvedValueOnce(
+      makeFailedJob("Transcript fetch timed out", {
+        kind: "video",
+        target_id: VIDEO_ID,
+      })
+    );
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useScanVideoEntities(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ videoId: VIDEO_ID }, { onError });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Transcript fetch timed out" })
+    );
+  });
+
+  it("fires onError immediately with status 409 when a scan is already in progress", async () => {
+    mockedScanVideoEntities.mockRejectedValueOnce({
+      type: "server",
+      message: "A scan is already in progress for this video",
+      status: 409,
+    });
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useScanVideoEntities(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ videoId: VIDEO_ID }, { onError });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ status: 409 }));
+    expect(mockedGetScanJob).not.toHaveBeenCalled();
   });
 });
 
-describe("useScanVideoEntities — onSuccess cache invalidation", () => {
+describe("useScanVideoEntities — cache invalidation", () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {
@@ -472,54 +597,13 @@ describe("useScanVideoEntities — onSuccess cache invalidation", () => {
     vi.clearAllMocks();
   });
 
-  it("invalidates ['video-entities', videoId] after a successful scan", async () => {
-    mockedScanVideoEntities.mockResolvedValueOnce(makeScanResultResponse());
-
-    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const { result } = renderHook(() => useScanVideoEntities(), {
-      wrapper: createWrapper(queryClient),
-    });
-
-    await act(async () => {
-      result.current.mutate({ videoId: VIDEO_ID });
-    });
-
-    await waitFor(() => result.current.isSuccess);
-
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ["video-entities", VIDEO_ID] })
+  it("invalidates only ['video-entities', videoId] on success", async () => {
+    mockedScanVideoEntities.mockResolvedValueOnce(
+      makeJob({ kind: "video", target_id: VIDEO_ID })
     );
-  });
-
-  it("uses the correct videoId in the cache key", async () => {
-    mockedScanVideoEntities.mockResolvedValueOnce(makeScanResultResponse());
-
-    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const SPECIFIC_VIDEO_ID = "specific-video-abc";
-
-    const { result } = renderHook(() => useScanVideoEntities(), {
-      wrapper: createWrapper(queryClient),
-    });
-
-    await act(async () => {
-      result.current.mutate({ videoId: SPECIFIC_VIDEO_ID });
-    });
-
-    await waitFor(() => result.current.isSuccess);
-
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ["video-entities", SPECIFIC_VIDEO_ID] })
+    mockedGetScanJob.mockResolvedValueOnce(
+      makeSucceededJob({}, { kind: "video", target_id: VIDEO_ID })
     );
-  });
-
-  it("does NOT invalidate caches when the scan mutation fails", async () => {
-    mockedScanVideoEntities.mockRejectedValueOnce({
-      type: "server",
-      message: "Internal server error",
-      status: 500,
-    });
 
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -531,31 +615,36 @@ describe("useScanVideoEntities — onSuccess cache invalidation", () => {
       result.current.mutate({ videoId: VIDEO_ID });
     });
 
-    await waitFor(() => result.current.isError);
-
-    expect(invalidateSpy).not.toHaveBeenCalled();
-  });
-
-  it("does NOT invalidate entity-detail or entity-videos (those belong to useScanEntity)", async () => {
-    mockedScanVideoEntities.mockResolvedValueOnce(makeScanResultResponse());
-
-    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
-
-    const { result } = renderHook(() => useScanVideoEntities(), {
-      wrapper: createWrapper(queryClient),
-    });
-
-    await act(async () => {
-      result.current.mutate({ videoId: VIDEO_ID });
-    });
-
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const invalidatedKeys = invalidateSpy.mock.calls.map(
-      (call) => (call[0] as { queryKey: unknown[] }).queryKey[0]
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey
+    );
+    expect(invalidatedKeys).toContainEqual(["video-entities", VIDEO_ID]);
+    expect(invalidatedKeys).not.toContainEqual(["entity-detail", VIDEO_ID]);
+    expect(invalidatedKeys).not.toContainEqual(["entity-videos", VIDEO_ID]);
+  });
+
+  it("does NOT invalidate any caches when the job fails", async () => {
+    mockedScanVideoEntities.mockResolvedValueOnce(
+      makeJob({ kind: "video", target_id: VIDEO_ID })
+    );
+    mockedGetScanJob.mockResolvedValueOnce(
+      makeFailedJob("boom", { kind: "video", target_id: VIDEO_ID })
     );
 
-    expect(invalidatedKeys).not.toContain("entity-detail");
-    expect(invalidatedKeys).not.toContain("entity-videos");
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useScanVideoEntities(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ videoId: VIDEO_ID });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useEntityMentions.ts
+++ b/frontend/src/hooks/useEntityMentions.ts
@@ -7,7 +7,7 @@
  */
 
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   fetchVideoEntities,
@@ -20,6 +20,7 @@ import {
   createEntity,
   scanEntity,
   scanVideoEntities,
+  getScanJob,
 } from "../api/entityMentions";
 import type {
   VideoEntitySummary,
@@ -36,6 +37,7 @@ import type {
   CreateEntityResponse,
   ScanRequest,
   ScanResultResponse,
+  ScanJob,
 } from "../api/entityMentions";
 import type { ApiError } from "../types/video";
 
@@ -658,6 +660,168 @@ export function useCheckDuplicate(name: string, entityType: string) {
 }
 
 // ---------------------------------------------------------------------------
+// Scan job polling (shared launch→poll flow for entity/video scans)
+// ---------------------------------------------------------------------------
+//
+// Entity-mention scans are launched as an async background job on the
+// backend (202) rather than blocking the request for the scan's full
+// duration, which can exceed the client timeout on large corpora. The flow
+// is:
+//   1. `mutate()` POSTs to launch the scan and receives a job_id.
+//   2. A polling query fetches GET /scan-jobs/{job_id} every 2s while the
+//      job's status is "running".
+//   3. Once the job reaches a terminal status, the relevant caches are
+//      invalidated (once per job) and the caller's onSuccess/onError
+//      callback fires with a shape matching the old synchronous response.
+
+/** Poll interval, in milliseconds, while a scan job is running. */
+const SCAN_POLL_INTERVAL_MS = 2000;
+
+/** Query key for a scan job's polled status. */
+function scanJobKey(jobId: string | null) {
+  return ["scan-job", jobId] as const;
+}
+
+/**
+ * Polls GET /scan-jobs/{jobId} every `SCAN_POLL_INTERVAL_MS` while the job's
+ * status is "running". Disabled when `jobId` is null.
+ */
+function useScanJobPoll(jobId: string | null) {
+  return useQuery<ScanJob, ApiError>({
+    queryKey: scanJobKey(jobId),
+    // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
+    queryFn: ({ signal }) => getScanJob(jobId as string, signal),
+    enabled: jobId !== null,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === "running" ? SCAN_POLL_INTERVAL_MS : false;
+    },
+    staleTime: SCAN_POLL_INTERVAL_MS,
+    gcTime: 5 * 60 * 1000,
+    retry: false,
+  });
+}
+
+/** Callbacks invoked once a launched scan job reaches a terminal status. */
+export interface ScanFlowCallbacks {
+  /** Fired when the job succeeds; `data` mirrors the pre-async ScanResultResponse shape. */
+  onSuccess?: (data: ScanResultResponse) => void;
+  /** Fired when the job fails, or when the launch request itself fails (e.g. 404/409). */
+  onError?: (error: ApiError) => void;
+}
+
+/** Public shape returned by useScanEntity / useScanVideoEntities. */
+export interface UseScanFlowResult<TVariables> {
+  /** Launches the scan; `callbacks` fire once the job reaches a terminal status. */
+  mutate: (variables: TVariables, callbacks?: ScanFlowCallbacks) => void;
+  /** True from the moment `mutate` is called until the job reaches a terminal status. */
+  isPending: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  /** The launch error, or a synthesized ApiError from a failed job's `error` string. */
+  error: ApiError | null;
+  /** The terminal scan result, once the job has succeeded. */
+  data: ScanResultResponse | undefined;
+  /** Resets the flow back to idle (e.g. before retrying). */
+  reset: () => void;
+}
+
+/**
+ * Internal factory shared by useScanEntity and useScanVideoEntities.
+ *
+ * Wraps a launch mutation and a job-status polling query behind a
+ * mutation-like interface so call sites barely change from the previous
+ * synchronous mutation: `mutate(variables, { onSuccess, onError })`,
+ * `isPending`, `data`, `error`.
+ *
+ * @param launch - Fetcher that POSTs the scan request and returns the job_id
+ * @param getInvalidationKeys - Given the job's target_id, returns the query
+ *   keys to invalidate once the job succeeds
+ */
+function useScanJobFlow<TVariables>(
+  launch: (variables: TVariables) => Promise<ScanJob>,
+  getInvalidationKeys: (targetId: string) => readonly (readonly unknown[])[]
+): UseScanFlowResult<TVariables> {
+  const queryClient = useQueryClient();
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const callbacksRef = useRef<ScanFlowCallbacks | null>(null);
+  // Guards against firing the terminal callback/invalidation more than once
+  // for the same job (the poll query can re-render with the same terminal
+  // status multiple times).
+  const settledJobIdRef = useRef<string | null>(null);
+
+  const launchMutation = useMutation<ScanJob, ApiError, TVariables>({
+    mutationFn: launch,
+    onSuccess: (job) => {
+      settledJobIdRef.current = null;
+      setActiveJobId(job.job_id);
+    },
+    onError: (err) => {
+      const callbacks = callbacksRef.current;
+      callbacksRef.current = null;
+      callbacks?.onError?.(err);
+    },
+  });
+
+  const { data: job } = useScanJobPoll(activeJobId);
+
+  useEffect(() => {
+    if (!job || job.status === "running") return;
+    if (activeJobId === null || settledJobIdRef.current === activeJobId) return;
+    settledJobIdRef.current = activeJobId;
+
+    const callbacks = callbacksRef.current;
+    callbacksRef.current = null;
+
+    if (job.status === "succeeded") {
+      for (const queryKey of getInvalidationKeys(job.target_id)) {
+        void queryClient.invalidateQueries({ queryKey: queryKey as unknown[] });
+      }
+      if (job.result) {
+        callbacks?.onSuccess?.({ data: job.result });
+      }
+    } else {
+      callbacks?.onError?.({
+        type: "server",
+        message: job.error ?? "Scan failed.",
+      });
+    }
+  }, [job, activeJobId, queryClient, getInvalidationKeys]);
+
+  const mutate = useCallback(
+    (variables: TVariables, callbacks?: ScanFlowCallbacks) => {
+      callbacksRef.current = callbacks ?? null;
+      settledJobIdRef.current = null;
+      setActiveJobId(null);
+      launchMutation.mutate(variables);
+    },
+    [launchMutation]
+  );
+
+  const reset = useCallback(() => {
+    setActiveJobId(null);
+    settledJobIdRef.current = null;
+    callbacksRef.current = null;
+    launchMutation.reset();
+  }, [launchMutation]);
+
+  const isPending =
+    launchMutation.isPending ||
+    (activeJobId !== null && (job === undefined || job.status === "running"));
+  const isSuccess = job?.status === "succeeded";
+  const isError = launchMutation.isError || job?.status === "failed";
+  const error: ApiError | null =
+    launchMutation.error ??
+    (job?.status === "failed"
+      ? { type: "server", message: job.error ?? "Scan failed." }
+      : null);
+  const data: ScanResultResponse | undefined =
+    job?.status === "succeeded" && job.result ? { data: job.result } : undefined;
+
+  return { mutate, isPending, isSuccess, isError, error, data, reset };
+}
+
+// ---------------------------------------------------------------------------
 // useScanEntity
 // ---------------------------------------------------------------------------
 
@@ -670,43 +834,50 @@ export interface ScanEntityVariables {
 }
 
 /**
- * Mutation hook that triggers a transcript scan for a single named entity
- * across all videos.
+ * Launch→poll hook that triggers an async transcript scan for a single named
+ * entity across all videos, then polls the job to completion.
+ *
+ * The scan runs as a background job on the backend (202 response). This
+ * hook polls `GET /scan-jobs/{job_id}` every 2s while the job is running and
+ * resolves via the `onSuccess`/`onError` callbacks once it reaches a
+ * terminal status — mirroring the ergonomics of a single long-running
+ * mutation without holding the HTTP connection open.
  *
  * On success, invalidates caches for:
  * - `entity-detail` (so the entity header reflects updated mention counts)
  * - `entity-videos` (so the entity-to-videos list refreshes)
  *
- * Error handling is left to the caller — use `mutation.isError` and
- * `mutation.error` to display inline error messages.
+ * A 409 launch error ("scan already in progress") and a failed job both
+ * surface via `onError` — inspect `error.status` (409 for "already running")
+ * vs. `error.message` (the job's real failure reason) to distinguish them.
  *
- * @returns UseMutationResult with `mutate({ entityId, options? })`
+ * @returns `{ mutate({ entityId, options? }, { onSuccess, onError }), isPending, data, error, ... }`
  *
  * @example
  * ```tsx
- * const mutation = useScanEntity();
- * mutation.mutate({ entityId: "ent-uuid", options: { dry_run: true } });
- * if (mutation.data) {
- *   console.log(mutation.data.data.mentions_found);
- * }
+ * const scan = useScanEntity();
+ * scan.mutate(
+ *   { entityId: "ent-uuid" },
+ *   {
+ *     onSuccess: (data) => console.log(data.data.mentions_found),
+ *     onError: (err) => console.error(err.message),
+ *   }
+ * );
  * ```
  */
-export function useScanEntity() {
-  const queryClient = useQueryClient();
-
-  return useMutation<ScanResultResponse, ApiError, ScanEntityVariables>({
-    mutationFn: ({ entityId, options }: ScanEntityVariables) =>
-      scanEntity(entityId, options),
-
-    onSuccess: (_data, variables) => {
-      void queryClient.invalidateQueries({
-        queryKey: ["entity-detail", variables.entityId],
-      });
-      void queryClient.invalidateQueries({
-        queryKey: ["entity-videos", variables.entityId],
-      });
-    },
-  });
+export function useScanEntity(): UseScanFlowResult<ScanEntityVariables> {
+  const launch = useCallback(
+    ({ entityId, options }: ScanEntityVariables) => scanEntity(entityId, options),
+    []
+  );
+  const getInvalidationKeys = useCallback(
+    (targetId: string) => [
+      ["entity-detail", targetId],
+      ["entity-videos", targetId],
+    ],
+    []
+  );
+  return useScanJobFlow(launch, getInvalidationKeys);
 }
 
 // ---------------------------------------------------------------------------
@@ -722,34 +893,31 @@ export interface ScanVideoEntitiesVariables {
 }
 
 /**
- * Mutation hook that triggers an entity scan across all known entities for
- * a single video's transcripts.
+ * Launch→poll hook that triggers an async entity scan across all known
+ * entities for a single video's transcripts, then polls the job to
+ * completion.
  *
- * On success, invalidates the cache for:
+ * See `useScanEntity` for the shared launch→poll behaviour. On success,
+ * invalidates the cache for:
  * - `video-entities` (so the EntityMentionsPanel refreshes with new detections)
  *
- * Error handling is left to the caller — use `mutation.isError` and
- * `mutation.error` to display inline error messages.
- *
- * @returns UseMutationResult with `mutate({ videoId, options? })`
+ * @returns `{ mutate({ videoId, options? }, { onSuccess, onError }), isPending, data, error, ... }`
  *
  * @example
  * ```tsx
- * const mutation = useScanVideoEntities();
- * mutation.mutate({ videoId: "dQw4w9WgXcQ" });
+ * const scan = useScanVideoEntities();
+ * scan.mutate({ videoId: "dQw4w9WgXcQ" }, { onSuccess: (data) => { ... } });
  * ```
  */
-export function useScanVideoEntities() {
-  const queryClient = useQueryClient();
-
-  return useMutation<ScanResultResponse, ApiError, ScanVideoEntitiesVariables>({
-    mutationFn: ({ videoId, options }: ScanVideoEntitiesVariables) =>
+export function useScanVideoEntities(): UseScanFlowResult<ScanVideoEntitiesVariables> {
+  const launch = useCallback(
+    ({ videoId, options }: ScanVideoEntitiesVariables) =>
       scanVideoEntities(videoId, options),
-
-    onSuccess: (_data, variables) => {
-      void queryClient.invalidateQueries({
-        queryKey: ["video-entities", variables.videoId],
-      });
-    },
-  });
+    []
+  );
+  const getInvalidationKeys = useCallback(
+    (targetId: string) => [["video-entities", targetId]],
+    []
+  );
+  return useScanJobFlow(launch, getInvalidationKeys);
 }

--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -747,11 +747,17 @@ export function EntityDetailPage() {
         },
         onError: (err) => {
           const status = (err as { status?: number } | null)?.status;
-          let msg = "Scan failed. Please try again.";
+          let msg: string;
           if (status === 404) {
             msg = "Entity not found. Please refresh the page.";
+          } else if (status === 409) {
+            msg = "A scan is already running for this entity.";
           } else if (status === 503 || status === 500) {
             msg = "Scan service unavailable. Please try again later.";
+          } else {
+            // The scan launched but failed while running — surface the
+            // backend's actual failure reason instead of a generic message.
+            msg = err.message || "Scan failed. Please try again.";
           }
           setScanMessage(msg);
           setScanMessageType("error");
@@ -963,6 +969,16 @@ export function EntityDetailPage() {
               "Scan for Mentions"
             )}
           </button>
+
+          {scanMutation.isPending && (
+            <p
+              role="status"
+              aria-live="polite"
+              className="text-sm text-slate-600 bg-slate-50 border border-slate-200 rounded-md px-3 py-1.5"
+            >
+              Scanning… (this can take a few minutes)
+            </p>
+          )}
 
           {scanMessage !== null && scanMessageType === "success" && (
             <p

--- a/frontend/src/pages/__tests__/EntityDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.test.tsx
@@ -900,5 +900,98 @@ describe("EntityDetailPage", () => {
 
       expect(screen.getByRole("alert")).toHaveTextContent(/entity not found/i);
     });
+
+    it("shows a distinct 'already running' message on a 409 launch conflict", () => {
+      const mockMutate = vi.fn().mockImplementation((_vars, callbacks) => {
+        callbacks?.onError?.({ status: 409, message: "A scan is already in progress for this entity" });
+      });
+
+      vi.mocked(useScanEntity).mockReturnValue({
+        mutate: mockMutate,
+        isPending: false,
+        isError: false,
+        error: null,
+        data: undefined,
+        reset: vi.fn(),
+        mutateAsync: vi.fn(),
+        isSuccess: false,
+        isIdle: true,
+        status: "idle",
+        variables: undefined,
+        context: undefined,
+        failureCount: 0,
+        failureReason: null,
+        isPaused: false,
+        submittedAt: 0,
+      } as ReturnType<typeof useScanEntity>);
+
+      renderPage();
+
+      fireEvent.click(screen.getByRole("button", { name: /scan for mentions/i }));
+
+      expect(screen.getByRole("alert")).toHaveTextContent(/already running/i);
+    });
+
+    it("shows the job's real failure reason (not a generic message) when the async scan job fails", () => {
+      // A job that fails asynchronously (after launch succeeded) surfaces via
+      // onError with no HTTP status — just the backend's real error string.
+      const mockMutate = vi.fn().mockImplementation((_vars, callbacks) => {
+        callbacks?.onError?.({ message: "Database connection lost during scan" });
+      });
+
+      vi.mocked(useScanEntity).mockReturnValue({
+        mutate: mockMutate,
+        isPending: false,
+        isError: false,
+        error: null,
+        data: undefined,
+        reset: vi.fn(),
+        mutateAsync: vi.fn(),
+        isSuccess: false,
+        isIdle: true,
+        status: "idle",
+        variables: undefined,
+        context: undefined,
+        failureCount: 0,
+        failureReason: null,
+        isPaused: false,
+        submittedAt: 0,
+      } as ReturnType<typeof useScanEntity>);
+
+      renderPage();
+
+      fireEvent.click(screen.getByRole("button", { name: /scan for mentions/i }));
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Database connection lost during scan"
+      );
+    });
+
+    it("shows a 'Scanning… (this can take a few minutes)' status message while the job is running", () => {
+      vi.mocked(useScanEntity).mockReturnValue({
+        mutate: vi.fn(),
+        isPending: true,
+        isError: false,
+        error: null,
+        data: undefined,
+        reset: vi.fn(),
+        mutateAsync: vi.fn(),
+        isSuccess: false,
+        isIdle: false,
+        status: "pending",
+        variables: { entityId: "entity-uuid-001" },
+        context: undefined,
+        failureCount: 0,
+        failureReason: null,
+        isPaused: false,
+        submittedAt: Date.now(),
+      } as ReturnType<typeof useScanEntity>);
+
+      renderPage();
+
+      expect(
+        screen.getByText(/scanning.*this can take a few minutes/i)
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -7,10 +7,13 @@ from entity to videos.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import time
 import uuid
 from collections import defaultdict
-from typing import Any
+from datetime import UTC, datetime
+from typing import Any, Literal
 
 from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response
 from fastapi.responses import JSONResponse
@@ -33,9 +36,10 @@ from chronovista.api.schemas.entity_mentions import (
     ManualAssociationResponse,
     MentionPreview,
     PhoneticMatchResponse,
+    ScanJobData,
+    ScanJobResponse,
     ScanRequest,
     ScanResultData,
-    ScanResultResponse,
     VideoEntitiesResponse,
     VideoEntitySummary,
 )
@@ -90,8 +94,21 @@ _tag_mgmt_service = TagManagementService(
     operation_log_repo=TagOperationLogRepository(),
 )
 
+logger = logging.getLogger(__name__)
+
 # In-flight scan guard: tracks entity/video scans currently running
 _scans_in_progress: set[str] = set()
+
+# Registry of asynchronous scan jobs, keyed by job id. Ephemeral and in-memory:
+# jobs do not survive a server restart (acceptable for a single-user tool — a
+# lost scan is simply re-run). If durability is ever needed, back this with a
+# jobs table.
+_scan_jobs: dict[str, ScanJobData] = {}
+# Strong references to running background scan tasks so the event loop does not
+# garbage-collect them mid-run.
+_scan_tasks: set[asyncio.Task[None]] = set()
+# Cap on retained jobs to bound memory; oldest terminal jobs are pruned first.
+_MAX_SCAN_JOBS = 100
 
 # Rate limiting configuration for duplicate check (50 req/min per client)
 RATE_LIMIT_DUPLICATE_CHECK = 50
@@ -1555,61 +1572,158 @@ def _merge_scan_results(results: list[ScanResult]) -> ScanResult:
     return merged
 
 
-def _build_scan_response(result: ScanResult) -> ScanResultResponse:
-    """Build a :class:`ScanResultResponse` from a :class:`ScanResult`.
+def _scan_result_to_data(result: ScanResult) -> ScanResultData:
+    """Convert a service-layer :class:`ScanResult` into API ``ScanResultData``."""
+    return ScanResultData(
+        segments_scanned=result.segments_scanned,
+        mentions_found=result.mentions_found,
+        mentions_skipped=result.mentions_skipped,
+        unique_entities=result.unique_entities,
+        unique_videos=result.unique_videos,
+        duration_seconds=result.duration_seconds,
+        dry_run=result.dry_run,
+    )
 
-    Parameters
-    ----------
-    result : ScanResult
-        Raw scan result from the service layer.
 
-    Returns
-    -------
-    ScanResultResponse
-        API response envelope.
+def _prune_scan_jobs() -> None:
+    """Bound the job registry by dropping the oldest terminal (finished) jobs.
+
+    Running jobs are never pruned. Relies on ``dict`` insertion order so the
+    oldest-registered finished jobs are removed first.
     """
-    return ScanResultResponse(
-        data=ScanResultData(
-            segments_scanned=result.segments_scanned,
-            mentions_found=result.mentions_found,
-            mentions_skipped=result.mentions_skipped,
-            unique_entities=result.unique_entities,
-            unique_videos=result.unique_videos,
-            duration_seconds=result.duration_seconds,
-            dry_run=result.dry_run,
+    if len(_scan_jobs) <= _MAX_SCAN_JOBS:
+        return
+    for job_id in list(_scan_jobs.keys()):
+        if len(_scan_jobs) <= _MAX_SCAN_JOBS:
+            break
+        if _scan_jobs[job_id].status != "running":
+            del _scan_jobs[job_id]
+
+
+async def _run_scan_job(
+    job_id: str,
+    guard_key: str,
+    *,
+    sources: list[str],
+    entity_ids: list[uuid.UUID] | None = None,
+    video_ids: list[str] | None = None,
+    entity_type: str | None = None,
+    language_code: str | None = None,
+    dry_run: bool = False,
+    full_rescan: bool = False,
+) -> None:
+    """Run a scan in the background and record the outcome on its job.
+
+    Never raises: any failure is captured on the job's ``status``/``error`` so
+    the polling client can observe it. Clears the in-flight guard when done.
+    """
+    job = _scan_jobs[job_id]
+    try:
+        service = _get_scan_service()
+        result = await _dispatch_scan(
+            service=service,
+            sources=sources,
+            entity_ids=entity_ids,
+            video_ids=video_ids,
+            entity_type=entity_type,
+            language_code=language_code,
+            dry_run=dry_run,
+            full_rescan=full_rescan,
+        )
+        job.result = _scan_result_to_data(result)
+        job.status = "succeeded"
+    except Exception as exc:  # noqa: BLE001 - surface any failure via the job
+        logger.exception("Scan job %s failed", job_id)
+        job.status = "failed"
+        job.error = str(exc)
+    finally:
+        job.finished_at = datetime.now(UTC)
+        _scans_in_progress.discard(guard_key)
+
+
+def _launch_scan_job(
+    *,
+    kind: Literal["entity", "video"],
+    target_id: str,
+    guard_key: str,
+    sources: list[str],
+    entity_ids: list[uuid.UUID] | None = None,
+    video_ids: list[str] | None = None,
+    entity_type: str | None = None,
+    language_code: str | None = None,
+    dry_run: bool = False,
+    full_rescan: bool = False,
+) -> ScanJobData:
+    """Register a scan job and start it as a background task.
+
+    The caller must have validated inputs and added ``guard_key`` to
+    ``_scans_in_progress``; the background task clears the guard on completion.
+    Returns the freshly-created job for the ``202`` response body.
+    """
+    job_id = str(uuid.uuid4())
+    job = ScanJobData(
+        job_id=job_id,
+        kind=kind,
+        target_id=target_id,
+        status="running",
+        result=None,
+        error=None,
+        started_at=datetime.now(UTC),
+        finished_at=None,
+    )
+    _scan_jobs[job_id] = job
+    _prune_scan_jobs()
+
+    task = asyncio.create_task(
+        _run_scan_job(
+            job_id,
+            guard_key,
+            sources=sources,
+            entity_ids=entity_ids,
+            video_ids=video_ids,
+            entity_type=entity_type,
+            language_code=language_code,
+            dry_run=dry_run,
+            full_rescan=full_rescan,
         )
     )
+    _scan_tasks.add(task)
+    task.add_done_callback(_scan_tasks.discard)
+    return job
 
 
 @router.post(
     "/entities/{entity_id}/scan",
-    response_model=ScanResultResponse,
-    status_code=200,
-    summary="Scan transcript segments for mentions of a specific entity",
+    response_model=ScanJobResponse,
+    status_code=202,
+    summary="Start an entity mention scan for a specific entity",
 )
 async def scan_entity(
     entity_id: uuid.UUID = Path(..., description="Named entity UUID"),
     request: ScanRequest = Body(default_factory=ScanRequest),
     session: AsyncSession = Depends(get_db),
-) -> ScanResultResponse:
-    """Trigger an entity mention scan for a single entity.
+) -> ScanJobResponse:
+    """Launch an asynchronous entity mention scan for a single entity.
 
-    Scans transcript segments for mentions of the specified entity using
-    PostgreSQL regex matching with word-boundary support.
+    Scanning transcript segments (and optionally titles/descriptions) can take
+    minutes on a large corpus, so this endpoint validates the request, starts
+    the scan as a background job, and returns ``202`` with a job id. Poll
+    ``GET /scan-jobs/{job_id}`` for progress and the final result.
 
     Parameters
     ----------
     entity_id : uuid.UUID
         UUID of the named entity to scan.
     request : ScanRequest
-        Optional scan configuration (language_code, dry_run, full_rescan).
+        Optional scan configuration (sources, language_code, dry_run,
+        full_rescan).
     session : AsyncSession
-        Injected database session.
+        Injected database session (used only for validation).
 
     Returns
     -------
-    ScanResultResponse
-        Scan result metrics wrapped in a ``data`` envelope.
+    ScanJobResponse
+        The created scan job (status ``"running"``) wrapped in ``data``.
     """
     # 1. Validate entity exists
     entity = await session.get(NamedEntityDB, entity_id)
@@ -1629,25 +1743,25 @@ async def scan_entity(
             message="A scan is already in progress for this entity"
         )
 
+    # 4. Launch the scan in the background and return the job (202).
     _scans_in_progress.add(guard_key)
     try:
-        # 4. Run the scan — dispatch based on sources
-        service = _get_scan_service()
-        sources = request.sources or ["transcript"]
-        result = await _dispatch_scan(
-            service=service,
-            sources=sources,
+        job = _launch_scan_job(
+            kind="entity",
+            target_id=str(entity_id),
+            guard_key=guard_key,
+            sources=request.sources or ["transcript"],
             entity_ids=[entity_id],
             entity_type=request.entity_type,
             language_code=request.language_code,
             dry_run=request.dry_run,
             full_rescan=request.full_rescan,
         )
-
-        # 5. Build response
-        return _build_scan_response(result)
-    finally:
+    except Exception:
+        # If we failed to even start the task, don't leak the guard.
         _scans_in_progress.discard(guard_key)
+        raise
+    return ScanJobResponse(data=job)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1657,35 +1771,35 @@ async def scan_entity(
 
 @router.post(
     "/videos/{video_id}/scan-entities",
-    response_model=ScanResultResponse,
-    status_code=200,
-    summary="Scan a single video for entity mentions",
+    response_model=ScanJobResponse,
+    status_code=202,
+    summary="Start an entity mention scan for a single video",
 )
 async def scan_video_entities(
     video_id: str = Path(..., description="YouTube video ID"),
     request: ScanRequest = Body(default_factory=ScanRequest),
     session: AsyncSession = Depends(get_db),
-) -> ScanResultResponse:
-    """Trigger an entity mention scan for a single video.
+) -> ScanJobResponse:
+    """Launch an asynchronous entity mention scan for a single video.
 
     Validates that the video exists, checks a concurrency guard to prevent
-    duplicate scans, then delegates to ``EntityMentionScanService.scan()``
-    with the given video ID.
+    duplicate scans, starts the scan as a background job, and returns ``202``
+    with a job id. Poll ``GET /scan-jobs/{job_id}`` for progress and result.
 
     Parameters
     ----------
     video_id : str
         YouTube video ID (string path parameter).
     request : ScanRequest
-        Optional scan parameters (entity_type, language_code, dry_run,
-        full_rescan).  All fields default to ``None`` / ``False``.
+        Optional scan parameters (sources, entity_type, language_code,
+        dry_run, full_rescan).
     session : AsyncSession
-        Database session (injected).
+        Database session (used only for validation).
 
     Returns
     -------
-    ScanResultResponse
-        Scan result metrics wrapped in a ``data`` envelope.
+    ScanJobResponse
+        The created scan job (status ``"running"``) wrapped in ``data``.
 
     Raises
     ------
@@ -1706,22 +1820,42 @@ async def scan_video_entities(
             message="A scan is already in progress for this video",
         )
 
+    # 3. Launch the scan in the background and return the job (202).
     _scans_in_progress.add(guard_key)
     try:
-        # 3. Run the scan — dispatch based on sources
-        service = _get_scan_service()
-        sources = request.sources or ["transcript"]
-        result = await _dispatch_scan(
-            service=service,
-            sources=sources,
+        job = _launch_scan_job(
+            kind="video",
+            target_id=video_id,
+            guard_key=guard_key,
+            sources=request.sources or ["transcript"],
             video_ids=[video_id],
             entity_type=request.entity_type,
             language_code=request.language_code,
             dry_run=request.dry_run,
             full_rescan=request.full_rescan,
         )
-
-        # 4. Build response
-        return _build_scan_response(result)
-    finally:
+    except Exception:
         _scans_in_progress.discard(guard_key)
+        raise
+    return ScanJobResponse(data=job)
+
+
+@router.get(
+    "/scan-jobs/{job_id}",
+    response_model=ScanJobResponse,
+    summary="Get the status and result of an entity scan job",
+)
+async def get_scan_job(
+    job_id: str = Path(..., description="Scan job identifier"),
+) -> ScanJobResponse:
+    """Return the current state of an asynchronous scan job.
+
+    While running, ``status`` is ``"running"`` and ``result`` is null. On
+    completion it becomes ``"succeeded"`` (with ``result`` metrics) or
+    ``"failed"`` (with ``error``). Jobs are in-memory and ephemeral, so an
+    unknown id (including after a server restart) returns ``404``.
+    """
+    job = _scan_jobs.get(job_id)
+    if job is None:
+        raise NotFoundError(resource_type="Scan job", identifier=job_id)
+    return ScanJobResponse(data=job)

--- a/src/chronovista/api/schemas/entity_mentions.py
+++ b/src/chronovista/api/schemas/entity_mentions.py
@@ -6,6 +6,7 @@ video entity summaries and entity-to-videos lookups.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -684,3 +685,65 @@ class ScanResultResponse(BaseModel):
     model_config = ConfigDict(strict=True)
 
     data: ScanResultData
+
+
+class ScanJobData(BaseModel):
+    """State of an asynchronous entity-mention scan job.
+
+    Scan jobs are tracked in an in-memory registry (ephemeral — a job does
+    not survive a server restart). This model is returned both when a scan is
+    launched (``202``) and when its status is polled.
+
+    Attributes
+    ----------
+    job_id : str
+        Unique identifier for the scan job.
+    kind : str
+        ``"entity"`` or ``"video"`` — what the scan targets.
+    target_id : str
+        The entity UUID or video ID being scanned.
+    status : str
+        ``"running"``, ``"succeeded"``, or ``"failed"``.
+    result : ScanResultData | None
+        Scan metrics, populated once the job has succeeded.
+    error : str | None
+        Error message if the job failed.
+    started_at : datetime
+        When the scan started.
+    finished_at : datetime | None
+        When the scan reached a terminal state, if it has.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    job_id: str = Field(..., description="Scan job identifier")
+    kind: Literal["entity", "video"] = Field(
+        ..., description="Whether the scan targets an entity or a video"
+    )
+    target_id: str = Field(
+        ..., description="Entity UUID or video ID being scanned"
+    )
+    status: Literal["running", "succeeded", "failed"] = Field(
+        ..., description="Current job status"
+    )
+    result: ScanResultData | None = Field(
+        None, description="Scan metrics once the job has succeeded"
+    )
+    error: str | None = Field(
+        None, description="Error message if the job failed"
+    )
+    started_at: datetime = Field(..., description="When the scan started")
+    finished_at: datetime | None = Field(
+        None, description="When the scan reached a terminal state"
+    )
+
+
+class ScanJobResponse(BaseModel):
+    """Response envelope for scan-job launch (202) and status endpoints.
+
+    Wraps ``ScanJobData`` inside a ``data`` key for consistent API formatting.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    data: ScanJobData

--- a/tests/integration/api/test_targeted_scan_endpoints.py
+++ b/tests/integration/api/test_targeted_scan_endpoints.py
@@ -3,12 +3,19 @@
 Covers:
   - POST /api/v1/entities/{entity_id}/scan
   - POST /api/v1/videos/{video_id}/scan-entities
+  - GET  /api/v1/scan-jobs/{job_id}
+
+The scan endpoints are asynchronous (fire-and-poll): the POST endpoints
+validate the request, launch the scan as an ``asyncio`` background task, and
+return ``202`` with a running :class:`ScanJobData`. Tests must poll
+``GET /scan-jobs/{job_id}`` until the job reaches a terminal state
+(``succeeded`` or ``failed``) to observe the scan outcome.
 
 All tests use an integration database seeded with minimal rows (channel,
 video, and named entity). The scan service itself is mocked via
 ``unittest.mock.patch`` so tests do not perform real transcript scanning —
 they validate the request-routing, entity/video validation, concurrency
-guard, and response structure only.
+guard, async job lifecycle, and response structure only.
 
 Auth: ``require_auth`` is bypassed via ``youtube_oauth`` mock following the
 same pattern used in ``test_entity_mentions_api.py``.
@@ -18,6 +25,7 @@ Feature 052 — Targeted Entity & Video-Level Mention Scanning
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
@@ -64,6 +72,62 @@ def _entity_scan_url(entity_id: str | uuid.UUID) -> str:
 def _video_scan_url(video_id: str) -> str:
     """Return the video entity-scan endpoint URL."""
     return f"/api/v1/videos/{video_id}/scan-entities"
+
+
+def _scan_job_url(job_id: str) -> str:
+    """Return the scan-job status endpoint URL."""
+    return f"/api/v1/scan-jobs/{job_id}"
+
+
+# ---------------------------------------------------------------------------
+# Polling helper
+# ---------------------------------------------------------------------------
+
+
+async def _poll_scan_job(
+    async_client: AsyncClient,
+    job_id: str,
+    *,
+    max_attempts: int = 50,
+    interval: float = 0.02,
+) -> dict[str, Any]:
+    """Poll ``GET /scan-jobs/{job_id}`` until the job reaches a terminal state.
+
+    The background scan task runs on the same event loop as the test, so
+    awaiting ``asyncio.sleep`` between polls yields control and lets it
+    progress. Must be called while any service-level mocks are still active
+    (i.e. inside the same ``with patch(...)`` block used to launch the scan)
+    so the background task observes the mocked service.
+
+    Parameters
+    ----------
+    async_client : AsyncClient
+        Test HTTP client.
+    job_id : str
+        The scan job id returned by the launch (202) response.
+    max_attempts : int
+        Maximum number of polls before giving up.
+    interval : float
+        Seconds to sleep between polls.
+
+    Returns
+    -------
+    dict[str, Any]
+        The final ``data`` payload once ``status`` is no longer ``"running"``.
+    """
+    data: dict[str, Any] | None = None
+    for _ in range(max_attempts):
+        await asyncio.sleep(interval)
+        response = await async_client.get(_scan_job_url(job_id))
+        assert response.status_code == 200, response.text
+        data = response.json()["data"]
+        if data["status"] != "running":
+            return data
+    assert data is not None
+    raise AssertionError(
+        f"Scan job {job_id} did not reach a terminal state after "
+        f"{max_attempts} polls (last status: {data['status']})"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -218,17 +282,19 @@ class TestEntityScanEndpoint:
     """Tests for POST /api/v1/entities/{entity_id}/scan."""
 
     # ------------------------------------------------------------------
-    # 200 success
+    # 202 launch
     # ------------------------------------------------------------------
 
-    async def test_entity_scan_returns_200_with_valid_active_entity(
+    async def test_entity_scan_returns_202_with_running_job(
         self,
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """200 response with ScanResultResponse envelope for a valid active entity.
+        """202 response with a running ScanJobData envelope for a valid entity.
 
-        The scan service is mocked so no real scanning occurs.
+        The scan service is mocked so no real scanning occurs. The job is
+        drained via polling before the mock is torn down to avoid leaking
+        a background task that would later hit the real (unmocked) service.
         """
         entity_id_str = seed_scan_data["entity_id_str"]
         mock_result = _make_scan_result(mentions_found=3, unique_entities=1)
@@ -246,24 +312,63 @@ class TestEntityScanEndpoint:
 
             response = await async_client.post(_entity_scan_url(entity_id_str))
 
-        assert response.status_code == 200, response.text
-        body = response.json()
+            assert response.status_code == 202, response.text
+            body = response.json()
+            assert "data" in body
+            job = body["data"]
+            assert job["kind"] == "entity"
+            assert job["target_id"] == entity_id_str
+            assert job["status"] == "running"
+            assert job["result"] is None
+            assert job["error"] is None
+            assert job["job_id"]
+            assert job["started_at"]
+            assert job["finished_at"] is None
 
-        # Verify response envelope structure
-        assert "data" in body
-        data = body["data"]
-        assert data["segments_scanned"] == mock_result.segments_scanned
-        assert data["mentions_found"] == mock_result.mentions_found
-        assert data["unique_entities"] == mock_result.unique_entities
-        assert data["unique_videos"] == mock_result.unique_videos
-        assert data["dry_run"] is False
+            # Drain the background task while the mock is still active.
+            await _poll_scan_job(async_client, job["job_id"])
 
-    async def test_entity_scan_200_with_empty_body(
+    async def test_entity_scan_poll_to_succeeded_with_counts(
         self,
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """POST with empty JSON body ``{}`` must use defaults and succeed."""
+        """Polling the job to completion surfaces the mocked scan counts."""
+        entity_id_str = seed_scan_data["entity_id_str"]
+        mock_result = _make_scan_result(mentions_found=3, unique_entities=1)
+
+        with (
+            patch("chronovista.api.deps.youtube_oauth") as mock_oauth,
+            patch(
+                "chronovista.api.routers.entity_mentions._get_scan_service"
+            ) as mock_get_service,
+        ):
+            mock_oauth.is_authenticated.return_value = True
+            mock_service = MagicMock()
+            mock_service.scan = AsyncMock(return_value=mock_result)
+            mock_get_service.return_value = mock_service
+
+            response = await async_client.post(_entity_scan_url(entity_id_str))
+            assert response.status_code == 202, response.text
+            job_id = response.json()["data"]["job_id"]
+
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
+        result = data["result"]
+        assert result is not None
+        assert result["segments_scanned"] == mock_result.segments_scanned
+        assert result["mentions_found"] == mock_result.mentions_found
+        assert result["unique_entities"] == mock_result.unique_entities
+        assert result["unique_videos"] == mock_result.unique_videos
+        assert result["dry_run"] is False
+
+    async def test_entity_scan_202_with_empty_body(
+        self,
+        async_client: AsyncClient,
+        seed_scan_data: dict[str, Any],
+    ) -> None:
+        """POST with empty JSON body ``{}`` must use defaults and launch."""
         entity_id_str = seed_scan_data["entity_id_str"]
         mock_result = _make_scan_result()
 
@@ -281,8 +386,12 @@ class TestEntityScanEndpoint:
             response = await async_client.post(
                 _entity_scan_url(entity_id_str), json={}
             )
+            assert response.status_code == 202, response.text
+            job_id = response.json()["data"]["job_id"]
 
-        assert response.status_code == 200, response.text
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
 
     async def test_entity_scan_calls_service_with_entity_id(
         self,
@@ -305,14 +414,15 @@ class TestEntityScanEndpoint:
             mock_service.scan = AsyncMock(return_value=mock_result)
             mock_get_service.return_value = mock_service
 
-            await async_client.post(_entity_scan_url(entity_id_str))
+            response = await async_client.post(_entity_scan_url(entity_id_str))
+            job_id = response.json()["data"]["job_id"]
 
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
         call_kwargs = mock_service.scan.call_args
         assert call_kwargs is not None
-        # entity_ids must include the entity UUID
-        entity_ids_arg = call_kwargs.kwargs.get(
-            "entity_ids", call_kwargs.args[0] if call_kwargs.args else None
-        )
+        entity_ids_arg = call_kwargs.kwargs.get("entity_ids")
         assert entity_ids_arg == [entity_uuid]
 
     async def test_entity_scan_passes_language_code_from_body(
@@ -335,11 +445,15 @@ class TestEntityScanEndpoint:
             mock_service.scan = AsyncMock(return_value=mock_result)
             mock_get_service.return_value = mock_service
 
-            await async_client.post(
+            response = await async_client.post(
                 _entity_scan_url(entity_id_str),
                 json={"language_code": "en"},
             )
+            job_id = response.json()["data"]["job_id"]
 
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
         call_kwargs = mock_service.scan.call_args
         assert call_kwargs is not None
         lang = call_kwargs.kwargs.get("language_code")
@@ -365,11 +479,16 @@ class TestEntityScanEndpoint:
             mock_service.scan = AsyncMock(return_value=mock_result)
             mock_get_service.return_value = mock_service
 
-            await async_client.post(
+            response = await async_client.post(
                 _entity_scan_url(entity_id_str),
                 json={"dry_run": True},
             )
+            job_id = response.json()["data"]["job_id"]
 
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
+        assert data["result"]["dry_run"] is True
         call_kwargs = mock_service.scan.call_args
         assert call_kwargs is not None
         dry_run_arg = call_kwargs.kwargs.get("dry_run")
@@ -384,7 +503,11 @@ class TestEntityScanEndpoint:
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """404 when the entity_id UUID does not exist in the database."""
+        """404 when the entity_id UUID does not exist in the database.
+
+        Validation happens before the scan is launched, so this is an
+        immediate response — no job is created.
+        """
         non_existent_uuid = uuid.uuid4()
 
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -404,7 +527,11 @@ class TestEntityScanEndpoint:
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """400 when the entity exists but has status 'merged' (not active)."""
+        """400 when the entity exists but has status 'merged' (not active).
+
+        Validation happens before the scan is launched, so this is an
+        immediate response — no job is created.
+        """
         inactive_id_str = seed_scan_data["inactive_entity_id_str"]
 
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -428,7 +555,11 @@ class TestEntityScanEndpoint:
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """409 when the concurrency guard already holds the key for this entity."""
+        """409 when the concurrency guard already holds the key for this entity.
+
+        The guard check happens before the scan is launched, so this is an
+        immediate response — no job is created.
+        """
         import chronovista.api.routers.entity_mentions as em_router
 
         entity_uuid = seed_scan_data["entity_id"]
@@ -453,7 +584,7 @@ class TestEntityScanEndpoint:
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """The concurrency guard must be removed after a successful scan."""
+        """The concurrency guard must be removed after the job succeeds."""
         import chronovista.api.routers.entity_mentions as em_router
 
         entity_uuid = seed_scan_data["entity_id"]
@@ -473,23 +604,22 @@ class TestEntityScanEndpoint:
             mock_service.scan = AsyncMock(return_value=mock_result)
             mock_get_service.return_value = mock_service
 
-            await async_client.post(_entity_scan_url(entity_id_str))
+            response = await async_client.post(_entity_scan_url(entity_id_str))
+            job_id = response.json()["data"]["job_id"]
+            data = await _poll_scan_job(async_client, job_id)
 
-        # Guard must be released
+        assert data["status"] == "succeeded"
         assert guard_key not in em_router._scans_in_progress, (
             f"Guard key {guard_key!r} still present after scan completion"
         )
 
-    async def test_entity_scan_guard_released_after_service_exception(
+    async def test_entity_scan_job_failed_when_service_raises(
         self,
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """The concurrency guard must be released even when scan() raises.
-
-        FastAPI's exception handler will convert the RuntimeError to a 500
-        response. The important thing is that the guard key is not left in
-        ``_scans_in_progress`` regardless of the response status.
+        """The job transitions to 'failed' with an error message when
+        scan() raises, and the concurrency guard is released regardless.
         """
         import chronovista.api.routers.entity_mentions as em_router
 
@@ -511,12 +641,16 @@ class TestEntityScanEndpoint:
             mock_service.scan = AsyncMock(side_effect=RuntimeError("scan failed"))
             mock_get_service.return_value = mock_service
 
-            # The 500 response is expected; we only care that the guard is cleaned up
-            try:
-                await async_client.post(_entity_scan_url(entity_id_str))
-            except Exception:
-                pass  # 500 responses may propagate in test mode
+            response = await async_client.post(_entity_scan_url(entity_id_str))
+            assert response.status_code == 202, response.text
+            job_id = response.json()["data"]["job_id"]
 
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "failed"
+        assert data["result"] is None
+        assert data["error"] is not None
+        assert "scan failed" in data["error"]
         assert guard_key not in em_router._scans_in_progress, (
             f"Guard key {guard_key!r} still present after scan failure"
         )
@@ -531,15 +665,15 @@ class TestVideoScanEndpoint:
     """Tests for POST /api/v1/videos/{video_id}/scan-entities."""
 
     # ------------------------------------------------------------------
-    # 200 success
+    # 202 launch / poll to succeeded
     # ------------------------------------------------------------------
 
-    async def test_video_scan_returns_200_with_valid_video(
+    async def test_video_scan_returns_202_with_running_job(
         self,
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """200 response with ScanResultResponse envelope for a valid video."""
+        """202 response with a running ScanJobData envelope for a valid video."""
         video_id = seed_scan_data["video_id"]
         mock_result = _make_scan_result(
             segments_scanned=5,
@@ -561,20 +695,28 @@ class TestVideoScanEndpoint:
 
             response = await async_client.post(_video_scan_url(video_id))
 
-        assert response.status_code == 200, response.text
-        body = response.json()
+            assert response.status_code == 202, response.text
+            body = response.json()
+            assert "data" in body
+            job = body["data"]
+            assert job["kind"] == "video"
+            assert job["target_id"] == video_id
+            assert job["status"] == "running"
+            assert job["result"] is None
+            assert job["error"] is None
 
-        assert "data" in body
-        data = body["data"]
-        assert data["segments_scanned"] == 5
-        assert data["mentions_found"] == 1
+            data = await _poll_scan_job(async_client, job["job_id"])
 
-    async def test_video_scan_200_with_zero_counts(
+        assert data["status"] == "succeeded"
+        assert data["result"]["segments_scanned"] == 5
+        assert data["result"]["mentions_found"] == 1
+
+    async def test_video_scan_poll_to_succeeded_with_zero_counts(
         self,
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """200 response with all-zero counts when video has no matching segments."""
+        """Job succeeds with all-zero counts when video has no matching segments."""
         video_id = seed_scan_data["video_id"]
         mock_result = _make_scan_result(
             segments_scanned=0,
@@ -596,11 +738,14 @@ class TestVideoScanEndpoint:
             mock_get_service.return_value = mock_service
 
             response = await async_client.post(_video_scan_url(video_id))
+            assert response.status_code == 202, response.text
+            job_id = response.json()["data"]["job_id"]
 
-        assert response.status_code == 200, response.text
-        data = response.json()["data"]
-        assert data["mentions_found"] == 0
-        assert data["unique_entities"] == 0
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
+        assert data["result"]["mentions_found"] == 0
+        assert data["result"]["unique_entities"] == 0
 
     async def test_video_scan_calls_service_with_video_id(
         self,
@@ -622,8 +767,12 @@ class TestVideoScanEndpoint:
             mock_service.scan = AsyncMock(return_value=mock_result)
             mock_get_service.return_value = mock_service
 
-            await async_client.post(_video_scan_url(video_id))
+            response = await async_client.post(_video_scan_url(video_id))
+            job_id = response.json()["data"]["job_id"]
 
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
         call_kwargs = mock_service.scan.call_args
         assert call_kwargs is not None
         video_ids_arg = call_kwargs.kwargs.get("video_ids")
@@ -649,22 +798,26 @@ class TestVideoScanEndpoint:
             mock_service.scan = AsyncMock(return_value=mock_result)
             mock_get_service.return_value = mock_service
 
-            await async_client.post(
+            response = await async_client.post(
                 _video_scan_url(video_id),
                 json={"entity_type": "person"},
             )
+            job_id = response.json()["data"]["job_id"]
 
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
         call_kwargs = mock_service.scan.call_args
         assert call_kwargs is not None
         entity_type_arg = call_kwargs.kwargs.get("entity_type")
         assert entity_type_arg == "person"
 
-    async def test_video_scan_200_with_empty_body(
+    async def test_video_scan_202_with_empty_body(
         self,
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """POST with empty body ``{}`` must use defaults and succeed."""
+        """POST with empty body ``{}`` must use defaults and launch."""
         video_id = seed_scan_data["video_id"]
         mock_result = _make_scan_result()
 
@@ -682,8 +835,12 @@ class TestVideoScanEndpoint:
             response = await async_client.post(
                 _video_scan_url(video_id), json={}
             )
+            assert response.status_code == 202, response.text
+            job_id = response.json()["data"]["job_id"]
 
-        assert response.status_code == 200, response.text
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
 
     # ------------------------------------------------------------------
     # 404 video not found
@@ -694,7 +851,11 @@ class TestVideoScanEndpoint:
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """404 when the video_id does not exist in the database."""
+        """404 when the video_id does not exist in the database.
+
+        Validation happens before the scan is launched, so this is an
+        immediate response — no job is created.
+        """
         non_existent_video_id = "nosuchvideo052"
 
         with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
@@ -714,7 +875,11 @@ class TestVideoScanEndpoint:
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """409 when the concurrency guard already holds the key for this video."""
+        """409 when the concurrency guard already holds the key for this video.
+
+        The guard check happens before the scan is launched, so this is an
+        immediate response — no job is created.
+        """
         import chronovista.api.routers.entity_mentions as em_router
 
         video_id = seed_scan_data["video_id"]
@@ -735,7 +900,7 @@ class TestVideoScanEndpoint:
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """The concurrency guard must be removed after a successful video scan."""
+        """The concurrency guard must be removed after the job succeeds."""
         import chronovista.api.routers.entity_mentions as em_router
 
         video_id = seed_scan_data["video_id"]
@@ -753,22 +918,22 @@ class TestVideoScanEndpoint:
             mock_service.scan = AsyncMock(return_value=mock_result)
             mock_get_service.return_value = mock_service
 
-            await async_client.post(_video_scan_url(video_id))
+            response = await async_client.post(_video_scan_url(video_id))
+            job_id = response.json()["data"]["job_id"]
+            data = await _poll_scan_job(async_client, job_id)
 
+        assert data["status"] == "succeeded"
         assert guard_key not in em_router._scans_in_progress, (
             f"Guard key {guard_key!r} still present after scan completion"
         )
 
-    async def test_video_scan_guard_released_after_service_exception(
+    async def test_video_scan_job_failed_when_service_raises(
         self,
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """The concurrency guard must be released even when scan() raises.
-
-        FastAPI converts the RuntimeError to a 500 response.  The guard
-        key must be absent from ``_scans_in_progress`` after the request
-        completes, regardless of the response status code.
+        """The job transitions to 'failed' with an error message when
+        scan() raises, and the concurrency guard is released regardless.
         """
         import chronovista.api.routers.entity_mentions as em_router
 
@@ -791,11 +956,16 @@ class TestVideoScanEndpoint:
             )
             mock_get_service.return_value = mock_service
 
-            try:
-                await async_client.post(_video_scan_url(video_id))
-            except Exception:
-                pass  # 500 responses may propagate in test mode
+            response = await async_client.post(_video_scan_url(video_id))
+            assert response.status_code == 202, response.text
+            job_id = response.json()["data"]["job_id"]
 
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "failed"
+        assert data["result"] is None
+        assert data["error"] is not None
+        assert "scan exploded" in data["error"]
         assert guard_key not in em_router._scans_in_progress, (
             f"Guard key {guard_key!r} still present after scan failure"
         )
@@ -804,12 +974,12 @@ class TestVideoScanEndpoint:
     # Response shape validation
     # ------------------------------------------------------------------
 
-    async def test_video_scan_response_has_all_required_fields(
+    async def test_video_scan_poll_result_has_all_required_fields(
         self,
         async_client: AsyncClient,
         seed_scan_data: dict[str, Any],
     ) -> None:
-        """The response body must contain all ScanResultData fields."""
+        """The polled job's ``result`` must contain all ScanResultData fields."""
         video_id = seed_scan_data["video_id"]
         mock_result = _make_scan_result(
             segments_scanned=20,
@@ -832,9 +1002,14 @@ class TestVideoScanEndpoint:
             mock_get_service.return_value = mock_service
 
             response = await async_client.post(_video_scan_url(video_id))
+            assert response.status_code == 202, response.text
+            job_id = response.json()["data"]["job_id"]
 
-        assert response.status_code == 200, response.text
-        data = response.json()["data"]
+            data = await _poll_scan_job(async_client, job_id)
+
+        assert data["status"] == "succeeded"
+        result = data["result"]
+        assert result is not None
 
         required_fields = {
             "segments_scanned",
@@ -846,4 +1021,30 @@ class TestVideoScanEndpoint:
             "dry_run",
         }
         for field in required_fields:
-            assert field in data, f"Missing required field '{field}' in response data"
+            assert field in result, f"Missing required field '{field}' in result"
+
+
+# ---------------------------------------------------------------------------
+# TestScanJobStatusEndpoint
+# ---------------------------------------------------------------------------
+
+
+class TestScanJobStatusEndpoint:
+    """Tests for GET /api/v1/scan-jobs/{job_id}."""
+
+    async def test_get_scan_job_404_when_unknown_id(
+        self,
+        async_client: AsyncClient,
+    ) -> None:
+        """404 when the job_id does not correspond to any tracked job.
+
+        Scan jobs are in-memory and ephemeral, so an unrecognized id
+        (including a syntactically valid but never-issued UUID) must 404.
+        """
+        unknown_job_id = str(uuid.uuid4())
+
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(_scan_job_url(unknown_job_id))
+
+        assert response.status_code == 404, response.text

--- a/tests/unit/api/test_entity_source_filter.py
+++ b/tests/unit/api/test_entity_source_filter.py
@@ -23,9 +23,11 @@ References
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -57,6 +59,52 @@ def _uuid() -> uuid.UUID:
 def _empty_scan_result(*, dry_run: bool = False) -> ScanResult:
     """Return a zeroed-out :class:`ScanResult` for mock returns."""
     return ScanResult(dry_run=dry_run)
+
+
+async def _poll_scan_job(
+    client: AsyncClient,
+    job_id: str,
+    *,
+    max_attempts: int = 50,
+    interval: float = 0.02,
+) -> dict[str, Any]:
+    """Poll ``GET /scan-jobs/{job_id}`` until the job reaches a terminal state.
+
+    The scan endpoints now launch the scan as an ``asyncio`` background task
+    and return ``202`` immediately. Awaiting ``asyncio.sleep`` between polls
+    yields control to the event loop so the background task can progress.
+    Must be called while the ``_get_scan_service`` patch is still active so
+    the background task observes the mocked service.
+
+    Parameters
+    ----------
+    client : AsyncClient
+        Test HTTP client (with ``require_auth``/``get_db`` overridden).
+    job_id : str
+        The scan job id returned by the launch (202) response.
+    max_attempts : int
+        Maximum number of polls before giving up.
+    interval : float
+        Seconds to sleep between polls.
+
+    Returns
+    -------
+    dict[str, Any]
+        The final ``data`` payload once ``status`` is no longer ``"running"``.
+    """
+    data: dict[str, Any] | None = None
+    for _ in range(max_attempts):
+        await asyncio.sleep(interval)
+        response = await client.get(f"/api/v1/scan-jobs/{job_id}")
+        assert response.status_code == 200, response.text
+        data = response.json()["data"]
+        if data["status"] != "running":
+            return data
+    assert data is not None
+    raise AssertionError(
+        f"Scan job {job_id} did not reach a terminal state after "
+        f"{max_attempts} polls (last status: {data['status']})"
+    )
 
 
 async def _build_client(
@@ -175,8 +223,11 @@ class TestScanEntitySourcesParameter:
                     f"/api/v1/entities/{entity_id}/scan",
                     json={"sources": ["title"]},
                 )
+                assert response.status_code == 202
+                job_id = response.json()["data"]["job_id"]
+                job_data = await _poll_scan_job(client, job_id)
 
-        assert response.status_code == 200
+        assert job_data["status"] == "succeeded"
         mock_service.scan.assert_not_called()
         mock_service.scan_metadata.assert_called_once()
         call_kwargs = mock_service.scan_metadata.call_args.kwargs
@@ -211,8 +262,11 @@ class TestScanEntitySourcesParameter:
                     f"/api/v1/entities/{entity_id}/scan",
                     json={},
                 )
+                assert response.status_code == 202
+                job_id = response.json()["data"]["job_id"]
+                job_data = await _poll_scan_job(client, job_id)
 
-        assert response.status_code == 200
+        assert job_data["status"] == "succeeded"
         mock_service.scan.assert_called_once()
         mock_service.scan_metadata.assert_not_called()
 
@@ -277,8 +331,11 @@ class TestScanVideoEntitiesSourcesParameter:
                     f"/api/v1/videos/{video_id}/scan-entities",
                     json={"sources": ["title", "description"]},
                 )
+                assert response.status_code == 202
+                job_id = response.json()["data"]["job_id"]
+                job_data = await _poll_scan_job(client, job_id)
 
-        assert response.status_code == 200
+        assert job_data["status"] == "succeeded"
         mock_service.scan.assert_not_called()
         mock_service.scan_metadata.assert_called_once()
         call_kwargs = mock_service.scan_metadata.call_args.kwargs
@@ -328,20 +385,22 @@ class TestScanVideoEntitiesSourcesParameter:
                         "sources": ["transcript", "title", "description"],
                     },
                 )
+                assert response.status_code == 202
+                job_id = response.json()["data"]["job_id"]
+                job_data = await _poll_scan_job(client, job_id)
 
-        assert response.status_code == 200
+        assert job_data["status"] == "succeeded"
         mock_service.scan.assert_called_once()
         mock_service.scan_metadata.assert_called_once()
 
-        body = response.json()
-        data = body["data"]
+        result = job_data["result"]
         # Merged numeric fields
-        assert data["segments_scanned"] == 150
-        assert data["mentions_found"] == 8
-        assert data["mentions_skipped"] == 3
-        assert data["unique_entities"] == 5
-        assert data["unique_videos"] == 2
-        assert data["duration_seconds"] == pytest.approx(2.0)
+        assert result["segments_scanned"] == 150
+        assert result["mentions_found"] == 8
+        assert result["mentions_skipped"] == 3
+        assert result["unique_entities"] == 5
+        assert result["unique_videos"] == 2
+        assert result["duration_seconds"] == pytest.approx(2.0)
 
     async def test_sources_tag_on_video_endpoint_returns_422(self) -> None:
         """Invalid source 'tag' on video scan endpoint returns 422."""

--- a/tests/unit/schemas/test_scan_schemas.py
+++ b/tests/unit/schemas/test_scan_schemas.py
@@ -1,7 +1,9 @@
 """
-Unit tests for ScanRequest, ScanResultData, and ScanResultResponse schemas.
+Unit tests for ScanRequest, ScanResultData, ScanResultResponse, ScanJobData,
+and ScanJobResponse schemas.
 
-Covers Feature 052 — Targeted Entity & Video-Level Mention Scanning.
+Covers Feature 052 — Targeted Entity & Video-Level Mention Scanning, and the
+async job-polling schemas added for the sync-to-async scan conversion.
 
 Tests:
 - ScanRequest defaults (all None/False)
@@ -9,14 +11,21 @@ Tests:
 - ScanRequest rejects invalid entity_type strings
 - ScanResultData field construction and all required fields
 - ScanResultResponse wraps ScanResultData inside ``data`` key
+- ScanJobData construction for running/succeeded/failed states
+- ScanJobData rejects invalid kind/status literal values
+- ScanJobResponse wraps ScanJobData inside ``data`` key
 """
 
 from __future__ import annotations
+
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
 
 from chronovista.api.schemas.entity_mentions import (
+    ScanJobData,
+    ScanJobResponse,
     ScanRequest,
     ScanResultData,
     ScanResultResponse,
@@ -41,6 +50,22 @@ def _make_scan_result_data(**overrides: object) -> ScanResultData:
     }
     defaults.update(overrides)
     return ScanResultData(**defaults)  # type: ignore[arg-type]
+
+
+def _make_running_job(**overrides: object) -> ScanJobData:
+    """Build a valid running ScanJobData with sensible defaults."""
+    defaults: dict[str, object] = {
+        "job_id": "11111111-1111-1111-1111-111111111111",
+        "kind": "entity",
+        "target_id": "22222222-2222-2222-2222-222222222222",
+        "status": "running",
+        "result": None,
+        "error": None,
+        "started_at": datetime(2026, 1, 1, tzinfo=UTC),
+        "finished_at": None,
+    }
+    defaults.update(overrides)
+    return ScanJobData(**defaults)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -326,3 +351,142 @@ class TestScanResultResponse:
         parsed = ScanResultResponse.model_validate_json(json_str)
         assert parsed.data.segments_scanned == 50
         assert parsed.data.dry_run is True
+
+
+# ---------------------------------------------------------------------------
+# TestScanJobData
+# ---------------------------------------------------------------------------
+
+
+class TestScanJobData:
+    """ScanJobData construction across running/succeeded/failed states."""
+
+    def test_running_job_has_null_result_and_error(self) -> None:
+        """A freshly-launched job has status='running', result=None, error=None."""
+        job = _make_running_job()
+        assert job.status == "running"
+        assert job.result is None
+        assert job.error is None
+        assert job.finished_at is None
+
+    def test_entity_kind_stored(self) -> None:
+        """kind='entity' must be accepted and stored."""
+        job = _make_running_job(kind="entity")
+        assert job.kind == "entity"
+
+    def test_video_kind_stored(self) -> None:
+        """kind='video' must be accepted and stored."""
+        job = _make_running_job(kind="video")
+        assert job.kind == "video"
+
+    def test_invalid_kind_raises_validation_error(self) -> None:
+        """An unrecognized kind value must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            _make_running_job(kind="channel")
+
+    def test_invalid_status_raises_validation_error(self) -> None:
+        """An unrecognized status value must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            _make_running_job(status="pending")
+
+    def test_succeeded_job_carries_result(self) -> None:
+        """A succeeded job carries a populated ScanResultData and no error."""
+        result = _make_scan_result_data(mentions_found=7)
+        job = _make_running_job(
+            status="succeeded",
+            result=result,
+            finished_at=datetime(2026, 1, 1, 0, 0, 5, tzinfo=UTC),
+        )
+        assert job.status == "succeeded"
+        assert job.result is not None
+        assert job.result.mentions_found == 7
+        assert job.error is None
+        assert job.finished_at is not None
+
+    def test_failed_job_carries_error_and_null_result(self) -> None:
+        """A failed job carries an error message and result=None."""
+        job = _make_running_job(
+            status="failed",
+            error="scan service unavailable",
+            finished_at=datetime(2026, 1, 1, 0, 0, 5, tzinfo=UTC),
+        )
+        assert job.status == "failed"
+        assert job.result is None
+        assert job.error == "scan service unavailable"
+
+    def test_missing_job_id_raises_validation_error(self) -> None:
+        """Omitting required job_id must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ScanJobData(  # type: ignore[call-arg]
+                kind="entity",
+                target_id="x",
+                status="running",
+                result=None,
+                error=None,
+                started_at=datetime(2026, 1, 1, tzinfo=UTC),
+                finished_at=None,
+            )
+
+    def test_missing_started_at_raises_validation_error(self) -> None:
+        """Omitting required started_at must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ScanJobData(  # type: ignore[call-arg]
+                job_id="11111111-1111-1111-1111-111111111111",
+                kind="entity",
+                target_id="x",
+                status="running",
+                result=None,
+                error=None,
+                finished_at=None,
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestScanJobResponse
+# ---------------------------------------------------------------------------
+
+
+class TestScanJobResponse:
+    """ScanJobResponse wraps ScanJobData under the ``data`` key."""
+
+    def test_data_field_contains_scan_job_data(self) -> None:
+        """ScanJobResponse.data must be a ScanJobData instance."""
+        job = _make_running_job()
+        resp = ScanJobResponse(data=job)
+        assert isinstance(resp.data, ScanJobData)
+
+    def test_data_values_accessible(self) -> None:
+        """Values in ScanJobData must be accessible via ScanJobResponse.data."""
+        job = _make_running_job(kind="video", target_id="abc123")
+        resp = ScanJobResponse(data=job)
+        assert resp.data.kind == "video"
+        assert resp.data.target_id == "abc123"
+
+    def test_missing_data_field_raises_validation_error(self) -> None:
+        """Omitting the required data field must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ScanJobResponse()  # type: ignore[call-arg]
+
+    def test_model_json_round_trip_running(self) -> None:
+        """ScanJobResponse for a running job must survive JSON round-trip."""
+        job = _make_running_job()
+        resp = ScanJobResponse(data=job)
+        json_str = resp.model_dump_json()
+        parsed = ScanJobResponse.model_validate_json(json_str)
+        assert parsed.data.status == "running"
+        assert parsed.data.result is None
+
+    def test_model_json_round_trip_succeeded(self) -> None:
+        """ScanJobResponse for a succeeded job must survive JSON round-trip."""
+        result = _make_scan_result_data(segments_scanned=42)
+        job = _make_running_job(
+            status="succeeded",
+            result=result,
+            finished_at=datetime(2026, 1, 1, 0, 0, 5, tzinfo=UTC),
+        )
+        resp = ScanJobResponse(data=job)
+        json_str = resp.model_dump_json()
+        parsed = ScanJobResponse.model_validate_json(json_str)
+        assert parsed.data.status == "succeeded"
+        assert parsed.data.result is not None
+        assert parsed.data.result.segments_scanned == 42


### PR DESCRIPTION
## Summary

- **Root cause**: The entity/video scan endpoints (`POST /entities/{id}/scan`, `POST /videos/{id}/scan-entities`) ran synchronously. On a large corpus, the scan exceeded the frontend's 5-minute request timeout, so the browser aborted the request and showed "Scan failed. Please try again." — while the backend kept running in its own DB session and successfully committed the new mentions. The scan actually succeeded; the UI just reported failure.
- **Fix**: Both endpoints now return `202 Accepted` with a `job_id` and run the scan as an in-memory background task. A new `GET /api/v1/scan-jobs/{job_id}` endpoint returns job status/result/error, backed by an ephemeral, bounded in-memory job registry. The in-flight guard is released by the background task itself; 404/400/409 validation still happens synchronously before the job launches. On the frontend, the scan buttons launch the job and poll `GET /scan-jobs/{job_id}` every 2s, showing a "Scanning… (this can take a few minutes)" aria-live status, with the real error surfaced on failure and a distinct message for 409.
- First of three branches addressing reported scan-related issues.

## Testing

- Scan endpoint tests rewritten for the 202+poll contract, including a failed-job path and the new status endpoint's 404 case
- Frontend hook/component tests for launch → poll → succeeded/failed and the 409 case
- Backend `mypy --strict` and `ruff` clean; frontend `tsc` clean
- API reference (`docs/user-guide/rest-api.md`) and `CHANGELOG.md` updated