### PR TITLE
fix(frontend): recover from stale lazy-loaded chunks after redeploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+### Fixed
+- **Recover from stale lazy-loaded chunks after a redeploy.** Route pages are code-split with `React.lazy`; when the app is rebuilt, chunk filenames get new content hashes and old chunks 404, so a browser tab still on the previous build fails with "Failed to fetch dynamically imported module". The app now handles Vite's `vite:preloadError` by reloading once (guarded against loops), and the server serves `index.html` with `Cache-Control: no-cache` so the reload fetches HTML referencing the current hashes.
+
 ## [0.57.0] - 2026-07-20
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
 
+### Fixed
+- **Recover from stale lazy-loaded chunks after a redeploy.** Route pages are code-split with `React.lazy`; when the app is rebuilt, chunk filenames get new content hashes and old chunks 404, so a browser tab still on the previous build fails with "Failed to fetch dynamically imported module". The app now handles Vite's `vite:preloadError` by reloading once (guarded against loops), and the server serves `index.html` with `Cache-Control: no-cache` so the reload fetches HTML referencing the current hashes.
+
 ## [0.57.0] - 2026-07-20
 
 ### Added

--- a/frontend/src/lib/__tests__/preloadErrorReload.test.ts
+++ b/frontend/src/lib/__tests__/preloadErrorReload.test.ts
@@ -1,0 +1,51 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installPreloadErrorReload } from "../preloadErrorReload";
+
+describe("installPreloadErrorReload", () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  // Install the handler exactly once — re-installing would stack listeners.
+  beforeAll(() => {
+    installPreloadErrorReload();
+  });
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload: reloadSpy },
+    });
+  });
+
+  function firePreloadError(): void {
+    window.dispatchEvent(new Event("vite:preloadError", { cancelable: true }));
+  }
+
+  it("reloads the page once when a dynamic import fails", () => {
+    firePreloadError();
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload again within the guard window (no reload loop)", () => {
+    firePreloadError();
+    firePreloadError();
+    firePreloadError();
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads again once the guard window has elapsed", () => {
+    vi.useFakeTimers();
+    try {
+      firePreloadError();
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(10_001);
+      firePreloadError();
+      expect(reloadSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/lib/preloadErrorReload.ts
+++ b/frontend/src/lib/preloadErrorReload.ts
@@ -1,0 +1,37 @@
+/**
+ * Recovery for stale lazy-loaded chunks after a redeploy.
+ *
+ * The app code-splits routes with `React.lazy(() => import(...))`. Vite emits
+ * content-hashed chunk filenames, so a rebuild/redeploy replaces every chunk
+ * with a new hash and removes the old files. A browser tab still running the
+ * *previous* build then tries to import a chunk name that no longer exists on
+ * the server, which 404s and surfaces as
+ * "Failed to fetch dynamically imported module".
+ *
+ * Vite dispatches a `vite:preloadError` event when a dynamic import fails. We
+ * handle it by reloading the page once, which fetches a fresh `index.html`
+ * (served with `Cache-Control: no-cache`) that references the current hashes.
+ * A short guard in `sessionStorage` prevents a reload loop if the reload does
+ * not resolve the failure (e.g. a genuinely offline network).
+ */
+
+const RELOAD_GUARD_KEY = "vite-preload-reloaded-at";
+const RELOAD_GUARD_WINDOW_MS = 10_000;
+
+/**
+ * Install the `vite:preloadError` handler that reloads once on a failed
+ * dynamic import. Safe to call once at app startup.
+ */
+export function installPreloadErrorReload(): void {
+  window.addEventListener("vite:preloadError", (event) => {
+    const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) ?? "0");
+    if (Date.now() - last <= RELOAD_GUARD_WINDOW_MS) {
+      // Already reloaded very recently — don't loop; let the error surface.
+      return;
+    }
+    sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+    // Prevent Vite from throwing the unhandled error before we reload.
+    event.preventDefault();
+    window.location.reload();
+  });
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,9 +16,13 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
+import { installPreloadErrorReload } from "./lib/preloadErrorReload";
 import { queryClient } from "./lib/queryClient";
 import { router } from "./router";
 import "./index.css";
+
+// Recover from stale lazy-loaded chunks after a redeploy (see module docs).
+installPreloadErrorReload();
 
 const rootElement = document.getElementById("root");
 

--- a/src/chronovista/api/main.py
+++ b/src/chronovista/api/main.py
@@ -285,5 +285,16 @@ if _serve_static and _static_dir.exists():
         This catch-all handles React Router paths like /onboarding, /channels,
         /videos/123, etc. API routes, /docs, /redoc, and /openapi.json continue
         to work because they are registered before this catch-all.
+
+        ``index.html`` is served with ``Cache-Control: no-cache`` so browsers
+        revalidate it on every load. After a redeploy the fresh HTML then
+        references the new content-hashed asset filenames, avoiding stale
+        references to chunks that no longer exist (which would otherwise fail
+        as "Failed to fetch dynamically imported module"). The hashed assets
+        under ``/assets`` remain safe to cache since their names change on
+        every build.
         """
-        return FileResponse("static/index.html")
+        return FileResponse(
+            "static/index.html",
+            headers={"Cache-Control": "no-cache"},
+        )


### PR DESCRIPTION
## Summary

- **Root cause**: Route pages are code-split with `React.lazy`. A rebuild changes Vite's content-hashed chunk filenames and removes the old ones, so a browser tab still running the previous build fails to import a route chunk that 404s ("Failed to fetch dynamically imported module") — intermittently, on any lazy route.
- **Fix**: Handle Vite's `vite:preloadError` event with a guarded, one-time page reload (`installPreloadErrorReload()`, wired up in `main.tsx`), and serve `index.html` with `Cache-Control: no-cache` so the reload fetches fresh HTML referencing the current asset hashes. Hashed `/assets` files remain cacheable.

## Testing

- Unit tests for the reload handler: reloads once, does not loop within the guard window, reloads again once the guard window elapses.
- `Cache-Control: no-cache` header verified against the SPA catch-all route.
- `tsc` + `ruff` + `mypy` clean.

This is the second of three branches addressing reported issues.
