### PR TITLE
docs: rewrite stale architecture & configuration content (Diátaxis PR 1/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ make dev-migrate
 
 You'll need a Google Cloud project with YouTube Data API v3 enabled and OAuth 2.0 credentials.
 
-**[Full setup guide](docs/getting-started/youtube-api-setup.md)** — covers consent screen configuration, test user setup, and common authentication errors.
+**[Full setup guide](https://aucontraire.github.io/chronovista/getting-started/youtube-api-setup/)** — covers consent screen configuration, test user setup, and common authentication errors.
 
 Quick reference for `.env`:
 ```env
@@ -390,7 +390,7 @@ chronovista/
 - Repository pattern isolating all database access
 - Layered architecture: CLI/API -> Services -> Repositories -> DB
 
-See [Architecture Overview](docs/architecture/overview.md) for details.
+See [Architecture Overview](https://aucontraire.github.io/chronovista/architecture/overview/) for details.
 
 ## Engineering Practice
 

--- a/docs/architecture/api-integration.md
+++ b/docs/architecture/api-integration.md
@@ -250,14 +250,12 @@ WRITE_SCOPES = [
 
 ### Progressive Scope Management
 
-```python
-class AuthService:
-    async def request_write_access(self):
-        """Upgrade to write scopes when needed."""
-        current_scopes = await self.get_current_scopes()
-        if "youtube" not in current_scopes:
-            await self.reauthenticate(WRITE_SCOPES)
-```
+OAuth scopes are configured via the `oauth_scopes` setting and handled by
+`OAuthService` in `src/chronovista/auth/oauth_service.py`. Read scopes are
+requested by default; adding write scopes (playlist management, rating,
+subscribing) requires re-running the OAuth flow so the user can grant the
+broader consent. Credentials are persisted to `{DATA_DIR}/youtube_token.json`
+and refreshed automatically while a valid refresh token exists.
 
 ## Error Handling
 
@@ -387,7 +385,11 @@ Triggers batch recovery of all deleted/unavailable videos for a channel.
 
 ### Dependency Injection
 
-Both endpoints use `get_recovery_deps()` from `api/deps.py` to obtain a `RecoveryDeps` bundle containing the CDX client, page parser, and orchestrator, all sharing a single database session per request.
+Both endpoints use `get_recovery_deps()` from `api/deps.py`, which returns a
+`tuple[CDXClient, PageParser, RateLimiter]`. The `RateLimiter` is a module-level
+singleton shared across requests (so the Wayback Machine rate limit is respected
+globally); the endpoint constructs the recovery orchestrator from these
+dependencies and the request-scoped database session.
 
 ## See Also
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -52,31 +52,39 @@ Clear separation between layers:
 
 ### Repository Pattern
 
-Abstracted data access with swappable implementations:
+Data access is abstracted behind a generic base. `BaseRepository` (an ABC in
+`repositories/base.py`) declares the async contract, and
+`BaseSQLAlchemyRepository` provides the concrete implementation that every
+specialized repository extends:
 
 ```python
-class VideoRepository(ABC):
+class BaseRepository(
+    ABC, Generic[ModelType, CreateSchemaType, UpdateSchemaType, IdType]
+):
     @abstractmethod
-    async def save(self, video: Video) -> None: ...
+    async def create(self, session: AsyncSession, *, obj_in: CreateSchemaType) -> ModelType: ...
 
     @abstractmethod
-    async def find_by_id(self, video_id: VideoId) -> Optional[Video]: ...
+    async def get(self, session: AsyncSession, id: IdType) -> ModelType | None: ...
+
+    @abstractmethod
+    async def get_multi(self, session: AsyncSession, *, skip: int = 0, limit: int = 100) -> list[ModelType]: ...
+
+    @abstractmethod
+    async def update(self, session: AsyncSession, *, db_obj: ModelType, obj_in: UpdateSchemaType) -> ModelType: ...
+
+    @abstractmethod
+    async def delete(self, session: AsyncSession, *, id: IdType) -> ModelType | None: ...
 ```
 
 ### Dependency Injection
 
-Loose coupling between components enables testing and flexibility:
-
-```python
-class SyncService:
-    def __init__(
-        self,
-        video_repo: VideoRepository,
-        youtube_api: YouTubeAPIClient,
-    ):
-        self.video_repo = video_repo
-        self.youtube_api = youtube_api
-```
+Loose coupling between components enables testing and flexibility. Services
+receive their collaborators (repositories, the `YouTubeService` client, a
+database session) rather than constructing them. In the REST API, FastAPI's
+`Depends()` wires these together per request — for example, the recovery
+endpoints obtain their dependencies from `get_recovery_deps()` in
+`api/deps.py`.
 
 ## Component Overview
 
@@ -92,35 +100,42 @@ Typer-based command-line interface:
 
 FastAPI-based HTTP interface:
 
-- 13 versioned endpoints under `/api/v1/`
+- 70+ versioned operations under `/api/v1/` (see the generated [REST API reference](../reference/api/index.md))
 - OAuth integration with CLI token cache
 - OpenAPI documentation (Swagger, ReDoc)
 - Pydantic V2 response schemas
-- Pagination and error handling
+- Pagination, filtering, and RFC 7807 error handling
 
 ### Service Layer
 
-Business logic services:
+Business logic lives in concrete service classes under `services/`. Most are
+plain classes; only three (`TakeoutService`, `TranscriptService`,
+`YouTubeService`) sit behind ABC interfaces in `services/interfaces/`.
+Representative services:
 
-- **AuthService** - OAuth authentication
-- **SyncService** - Data synchronization
-- **TranscriptService** - Multi-language transcript management
-- **TopicService** - Topic analytics
-- **TakeoutService** - Google Takeout processing
-- **RecoveryOrchestrator** - Wayback Machine video recovery coordination
-- **ChannelRecoveryOrchestrator** - Channel-level archive recovery with two-tier overwrite
-- **CDXClient** - Wayback Machine CDX API client with caching and retry
-- **PageParser** - Archived YouTube page metadata extraction (5-pattern like count, channel metadata)
+- **YouTubeService** - YouTube Data API v3 client wrapper
+- **TranscriptService** - Fetch and download transcripts
+- **TakeoutService** / **TakeoutSeedingService** - Parse and seed Google Takeout archives
+- **EnrichmentService** (`services/enrichment/`) - Metadata enrichment via the API
+- **TagNormalizationService** / **TagManagementService** - Canonical tag pipeline and curation
+- **EntityMentionScanService** - Named-entity mention detection in transcripts
+- **TranscriptCorrectionService** / **BatchCorrectionService** - Correction workflows
+- **TopicAnalyticsService** / **TopicGraphService** - Topic analytics and relationship graphs
+- **Recovery orchestrators** (`services/recovery/`) - Wayback Machine video/channel recovery, plus `CDXClient`, `PageParser`, and `RateLimiter`
 
 ### Repository Layer
 
-Data access abstractions:
+Data access abstractions (all extending `BaseSQLAlchemyRepository`):
 
 - **ChannelRepository** - Channel data
 - **VideoRepository** - Video data
-- **TranscriptRepository** - Transcript storage
-- **TopicRepository** - Topic classification
+- **VideoTranscriptRepository** - Transcript storage
+- **TopicCategoryRepository** - Topic classification
 - **UserVideoRepository** - Watch history
+- **CanonicalTagRepository** / **TagAliasRepository** - Tag normalization
+- **NamedEntityRepository** / **EntityMentionRepository** - Entity knowledge base
+
+...and ~14 more, one per persisted entity.
 
 ### Database Layer
 
@@ -241,7 +256,7 @@ async def fetch_video(self, video_id: str) -> Video:
 2. FastAPI: Validate auth, parse year filters
            |
            v
-3. Dependencies: get_recovery_deps() → CDXClient, PageParser, Orchestrator
+3. Dependencies: get_recovery_deps() → (CDXClient, PageParser, RateLimiter)
            |
            v
 4. Idempotency Guard: Skip if recovered within 5 minutes

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -4,39 +4,82 @@ Detailed component design and service architecture.
 
 ## Service Architecture
 
+chronovista's business logic lives in concrete service classes under
+`src/chronovista/services/`. Services are **plain classes** that receive their
+collaborators (repositories, the `YouTubeService` client, a database session)
+via their constructors — there is no service-locator or global registry. Only
+three services sit behind ABC interfaces (see [Service Interfaces](#service-interfaces)).
+
 ```
-                    Service Layer
-+-------------------------------------------------------------------+
-|                                                                    |
-|  +---------------+  +---------------+  +---------------+           |
-|  |   AuthService |  | ChannelService|  |SmartTranscript|           |
-|  |               |  |               |  |   Service     |           |
-|  +-------+-------+  +-------+-------+  +-------+-------+           |
-|          |                  |                  |                    |
-|  +---------------+  +---------------+  +---------------+           |
-|  |GoogleTakeout  |  |LanguagePref   |  |  ExportService|           |
-|  |   Parser      |  |   Service     |  |               |           |
-|  +-------+-------+  +-------+-------+  +-------+-------+           |
-|          |                  |                  |                    |
-|  +---------------+  +---------------+  +---------------+           |
-|  |  TagService   |  | UserAction    |  |  TopicService |           |
-|  |               |  |   Service     |  |               |           |
-|  +---------------+  +---------------+  +---------------+           |
-|          |                  |                  |                    |
-|  +---------------+  +---------------+  +---------------+           |
-|  | Recovery      |  |  CDXClient   |  |  PageParser   |           |
-|  | Orchestrator  |  |              |  |               |           |
-|  +---------------+  +---------------+  +---------------+           |
-|          |                  |                  |                    |
-|  +---------------+                                                 |
-|  | ChannelRecovery|                                                |
-|  | Orchestrator   |                                                |
-|  +---------------+                                                 |
-|                                                                    |
-+-------------------------------------------------------------------+
+                              Service Layer
++-----------------------------------------------------------------------------+
+|                                                                             |
+|  Ingestion & Sync            Transcripts & Corrections                      |
+|  +----------------------+    +-------------------------------+              |
+|  | YouTubeService       |    | TranscriptService             |              |
+|  | TakeoutService       |    | TranscriptCorrectionService   |              |
+|  | TakeoutSeedingService|    | BatchCorrectionService        |              |
+|  | EnrichmentService    |    | SegmentService                |              |
+|  +----------------------+    +-------------------------------+              |
+|                                                                             |
+|  Tags & Entities             Topics & Analytics                             |
+|  +----------------------+    +-------------------------------+              |
+|  | TagNormalizationSvc  |    | TopicAnalyticsService         |              |
+|  | TagManagementService |    | TopicGraphService             |              |
+|  | TagBackfillService   |    | ImageCacheService             |              |
+|  | EntityMentionScanSvc  |    | OnboardingService             |              |
+|  | PhoneticMatcher      |    |                               |              |
+|  +----------------------+    +-------------------------------+              |
+|                                                                             |
+|  Recovery (services/recovery/)                                              |
+|  +--------------------------------------------------------------+          |
+|  | RecoveryOrchestrator  ChannelRecoveryOrchestrator            |          |
+|  | CDXClient   PageParser   RateLimiter                         |          |
+|  +--------------------------------------------------------------+          |
+|                                                                             |
++-----------------------------------------------------------------------------+
+                                    |
+                                    v
+                         Repository Layer  ->  PostgreSQL
+```
+
+> For the exhaustive, always-current list of service classes and their public
+> methods, see the generated [Code reference](../reference/code/). This page
+> describes the design; the reference documents the surface.
+
+## Service Interfaces
+
+Most services are concrete classes with no abstract base. Three services are
+defined against ABC interfaces in `services/interfaces/`, because they wrap
+external systems and benefit from being swappable in tests:
+
+| Interface | Implementation | Wraps |
+|-----------|----------------|-------|
+| `YouTubeServiceInterface` | `YouTubeService` | YouTube Data API v3 |
+| `TranscriptServiceInterface` | `TranscriptService` | `youtube-transcript-api` + captions |
+| `TakeoutServiceInterface` | `TakeoutService` | Google Takeout archive parsing |
+
+Example (`youtube_service_interface.py`):
+
+```python
+class YouTubeServiceInterface(ABC):
+    @abstractmethod
+    async def get_video_details(self, video_id: VideoId) -> Video | None: ...
+
+    @abstractmethod
+    async def get_channel_details(self, channel_id: ChannelId) -> Channel | None: ...
+
+    @abstractmethod
+    async def download_caption(self, caption_id: str, fmt: str = "srt") -> str | None: ...
+
+    @abstractmethod
+    async def check_credentials(self) -> bool: ...
 ```
 
 ## Recovery Services
+
+The recovery subsystem (`services/recovery/`) reconstructs metadata for deleted
+or unavailable videos and channels from the Internet Archive's Wayback Machine.
 
 ### RecoveryOrchestrator
 
@@ -46,7 +89,7 @@ Coordinates deleted video recovery via the Wayback Machine:
 1. Check video eligibility (must exist, must not be AVAILABLE)
 2. Query CDX API for archived snapshots
 3. Iterate snapshots (max 20, 600s timeout)
-4. Extract metadata via PageParser (JSON → meta tags → Selenium)
+4. Extract metadata via PageParser (JSON -> meta tags -> Selenium)
 5. Apply three-tier overwrite policy
 6. Create stub channels for unknown channel_ids (FK safety)
 7. Update video record and persist recovered tags
@@ -56,7 +99,7 @@ Coordinates deleted video recovery via the Wayback Machine:
 
 Async client for the Wayback Machine CDX API:
 
-- File-based caching with 24-hour TTL
+- File-based caching with a configurable TTL (`cdx_cache_ttl_hours` setting)
 - Separate cache keys per year filter (`{video_id}_from2018.json`)
 - Exponential backoff retry (3 retries, base 2s)
 - Rate limit handling (60s pause on 429)
@@ -71,22 +114,17 @@ Extracts metadata from archived YouTube video pages using three strategies:
 2. **Meta tag fallback** — Parses Open Graph (`og:`) and `itemprop` HTML meta tags via BeautifulSoup (covers pre-2017 pages lacking JSON)
 3. **Selenium fallback** — Optional rendering for pre-2017 pages requiring JavaScript (requires `selenium` + `webdriver-manager`)
 
-Includes removal notice detection (playability status, title checks, body text patterns) to skip archived pages that show "Video unavailable" instead of real content.
-
-Additional extraction patterns (v0.28.0):
-- **5-pattern like count** — Extracts like counts from multiple page layout variants
-- **Truncated description replacement** — Replaces `og:description` truncated text with full description from JSON when available
-- **Channel metadata extraction** — Extracts channel title and ID from video pages for auto-channel recovery
+Includes removal notice detection (playability status, title checks, body text patterns) to skip archived pages that show "Video unavailable" instead of real content. It also extracts channel title and ID from video pages to drive automatic channel recovery.
 
 ### ChannelRecoveryOrchestrator
 
-Coordinates channel-level archive recovery (v0.28.0):
+Coordinates channel-level archive recovery:
 
 ```
 1. Load all deleted/unavailable videos for the channel
 2. Iterate videos through RecoveryOrchestrator
 3. Extract channel metadata from recovered video pages (auto-channel recovery)
-4. Apply two-tier overwrite policy for channel record:
+4. Apply two-tier overwrite policy for the channel record:
    - Immutable fields: fill-if-NULL only (title, description)
    - Mutable fields: overwrite-if-newer (thumbnail, subscriber count)
 5. Return per-video recovery outcomes with summary statistics
@@ -94,187 +132,76 @@ Coordinates channel-level archive recovery (v0.28.0):
 
 ### Recovery Dependency Injection
 
-Recovery services are wired via `get_recovery_deps()` in `api/deps.py`:
+Recovery dependencies are wired via `get_recovery_deps()` in `api/deps.py`. It
+returns a **tuple**, not a bundle object:
 
 ```python
-async def get_recovery_deps(
-    session: AsyncSession = Depends(get_session),
-) -> RecoveryDeps:
-    """Provides CDXClient, PageParser, and RecoveryOrchestrator."""
+def get_recovery_deps() -> tuple[CDXClient, PageParser, RateLimiter]:
+    """Provide the CDX client, page parser, and shared rate limiter."""
     ...
 ```
 
-This factory creates the full recovery dependency graph (CDX client, page parser, orchestrator) per-request with shared database session.
+The `RateLimiter` is a module-level singleton (`RateLimiter(rate=40.0)`) so the
+Wayback Machine rate limit is respected across all concurrent requests, while a
+fresh `CDXClient` and `PageParser` are created per call. The endpoint constructs
+the orchestrator from these three dependencies plus the request-scoped database
+session.
 
 ### Idempotency Guard
 
-Recovery endpoints enforce a 5-minute idempotency window. If `recovered_at` is within the last 5 minutes, the endpoint returns the existing result without re-querying the Wayback Machine. This prevents redundant CDX/page-fetch cycles from duplicate requests or UI retries.
-
-## Core Services
-
-### AuthService
-
-Manages OAuth 2.0 authentication with YouTube:
-
-```python
-class AuthService(ABC):
-    @abstractmethod
-    async def authenticate(self) -> Credentials: ...
-
-    @abstractmethod
-    async def refresh_token(self) -> Credentials: ...
-
-    @abstractmethod
-    async def revoke_access(self) -> None: ...
-
-    @abstractmethod
-    async def get_current_user(self) -> User: ...
-```
-
-### ChannelService
-
-Manages YouTube channels and subscriptions:
-
-```python
-class ChannelService(ABC):
-    @abstractmethod
-    async def sync_subscriptions(self) -> List[Channel]: ...
-
-    @abstractmethod
-    async def get_channel_details(self, channel_id: ChannelId) -> Channel: ...
-
-    @abstractmethod
-    async def get_videos_by_channel(self, channel_id: ChannelId) -> List[Video]: ...
-
-    @abstractmethod
-    async def get_watched_videos_by_channel(
-        self, channel_id: ChannelId
-    ) -> List[UserVideo]: ...
-
-    @abstractmethod
-    async def extract_and_store_keywords(
-        self, channel_id: ChannelId
-    ) -> List[ChannelKeyword]: ...
-```
-
-### SmartTranscriptService
-
-Intelligent multi-language transcript management:
-
-```python
-class SmartTranscriptService(ABC):
-    @abstractmethod
-    async def download_intelligent_transcripts(
-        self, video_id: VideoId
-    ) -> List[VideoTranscript]: ...
-
-    @abstractmethod
-    async def get_available_languages(self, video_id: VideoId) -> List[str]: ...
-
-    @abstractmethod
-    async def should_download_transcript(
-        self, video_id: VideoId, lang: str
-    ) -> bool: ...
-
-    @abstractmethod
-    async def get_transcript_quality_score(
-        self, video_id: VideoId, lang: str
-    ) -> float: ...
-
-    @abstractmethod
-    async def prioritize_transcripts_by_quality(
-        self, video_id: VideoId
-    ) -> List[VideoTranscript]: ...
-```
-
-### LanguagePreferenceService
-
-Manages user language preferences:
-
-```python
-class LanguagePreferenceService(ABC):
-    @abstractmethod
-    async def set_language_preference(
-        self, lang: str, pref_type: LanguagePreferenceType
-    ) -> None: ...
-
-    @abstractmethod
-    async def get_preferred_languages(self) -> List[UserLanguagePreference]: ...
-
-    @abstractmethod
-    async def get_download_strategy(
-        self, video_id: VideoId
-    ) -> TranscriptDownloadStrategy: ...
-```
-
-### TagService
-
-Manages tags and topic classification:
-
-```python
-class TagService(ABC):
-    @abstractmethod
-    async def extract_video_tags(self, video_id: VideoId) -> List[VideoTag]: ...
-
-    @abstractmethod
-    async def extract_channel_keywords(
-        self, channel_id: ChannelId
-    ) -> List[ChannelKeyword]: ...
-
-    @abstractmethod
-    async def sync_topic_categories(
-        self, topic_ids: List[str]
-    ) -> List[TopicCategory]: ...
-
-    @abstractmethod
-    async def get_related_videos_by_tags(self, tags: List[str]) -> List[str]: ...
-```
-
-### GoogleTakeoutService
-
-Processes Google Takeout data:
-
-```python
-class GoogleTakeoutService:
-    async def parse_watch_history(self, path: Path) -> List[WatchHistoryEntry]: ...
-
-    async def parse_subscriptions(self, path: Path) -> List[Subscription]: ...
-
-    async def parse_playlists(self, path: Path) -> List[Playlist]: ...
-
-    async def enrich_with_api_data(
-        self, entries: List[WatchHistoryEntry]
-    ) -> List[Video]: ...
-```
+Recovery endpoints enforce a 5-minute idempotency window. If `recovered_at` is
+within the last 5 minutes, the endpoint returns the existing result without
+re-querying the Wayback Machine. This prevents redundant CDX/page-fetch cycles
+from duplicate requests or UI retries.
 
 ## Repository Layer
 
+Data access follows the repository pattern with a two-tier generic base in
+`repositories/base.py`.
+
 ### Base Repository
 
+`BaseRepository` is an ABC declaring the async contract;
+`BaseSQLAlchemyRepository` is the concrete generic implementation that every
+specialized repository extends.
+
 ```python
-class BaseRepository(ABC, Generic[T]):
+class BaseRepository(
+    ABC, Generic[ModelType, CreateSchemaType, UpdateSchemaType, IdType]
+):
     @abstractmethod
-    async def save(self, entity: T) -> None: ...
+    async def create(self, session: AsyncSession, *, obj_in: CreateSchemaType) -> ModelType: ...
 
     @abstractmethod
-    async def find_by_id(self, id: str) -> Optional[T]: ...
+    async def get(self, session: AsyncSession, id: IdType) -> ModelType | None: ...
 
     @abstractmethod
-    async def find_all(self) -> List[T]: ...
+    async def get_multi(self, session: AsyncSession, *, skip: int = 0, limit: int = 100) -> list[ModelType]: ...
 
     @abstractmethod
-    async def delete(self, id: str) -> bool: ...
+    async def update(self, session: AsyncSession, *, db_obj: ModelType, obj_in: UpdateSchemaType) -> ModelType: ...
+
+    @abstractmethod
+    async def delete(self, session: AsyncSession, *, id: IdType) -> ModelType | None: ...
 ```
+
+`BaseSQLAlchemyRepository` adds `exists(session, id) -> bool` alongside the
+concrete implementations.
 
 ### Specialized Repositories
 
+There is one repository per persisted entity (~21 in total). Representative
+examples:
+
 | Repository | Entity | Key Features |
 |------------|--------|--------------|
-| ChannelRepository | Channel | Subscription tracking |
-| VideoRepository | Video | Multi-language support |
-| TranscriptRepository | Transcript | Quality scoring |
-| TopicRepository | Topic | Hierarchical structure |
-| UserVideoRepository | UserVideo | Watch history |
+| `ChannelRepository` | Channel | Subscription tracking, availability status |
+| `VideoRepository` | Video | Multi-language fields, recovery columns |
+| `VideoTranscriptRepository` | VideoTranscript | Quality scoring, language codes |
+| `TopicCategoryRepository` | TopicCategory | Hierarchical structure |
+| `UserVideoRepository` | UserVideo | Watch history |
+| `CanonicalTagRepository` / `TagAliasRepository` | Canonical tags / aliases | Tag normalization joins |
+| `NamedEntityRepository` / `EntityMentionRepository` | Entities / mentions | Entity knowledge base |
 
 ## Data Enrichment Pipeline
 
@@ -283,34 +210,24 @@ Google Takeout
      |
      v
 +--------------------+
-| Parse Takeout Files|
-| - watch-history.json
+| Parse Takeout Files|  TakeoutService
+| - watch-history.html/json
 | - subscriptions.csv
-| - playlists.json
+| - playlists.csv
 +--------+-----------+
          |
          v
 +--------------------+
-| Extract Identifiers|
-| - Video IDs
-| - Channel IDs
-| - Playlist IDs
+| Seed the Database  |  TakeoutSeedingService / SeedingOrchestrator
+| - Videos, Channels, Playlists, UserVideos
 +--------+-----------+
          |
          v
 +--------------------+
-| Batch API Calls    |
+| Enrich via the API |  EnrichmentService
 | - videos.list()
 | - channels.list()
-| - Rate limited
-+--------+-----------+
-         |
-         v
-+--------------------+
-| Apply Preferences  |
-| - Language filter
-| - Quality filter
-| - Topic filter
+| - Rate limited, priority-tiered
 +--------+-----------+
          |
          v
@@ -324,31 +241,19 @@ Google Takeout
 
 ## Rate Limiting Strategy
 
-### API Client
-
-```python
-class RateLimitedAPIClient:
-    def __init__(
-        self,
-        requests_per_minute: int = 100,
-        daily_quota: int = 10000,
-    ):
-        self.rate_limiter = AsyncLimiter(requests_per_minute, 60)
-        self.quota_tracker = QuotaTracker(daily_quota)
-
-    async def call_api(self, operation: str, cost: int = 1):
-        await self.rate_limiter.acquire()
-        if not self.quota_tracker.can_spend(cost):
-            raise QuotaExceededException()
-        self.quota_tracker.spend(cost)
-        return await self._execute(operation)
-```
+The YouTube Data API client (`YouTubeService`) is async and batches requests
+(up to 50 IDs per `videos.list`/`channels.list` call). Request pacing is
+governed by the `api_rate_limit`, `concurrent_requests`, `request_timeout`,
+`retry_attempts`, and `retry_backoff` settings. The recovery subsystem uses its
+own `RateLimiter` for Wayback Machine traffic.
 
 ### Retry Logic
 
+Transient failures are retried with exponential backoff (via `tenacity`):
+
 ```python
 @retry(
-    retry=retry_if_exception_type((APIError, NetworkError)),
+    retry=retry_if_exception_type((YouTubeAPIError, NetworkError)),
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=60),
     before_sleep=before_sleep_log(logger, logging.WARNING),
@@ -359,80 +264,56 @@ async def fetch_with_retry(self, video_id: str):
 
 ## Configuration Management
 
-### Environment-Based
+Configuration is **environment-based** (Pydantic `Settings`, `BaseSettings`);
+there is no YAML configuration file. See [Configuration](../getting-started/configuration.md)
+for the full list of environment variables.
 
 ```python
 class Settings(BaseSettings):
-    youtube_api_key: str
-    youtube_client_id: str
-    youtube_client_secret: str
-    database_url: str
+    youtube_api_key: str = Field(default="")
+    youtube_client_id: str = Field(default="")
+    youtube_client_secret: str = Field(default="")
+    database_url: str = Field(...)
+    oauth_redirect_uri: str = Field(...)
+    data_dir: Path = Field(default=Path("./data"))
 
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-    )
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 ```
 
-### Language Configuration
-
-```yaml
-# ~/.chronovista/language_config.yaml
-language_preferences:
-  fluent: [en-US, es-ES]
-  learning: [it-IT]
-  curious: [fr-FR]
-  exclude: [zh-CN]
-
-auto_download_rules:
-  fluent_languages: true
-  learning_languages: true
-  max_transcripts_per_video: 3
-```
+Language preferences are **not** stored in a config file — they live in the
+`user_language_preferences` database table and are managed through the
+`languages` CLI command group and the `UserLanguagePreferenceRepository`.
 
 ## Error Handling
 
 ### Custom Exceptions
 
+All first-class errors derive from `ChronovistaError` (`src/chronovista/exceptions.py`):
+
 ```python
 class ChronovistaError(Exception):
     """Base exception for all chronovista errors."""
-    pass
 
-class AuthenticationError(ChronovistaError):
-    """Authentication failed."""
-    pass
 
-class QuotaExceededError(ChronovistaError):
-    """API quota exceeded."""
-    pass
-
-class TranscriptNotFoundError(ChronovistaError):
-    """Transcript not available."""
-    pass
+class AuthenticationError(ChronovistaError): ...
+class QuotaExceededException(ChronovistaError): ...
+class YouTubeAPIError(ChronovistaError): ...
+class RecoveryError(ChronovistaError): ...          # -> CDXError, PageParseError, RecoveryDependencyError
+class APIError(ChronovistaError): ...               # -> NotFoundError, BadRequestError, ConflictError, ...
 ```
+
+The `APIError` subtree maps onto HTTP responses (RFC 7807 problem details); the
+`RecoveryError` subtree covers the Wayback Machine recovery path.
 
 ### Error Recovery
 
-```python
-async def sync_with_recovery(self, items: List[str]):
-    failed = []
-    for item in items:
-        try:
-            await self.sync_item(item)
-        except TransientError:
-            await asyncio.sleep(5)
-            failed.append(item)
-        except PermanentError as e:
-            logger.error(f"Permanent error for {item}: {e}")
-
-    # Retry failed items
-    if failed:
-        await self.sync_with_recovery(failed)
-```
+Services degrade gracefully around external APIs — a failed item is logged and
+skipped rather than aborting a whole batch, and transient failures are retried
+with backoff before being surfaced.
 
 ## See Also
 
 - [Architecture Overview](overview.md) - High-level design
 - [Data Model](data-model.md) - Database schema
 - [API Integration](api-integration.md) - YouTube API details
+- [Code Reference](../reference/code/) - Generated service/repository docs

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -47,29 +47,9 @@ DATABASE_URL=mysql+aiomysql://username:password@localhost:3306/chronovista
 ## Language Configuration
 
 chronovista supports multi-language preferences for transcript management.
-
-Create `~/.chronovista/language_config.yaml`:
-
-```yaml
-language_preferences:
-  fluent:
-    - en-US  # Native English
-    - es-ES  # Fluent Spanish
-  learning:
-    - it-IT  # Studying Italian
-    - pt-BR  # Learning Portuguese
-  curious:
-    - fr-FR  # Sometimes interesting
-  exclude:
-    - zh-CN  # Not interested
-
-auto_download_rules:
-  fluent_languages: true
-  learning_languages: true
-  curious_languages: false
-  max_transcripts_per_video: 3
-  short_video_threshold: 300  # seconds
-```
+Preferences are **stored in the database** (the `user_language_preferences`
+table) — there is no YAML config file. Manage them with the `languages` command
+group.
 
 ### Language Preference Types
 
@@ -80,18 +60,26 @@ auto_download_rules:
 | `curious` | Languages you find interesting | No (default) |
 | `exclude` | Languages to skip entirely | Never |
 
-### Setting Preferences via CLI
+### Managing Preferences via CLI
 
 ```bash
-# Set language preferences
-chronovista languages set --fluent en-US,es-ES --learning it-IT --curious fr-FR
+# Interactive setup / add preferences for one or more languages
+chronovista languages set
 
-# View current preferences
-chronovista languages show
+# Add a single language at a given tier
+chronovista languages add
 
-# Configure auto-download behavior
-chronovista languages config --auto-download learning
+# List current preferences
+chronovista languages list
+
+# Remove a language, or reset all preferences
+chronovista languages remove
+chronovista languages reset
 ```
+
+Run `chronovista languages --help` (or see the generated
+[CLI reference](../reference/cli.md)) for the exact flags each subcommand
+accepts.
 
 ## OAuth Scope Management
 
@@ -162,38 +150,25 @@ proxy_config = WebshareProxyConfig(
 
 ## Application Configuration
 
-### CLI Configuration
+All application configuration is environment-based (via Pydantic `Settings`);
+there is no `config.yaml`. Beyond the required variables above, these optional
+environment variables tune behavior (defaults shown):
 
-Configure CLI behavior in `~/.chronovista/config.yaml`:
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LOG_LEVEL` | Logging verbosity | `INFO` |
+| `DATA_DIR` | Directory for the OAuth token and app data | `./data` |
+| `CACHE_DIR` | Directory for the CDX/image cache | `./cache` |
+| `LOGS_DIR` | Directory for log files | `./logs` |
+| `EXPORT_DIR` | Default export output directory | `./exports` |
+| `EXPORT_FORMAT` | Default export format | `csv` |
+| `API_RATE_LIMIT` | YouTube API requests per minute | `100` |
+| `CONCURRENT_REQUESTS` | Max concurrent API requests | (see `settings.py`) |
+| `RETRY_ATTEMPTS` | Retry attempts for transient failures | `3` |
+| `CDX_CACHE_TTL_HOURS` | Wayback CDX cache lifetime | (see `settings.py`) |
 
-```yaml
-cli:
-  output_format: rich  # rich, json, plain
-  color_enabled: true
-  progress_bars: true
-  verbose: false
-
-export:
-  default_format: csv
-  include_headers: true
-  date_format: "%Y-%m-%d"
-
-sync:
-  batch_size: 50
-  retry_attempts: 3
-  retry_delay: 5
-```
-
-### Logging Configuration
-
-```yaml
-logging:
-  level: INFO
-  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-  file: ~/.chronovista/logs/chronovista.log
-  max_size: 10MB
-  backup_count: 5
-```
+See `src/chronovista/config/settings.py` for the authoritative list and default
+values.
 
 ## Development Configuration
 
@@ -244,15 +219,17 @@ python -c "import secrets; print(secrets.token_urlsafe(32))"
 
 ### Credential Storage
 
-OAuth tokens are stored encrypted in `~/.chronovista/credentials/`:
+The OAuth token is written to `youtube_token.json` inside the configured
+`DATA_DIR` (default `./data/`):
 
 ```
-~/.chronovista/
-├── credentials/
-│   └── youtube_token.json  # Encrypted OAuth token
-├── config.yaml
-└── language_config.yaml
+$DATA_DIR/
+└── youtube_token.json   # OAuth access + refresh token (JSON)
 ```
+
+The token file contains a live refresh token, so treat it like a credential:
+keep `DATA_DIR` out of version control and off shared storage. Delete the file
+(or run the auth flow again) to force re-authentication.
 
 ## Next Steps
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -120,7 +120,7 @@ Project-specific terminology used throughout chronovista documentation and code.
 :   A user-submitted edit to a transcript segment's text. Each correction records the original text, corrected text, correction type, and version number in an append-only audit trail (`transcript_corrections` table). Corrections are applied via the inline edit UI in the transcript panel or the REST API.
 
 **Correction Type**
-:   A classification for why a segment was corrected. Values: `spelling`, `asr_error` (automatic speech recognition mistake), `context_correction`, `profanity_fix`, `formatting`, `revert`. The `revert` type is reserved for the system and cannot be submitted manually.
+:   A classification for why a segment was corrected. Values: `spelling` (typos/misspellings of common words), `proper_noun` (misrecognized names of people, places, or organizations), `context_correction` (right sound, wrong word), `word_boundary` (run-together or wrongly split words), `formatting` (punctuation, capitalization, spacing), `profanity_fix` (garbled or censored profanity), `other`, and `revert`. The `revert` type is reserved for the system and cannot be submitted manually.
 
 **SegmentEditState**
 :   A TypeScript discriminated union representing the four mutually exclusive UI states of a transcript segment: `read` (default), `editing` (inline edit form open), `confirming-revert` (revert confirmation visible), `history` (correction history panel expanded). Enforces single-edit-at-a-time — only one segment can be in a non-read state.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ chronovista is a CLI application that enables users to access, store, and explor
 
     ---
 
-    Advanced topic classification with 17 CLI commands for content discovery and trend analysis
+    Advanced topic classification with a full CLI command group for content discovery and trend analysis
 
 -   :material-database:{ .lg .middle } **Local Storage**
 
@@ -67,7 +67,7 @@ chronovista is a CLI application that enables users to access, store, and explor
 
     ---
 
-    FastAPI-powered REST API with 20+ endpoints for programmatic access to videos, transcripts, and search
+    FastAPI-powered REST API with 70+ endpoints for programmatic access to videos, transcripts, entities, tags, and search
 
 -   :material-delete-restore:{ .lg .middle } **Deleted Content Recovery**
 
@@ -80,13 +80,13 @@ chronovista is a CLI application that enables users to access, store, and explor
 ## Project Status
 
 !!! success "Current Status"
-    - **10,900+ tests** (7,403+ backend, 3,519+ frontend) with **90%+ coverage**
-    - **Comprehensive Pydantic models** with advanced validation and type safety
+    - **Thousands of automated tests** across backend and frontend with a **90%+ coverage** gate
+    - **Comprehensive Pydantic V2 models** with advanced validation and type safety (mypy strict)
     - **Real API integration testing** with YouTube API data validation
     - **Advanced repository pattern** with async support and composite keys
     - **Rate-limited API service** with intelligent error handling and retry logic
-    - **Wayback Machine recovery** for deleted/unavailable video and channel metadata via CLI, REST API, and frontend (v0.28.0)
-    - **React frontend** with video browsing, transcript search, deep link navigation, and recovery UI (v0.21.0)
+    - **Wayback Machine recovery** for deleted/unavailable video and channel metadata via CLI, REST API, and frontend
+    - **React frontend** with video browsing, transcript search, deep link navigation, tag merging, and recovery UI
 
 ## Quick Example
 


### PR DESCRIPTION
## Summary

This is PR 1 of 2 for the Diátaxis documentation restructure. It focuses on **content correctness** before the nav reorganization lands in PR 2.

Every claim in the touched pages was verified against `src/`. The docs previously described services, classes, config files, and CLI commands that do not exist in the codebase.

- `system-design.md`: replaced 9 fabricated service ABCs (AuthService, ChannelService, SmartTranscriptService, TagService, GoogleTakeoutService, etc.) with the real concrete service map; documented the 3 actual ABC interfaces (YouTube/Transcript/Takeout); corrected `get_recovery_deps()` to return `tuple[CDXClient, PageParser, RateLimiter]`; documented the real `BaseRepository` / `BaseSQLAlchemyRepository` contract and exception hierarchy; dropped the YAML language-config fiction.
- `overview.md`: real service-layer and repository names, corrected the "13 endpoints" claim, fixed the repository-pattern and recovery-deps examples.
- `api-integration.md`: removed the fictional AuthService progressive-scope example and the "RecoveryDeps bundle" claim.
- `configuration.md`: language preferences live in the DB (not `~/.chronovista/language_config.yaml`); documented the real `languages` subcommands (list/set/add/remove/reset, not show/config); removed the `~/.chronovista/config.yaml` and logging YAML fiction; OAuth token is plain JSON at `$DATA_DIR/youtube_token.json` (not "encrypted in `~/.chronovista/credentials/`").
- `index.md`: dropped frozen test counts and version pins; corrected grid-card counts (topics command group, 70+ REST endpoints).
- `glossary.md`: corrected the `CorrectionType` enum values (`asr_error` is gone; real values are spelling/proper_noun/context_correction/word_boundary/formatting/profanity_fix/other/revert).

`data-model.md` was reviewed and left unchanged — its SQL and Pydantic models are accurate and current.

PR 2 will reorganize the nav into Diátaxis buckets (tutorials/how-to/reference/explanation) and move/split files accordingly.

The mkdocs site still builds clean (non-strict) with these changes.

## Test plan

- [x] mkdocs build (non-strict) succeeds
- [x] Every rewritten claim cross-checked against `src/` (service classes, ABC interfaces, repository base classes, exception hierarchy, CLI subcommands, config file locations, enum values)