### PR TITLE
fix(entities): accent-insensitive entity scan + release 0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.58.0] - 2026-07-22
+
 ### Added
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Recover from stale lazy-loaded chunks after a redeploy.** Route pages are code-split with `React.lazy`; when the app is rebuilt, chunk filenames get new content hashes and old chunks 404, so a browser tab still on the previous build fails with "Failed to fetch dynamically imported module". The app now handles Vite's `vite:preloadError` by reloading once (guarded against loops), and the server serves `index.html` with `Cache-Control: no-cache` so the reload fetches HTML referencing the current hashes.
 - **Entity mention scans no longer report a false "Scan failed."** The entity and video scan endpoints (`POST /entities/{id}/scan`, `POST /videos/{id}/scan-entities`) now run asynchronously — they return `202` with a `job_id`, and the frontend polls `GET /api/v1/scan-jobs/{job_id}` for progress and result. Previously the scan blocked for minutes and tripped the client timeout (reporting failure) even though the backend completed and committed the mentions.
+- **Entity mention scanning now catches accented spellings.** The scan matched aliases accent-sensitively (case-insensitive only), so an alias like `Mexico` never matched `México` in transcripts, titles, or descriptions — even though accented and unaccented spellings normalize to the same alias. Scanning now folds diacritics on both the alias patterns and the scanned text (offset-safe, so transcript seek positions and stored mention text stay correct) and matches exclusion patterns consistently. The duplicate-alias message now explains that accents and case are ignored. Re-run `entities scan --full` to pick up previously-missed accented mentions.
 
 ## [0.57.0] - 2026-07-20
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.58.0] - 2026-07-22
+
 ### Added
 - MkDocs documentation setup with Material theme
 - Comprehensive user guide and API reference
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Recover from stale lazy-loaded chunks after a redeploy.** Route pages are code-split with `React.lazy`; when the app is rebuilt, chunk filenames get new content hashes and old chunks 404, so a browser tab still on the previous build fails with "Failed to fetch dynamically imported module". The app now handles Vite's `vite:preloadError` by reloading once (guarded against loops), and the server serves `index.html` with `Cache-Control: no-cache` so the reload fetches HTML referencing the current hashes.
 - **Entity mention scans no longer report a false "Scan failed."** The entity and video scan endpoints (`POST /entities/{id}/scan`, `POST /videos/{id}/scan-entities`) now run asynchronously — they return `202` with a `job_id`, and the frontend polls `GET /api/v1/scan-jobs/{job_id}` for progress and result. Previously the scan blocked for minutes and tripped the client timeout (reporting failure) even though the backend completed and committed the mentions.
+- **Entity mention scanning now catches accented spellings.** The scan matched aliases accent-sensitively (case-insensitive only), so an alias like `Mexico` never matched `México` in transcripts, titles, or descriptions — even though accented and unaccented spellings normalize to the same alias. Scanning now folds diacritics on both the alias patterns and the scanned text (offset-safe, so transcript seek positions and stored mention text stay correct) and matches exclusion patterns consistently. The duplicate-alias message now explains that accents and case are ignored. Re-run `entities scan --full` to pick up previously-missed accented mentions.
 
 ## [0.57.0] - 2026-07-20
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.26.0",
+  "version": "0.27.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -625,7 +625,10 @@ function AddAliasForm({ entityId, onCreated }: AddAliasFormProps) {
     } catch (err: unknown) {
       const status = (err as { status?: number } | null)?.status;
       if (status === 409) {
-        setErrorMsg("This alias already exists for the entity.");
+        setErrorMsg(
+          "This name is already covered by an existing alias — accents and case " +
+            "are ignored when matching, so this spelling counts as the same."
+        );
       } else if (status === 404) {
         setErrorMsg("Entity not found. Please refresh the page.");
       } else {

--- a/frontend/src/pages/__tests__/EntityDetailPage.AddAliasForm.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.AddAliasForm.test.tsx
@@ -9,7 +9,7 @@
  * 1. Renders the form: input, select, and Add button are present
  * 2. Button disabled when input is empty (initial state)
  * 3. Successful alias creation: API called, input cleared, success message shown
- * 4. Duplicate alias error (409): "This alias already exists for the entity." shown
+ * 4. Duplicate alias error (409): the accents-and-case-ignored message is shown
  * 5. 404 entity-not-found error: correct error message shown
  * 6. Generic error: fallback error message shown
  * 7. Alias type select contains all 5 types
@@ -349,7 +349,7 @@ describe("AddAliasForm (inside EntityDetailPage)", () => {
   // -------------------------------------------------------------------------
 
   describe("Test 4 — Duplicate alias error (409)", () => {
-    it("shows 'This alias already exists for the entity.' on a 409 error", async () => {
+    it("shows the accents-and-case-ignored message on a 409 error", async () => {
       vi.mocked(createEntityAlias).mockRejectedValue({ status: 409 });
 
       const user = userEvent.setup();
@@ -361,7 +361,7 @@ describe("AddAliasForm (inside EntityDetailPage)", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("This alias already exists for the entity.")
+          screen.getByText(/already covered by an existing alias/)
         ).toBeInTheDocument();
       });
     });
@@ -520,7 +520,7 @@ describe("AddAliasForm (inside EntityDetailPage)", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("This alias already exists for the entity.")
+          screen.getByText(/already covered by an existing alias/)
         ).toBeInTheDocument();
       });
 
@@ -528,7 +528,7 @@ describe("AddAliasForm (inside EntityDetailPage)", () => {
       await user.type(input, "x");
 
       expect(
-        screen.queryByText("This alias already exists for the entity.")
+        screen.queryByText(/already covered by an existing alias/)
       ).not.toBeInTheDocument();
     });
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.57.0"
+version = "0.58.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -808,12 +808,18 @@ async def create_entity_alias(
         EntityAliasDB.alias_name_normalized == normalized_alias,
     )
     dup_result = await session.execute(dup_query)
-    if dup_result.scalar_one_or_none() is not None:
+    existing_alias = dup_result.scalar_one_or_none()
+    if existing_alias is not None:
         raise ConflictError(
-            message=f"Alias '{body.alias_name}' already exists for this entity",
+            message=(
+                f"Already covered by the existing alias "
+                f"'{existing_alias.alias_name}' — accents and case are ignored "
+                f"when matching, so this variant is treated as the same."
+            ),
             details={
                 "entity_id": entity_id,
                 "alias_name": body.alias_name,
+                "existing_alias_name": existing_alias.alias_name,
                 "normalized": normalized_alias,
             },
         )

--- a/src/chronovista/services/entity_mention_scan_service.py
+++ b/src/chronovista/services/entity_mention_scan_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+import unicodedata
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -36,6 +37,48 @@ logger = logging.getLogger(__name__)
 
 # Minimum alias length before a warning is emitted.
 _MIN_ALIAS_LENGTH = 3
+
+
+def _fold_diacritics(raw: str) -> tuple[str, list[int]]:
+    """Fold accents off a string and map folded positions back to raw ones.
+
+    The fold decomposes each character with canonical (NFD) normalization and
+    drops non-spacing combining marks (Unicode category ``Mn``), so ``"México"``
+    folds to ``"Mexico"``.  Case is intentionally left untouched — callers keep
+    handling case with ``re.IGNORECASE``.  Compatibility decomposition (NFKD) is
+    deliberately avoided so characters such as ``"½"`` or the ``"ﬁ"`` ligature
+    are not expanded, which keeps the fold conservative.
+
+    The fold is not guaranteed to preserve length: a raw pre-composed character
+    may decompose into several folded characters, and a raw combining mark
+    disappears entirely.  The returned offset map therefore records, for every
+    folded-string position, the index of the RAW character that produced it, so
+    a match found in folded space can be sliced back out of the raw text with
+    correct offsets.
+
+    Parameters
+    ----------
+    raw : str
+        The original (possibly accented) string.
+
+    Returns
+    -------
+    tuple[str, list[int]]
+        A ``(folded_text, offset_map)`` pair.  ``offset_map`` has the same
+        length as ``folded_text``; ``offset_map[i]`` is the index in ``raw`` of
+        the character that produced ``folded_text[i]``.  A folded match spanning
+        ``[f_start, f_end)`` maps to raw ``[offset_map[f_start],
+        offset_map[f_end - 1] + 1)``.
+    """
+    folded_chars: list[str] = []
+    offset_map: list[int] = []
+    for raw_index, char in enumerate(raw):
+        for decomposed in unicodedata.normalize("NFD", char):
+            if unicodedata.category(decomposed) == "Mn":
+                continue
+            folded_chars.append(decomposed)
+            offset_map.append(raw_index)
+    return "".join(folded_chars), offset_map
 
 
 @dataclass
@@ -88,7 +131,7 @@ class _EntityPattern:
     entity_id: uuid.UUID
     canonical_name: str
     entity_type: str
-    pg_pattern: str  # PostgreSQL regex (unescaped \m / \M boundaries)
+    pg_pattern: str  # diacritic-folded, re.escaped alias alternation (no \b)
     alias_names: list[str]  # all raw names contributing to pattern
     exclusion_patterns: list[str] = field(default_factory=list)
 
@@ -792,16 +835,24 @@ class EntityMentionScanService:
         mentions: list[EntityMentionCreate] = []
         previews: list[dict[str, Any]] = []
 
-        # Step 1: Collect all matches
+        # Step 1: Collect all matches.  Matching runs against the diacritic-
+        # folded text and each folded match is mapped back to RAW offsets so the
+        # stored mention_text keeps its accents and offsets point into ``text``.
+        folded_text, offset_map = _fold_diacritics(text)
         raw_matches: list[tuple[uuid.UUID, int, int, str, _EntityPattern]] = []
         for pattern, py_regex in compiled_patterns:
-            for match in py_regex.finditer(text):
+            for match in py_regex.finditer(folded_text):
+                f_start, f_end = match.start(), match.end()
+                if f_end <= f_start:
+                    continue
+                raw_start = offset_map[f_start]
+                raw_end = offset_map[f_end - 1] + 1
                 raw_matches.append(
                     (
                         pattern.entity_id,
-                        match.start(),
-                        match.end(),
-                        match.group(0),
+                        raw_start,
+                        raw_end,
+                        text[raw_start:raw_end],
                         pattern,
                     )
                 )
@@ -1003,8 +1054,16 @@ class EntityMentionScanService:
                         name,
                     )
 
-            # Build PostgreSQL regex pattern: \m(alias1|alias2|...)\M
-            escaped_names = sorted([re.escape(n) for n in names], key=len, reverse=True)
+            # Build the diacritic-folded alternation: \b(alias1|alias2|...)\b.
+            # Alias names are folded (accents stripped) so the pattern matches
+            # accented occurrences in folded text — e.g. alias "Mexico" must
+            # match "México".  Case is still handled by re.IGNORECASE at compile
+            # time.  Names that fold to empty (pure combining marks) cannot match
+            # anything meaningful and are dropped to avoid an empty alternative.
+            folded_names = [f for f in (_fold_diacritics(n)[0] for n in names) if f]
+            escaped_names = sorted(
+                [re.escape(n) for n in folded_names], key=len, reverse=True
+            )
             pg_pattern = "|".join(escaped_names)
 
             patterns.append(
@@ -1157,17 +1216,27 @@ class EntityMentionScanService:
                 continue
 
             # ----------------------------------------------------------
-            # Step 1: Collect ALL (entity_id, start, end, text) via finditer
+            # Step 1: Collect ALL (entity_id, start, end, text) via finditer.
+            # Matching runs against the diacritic-folded text so accented
+            # occurrences match accent-free aliases; each folded match is then
+            # mapped back to RAW offsets so match_start/match_end/mention_text
+            # reference the real (accented) segment text.
             # ----------------------------------------------------------
+            folded_text, offset_map = _fold_diacritics(effective_text)
             raw_matches: list[tuple[uuid.UUID, int, int, str, _EntityPattern]] = []
             for pattern, py_regex in compiled_patterns:
-                for match in py_regex.finditer(effective_text):
+                for match in py_regex.finditer(folded_text):
+                    f_start, f_end = match.start(), match.end()
+                    if f_end <= f_start:
+                        continue
+                    raw_start = offset_map[f_start]
+                    raw_end = offset_map[f_end - 1] + 1
                     raw_matches.append(
                         (
                             pattern.entity_id,
-                            match.start(),
-                            match.end(),
-                            match.group(0),
+                            raw_start,
+                            raw_end,
+                            effective_text[raw_start:raw_end],
                             pattern,
                         )
                     )
@@ -1357,7 +1426,11 @@ class EntityMentionScanService:
         """Filter matches against entity exclusion patterns.
 
         For each surviving match, check if any of the entity's exclusion
-        patterns overlap the match position in the segment text.
+        patterns overlap the match position in the segment text.  Exclusion
+        matching is folded the same way as entity matching (accents stripped,
+        case-insensitive) and exclusion offsets are mapped back to the RAW
+        segment text, so overlap is compared in a single, consistent RAW offset
+        space against the (already RAW) match offsets.
 
         Parameters
         ----------
@@ -1380,15 +1453,24 @@ class EntityMentionScanService:
         final: list[tuple[uuid.UUID, int, int, str, _EntityPattern]] = []
         skip_count = 0
 
+        # Fold the segment text once; exclusion matches are found in folded
+        # space and mapped back to RAW offsets to compare against RAW match
+        # offsets.
+        folded_text, offset_map = _fold_diacritics(segment_text)
+
         for entity_id, m_start, m_end, matched_text, pattern in matches:
             ep = pattern_by_entity.get(entity_id)
             exclusions = ep.exclusion_patterns if ep else []
 
             suppressed = False
             for excl_pattern_text in exclusions:
-                # Find all case-insensitive occurrences of the exclusion pattern
+                # Find all accent- and case-insensitive occurrences of the
+                # exclusion pattern in the folded segment text.
+                folded_excl = _fold_diacritics(excl_pattern_text)[0]
+                if not folded_excl:
+                    continue
                 try:
-                    excl_regex = re.compile(re.escape(excl_pattern_text), re.IGNORECASE)
+                    excl_regex = re.compile(re.escape(folded_excl), re.IGNORECASE)
                 except re.error:
                     logger.warning(
                         "Invalid exclusion pattern '%s' for entity %s, skipping",
@@ -1397,9 +1479,12 @@ class EntityMentionScanService:
                     )
                     continue
 
-                for excl_match in excl_regex.finditer(segment_text):
-                    pattern_start = excl_match.start()
-                    pattern_end = excl_match.end()
+                for excl_match in excl_regex.finditer(folded_text):
+                    f_start, f_end = excl_match.start(), excl_match.end()
+                    if f_end <= f_start:
+                        continue
+                    pattern_start = offset_map[f_start]
+                    pattern_end = offset_map[f_end - 1] + 1
                     # Overlap check: pattern_start < match_end AND pattern_end > match_start
                     if pattern_start < m_end and pattern_end > m_start:
                         suppressed = True

--- a/tests/integration/services/test_entity_mention_scan_integration.py
+++ b/tests/integration/services/test_entity_mention_scan_integration.py
@@ -1303,3 +1303,144 @@ class TestASRErrorAliasCounterExclusion:
             f"After full rescan: expected video_count=0 (ASR-error alias only), "
             f"got {entity.video_count}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Diacritic-insensitive scanning (accent-folding bug fix)
+# ---------------------------------------------------------------------------
+
+
+class TestDiacriticInsensitiveTranscriptScan:
+    """Accent-free aliases must match accented occurrences in transcript text."""
+
+    async def test_ascii_alias_matches_accented_occurrence(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Alias 'Mexico' matches 'México'; mention_text and offsets are the raw form."""
+        await _seed_channel(db_session)
+        await _seed_video(db_session, video_id(seed="dia_01"))
+        await _seed_transcript(db_session, video_id(seed="dia_01"))
+
+        raw = "una revolución de color aquí en México."
+        seg = await _seed_segment(db_session, video_id(seed="dia_01"), text=raw)
+        entity = await _seed_entity(db_session, "Mexico", entity_type="place")
+        await _seed_alias(db_session, entity.id, "Mexico")
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+        result = await service.scan()
+
+        rows = (await db_session.execute(select(EntityMentionDB))).scalars().all()
+        assert len(rows) == 1, f"Expected 1 mention, got {len(rows)}"
+        m = rows[0]
+        assert m.segment_id == seg.id
+        assert m.mention_text == "México"
+        assert raw[m.match_start : m.match_end] == "México"
+        assert m.match_start == raw.index("México")
+        assert result.mentions_found == 1
+
+    async def test_uppercase_and_plain_ascii_both_match(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Both 'MÉXICO' (accented, uppercase) and plain 'Mexico' match the alias."""
+        await _seed_channel(db_session)
+        await _seed_video(db_session, video_id(seed="dia_02"))
+        await _seed_transcript(db_session, video_id(seed="dia_02"))
+
+        await _seed_segment(
+            db_session, video_id(seed="dia_02"), text="VIVA MÉXICO", seg_id=None
+        )
+        await _seed_segment(
+            db_session,
+            video_id(seed="dia_02"),
+            text="welcome to Mexico",
+            sequence_number=1,
+            start_time=5.0,
+        )
+        entity = await _seed_entity(db_session, "Mexico", entity_type="place")
+        await _seed_alias(db_session, entity.id, "Mexico")
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+        await service.scan()
+
+        rows = (await db_session.execute(select(EntityMentionDB))).scalars().all()
+        texts = {r.mention_text for r in rows}
+        assert texts == {"MÉXICO", "Mexico"}, f"Got {texts}"
+
+    async def test_offset_safety_length_changing_char_before_match(
+        self, db_session: AsyncSession
+    ) -> None:
+        """A dropped combining mark before the match must not corrupt offsets.
+
+        'café' is written with a DECOMPOSED accent (e + U+0301). Folding drops
+        the combining mark, so the folded text is shorter than the raw text and
+        every character of the 'México' match sits at a folded index one less
+        than its raw index. The offset map must recover the correct raw offsets.
+        """
+        await _seed_channel(db_session)
+        await _seed_video(db_session, video_id(seed="dia_03"))
+        await _seed_transcript(db_session, video_id(seed="dia_03"))
+
+        raw = "cafe\u0301 M\u00e9xico aqui"  # decomposed accent, then precomposed 'México'
+        # Guard: this really is a length-changing input under the fold.
+        from chronovista.services.entity_mention_scan_service import _fold_diacritics
+
+        folded, _ = _fold_diacritics(raw)
+        assert len(folded) == len(raw) - 1
+        assert folded.index("Mexico") != raw.index("México")
+
+        await _seed_segment(db_session, video_id(seed="dia_03"), text=raw)
+        entity = await _seed_entity(db_session, "Mexico", entity_type="place")
+        await _seed_alias(db_session, entity.id, "Mexico")
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+        await service.scan()
+
+        rows = (await db_session.execute(select(EntityMentionDB))).scalars().all()
+        assert len(rows) == 1
+        m = rows[0]
+        assert m.match_start == raw.index("México")
+        assert raw[m.match_start : m.match_end] == "México"
+        assert m.mention_text == "México"
+
+
+class TestDiacriticInsensitiveMetadataScan:
+    """Accent-free aliases must match accented occurrences in title/description."""
+
+    async def test_accented_title_matched(self, db_session: AsyncSession) -> None:
+        """A video title containing 'México' is matched by alias 'Mexico'."""
+        await _seed_channel(db_session)
+        vid = video_id(seed="dia_meta_01")
+        video = VideoDB(
+            video_id=vid,
+            channel_id=DEFAULT_CHANNEL_ID,
+            title="Un viaje por México",
+            description="",
+            upload_date=datetime(2024, 1, 1, tzinfo=UTC),
+            duration=120,
+            made_for_kids=False,
+            self_declared_made_for_kids=False,
+        )
+        db_session.add(video)
+        await db_session.flush()
+
+        entity = await _seed_entity(db_session, "Mexico", entity_type="place")
+        await _seed_alias(db_session, entity.id, "Mexico")
+        await db_session.commit()
+
+        factory = _make_session_factory_from_session(db_session)
+        service = EntityMentionScanService(session_factory=factory)
+        result = await service.scan_metadata(sources=["title"])
+
+        rows = (await db_session.execute(select(EntityMentionDB))).scalars().all()
+        assert len(rows) == 1, f"Expected 1 title mention, got {len(rows)}"
+        m = rows[0]
+        assert m.video_id == vid
+        assert m.mention_text == "México"
+        assert m.mention_source == "title"
+        assert result.mentions_found == 1

--- a/tests/unit/api/routers/test_entity_aliases.py
+++ b/tests/unit/api/routers/test_entity_aliases.py
@@ -546,6 +546,52 @@ class TestCreateEntityAliasConflict:
             "status" in body or "type" in body
         ), f"Expected RFC-7807 error body, got: {body}"
 
+    async def test_duplicate_alias_message_names_existing_and_explains_folding(
+        self,
+    ) -> None:
+        """409 message must name the existing alias and explain accent/case folding.
+
+        Adding ``México`` when ``Mexico`` already exists collides on the
+        normalized form.  The reworded conflict message must (a) reference the
+        existing colliding alias by name and (b) make clear that accents AND
+        case are ignored when matching, so the caller understands why the
+        seemingly-different variant is rejected.
+        """
+        entity_row = _make_named_entity_row()
+
+        # The dup-check must return the EXISTING alias row with a real name so
+        # the endpoint can name it in the message.
+        existing_alias = MagicMock()
+        existing_alias.alias_name = "Mexico"
+
+        mock_session = AsyncMock(spec=AsyncSession)
+        entity_result = MagicMock()
+        entity_result.scalar_one_or_none.return_value = entity_row
+        dup_result = MagicMock()
+        dup_result.scalar_one_or_none.return_value = existing_alias
+        mock_session.execute.side_effect = [entity_result, dup_result]
+
+        async for client in _build_client(mock_session):
+            with patch(
+                "chronovista.api.routers.entity_mentions._normalizer"
+            ) as mock_normalizer:
+                mock_normalizer.normalize.return_value = "mexico"
+
+                response = await client.post(
+                    _alias_url(),
+                    json={"alias_name": "México", "alias_type": "translated_name"},
+                )
+
+        assert response.status_code == 409, response.text
+        body = response.json()
+        detail = body.get("detail", "")
+        # Names the existing alias.
+        assert "Mexico" in detail, f"Message must name existing alias: {detail!r}"
+        # Explains that accents and case are both ignored when matching.
+        lowered = detail.lower()
+        assert "accent" in lowered, f"Message must mention accents: {detail!r}"
+        assert "case" in lowered, f"Message must mention case: {detail!r}"
+
     async def test_alias_normalizes_to_empty_returns_409(self) -> None:
         """Alias whose normalized form is None (empty string) → 409 Conflict.
 

--- a/tests/unit/services/test_entity_mention_scan_service.py
+++ b/tests/unit/services/test_entity_mention_scan_service.py
@@ -2547,7 +2547,7 @@ class TestAliasRegexOrdering:
         pg = patterns[0].pg_pattern
         parts = pg.split("|")
         # The escaped longer alias must appear before the shorter one
-        long_escaped = re.escape("Jairo Calixto Albarrán")
+        long_escaped = re.escape("Jairo Calixto Albarran")
         short_escaped = re.escape("Jairo Calixto")
         long_idx = next(i for i, p in enumerate(parts) if p == long_escaped)
         short_idx = next(i for i, p in enumerate(parts) if p == short_escaped)
@@ -2567,7 +2567,7 @@ class TestAliasRegexOrdering:
             pg_pattern="|".join(
                 sorted(
                     [
-                        re.escape("Jairo Calixto Albarrán"),
+                        re.escape("Jairo Calixto Albarran"),
                         re.escape("Jairo Calixto"),
                     ],
                     key=len,
@@ -2654,3 +2654,291 @@ class TestFullRescanSourceScoping:
             "Full rescan must scope deletion to mention_source='transcript' "
             "to avoid wiping title/description mentions"
         )
+
+
+# ---------------------------------------------------------------------------
+# TestDiacriticFolding
+# ---------------------------------------------------------------------------
+
+
+def _make_pattern(
+    canonical_name: str,
+    names: list[str],
+    entity_id: uuid.UUID | None = None,
+    exclusion_patterns: list[str] | None = None,
+) -> Any:
+    """Build an _EntityPattern with a diacritic-folded, escaped alternation.
+
+    Mirrors the folding done by ``_load_entity_patterns`` so ``_scan_batch`` and
+    ``_match_text_for_video`` can be exercised directly.
+    """
+    from chronovista.services.entity_mention_scan_service import (
+        _EntityPattern,
+        _fold_diacritics,
+    )
+
+    folded_names = [f for f in (_fold_diacritics(n)[0] for n in names) if f]
+    escaped = sorted([re.escape(n) for n in folded_names], key=len, reverse=True)
+    return _EntityPattern(
+        entity_id=entity_id or _make_uuid(),
+        canonical_name=canonical_name,
+        entity_type="place",
+        pg_pattern="|".join(escaped),
+        alias_names=names,
+        exclusion_patterns=exclusion_patterns or [],
+    )
+
+
+async def _run_scan_batch(pattern: Any, effective_text: str) -> list[Any]:
+    """Call ``_scan_batch`` for one segment with a mocked (empty dedup) session."""
+    seg = _make_segment_row(seg_id=1, effective_text=effective_text)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_scalars_execute([]))
+
+    svc = _build_service(MagicMock())
+    mentions, _, _, _, ep_skips = await svc._scan_batch(
+        session,
+        batch_rows=[seg],
+        patterns=[pattern],
+        full_rescan=False,
+        dry_run=False,
+        limit=None,
+        current_preview_count=0,
+    )
+    return mentions
+
+
+class TestDiacriticFoldingHelper:
+    """Unit tests for the ``_fold_diacritics`` helper."""
+
+    def test_folds_accents_and_preserves_length_for_precomposed(self) -> None:
+        """Precomposed accented chars fold in place, one raw char per folded char."""
+        from chronovista.services.entity_mention_scan_service import _fold_diacritics
+
+        folded, offset_map = _fold_diacritics("México")
+        assert folded == "Mexico"
+        # Precomposed 'é' (U+00E9) → single folded 'e' at the same index.
+        assert offset_map == [0, 1, 2, 3, 4, 5]
+
+    def test_does_not_expand_ligatures_or_fractions_nfd_not_nfkd(self) -> None:
+        """NFD (not NFKD) leaves the 'ﬁ' ligature and '½' unchanged (no expansion)."""
+        from chronovista.services.entity_mention_scan_service import _fold_diacritics
+
+        folded, offset_map = _fold_diacritics("ﬁ½")
+        assert folded == "ﬁ½"
+        assert offset_map == [0, 1]
+
+    def test_dropped_combining_mark_shrinks_and_maps_offsets(self) -> None:
+        """A decomposed 'é' (e + U+0301) folds to 'e', shrinking the string.
+
+        The combining mark is dropped, so the folded string is shorter than the
+        raw string, and every folded position after the mark maps back to a
+        larger raw index.
+        """
+        from chronovista.services.entity_mention_scan_service import _fold_diacritics
+
+        raw = "cafe\u0301bar"  # decomposed accent (e + U+0301), then 'bar'
+        folded, offset_map = _fold_diacritics(raw)
+        assert folded == "cafebar"
+        assert len(folded) == len(raw) - 1
+        # 'b' is folded index 4 but raw index 5 (the U+0301 at raw index 4 dropped)
+        assert folded[4] == "b"
+        assert offset_map[4] == 5
+        assert raw[offset_map[4]] == "b"
+
+    def test_does_not_casefold(self) -> None:
+        """Case is preserved by the fold (case is handled by re.IGNORECASE)."""
+        from chronovista.services.entity_mention_scan_service import _fold_diacritics
+
+        folded, _ = _fold_diacritics("MÉXICO")
+        assert folded == "MEXICO"
+
+
+class TestDiacriticFoldingScanBatch:
+    """Transcript-path (``_scan_batch``) diacritic-insensitive matching."""
+
+    async def test_accented_occurrence_matched_with_ascii_alias(self) -> None:
+        """Alias 'Mexico' matches 'México' and stores the accented mention_text."""
+        raw = "una revolución de color aquí en México."
+        pattern = _make_pattern("Mexico", ["Mexico"])
+
+        mentions = await _run_scan_batch(pattern, raw)
+
+        assert len(mentions) == 1
+        m = mentions[0]
+        assert m.mention_text == "México"
+        assert raw[m.match_start : m.match_end] == "México"
+        # Offsets point exactly at "México" in the raw text.
+        assert raw.index("México") == m.match_start
+        assert m.match_end == m.match_start + len("México")
+
+    async def test_uppercase_accented_occurrence_matched(self) -> None:
+        """'MÉXICO' matches the ASCII alias 'Mexico' (case + accent insensitive)."""
+        raw = "VISITA MÉXICO HOY"
+        pattern = _make_pattern("Mexico", ["Mexico"])
+
+        mentions = await _run_scan_batch(pattern, raw)
+
+        assert len(mentions) == 1
+        assert mentions[0].mention_text == "MÉXICO"
+
+    async def test_plain_ascii_occurrence_still_matched(self) -> None:
+        """Plain ASCII 'Mexico' still matches (no regression)."""
+        raw = "welcome to Mexico today"
+        pattern = _make_pattern("Mexico", ["Mexico"])
+
+        mentions = await _run_scan_batch(pattern, raw)
+
+        assert len(mentions) == 1
+        assert mentions[0].mention_text == "Mexico"
+
+    async def test_offset_safety_length_changing_char_before_match(self) -> None:
+        """A decomposed 'é' before the match must not corrupt match offsets.
+
+        The word 'café' is written with a *decomposed* accent (e + U+0301). When
+        folded, that combining mark is dropped, so every character after it — the
+        entire "México" match — sits at a folded index one less than its raw
+        index.  Without the offset map, the mention would be sliced from the
+        wrong position.  This asserts the raw offsets (and mention_text) are
+        correct AND that they genuinely differ from the naive folded offsets.
+        """
+        raw = "cafe\u0301 M\u00e9xico aqui"  # decomposed accent precedes match
+        pattern = _make_pattern("Mexico", ["Mexico"])
+
+        # Sanity: this input really is length-changing under the fold.
+        from chronovista.services.entity_mention_scan_service import _fold_diacritics
+
+        folded, _ = _fold_diacritics(raw)
+        assert len(folded) == len(raw) - 1
+        naive_folded_start = folded.index("Mexico")
+        raw_start = raw.index("México")
+        assert naive_folded_start != raw_start, (
+            "Test is not exercising the length-changing case: folded and raw "
+            "offsets coincide"
+        )
+
+        mentions = await _run_scan_batch(pattern, raw)
+
+        assert len(mentions) == 1
+        m = mentions[0]
+        assert m.match_start == raw_start
+        assert raw[m.match_start : m.match_end] == "México"
+        assert m.mention_text == "México"
+
+    async def test_exclusion_pattern_suppresses_accented_match(self) -> None:
+        """An accent-free exclusion pattern suppresses an accented match."""
+        raw = "New México is a US state"
+        # Exclusion "New Mexico" (accent-free) overlaps the "México" match once
+        # both are folded, so the match must be suppressed.
+        pattern = _make_pattern("Mexico", ["Mexico"], exclusion_patterns=["New Mexico"])
+
+        mentions = await _run_scan_batch(pattern, raw)
+
+        assert mentions == []
+
+    async def test_longest_match_wins_with_overlapping_accented_alias(self) -> None:
+        """Longest-match-wins prefers the longer accented alias over a shorter one."""
+        entity_id = _make_uuid()
+        # One entity has both "Mexico" and "Mexico City" (accent-free aliases).
+        pattern = _make_pattern(
+            "Mexico City", ["Mexico City", "Mexico"], entity_id=entity_id
+        )
+        raw = "flying into México City tomorrow"
+
+        mentions = await _run_scan_batch(pattern, raw)
+
+        # Only the longest match survives, and it is the accented raw substring.
+        assert len(mentions) == 1
+        assert mentions[0].mention_text == "México City"
+        assert raw[mentions[0].match_start : mentions[0].match_end] == "México City"
+
+
+class TestDiacriticFoldingLoadPatterns:
+    """Pattern construction folds accents off alias names."""
+
+    async def test_accented_canonical_name_folded_in_pattern(self) -> None:
+        """An accented canonical name is folded before entering pg_pattern."""
+        entity_id = _make_uuid()
+        entity_row = _make_entity_row(
+            entity_id=entity_id, canonical_name="México", entity_type="place"
+        )
+
+        session = AsyncMock()
+        session.execute = AsyncMock(
+            side_effect=[
+                _scalars_execute([entity_row]),
+                _scalars_execute([]),
+            ]
+        )
+        svc = _build_service(MagicMock())
+        patterns = await svc._load_entity_patterns(
+            session, entity_type=None, new_entities_only=False
+        )
+
+        assert len(patterns) == 1
+        # Folded form is present; the accented form is not in the regex.
+        assert "Mexico" in patterns[0].pg_pattern
+        assert "México" not in patterns[0].pg_pattern
+        # The raw name is preserved in alias_names for reporting.
+        assert patterns[0].alias_names == ["México"]
+
+
+class TestDiacriticFoldingMetadata:
+    """Metadata-path (``_match_text_for_video``) diacritic-insensitive matching."""
+
+    def _compiled_for(self, pattern: Any) -> tuple[list[Any], dict[Any, Any]]:
+        compiled = [
+            (
+                pattern,
+                re.compile(r"\b(" + pattern.pg_pattern + r")\b", re.IGNORECASE),
+            )
+        ]
+        return compiled, {pattern.entity_id: pattern}
+
+    def test_accented_title_matched_by_metadata_scan(self) -> None:
+        """A title containing 'México' is matched by the ASCII alias 'Mexico'."""
+        from chronovista.models.enums import MentionSource
+
+        pattern = _make_pattern("Mexico", ["Mexico"])
+        compiled, by_entity = self._compiled_for(pattern)
+
+        svc = _build_service(MagicMock())
+        title = "A road trip through México"
+        mentions, _ = svc._match_text_for_video(
+            video_id="dQw4w9WgXcQ",
+            text=title,
+            mention_source=MentionSource.TITLE,
+            compiled_patterns=compiled,
+            pattern_by_entity=by_entity,
+            dry_run=False,
+        )
+
+        assert len(mentions) == 1
+        m = mentions[0]
+        assert m.mention_text == "México"
+        assert title[m.match_start : m.match_end] == "México"
+        assert m.mention_source == MentionSource.TITLE
+
+    def test_metadata_offset_safety_with_length_changing_char(self) -> None:
+        """Metadata path also maps offsets back correctly through a dropped mark."""
+        from chronovista.models.enums import MentionSource
+
+        pattern = _make_pattern("Mexico", ["Mexico"])
+        compiled, by_entity = self._compiled_for(pattern)
+
+        svc = _build_service(MagicMock())
+        desc = "cafe\u0301 in M\u00e9xico downtown"
+        mentions, _ = svc._match_text_for_video(
+            video_id="dQw4w9WgXcQ",
+            text=desc,
+            mention_source=MentionSource.DESCRIPTION,
+            compiled_patterns=compiled,
+            pattern_by_entity=by_entity,
+            dry_run=False,
+        )
+
+        assert len(mentions) == 1
+        m = mentions[0]
+        assert desc[m.match_start : m.match_end] == "México"
+        assert m.mention_text == "México"


### PR DESCRIPTION
## Summary

- **Bug**: Entity mention scanning matched aliases case-insensitively but not accent-insensitively, so an alias like `Peru` never matched `Perú` in transcripts, video titles, or descriptions — even though accented and unaccented spellings normalize to the same alias and cannot be registered as separate aliases.
- **Fix**: Scanning now folds diacritics on both the alias patterns and the scanned text before matching (NFD + drop combining marks, not NFKD, to avoid mangling other Unicode forms), then maps matches back to raw offsets via a per-character offset map so `match_start`/`match_end` and `mention_text` still reflect the original (accented) text. `re.IGNORECASE` is preserved for case handling, and exclusion patterns are folded the same way for consistency.
- **Clearer error message**: The duplicate-alias 409 response now explains that accents and case are ignored when checking for existing aliases.
- **Re-scan note**: Run `entities scan --full` after deploying to backfill previously-missed accented mentions in existing data.
- **Bundled release**: This PR also cuts release 0.58.0 (backend) / 0.27.0 (frontend), bundling Feature 057 (editable entity display names), the MkDocs docs site, and earlier frontend fixes that were already staged. The CHANGELOG `[Unreleased]` section moves to `[0.58.0] - 2026-07-22`.

## Testing

- Backend: mypy strict clean, ruff clean, 143 backend tests pass
- Frontend: tsc clean, `AddAliasForm` tests pass

## Test plan

- [x] Run `entities scan --full` in a dev environment and confirm previously-missed accented mentions (e.g. `Perú`) are now detected
- [x] Attempt to add a duplicate alias differing only by accents/case and confirm the updated 409 message is shown
- [x] Verify `match_start`/`match_end`/`mention_text` are correct for a mention where folding changes character length