### PR TITLE
fix(corrections): restore cross-segment candidate suggestions (query perf, 0.58.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.58.0] - 2026-07-22
+## [0.58.1] - 2026-07-22
+
+### Fixed
+- **Cross-segment candidate suggestions load again (batch corrections page).** The `GET /corrections/batch/cross-segment/candidates` endpoint had grown to ~20s and tripped the frontend's 10s request timeout, so the "Suggested Cross-Segment Candidates" panel showed "Failed to load…". Two causes: (1) the adjacency query filtered on a `CASE(has_correction, corrected_text, text)` expression, which is opaque to the existing `pg_trgm` GIN indexes and forced a full parallel seq-scan of the ~1.5M-row segment self-join — it now filters the raw `text`/`corrected_text` columns (a super-set candidate filter; the existing effective-text re-check preserves exact correctness), so the trigram indexes engage; (2) very short boundary splits (1-2 char fragments like `M`/`lo`) had almost no index selectivity and dominated cost — such splits are now skipped unless at least one side is a 4+ char anchor and neither side is a single character, which also removes low-quality noise candidates. End-to-end discovery dropped from ~20s to ~3s. No schema change (the trigram indexes already exist from migration `056`).
 
 ### Added
 - MkDocs documentation setup with Material theme

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.58.0] - 2026-07-22
+## [0.58.1] - 2026-07-22
+
+### Fixed
+- **Cross-segment candidate suggestions load again (batch corrections page).** The `GET /corrections/batch/cross-segment/candidates` endpoint had grown to ~20s and tripped the frontend's 10s request timeout, so the "Suggested Cross-Segment Candidates" panel showed "Failed to load…". Two causes: (1) the adjacency query filtered on a `CASE(has_correction, corrected_text, text)` expression, which is opaque to the existing `pg_trgm` GIN indexes and forced a full parallel seq-scan of the ~1.5M-row segment self-join — it now filters the raw `text`/`corrected_text` columns (a super-set candidate filter; the existing effective-text re-check preserves exact correctness), so the trigram indexes engage; (2) very short boundary splits (1-2 char fragments like `M`/`lo`) had almost no index selectivity and dominated cost — such splits are now skipped unless at least one side is a 4+ char anchor and neither side is a single character, which also removes low-quality noise candidates. End-to-end discovery dropped from ~20s to ~3s. No schema change (the trigram indexes already exist from migration `056`).
 
 ### Added
 - MkDocs documentation setup with Material theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.58.0"
+version = "0.58.1"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/services/cross_segment_discovery.py
+++ b/src/chronovista/services/cross_segment_discovery.py
@@ -255,6 +255,30 @@ def _is_stopword_split(prefix: str, suffix: str) -> bool:
     )
 
 
+# A boundary split is only worth querying when it has a selective anchor.
+# The batched adjacency query is dominated by splits where BOTH sides are
+# short: a 1-2 char fragment (e.g. "M" / "lo") has almost no trigram
+# selectivity and matches hundreds of thousands of segments. We therefore
+# require neither side to be a single character AND at least one side to be a
+# substantial (>= 4 char) anchor that lets PostgreSQL drive the self-join from
+# a small row set. This keeps precise splits like "Chomski"/"is" or
+# "El"/"Musk" while dropping noise like "M"/"lo" — cutting the batched query
+# from ~12s to ~1s on a ~1.5M-row segment table.
+_MIN_BOUNDARY_FRAGMENT_LEN = 2
+_MIN_BOUNDARY_ANCHOR_LEN = 4
+
+
+def _is_too_short_split(prefix: str, suffix: str) -> bool:
+    """Return True if a boundary split lacks a selective anchor.
+
+    Splits where both sides are short produce low-selectivity trigram scans
+    (huge candidate sets) and are poor ASR boundary-error indicators, so they
+    are skipped for both quality and performance.
+    """
+    shorter, longer = sorted((len(prefix.strip()), len(suffix.strip())))
+    return shorter < _MIN_BOUNDARY_FRAGMENT_LEN or longer < _MIN_BOUNDARY_ANCHOR_LEN
+
+
 def _effective_text(segment: Any) -> str:
     """Return the effective text for a segment (corrected if available)."""
     if segment.has_correction and segment.corrected_text:
@@ -466,6 +490,8 @@ class CrossSegmentDiscovery:
                 if _is_stopword_split(prefix, suffix):
                     skipped_stopword += 1
                     continue
+                if _is_too_short_split(prefix, suffix):
+                    continue
                 split_entries.append(
                     (prefix, suffix, alias_name, canonical_name, entity_type)
                 )
@@ -618,19 +644,25 @@ class CrossSegmentDiscovery:
         seg_n = TranscriptSegmentDB.__table__.alias("seg_n")
         seg_n1 = TranscriptSegmentDB.__table__.alias("seg_n1")
 
-        eff_text_n = case(
-            (seg_n.c.has_correction, seg_n.c.corrected_text),
-            else_=seg_n.c.text,
-        )
-        eff_text_n1 = case(
-            (seg_n1.c.has_correction, seg_n1.c.corrected_text),
-            else_=seg_n1.c.text,
-        )
-
+        # Candidate pre-filter on the RAW ``text``/``corrected_text`` columns so
+        # PostgreSQL can use the pg_trgm GIN indexes (``idx_segments_text_trgm`` /
+        # ``idx_segments_corrected_text_trgm``). A ``CASE(has_correction,
+        # corrected_text, text)`` expression is opaque to those indexes and forces a
+        # full parallel seq-scan of the ~1.5M-row self-join (~20s for the whole
+        # request). Matching either the original or the corrected text yields a
+        # strict super-set of the effective-text match; the ``_effective_text``
+        # re-check in the callers then enforces exact correctness, so this query is
+        # purely a fast candidate filter.
         or_conditions = [
             and_(
-                eff_text_n.ilike(f"%{prefix}"),
-                eff_text_n1.ilike(f"{suffix}%"),
+                or_(
+                    seg_n.c.text.ilike(f"%{prefix}"),
+                    seg_n.c.corrected_text.ilike(f"%{prefix}"),
+                ),
+                or_(
+                    seg_n1.c.text.ilike(f"{suffix}%"),
+                    seg_n1.c.corrected_text.ilike(f"{suffix}%"),
+                ),
             )
             for prefix, suffix in prefix_suffix_pairs
         ]
@@ -869,6 +901,8 @@ class CrossSegmentDiscovery:
                 if not prefix.strip() or not suffix.strip():
                     continue
                 if _is_stopword_split(prefix, suffix):
+                    continue
+                if _is_too_short_split(prefix, suffix):
                     continue
                 split_entries.append((prefix, suffix, pattern))
 

--- a/tests/unit/services/test_cross_segment_discovery.py
+++ b/tests/unit/services/test_cross_segment_discovery.py
@@ -39,6 +39,7 @@ from chronovista.services.cross_segment_discovery import (
     _generate_splits,
     _generate_word_splits,
     _is_stopword_split,
+    _is_too_short_split,
 )
 
 # ---------------------------------------------------------------------------
@@ -1919,3 +1920,99 @@ class TestCrossSegmentCandidateDiscoverySource:
         kwargs["discovery_source"] = "custom_strategy"
         candidate = CrossSegmentCandidate(**kwargs)
         assert candidate.discovery_source == "custom_strategy"
+
+
+# ---------------------------------------------------------------------------
+# Performance-regression guard: the batched adjacency query must filter on the
+# RAW text/corrected_text columns (trigram-index friendly) and NOT a CASE
+# expression, which is opaque to idx_segments_text_trgm and forces a full
+# seq-scan of the ~1.5M-row self-join (~20s → endpoint timeout).
+# See cross_segment_discovery._find_adjacent_pairs_batched.
+# ---------------------------------------------------------------------------
+
+
+class TestBatchedQueryIsIndexFriendly:
+    """Lock in the trigram-index-friendly shape of the batched adjacency query."""
+
+    async def _compiled_sql(self) -> str:
+        from sqlalchemy.dialects import postgresql
+
+        discovery = CrossSegmentDiscovery(batch_service=_make_batch_service([]))
+        session = _make_mock_session()
+        result_mock = MagicMock()
+        result_mock.fetchall.return_value = []
+        session.execute = AsyncMock(return_value=result_mock)
+
+        await discovery._find_adjacent_pairs_batched(
+            session, [("Roy", "Cohn"), ("Matt", "Lee")]
+        )
+
+        stmt = session.execute.call_args.args[0]
+        return str(
+            stmt.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    async def test_filters_on_raw_text_columns_not_case_expression(self) -> None:
+        """The ILIKE candidate filter targets raw text/corrected_text, never CASE."""
+        sql = await self._compiled_sql()
+        # Both raw columns participate in the filter (trigram indexes cover them).
+        assert "corrected_text" in sql
+        assert sql.count("ILIKE") >= 4  # 2 pairs × (text OR corrected_text) per side
+        # A CASE(has_correction, corrected_text, text) expression would defeat the
+        # pg_trgm GIN index — its reappearance here is the regression we guard against.
+        assert "CASE" not in sql.upper()
+
+    async def test_prefix_and_suffix_wildcards_preserved(self) -> None:
+        """Prefix match is a trailing-anchored '%prefix'; suffix is 'suffix%'."""
+        sql = await self._compiled_sql()
+        # literal_binds under the pyformat paramstyle doubles the '%' wildcard.
+        assert "'%Roy'" in sql or "'%%Roy'" in sql
+        assert "'Cohn%'" in sql or "'Cohn%%'" in sql
+
+
+class TestIsTooShortSplit:
+    """Boundary-split length guard: drops low-selectivity noise splits.
+
+    Rule: neither side may be a single char, AND at least one side must be a
+    substantial (>= 4 char) anchor so PostgreSQL can drive the self-join from a
+    small row set. This is a quality + performance filter (see
+    _is_too_short_split docstring).
+    """
+
+    @pytest.mark.parametrize(
+        "prefix,suffix",
+        [
+            ("Chomski", "is"),  # 7 + 2: long selective prefix, short suffix
+            ("El", "Musk"),  # 2 + 4: short prefix, selective suffix
+            ("Roy", "Cohn"),  # 3 + 4
+            ("Matt", "Lee"),  # 4 + 3
+        ],
+    )
+    def test_keeps_splits_with_a_selective_anchor(
+        self, prefix: str, suffix: str
+    ) -> None:
+        assert _is_too_short_split(prefix, suffix) is False
+
+    @pytest.mark.parametrize(
+        "prefix,suffix",
+        [
+            ("M", "lo"),  # 1 + 2: single-char side
+            ("l", "mosk"),  # 1 + 4: single-char side
+            ("fe", "de"),  # 2 + 2: no 4-char anchor
+            ("Roy", "K"),  # 3 + 1: single-char side
+            ("LA", "no"),  # 2 + 2: no 4-char anchor
+        ],
+    )
+    def test_drops_splits_without_a_selective_anchor(
+        self, prefix: str, suffix: str
+    ) -> None:
+        assert _is_too_short_split(prefix, suffix) is True
+
+    def test_strips_whitespace_before_measuring(self) -> None:
+        # "  Roy " -> "Roy" (3), " Cohn" -> "Cohn" (4): kept.
+        assert _is_too_short_split("  Roy ", " Cohn") is False
+        # " a " -> "a" (1): single-char after strip, dropped.
+        assert _is_too_short_split(" a ", "Musk") is True


### PR DESCRIPTION
## Summary

The **Suggested Cross-Segment Candidates** panel (`GET /corrections/batch/cross-segment/candidates`) showed "Failed to load…" because the endpoint had grown to ~20s, tripping the frontend's 10s request timeout.

Two root causes, both in `CrossSegmentDiscovery`:

- **CASE-expr blocked trigram indexes**: the adjacency self-join filtered on `CASE(has_correction, corrected_text, text)`, which is opaque to the existing `pg_trgm` GIN indexes and forced a full parallel seq-scan of the ~1.5M-row segment self-join. `EXPLAIN` confirmed the CASE expression forced the seq-scan, while filtering the raw `text`/`corrected_text` columns directly lets the planner use `idx_segments_text_trgm` / `idx_segments_corrected_text_trgm` via `BitmapOr`. This is a super-set candidate filter; the existing effective-text re-check afterward preserves exact correctness.
- **Low-selectivity short splits**: very short boundary splits (1-2 char fragments like "M"/"lo") had almost no trigram selectivity and dominated cost while also producing low-quality noise candidates. These are now skipped unless at least one side is a 4+ char anchor and neither side is a single character.

## Result

- End-to-end discovery: **~20s → ~3s** against production data.
- No schema change — the trigram indexes already exist from migration 056.
- Backend version bumped to **0.58.1** (frontend unchanged at 0.27.0). This fix is unrelated to the already-released 0.58.0.

## Test plan

- [x] 105 cross-segment discovery tests, including a new SQL-shape regression guard asserting the query filters raw text columns (not the CASE expression) and new `_is_too_short_split` cases
- [x] 349 adjacent tests green
- [x] `mypy --strict` clean
- [x] `ruff check` clean