### PR TITLE
docs: correct stale references (recovery routes, pre-commit, versions, branch)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,7 +53,7 @@ make test-cov
 
 ### 5. Submit Pull Request
 
-- Create PR against `main` branch
+- Create PR against `master` branch
 - Fill out PR template
 - Link related issues
 

--- a/docs/development/code-style.md
+++ b/docs/development/code-style.md
@@ -235,20 +235,22 @@ Automatic formatting on commit:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 25.1.0
     hooks:
       - id: black
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
+        files: ^(src/chronovista/|tests/)
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.12.3
     hooks:
-      - id: ruff
+      - id: ruff-check
+        args: [--fix]
+        files: ^(src/chronovista/|tests/)
 ```
+
+Import sorting is handled by Ruff's `I` rule — there is no separate `isort`
+hook. Black is also enforced in CI (`black --check`), so a commit that skips
+the hook is still caught on the PR.
 
 Install:
 ```bash

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -21,9 +21,8 @@ chronovista uses environment variables for configuration. Create a `.env` file i
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `LOG_LEVEL` | Logging verbosity | `INFO` |
-| `YOUTUBE_REDIRECT_URI` | OAuth callback URL | `http://localhost:8080/auth/callback` |
+| `OAUTH_REDIRECT_URI` | OAuth callback URL | `http://localhost:8080/auth/callback` |
 | `API_RATE_LIMIT` | Requests per minute | `100` |
-| `TRANSCRIPT_DOWNLOAD_DELAY` | Delay between transcript downloads (seconds) | `5` |
 
 ## Database Configuration
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -31,7 +31,7 @@ Run CLI commands inside the container:
 
 ```bash
 make docker-shell          # Opens bash inside the container
-chronovista videos list --limit 10
+chronovista tags list --limit 10
 ```
 
 !!! note "What Runs Where"

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -60,7 +60,7 @@ Project-specific terminology used throughout chronovista documentation and code.
 :   A video or channel's current accessibility state. Values: `available` (normal), `deleted`, `private`, `unavailable` (generic), `region_restricted`. Replaces the legacy `deleted_flag` boolean with richer status tracking.
 
 **Recovery**
-:   The process of extracting metadata from a Wayback Machine snapshot of a deleted YouTube page and updating the local database. **Video recovery** pulls title, description, tags, thumbnail, channel info, like/view counts, and upload date using a three-tier overwrite policy. **Channel recovery** pulls title, description, subscriber count, video count, thumbnail, and country using a two-tier overwrite policy. Recovery is available via CLI (`chronovista recover video`), REST API (`POST /api/v1/recovery/videos/{id}` and `POST /api/v1/recovery/channels/{id}`), and the frontend's "Recover from Web Archive" button.
+:   The process of extracting metadata from a Wayback Machine snapshot of a deleted YouTube page and updating the local database. **Video recovery** pulls title, description, tags, thumbnail, channel info, like/view counts, and upload date using a three-tier overwrite policy. **Channel recovery** pulls title, description, subscriber count, video count, thumbnail, and country using a two-tier overwrite policy. Recovery is available via CLI (`chronovista recover video`), REST API (`POST /api/v1/videos/{id}/recover` and `POST /api/v1/channels/{id}/recover`), and the frontend's "Recover from Web Archive" button.
 
 **Recovery Source**
 :   The origin of recovered metadata, recorded in the `recovery_source` field. Typically `wayback_machine` for data extracted from Internet Archive snapshots.

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,12 +166,12 @@ chronovista is a CLI application that enables users to access, store, and explor
 
     ```bash
     # Recover a video via the API
-    curl -X POST "http://localhost:8765/api/v1/recovery/videos/dQw4w9WgXcQ" \
+    curl -X POST "http://localhost:8765/api/v1/videos/dQw4w9WgXcQ/recover" \
       -H "Content-Type: application/json" \
       -d '{"start_year": 2018, "end_year": 2020}'
 
     # Recover a channel via the API
-    curl -X POST "http://localhost:8765/api/v1/recovery/channels/UCxxxxxx"
+    curl -X POST "http://localhost:8765/api/v1/channels/UCxxxxxx/recover"
 
     # Repeated requests within 5 minutes return cached results
     ```

--- a/docs/maintaining/release-process.md
+++ b/docs/maintaining/release-process.md
@@ -53,7 +53,7 @@ gh pr create --title "Release v$(poetry version -s)"
 After PR is approved:
 
 ```bash
-git checkout main
+git checkout master
 git pull
 git tag v$(poetry version -s)
 git push origin v$(poetry version -s)

--- a/docs/maintaining/versioning.md
+++ b/docs/maintaining/versioning.md
@@ -30,7 +30,7 @@ For pre-release versions:
 
 ## Current Status
 
-chronovista is currently at version **0.8.0** (pre-1.0), which means:
+chronovista is pre-1.0 (see the version badge / GitHub releases for the current version), which means:
 
 - API may change between minor versions
 - Suitable for personal use and testing
@@ -42,10 +42,10 @@ chronovista is currently at version **0.8.0** (pre-1.0), which means:
 # Show current version
 poetry version
 
-# Bump patch (0.8.0 -> 0.8.1)
+# Bump patch (e.g. 0.57.0 -> 0.57.1)
 poetry version patch
 
-# Bump minor (0.8.0 -> 0.9.0)
+# Bump minor (e.g. 0.57.0 -> 0.58.0)
 poetry version minor
 
 # Bump major (0.9.0 -> 1.0.0)


### PR DESCRIPTION
Quick-win corrections from the docs-vs-code audit — the cheapest, clearly-wrong items that were actively misinforming, ahead of the larger grounded-on-code Diataxis rework.

- Wrong recovery REST routes fixed in index.md and glossary.md (`/api/v1/recovery/videos/{id}` -> `/api/v1/videos/{id}/recover`).
- code-style.md pre-commit block updated to match the real `.pre-commit-config.yaml` (Black 25.1.0, ruff-check v0.12.3, no isort hook) and notes Black is CI-enforced.
- configuration.md: `YOUTUBE_REDIRECT_URI` -> `OAUTH_REDIRECT_URI`; removed the non-existent `TRANSCRIPT_DOWNLOAD_DELAY`.
- versioning.md: stopped hard-coding "0.8.0" as current; realistic bump examples.
- quickstart.md: `videos list` (no such command) -> `tags list`.
- `main` -> `master` branch references.

Verified `mkdocs build` still succeeds. Larger items (generated CLI/API reference, configuration.md YAML-config-file rewrite, system-design.md) are tracked for follow-up.