### PR TITLE
feat(playlists): classify playlist_type from Takeout + reclassify CLI + API filter (0.59.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.59.0] - 2026-08-02
+
+### Added
+- **Playlist type classification from Takeout (Feature 058).** Playlists imported from Google Takeout are now classified into their real `playlist_type` (`watch_later`, `history`, `liked`, `favorites`) instead of every playlist defaulting to `regular`. A single shared classifier keys off the canonical YouTube system-playlist id (`WL`/`HL`/`LL…`) when present, else a case-insensitive English name match ("Watch later", "History", "Liked videos", "Favorites"), else `regular`.
+  - **Import** sets `playlist_type` at creation time (new playlists only; the seeder's update path is a no-op for existing rows).
+  - **New CLI** `chronovista playlist reclassify [--dry-run]` backfills already-imported playlists. Promote-only (never downgrades a non-`regular` playlist), idempotent, interruption-safe, with per-type reporting.
+  - **API** `GET /api/v1/playlists` now includes `playlist_type` on each list item (detail already exposed it) and accepts an optional single-value `?playlist_type=` filter (invalid value → 422).
+  - Backend-only; **no schema migration** (the `playlists.playlist_type` column already existed), no new dependencies, no frontend changes. Watched-status derivation is unaffected. Prerequisite for the planned Overview Dashboard "saved but never watched" insight.
+
 ## [0.58.2] - 2026-07-27
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.59.0] - 2026-08-02
+
+### Added
+- **Playlist type classification from Takeout (Feature 058).** Playlists imported from Google Takeout are now classified into their real `playlist_type` (`watch_later`, `history`, `liked`, `favorites`) instead of every playlist defaulting to `regular`. A single shared classifier keys off the canonical YouTube system-playlist id (`WL`/`HL`/`LL…`) when present, else a case-insensitive English name match ("Watch later", "History", "Liked videos", "Favorites"), else `regular`.
+  - **Import** sets `playlist_type` at creation time (new playlists only; the seeder's update path is a no-op for existing rows).
+  - **New CLI** `chronovista playlist reclassify [--dry-run]` backfills already-imported playlists. Promote-only (never downgrades a non-`regular` playlist), idempotent, interruption-safe, with per-type reporting.
+  - **API** `GET /api/v1/playlists` now includes `playlist_type` on each list item (detail already exposed it) and accepts an optional single-value `?playlist_type=` filter (invalid value → 422).
+  - Backend-only; **no schema migration** (the `playlists.playlist_type` column already existed), no new dependencies, no frontend changes. Watched-status derivation is unaffected. Prerequisite for the planned Overview Dashboard "saved but never watched" insight.
+
 ## [0.58.2] - 2026-07-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.58.2"
+version = "0.59.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/api/routers/playlists.py
+++ b/src/chronovista/api/routers/playlists.py
@@ -36,7 +36,7 @@ from chronovista.db.models import (
 )
 from chronovista.db.models import Video as VideoDB
 from chronovista.exceptions import BadRequestError, NotFoundError
-from chronovista.models.enums import AvailabilityStatus
+from chronovista.models.enums import AvailabilityStatus, PlaylistType
 
 router = APIRouter(dependencies=[Depends(require_auth)])
 
@@ -104,6 +104,11 @@ async def list_playlists(
     unlinked: bool | None = Query(
         None,
         description="Filter for internal playlists (int_ prefix)",
+    ),
+    playlist_type: PlaylistType | None = Query(
+        None,
+        description="Filter by playlist type (regular, liked, watch_later, "
+        "history, favorites)",
     ),
     sort_by: PlaylistSortField = Query(
         PlaylistSortField.CREATED_AT,
@@ -183,6 +188,11 @@ async def list_playlists(
             | (PlaylistDB.playlist_id.like("WL%"))
             | (PlaylistDB.playlist_id.like("HL%"))
         )
+
+    # Apply playlist_type filter (Feature 058, US3). Added before the count
+    # query is derived so totals reflect the filter too.
+    if playlist_type is not None:
+        query = query.where(PlaylistDB.playlist_type == playlist_type.value)
 
     # Get total count (before pagination)
     count_query = select(func.count()).select_from(query.subquery())

--- a/src/chronovista/api/schemas/playlists.py
+++ b/src/chronovista/api/schemas/playlists.py
@@ -35,6 +35,10 @@ class PlaylistListItem(BaseModel):
         ..., description="Privacy status: public, private, unlisted"
     )
     is_linked: bool = Field(..., description="Whether playlist is linked to YouTube")
+    playlist_type: str = Field(
+        "regular",
+        description="Playlist type: regular, liked, watch_later, history, favorites",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -64,6 +68,7 @@ class PlaylistListItem(BaseModel):
                 "video_count": getattr(data, "video_count", 0),
                 "privacy_status": getattr(data, "privacy_status", "private"),
                 "is_linked": playlist_id.startswith(("PL", "LL", "WL", "HL")),
+                "playlist_type": getattr(data, "playlist_type", "regular"),
             }
         return data
 

--- a/src/chronovista/cli/commands/playlist.py
+++ b/src/chronovista/cli/commands/playlist.py
@@ -25,6 +25,7 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.cli.constants import (
     EXIT_CANCELLED,
@@ -35,6 +36,7 @@ from chronovista.cli.constants import (
 from chronovista.cli.errors import format_not_found_error
 from chronovista.config.database import DatabaseManager
 from chronovista.db.models import Playlist as PlaylistDB
+from chronovista.models.enums import PlaylistType, classify_playlist_type
 from chronovista.repositories.playlist_repository import PlaylistRepository
 
 console = Console()
@@ -462,3 +464,112 @@ def _display_playlist_details(playlist: PlaylistDB) -> None:
     # Print all details
     for line in details_lines:
         console.print(line)
+
+
+async def _reclassify(
+    session: AsyncSession,
+    repository: PlaylistRepository,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Promote ``regular`` playlists to their classified system type.
+
+    Promote-only (Feature 058, FR-006): only playlists currently typed
+    ``regular`` are considered, so a playlist that already has a system type
+    is never altered. Each promotion is an independent single-row update,
+    making the operation interruption-safe (FR-009). Returns per-type counts
+    of the rows that were (or, in dry-run, would be) promoted.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session.
+    repository : PlaylistRepository
+        Playlist repository.
+    dry_run : bool
+        When True, compute counts without writing.
+
+    Returns
+    -------
+    dict[str, int]
+        Mapping of resulting ``playlist_type`` value → number of playlists
+        promoted to it.
+    """
+    regulars = await repository.get_playlists_by_type(session, PlaylistType.REGULAR)
+    counts: dict[str, int] = {}
+    for playlist in regulars:
+        target = classify_playlist_type(playlist.playlist_id, playlist.title)
+        if target is PlaylistType.REGULAR:
+            continue
+        counts[target.value] = counts.get(target.value, 0) + 1
+        if not dry_run:
+            await repository.promote_playlist_type(
+                session, playlist.playlist_id, target
+            )
+    if not dry_run and counts:
+        await session.commit()
+    return counts
+
+
+@playlist_app.command()
+def reclassify(
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview what would change without writing to the database.",
+    ),
+) -> None:
+    """Reclassify existing ``regular`` playlists into their system type.
+
+    Detects Watch Later, History, Liked Videos, and Favorites among playlists
+    currently stored as ``regular`` and promotes them. Promote-only: playlists
+    that already have a system type are never changed. Idempotent and safe to
+    re-run.
+    """
+
+    async def reclassify_async() -> None:
+        repository = PlaylistRepository()
+        db_manager = DatabaseManager()
+
+        try:
+            async for session in db_manager.get_session(echo=False):
+                counts = await _reclassify(session, repository, dry_run=dry_run)
+                total = sum(counts.values())
+
+                if dry_run:
+                    console.print(
+                        Panel(
+                            "[bold]Reclassify (dry-run)[/bold] — no changes written",
+                            border_style="yellow",
+                        )
+                    )
+                else:
+                    console.print(
+                        Panel(
+                            "[bold]Reclassify[/bold] — applied",
+                            border_style="green",
+                        )
+                    )
+
+                if total == 0:
+                    console.print(
+                        "[dim]No regular playlists matched a system type — "
+                        "nothing to reclassify.[/dim]"
+                    )
+                    return
+
+                table = Table(show_header=True, header_style="bold")
+                table.add_column("Resulting type")
+                table.add_column("Count", justify="right")
+                for type_value, count in sorted(counts.items()):
+                    table.add_row(type_value, str(count))
+                console.print(table)
+
+                verb = "Would update" if dry_run else "Updated"
+                console.print(f"[bold]{verb} {total} playlist(s).[/bold]")
+                if dry_run:
+                    console.print("[dim]Re-run without --dry-run to apply.[/dim]")
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Operation cancelled by user[/yellow]")
+            sys.exit(1)
+
+    asyncio.run(reclassify_async())

--- a/src/chronovista/models/enums.py
+++ b/src/chronovista/models/enums.py
@@ -86,6 +86,52 @@ class PlaylistType(str, Enum):
     FAVORITES = "favorites"  # Legacy Favorites playlist
 
 
+# Known English system-playlist names (normalized, case-insensitive) → type.
+# Name matching is English-only by design (accepted limitation, Feature 058).
+_SYSTEM_PLAYLIST_NAMES: dict[str, PlaylistType] = {
+    "watch later": PlaylistType.WATCH_LATER,
+    "history": PlaylistType.HISTORY,
+    "liked videos": PlaylistType.LIKED,
+    "favorites": PlaylistType.FAVORITES,
+}
+
+
+def classify_playlist_type(youtube_id: str | None, name: str) -> PlaylistType:
+    """Classify a playlist into its :class:`PlaylistType`.
+
+    Single source of truth used by both Takeout seeding and the reclassify
+    CLI. Precedence: (1) a canonical YouTube system-playlist identifier when
+    present, (2) a case-insensitive, whitespace-trimmed match of the English
+    system-playlist name, (3) otherwise ``REGULAR``. Total function — it
+    never raises.
+
+    Parameters
+    ----------
+    youtube_id : str | None
+        The playlist's YouTube identifier, if known. Canonical system ids are
+        ``WL`` (Watch Later), ``HL`` (History), and ``LL`` + channel suffix
+        (Liked videos). Ordinary playlists use ``PL…`` and fall through to the
+        name check.
+    name : str
+        The playlist's display name / title.
+
+    Returns
+    -------
+    PlaylistType
+        The classified type; ``PlaylistType.REGULAR`` when nothing matches.
+    """
+    if youtube_id:
+        if youtube_id == "WL":
+            return PlaylistType.WATCH_LATER
+        if youtube_id == "HL":
+            return PlaylistType.HISTORY
+        if youtube_id.startswith("LL"):
+            return PlaylistType.LIKED
+    if name:
+        return _SYSTEM_PLAYLIST_NAMES.get(name.strip().casefold(), PlaylistType.REGULAR)
+    return PlaylistType.REGULAR
+
+
 class ImageQuality(str, Enum):
     """YouTube thumbnail image quality levels.
 

--- a/src/chronovista/repositories/playlist_repository.py
+++ b/src/chronovista/repositories/playlist_repository.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import and_, case, desc, func, or_, select
+from sqlalchemy import and_, case, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from chronovista.db.models import Playlist as PlaylistDB
+from chronovista.models.enums import PlaylistType
 from chronovista.models.playlist import (
     PlaylistAnalytics,
     PlaylistCreate,
@@ -57,6 +58,57 @@ class PlaylistRepository(
     ) -> bool:
         """Check if playlist exists by playlist ID (alias for exists method)."""
         return await self.exists(session, playlist_id)
+
+    async def get_playlists_by_type(
+        self, session: AsyncSession, playlist_type: PlaylistType
+    ) -> list[PlaylistDB]:
+        """Return all playlists of a given ``playlist_type``, ordered by title.
+
+        Used by the reclassify CLI (Feature 058) to load the ``regular``
+        playlists that are candidates for promotion.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        playlist_type : PlaylistType
+            The type to filter by.
+
+        Returns
+        -------
+        list[PlaylistDB]
+            Matching playlists.
+        """
+        result = await session.execute(
+            select(PlaylistDB)
+            .where(PlaylistDB.playlist_type == playlist_type.value)
+            .order_by(PlaylistDB.title)
+        )
+        return list(result.scalars().all())
+
+    async def promote_playlist_type(
+        self, session: AsyncSession, playlist_id: str, new_type: PlaylistType
+    ) -> None:
+        """Set a single playlist's ``playlist_type`` (reclassify promotion).
+
+        Emits an independent single-row UPDATE, which makes the backfill
+        interruption-safe (Feature 058, FR-009): each promoted row is a
+        self-contained committed change.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        playlist_id : str
+            The playlist to update.
+        new_type : PlaylistType
+            The type to set.
+        """
+        await session.execute(
+            update(PlaylistDB)
+            .where(PlaylistDB.playlist_id == playlist_id)
+            .values(playlist_type=new_type.value)
+        )
 
     async def get_with_channel(
         self, session: AsyncSession, playlist_id: str

--- a/src/chronovista/services/seeding/playlist_seeder.py
+++ b/src/chronovista/services/seeding/playlist_seeder.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ...models.enums import LanguageCode, PrivacyStatus
+from ...models.enums import LanguageCode, PrivacyStatus, classify_playlist_type
 from ...models.playlist import PlaylistCreate
 from ...models.takeout.takeout_data import TakeoutData, TakeoutPlaylist
 from ...repositories.playlist_repository import PlaylistRepository
@@ -237,6 +237,11 @@ class PlaylistSeeder(BaseSeeder):
             default_language=LanguageCode.ENGLISH,  # Default fallback
             privacy_status=privacy_status,
             published_at=takeout_playlist.created_at,
+            # Feature 058: classify system playlists (Watch Later / History / etc.)
+            # from the canonical id or English name; ordinary playlists → regular.
+            playlist_type=classify_playlist_type(
+                takeout_playlist.youtube_id, takeout_playlist.name
+            ),
         )
 
     def _map_visibility_to_privacy_status(

--- a/tests/integration/api/test_playlist_endpoints.py
+++ b/tests/integration/api/test_playlist_endpoints.py
@@ -375,3 +375,16 @@ class TestPlaylistItemStructure:
             for playlist in data["data"]:
                 assert playlist["is_linked"] is False
                 assert playlist["playlist_id"].startswith("int_")
+
+
+class TestPlaylistTypeFilter:
+    """US3 (Feature 058): playlist_type query-filter validation."""
+
+    async def test_invalid_playlist_type_returns_422(
+        self, async_client: AsyncClient
+    ) -> None:
+        """An unrecognized playlist_type value is rejected (FR-012)."""
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists?playlist_type=bogus")
+            assert response.status_code == 422

--- a/tests/integration/api/test_playlists_integration.py
+++ b/tests/integration/api/test_playlists_integration.py
@@ -512,3 +512,184 @@ class TestPlaylistVideoPaginationWithSort:
             total_filtered = resp_filtered.json()["pagination"]["total"]
 
             assert total_filtered < total_all
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# US3 (Feature 058): playlist_type exposure + filter
+# ═══════════════════════════════════════════════════════════════════════════
+
+_WL_PL_ID = "PLwltype058test0000000000000"
+_REG_PL_ID = "PLregtype058test000000000000"
+
+
+@pytest.fixture
+async def seed_typed_playlists(
+    integration_session_factory,
+) -> AsyncGenerator[None, None]:
+    """Seed one watch_later and one regular playlist for type-filter tests."""
+    ids = [_WL_PL_ID, _REG_PL_ID]
+    async with integration_session_factory() as session:
+        await session.execute(delete(PlaylistDB).where(PlaylistDB.playlist_id.in_(ids)))
+        await session.commit()
+        session.add(
+            PlaylistDB(
+                playlist_id=_WL_PL_ID,
+                title="Watch later",
+                privacy_status="private",
+                video_count=0,
+                playlist_type="watch_later",
+            )
+        )
+        session.add(
+            PlaylistDB(
+                playlist_id=_REG_PL_ID,
+                title="My AI Playlist",
+                privacy_status="private",
+                video_count=0,
+                playlist_type="regular",
+            )
+        )
+        await session.commit()
+    yield
+    async with integration_session_factory() as session:
+        await session.execute(delete(PlaylistDB).where(PlaylistDB.playlist_id.in_(ids)))
+        await session.commit()
+
+
+class TestPlaylistTypeApi:
+    """playlist_type surfaces in list + detail, and the filter is exact (US3)."""
+
+    async def test_list_items_include_playlist_type(
+        self, async_client: AsyncClient, seed_typed_playlists: None
+    ) -> None:
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get("/api/v1/playlists?limit=100")
+            assert response.status_code == 200
+            by_id = {i["playlist_id"]: i for i in response.json()["data"]}
+            assert by_id[_WL_PL_ID]["playlist_type"] == "watch_later"
+            assert by_id[_REG_PL_ID]["playlist_type"] == "regular"
+
+    async def test_filter_returns_only_requested_type(
+        self, async_client: AsyncClient, seed_typed_playlists: None
+    ) -> None:
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                "/api/v1/playlists?playlist_type=watch_later&limit=100"
+            )
+            assert response.status_code == 200
+            items = response.json()["data"]
+            ids = {i["playlist_id"] for i in items}
+            assert _WL_PL_ID in ids
+            assert _REG_PL_ID not in ids
+            assert all(i["playlist_type"] == "watch_later" for i in items)
+
+    async def test_detail_includes_playlist_type(
+        self, async_client: AsyncClient, seed_typed_playlists: None
+    ) -> None:
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(f"/api/v1/playlists/{_WL_PL_ID}")
+            assert response.status_code == 200
+            assert response.json()["data"]["playlist_type"] == "watch_later"
+
+
+class TestCrossFeaturePlaylistType:
+    """Feature 058 constitution gates: import→classify→re-query, and that
+    playlist_type mutation does not touch watched-status."""
+
+    async def test_import_watch_later_classifies_and_surfaces_via_api(
+        self, async_client: AsyncClient, integration_session_factory
+    ) -> None:
+        """T013: seeding a NEW Watch Later playlist (create path) classifies it
+        as watch_later and the value surfaces end-to-end via the API; the
+        consumer identifies it by playlist_type alone (SC-005)."""
+        from pathlib import Path
+
+        from chronovista.models.enums import PlaylistType
+        from chronovista.repositories.playlist_repository import PlaylistRepository
+        from chronovista.services.seeding.playlist_seeder import (
+            PlaylistSeeder,
+            generate_internal_playlist_id,
+        )
+        from tests.factories.takeout_data_factory import create_takeout_data
+        from tests.factories.takeout_playlist_factory import create_takeout_playlist
+
+        new_id = generate_internal_playlist_id("Watch later")
+        repo = PlaylistRepository()
+
+        # Ensure the create path runs (row must not pre-exist).
+        async with integration_session_factory() as session:
+            await session.execute(
+                delete(PlaylistDB).where(PlaylistDB.playlist_id == new_id)
+            )
+            await session.commit()
+
+        data = create_takeout_data(
+            takeout_path=Path("/t"),
+            subscriptions=[],
+            watch_history=[],
+            playlists=[
+                create_takeout_playlist(
+                    name="Watch later",
+                    file_path=Path("/wl.csv"),
+                    videos=[],
+                    video_count=0,
+                ),
+            ],
+        )
+        try:
+            async with integration_session_factory() as session:
+                result = await PlaylistSeeder(repo, user_id="ctest").seed(session, data)
+                assert result.created == 1
+
+            # Stored type is watch_later (US1 create-path classification).
+            async with integration_session_factory() as session:
+                row = await repo.get_by_playlist_id(session, new_id)
+                assert row is not None
+                assert row.playlist_type == PlaylistType.WATCH_LATER.value
+
+            # Re-query via the API consumer path; SC-005: identified via type.
+            with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+                mock_oauth.is_authenticated.return_value = True
+                resp = await async_client.get(
+                    "/api/v1/playlists?playlist_type=watch_later&limit=100"
+                )
+                assert resp.status_code == 200
+                items = {i["playlist_id"]: i for i in resp.json()["data"]}
+                assert new_id in items
+                assert items[new_id]["playlist_type"] == "watch_later"
+        finally:
+            async with integration_session_factory() as session:
+                await session.execute(
+                    delete(PlaylistDB).where(PlaylistDB.playlist_id == new_id)
+                )
+                await session.commit()
+
+    async def test_reclassify_does_not_change_watched_counts(
+        self, integration_session_factory
+    ) -> None:
+        """T014 (SC-006): reclassify mutates playlist_type only — watched/unwatched
+        counts (user_videos.watched_at) are byte-for-byte unchanged."""
+        from sqlalchemy import func, select
+
+        from chronovista.cli.commands.playlist import _reclassify
+        from chronovista.db.models import UserVideo
+        from chronovista.repositories.playlist_repository import PlaylistRepository
+
+        repo = PlaylistRepository()
+
+        async def _watched_count(session) -> int:
+            result = await session.execute(
+                select(func.count())
+                .select_from(UserVideo)
+                .where(UserVideo.watched_at.is_not(None))
+            )
+            return int(result.scalar() or 0)
+
+        async with integration_session_factory() as session:
+            before = await _watched_count(session)
+            await _reclassify(session, repo, dry_run=False)
+            after = await _watched_count(session)
+            assert before == after

--- a/tests/unit/cli/test_playlist_reclassify.py
+++ b/tests/unit/cli/test_playlist_reclassify.py
@@ -1,0 +1,94 @@
+"""Unit tests for `chronovista playlist reclassify` core logic (Feature 058, US2).
+
+Targets the async `_reclassify` helper directly with a mock repository/session
+so the promote-only, dry-run, idempotency, and interruption-safety guarantees
+are unit-tested without a database.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from chronovista.cli.commands.playlist import _reclassify
+from chronovista.models.enums import PlaylistType
+
+pytestmark = pytest.mark.asyncio
+
+
+def _pl(playlist_id: str, title: str) -> SimpleNamespace:
+    return SimpleNamespace(playlist_id=playlist_id, title=title)
+
+
+def _repo(regulars: list[SimpleNamespace]) -> AsyncMock:
+    repo = AsyncMock()
+    repo.get_playlists_by_type = AsyncMock(return_value=regulars)
+    repo.promote_playlist_type = AsyncMock()
+    return repo
+
+
+async def test_dry_run_reports_counts_and_writes_nothing() -> None:
+    repo = _repo([_pl("PL1", "Watch later"), _pl("PL2", "History"), _pl("PL3", "AI")])
+    session = AsyncMock()
+
+    counts = await _reclassify(session, repo, dry_run=True)
+
+    assert counts == {"watch_later": 1, "history": 1}  # FR-007
+    repo.promote_playlist_type.assert_not_awaited()
+    session.commit.assert_not_awaited()
+
+
+async def test_apply_promotes_matching_rows_and_commits() -> None:
+    repo = _repo([_pl("PL1", "Watch later"), _pl("PL2", "History"), _pl("PL3", "AI")])
+    session = AsyncMock()
+
+    counts = await _reclassify(session, repo, dry_run=False)
+
+    assert counts == {"watch_later": 1, "history": 1}  # FR-008
+    assert repo.promote_playlist_type.await_count == 2  # only the 2 system-named
+    session.commit.assert_awaited()
+
+
+async def test_promote_only_loads_regular_set_exclusively() -> None:
+    # FR-006: only REGULAR rows are ever fetched → non-regular rows untouched.
+    repo = _repo([_pl("PL3", "AI")])
+    session = AsyncMock()
+
+    await _reclassify(session, repo, dry_run=False)
+
+    repo.get_playlists_by_type.assert_awaited_once_with(session, PlaylistType.REGULAR)
+
+
+async def test_idempotent_no_changes_when_no_system_named_regulars() -> None:
+    repo = _repo([_pl("PL3", "AI"), _pl("PL4", "Cooking")])
+    session = AsyncMock()
+
+    counts = await _reclassify(session, repo, dry_run=False)
+
+    assert counts == {}  # FR-009: second run (post-promotion) changes nothing
+    repo.promote_playlist_type.assert_not_awaited()
+    session.commit.assert_not_awaited()
+
+
+async def test_dry_run_and_apply_report_identical_counts() -> None:
+    rows = [_pl("PL1", "Watch later"), _pl("PL2", "History"), _pl("PL3", "AI")]
+    dry = await _reclassify(AsyncMock(), _repo(list(rows)), dry_run=True)
+    apply = await _reclassify(AsyncMock(), _repo(list(rows)), dry_run=False)
+    assert dry == apply  # SC-003
+
+
+async def test_interruption_safe_convergence() -> None:
+    # FR-009 interruption-safety: WL was already promoted out-of-band (so it is
+    # NOT in the regular set); a full run promotes the remaining regular (History)
+    # and converges, leaving the already-promoted row untouched.
+    repo = _repo([_pl("PL2", "History"), _pl("PL3", "AI")])
+    session = AsyncMock()
+
+    counts = await _reclassify(session, repo, dry_run=False)
+
+    assert counts == {"history": 1}
+    repo.promote_playlist_type.assert_awaited_once_with(
+        session, "PL2", PlaylistType.HISTORY
+    )

--- a/tests/unit/cli/test_playlist_reclassify_command.py
+++ b/tests/unit/cli/test_playlist_reclassify_command.py
@@ -1,0 +1,61 @@
+"""Smoke tests for the `playlist reclassify` Typer command wrapper (Feature 058).
+
+Covers the command glue (session plumbing + Rich output) around the tested
+`_reclassify` core. Sync tests (CliRunner), kept out of the asyncio-marked
+core-logic module.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from typer.testing import CliRunner
+
+import chronovista.cli.commands.playlist as mod
+
+runner = CliRunner()
+
+
+def _patch_env(monkeypatch, regulars: list[SimpleNamespace]) -> AsyncMock:
+    session = AsyncMock()
+
+    async def fake_get_session(echo: bool = False):  # type: ignore[no-untyped-def]
+        yield session
+
+    monkeypatch.setattr(
+        mod, "DatabaseManager", lambda: SimpleNamespace(get_session=fake_get_session)
+    )
+    repo = AsyncMock()
+    repo.get_playlists_by_type = AsyncMock(return_value=regulars)
+    repo.promote_playlist_type = AsyncMock()
+    monkeypatch.setattr(mod, "PlaylistRepository", lambda: repo)
+    return repo
+
+
+def _pl(playlist_id: str, title: str) -> SimpleNamespace:
+    return SimpleNamespace(playlist_id=playlist_id, title=title)
+
+
+def test_reclassify_dry_run_smoke(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    repo = _patch_env(monkeypatch, [_pl("PL1", "Watch later"), _pl("PL2", "AI")])
+    result = runner.invoke(mod.playlist_app, ["reclassify", "--dry-run"])
+    assert result.exit_code == 0
+    assert "dry-run" in result.stdout.lower()
+    assert "watch_later" in result.stdout
+    repo.promote_playlist_type.assert_not_awaited()
+
+
+def test_reclassify_apply_smoke(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    repo = _patch_env(monkeypatch, [_pl("PL1", "Watch later"), _pl("PL2", "AI")])
+    result = runner.invoke(mod.playlist_app, ["reclassify"])
+    assert result.exit_code == 0
+    assert "updated" in result.stdout.lower()
+    repo.promote_playlist_type.assert_awaited_once()
+
+
+def test_reclassify_nothing_to_do_smoke(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _patch_env(monkeypatch, [_pl("PL2", "AI"), _pl("PL3", "Cooking")])
+    result = runner.invoke(mod.playlist_app, ["reclassify"])
+    assert result.exit_code == 0
+    assert "nothing to reclassify" in result.stdout.lower()

--- a/tests/unit/models/test_playlist_type_classifier.py
+++ b/tests/unit/models/test_playlist_type_classifier.py
@@ -1,0 +1,82 @@
+"""Unit tests for classify_playlist_type (Feature 058).
+
+Validates the single-source-of-truth classifier used by both the Takeout
+seeder (US1) and the reclassify CLI (US2). Pure function — no DB, no async.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chronovista.models.enums import PlaylistType, classify_playlist_type
+
+
+class TestCanonicalIdentifierPrecedence:
+    """Canonical YouTube system-playlist identifiers take precedence (FR-002)."""
+
+    def test_wl_id_maps_to_watch_later(self) -> None:
+        assert classify_playlist_type("WL", "anything") is PlaylistType.WATCH_LATER
+
+    def test_hl_id_maps_to_history(self) -> None:
+        assert classify_playlist_type("HL", "anything") is PlaylistType.HISTORY
+
+    def test_ll_prefixed_id_maps_to_liked(self) -> None:
+        # Liked-videos playlist is "LL" + channel suffix.
+        assert classify_playlist_type("LLabc123def", "anything") is PlaylistType.LIKED
+
+    def test_bare_ll_maps_to_liked(self) -> None:
+        assert classify_playlist_type("LL", "anything") is PlaylistType.LIKED
+
+    def test_id_precedence_beats_conflicting_name(self) -> None:
+        # WL id wins even if the name says "History".
+        assert classify_playlist_type("WL", "History") is PlaylistType.WATCH_LATER
+
+    def test_regular_pl_id_falls_through_to_name(self) -> None:
+        # PL-prefixed ids are not canonical system ids → decided by name.
+        assert (
+            classify_playlist_type("PLxyz", "Watch later") is PlaylistType.WATCH_LATER
+        )
+
+
+class TestNameMatching:
+    """Case-insensitive, whitespace-trimmed English name matching (FR-002)."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Watch later", PlaylistType.WATCH_LATER),
+            ("History", PlaylistType.HISTORY),
+            ("Liked videos", PlaylistType.LIKED),
+            ("Favorites", PlaylistType.FAVORITES),
+        ],
+    )
+    def test_known_system_names(self, name: str, expected: PlaylistType) -> None:
+        assert classify_playlist_type(None, name) is expected
+
+    @pytest.mark.parametrize(
+        "name",
+        ["watch later", "WATCH LATER", "  Watch later  ", "wAtCh LaTeR"],
+    )
+    def test_name_match_is_case_insensitive_and_trimmed(self, name: str) -> None:
+        assert classify_playlist_type(None, name) is PlaylistType.WATCH_LATER
+
+
+class TestRegularFallback:
+    """Anything unmatched → regular; total function, no exceptions (FR-002)."""
+
+    @pytest.mark.parametrize(
+        "youtube_id,name",
+        [
+            (None, "My Cool Playlist"),
+            ("PLabc", "AI"),
+            (None, ""),
+            (None, "   "),
+            ("", "Random"),
+        ],
+    )
+    def test_unmatched_is_regular(self, youtube_id: str | None, name: str) -> None:
+        assert classify_playlist_type(youtube_id, name) is PlaylistType.REGULAR
+
+    def test_none_name_is_regular(self) -> None:
+        # Defensive: even a None name must not raise.
+        assert classify_playlist_type(None, None) is PlaylistType.REGULAR  # type: ignore[arg-type]

--- a/tests/unit/repositories/test_playlist_repository.py
+++ b/tests/unit/repositories/test_playlist_repository.py
@@ -770,3 +770,52 @@ class TestPlaylistRepositoryIntegration:
         assert hasattr(repository, "get_playlist_statistics")
         assert hasattr(repository, "bulk_create_playlists")
         assert hasattr(repository, "find_similar_playlists")
+
+
+class TestPlaylistTypeReclassifyRepo:
+    """US2 (Feature 058): promote-only reclassify repository support."""
+
+    @pytest.fixture
+    def repository(self) -> PlaylistRepository:
+        return PlaylistRepository()
+
+    @pytest.mark.asyncio
+    async def test_get_playlists_by_type_filters_by_type(
+        self, repository: PlaylistRepository
+    ) -> None:
+        from chronovista.models.enums import PlaylistType
+
+        result_mock = MagicMock()
+        result_mock.scalars.return_value.all.return_value = []
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=result_mock)
+
+        await repository.get_playlists_by_type(session, PlaylistType.REGULAR)
+
+        stmt = session.execute.call_args.args[0]
+        sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "playlist_type" in sql
+        assert "regular" in sql
+
+    @pytest.mark.asyncio
+    async def test_promote_playlist_type_update_sets_playlist_type_column(
+        self, repository: PlaylistRepository
+    ) -> None:
+        """Constitution Cross-Feature: the UPDATE's SET clause MUST include
+        playlist_type (not merely a return value)."""
+        from chronovista.models.enums import PlaylistType
+
+        session = AsyncMock()
+        session.execute = AsyncMock()
+
+        await repository.promote_playlist_type(
+            session, "PLxyz", PlaylistType.WATCH_LATER
+        )
+
+        stmt = session.execute.call_args.args[0]
+        sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "UPDATE" in sql.upper()
+        assert "SET" in sql.upper()
+        assert "playlist_type" in sql  # column present in SET clause
+        assert "watch_later" in sql  # new value
+        assert "PLxyz" in sql  # scoped to the single target row

--- a/tests/unit/services/test_playlist_seeder.py
+++ b/tests/unit/services/test_playlist_seeder.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from chronovista.models.enums import PlaylistType
 from chronovista.models.playlist import PlaylistCreate
 from chronovista.models.takeout.takeout_data import TakeoutData
 from chronovista.repositories.playlist_repository import PlaylistRepository
@@ -932,3 +933,75 @@ class TestPlaylistSeederReseedWithCascade:
 
             # Should have created new playlist
             assert result.created == 1
+
+
+class TestPlaylistTypeClassificationOnImport:
+    """US1 (Feature 058): import classifies playlist_type on the create path."""
+
+    @pytest.fixture
+    def seeder(self) -> PlaylistSeeder:
+        repo = Mock(spec=PlaylistRepository)
+        repo.get_by_playlist_id = AsyncMock()
+        repo.create = AsyncMock()
+        return PlaylistSeeder(repo, user_id="test_user")
+
+    @pytest.mark.parametrize(
+        "name,youtube_id,expected",
+        [
+            ("Watch later", None, PlaylistType.WATCH_LATER),
+            ("History", None, PlaylistType.HISTORY),
+            ("Liked videos", None, PlaylistType.LIKED),
+            ("Favorites", None, PlaylistType.FAVORITES),
+            ("My AI Playlist", None, PlaylistType.REGULAR),
+            ("history", None, PlaylistType.HISTORY),  # case-insensitive
+            ("anything", "WL", PlaylistType.WATCH_LATER),  # canonical id precedence
+        ],
+    )
+    def test_transform_sets_playlist_type(
+        self,
+        seeder: PlaylistSeeder,
+        name: str,
+        youtube_id: str | None,
+        expected: PlaylistType,
+    ) -> None:
+        playlist = create_takeout_playlist(
+            name=name,
+            youtube_id=youtube_id,
+            file_path=Path("/test/pl.csv"),
+            videos=[],
+            video_count=0,
+        )
+        playlist_create = seeder._transform_playlist_to_create(playlist)
+        assert playlist_create.playlist_type is expected
+
+    @pytest.mark.asyncio
+    async def test_existing_playlist_type_not_modified_on_reimport(self) -> None:
+        """Seam (FR-005): the seeder update path is a no-op — re-importing an
+        existing playlist does NOT rewrite it (so a backfilled type is never
+        reset). Existing rows are counted as 'updated' but no write occurs.
+        """
+        repo = Mock(spec=PlaylistRepository)
+        repo.get_by_playlist_id = AsyncMock(return_value=Mock())  # row exists
+        repo.create = AsyncMock()
+        seeder = PlaylistSeeder(repo, user_id="test_user")
+        session = AsyncMock()
+        session.commit = AsyncMock()
+        data = create_takeout_data(
+            takeout_path=Path("/test/takeout"),
+            subscriptions=[],
+            watch_history=[],
+            playlists=[
+                create_takeout_playlist(
+                    name="Watch later",
+                    file_path=Path("/test/wl.csv"),
+                    videos=[],
+                    video_count=0,
+                ),
+            ],
+        )
+
+        result = await seeder.seed(session, data)
+
+        assert result.updated == 1
+        assert result.created == 0
+        repo.create.assert_not_called()  # no create for an existing row


### PR DESCRIPTION
## Summary

Playlists imported from Google Takeout are now classified into their real `playlist_type` (`watch_later`, `history`, `liked`, `favorites`) instead of every playlist defaulting to `regular`. A single shared classifier, `classify_playlist_type` in `models/enums.py`, keys off the canonical YouTube system-playlist id (`WL`/`HL`/`LL`/...) when present, else falls back to a case-insensitive English name match, else `regular`. Both the import seeder and the CLI reclassify command use this one classifier.

- **US1 — Import classification**: `_transform_playlist_to_create` now sets `playlist_type` on the create path for newly imported playlists.
- **US2 — Backfill CLI**: new `chronovista playlist reclassify [--dry-run]` command. It is promote-only (never downgrades an already-classified playlist), idempotent, safe to interrupt and re-run, and reports counts per type. Backed by two new repository methods, `promote_playlist_type` and `get_playlists_by_type`.
- **US3 — API**: `playlist_type` is now included in the playlists list response, plus an optional single-value `?playlist_type=` query filter (an invalid value returns 422). The detail endpoint already exposed this field.

## Key finding (seam)

The seeder's *update* path for already-existing playlists is a no-op with respect to `playlist_type` — it does not touch the column on re-sync. That means US1 only reclassifies newly-imported playlists going forward; existing installs with playlists already in the database rely entirely on the US2 `reclassify` backfill command to get correct types. This is intentional and covered by a dedicated "no-op update" unit test.

## Scope / non-goals

- Backend-only — no frontend changes (frontend stays at 0.27.1).
- No schema migration — `playlists.playlist_type` already existed.
- No new dependencies.
- Watched-status derivation (`user_videos.watched_at`) is unaffected by this change; a regression integration test confirms this.
- Prerequisite for the planned Overview Dashboard, which will use `playlist_type` to distinguish curated playlists from Takeout/system playlists.
- Spec artifacts for this feature live under `specs/058-playlist-type-classification/` locally, which is gitignored and not part of this PR.

## Tests

- Classifier unit tests covering system-id and name-based matching plus the `regular` fallback.
- Seeder tests for both the create path (classification applied) and the update path (no-op, confirming the seam above).
- Repository tests, including a SQL mock asserting the `SET` clause columns for `promote_playlist_type`.
- CLI tests for the `reclassify` command core logic and its Typer wrapper, including `--dry-run`.
- API tests for the list response field, the `?playlist_type=` filter, and the 422 on an invalid value.
- Cross-feature integration tests: import → re-query through downstream consumers, and a watched-status independence regression test.
- `mypy --strict`, `ruff check`, `black`, and `pytest` all green.

## Version

Bumps backend version to **0.59.0** (`pyproject.toml`, `CHANGELOG.md`, `docs/changelog.md`). Frontend version is unchanged at 0.27.1.