### PR TITLE
ci: deploy MkDocs site to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,73 @@
+name: Deploy Docs
+
+# Build the MkDocs site and publish it to GitHub Pages
+# (https://aucontraire.github.io/chronovista/).
+#
+# Uses the modern GitHub Actions Pages deployment (upload-pages-artifact +
+# deploy-pages). The repository's Pages "Source" must be set to "GitHub Actions"
+# (Settings → Pages → Build and deployment → Source).
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch: {}
+
+# Grant the token the permissions needed to deploy to Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent Pages deployment; don't cancel an in-progress deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Cache Poetry dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-docs-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: poetry-docs-${{ runner.os }}-
+
+      - name: Install docs dependencies
+        run: poetry install --no-interaction --with docs
+
+      - name: Build MkDocs site
+        run: poetry run mkdocs build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,11 @@
 site_name: chronovista
 site_description: Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history
 site_author: chronovista Contributors
-site_url: https://docs.chronovista.dev
+site_url: https://aucontraire.github.io/chronovista/
 
-repo_name: chronovista/chronovista
-repo_url: https://github.com/chronovista/chronovista
-edit_uri: edit/main/docs/
+repo_name: aucontraire/chronovista
+repo_url: https://github.com/aucontraire/chronovista
+edit_uri: edit/master/docs/
 
 theme:
   name: material
@@ -165,13 +165,8 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/chronovista/chronovista
+      link: https://github.com/aucontraire/chronovista
       name: chronovista on GitHub
-  version:
-    provider: mike
-  analytics:
-    provider: google
-    property: G-XXXXXXXXXX  # Replace with actual GA4 property ID
   generator: false
 
 extra_css:


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the MkDocs site and deploys it to GitHub Pages (aucontraire.github.io/chronovista) using the modern deploy-pages flow (upload-pages-artifact + deploy-pages), triggered on push to master (docs/**, mkdocs.yml, the workflow) and manual dispatch.

Also fixes placeholder `site_url`/`repo_url`/`repo_name`/`edit_uri` in mkdocs.yml (previously pointed at `chronovista/chronovista` on `main`; now `aucontraire/chronovista` on `master`), and removes the broken `mike` version provider and placeholder GA4 analytics id.

Build verified locally (`mkdocs build` succeeds). The first publish will show current docs as-is; content will be reworked separately as part of the grounded-on-code Diátaxis migration in progress.

Note: the Pages "Source" is already set to "GitHub Actions" in repo settings.