### PR TITLE
chore: wire up pre-commit (Black + Ruff) and a blame-ignore list

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# Revisions listed here are skipped by `git blame` so that bulk mechanical
+# changes (e.g. a repo-wide formatter run) don't obscure real authorship.
+#
+# GitHub's web "Blame" view honors this file automatically. For the local CLI,
+# enable it once per clone:
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Only list commits that are PURELY mechanical (no behavior change).
+
+# chore: adopt Black formatting repo-wide (#136 / PR #137) — 312 files reformatted
+593860812ae826c72b1e09ec93f4b64f88cbff72

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# Pre-commit hooks: run Black and Ruff on staged Python files before every commit,
+# so formatting/lint issues are fixed locally instead of failing in CI.
+#
+# One-time setup after cloning:
+#     poetry run pre-commit install
+#
+# Scope and versions match the CI lint job (black --check + ruff check on
+# src/chronovista/ and tests/). When Black or Ruff are bumped in pyproject.toml,
+# bump the `rev` values here to match (or run `pre-commit autoupdate`).
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        files: ^(src/chronovista/|tests/)
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.3
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+        files: ^(src/chronovista/|tests/)

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -61,6 +61,19 @@ make dev-migrate
 poetry run pre-commit install
 ```
 
+This runs **Black** (format) and **Ruff** (lint, with autofix) on staged Python
+files under `src/chronovista/` and `tests/` before every commit — the same
+checks CI enforces, caught locally instead of in a failed build. If a hook
+reformats or fixes files, the commit is aborted; re-stage the changes and
+commit again.
+
+Also enable the shared blame-ignore list so `git blame` skips the one-time
+repo-wide formatting commit (GitHub's web blame does this automatically):
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ### 5. Configure Environment
 
 ```bash


### PR DESCRIPTION
The `pre-commit` dev dependency and setup docs referenced running `pre-commit install`, but no `.pre-commit-config.yaml` existed, so the hook did nothing.

- Adds `.pre-commit-config.yaml` running Black + Ruff (matching CI's scope/versions) on staged Python files, so formatting/lint issues are caught locally before commit instead of failing CI.
- Adds `.git-blame-ignore-revs` listing the #136 repo-wide reformat commit so `git blame` (including GitHub's web blame) skips it.
- Updates `docs/development/setup.md` with the one-time enable steps.

Note: contributors need to run `poetry run pre-commit install` once after pulling this.