### PR TITLE
feat(overview): watched-vs-saved dashboard & per-playlist watch filtering (Feature 061)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.0] - 2026-08-03
+
+### Added
+- **Watched vs. saved, in-context and in aggregate (Feature 061).** "Watched" and "saved in a playlist" are independent facts, and the UI could not tell them apart. Watched-status derives **solely** from `user_videos.watched_at` and is never inferred from playlist membership — YouTube does not remove watched videos from Watch Later, so a playlist legitimately holds a mix.
+  - **Per-playlist stats and filtering.** Each playlist detail page gains a `total / watched / unwatched` header and an All / Watched / Unwatched filter. The header describes the whole playlist and deliberately does **not** move with the filter, while the result count does — two quantities that are asserted separately, because conflating them is the easy bug. The filter lives in the address as `?watched_status=`, so a filtered view is shareable and the dashboard can deep-link into it. Each row carries its own watched state, batch-loaded per page.
+  - **New Overview Dashboard** at `/overview`, headlined by **Saved & Forgotten** — videos saved to a curated playlist and never watched (609 on the author's library) — plus Watch Later depth, a playlist inventory by type, and library-wide rollups. One request serves every figure, so the numbers cannot disagree with each other.
+  - **New `GET /api/v1/overview`**; `GET /api/v1/playlists/{id}/videos` gains `watched_status` and a `stats` object with `watched: bool` per item; `GET /api/v1/videos` gains `saved_unwatched`.
+  - Read-only throughout: no migration, no schema change, no write path, no CLI change.
+
+### Fixed
+- **The History playlist is not "trivially all-watched".** It holds 2,997 videos of which 116 have no watch record — the Takeout playlist export and the watch-history import are separate sources and need not agree. A non-empty Unwatched view for History is correct output, not a bug to be "fixed" by inferring watched-status from membership.
+
+### Performance
+- **Query shape, not indexes, is what matters here** — a third instance of the same lesson in this repo. Measured against production (89,465 memberships, 51,271 watch rows), each pair returning *identical numbers*, so value-only tests cannot tell them apart:
+  - playlist header: correlated `EXISTS` **25,676 ms** → non-correlated `IN` **69 ms**
+  - dashboard: `LEFT JOIN LATERAL` per membership row **50,893 ms** → CTE form **131 ms**
+- Under a watched filter the per-page watched lookup is skipped entirely: the page's rows already satisfy the `WHERE` clause, so re-querying would ask the database to rediscover what it just proved.
+- The dashboard CTEs are deliberately **not** `MATERIALIZED`. Each is referenced once, so PostgreSQL inlines and plans across the boundary; forcing materialisation measured *slower* (~134 ms vs ~85 ms). The win over the LATERAL form came from removing the per-row correlation, not from an optimisation fence.
+- Measured: `/overview` **98 ms** (budget 2 s); playlist page **50–99 ms** across all three filter values (budget 1 s).
+
+### Accessibility
+- The filter is a keyboard-operable tablist with arrow/Home/End and an exposed selected value; result-count changes are announced through a live region; watched state is carried by **text**, never colour alone; every dashboard figure is bound to its label via `dl`/`dt`/`dd`; system lists are marked with the words "System list" rather than styling.
+
+### Internal
+- Saved & Forgotten has exactly **one** derivation, consumed by both the dashboard and the videos-list filter, so the two cannot drift — an equality test guards it as a backstop rather than doing the job of the mechanism. "Curated" is tested **positively** as `playlist_type = 'regular'`, so `liked` and `favorites` — types the upstream enum defines but this feature never names — are excluded automatically; `is_system` is likewise derived as "not regular" rather than from a hardcoded pair. The playlist inventory is produced by `GROUP BY` over whatever exists, which makes a newly-introduced playlist type visible instead of silently absent.
+- `StatGrid` extracted from Settings' database-statistics grid on its third call site.
+- Filed during this work: **#160** (`make quality` cannot pass and diverges from CI), **#161** (`user_videos` lacks an index on `video_id`).
+
 ## [0.60.0] - 2026-08-02
 
 ### Fixed

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,7 @@ src/api/*.ts
 !src/api/entityMentions.ts
 !src/api/onboarding.ts
 !src/api/settings.ts
+!src/api/overview.ts
 
 # Environment
 .env

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.27.1",
+  "version": "0.28.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/overview.ts
+++ b/frontend/src/api/overview.ts
@@ -1,0 +1,81 @@
+/**
+ * API client for the Overview Dashboard endpoint (Feature 061).
+ *
+ * Covers:
+ * - GET /api/v1/overview — library aggregates in a single request
+ *
+ * Hand-written, like every other module here. `orval.config.ts` and
+ * `make generate-api` exist and make the repo look like it has a generated
+ * client, but `contracts/openapi.json` does not exist and orval's `clean: true`
+ * would delete the hand-written modules in this directory. See GitHub #158.
+ */
+
+import { apiFetch } from "./config";
+
+// ---------------------------------------------------------------------------
+// Response types (match backend api/schemas/overview.py)
+// ---------------------------------------------------------------------------
+
+export interface PlaylistTypeCount {
+  playlist_type: string;
+  playlist_count: number;
+  /**
+   * True for every type except `regular`.
+   *
+   * Derived by the backend as "not regular", never from a named set — so a
+   * `liked` or `favorites` playlist is correctly flagged rather than being
+   * shown as user curation.
+   */
+  is_system: boolean;
+}
+
+export interface WatchLaterDepth {
+  total: number;
+  unwatched: number;
+  /**
+   * Target for the unwatched deep link (FR-025, FR-025a).
+   *
+   * Null when more than one Watch Later playlist exists: the depth spans all of
+   * them, so no single playlist matches the figure clicked, and the figure is
+   * rendered non-interactively instead.
+   */
+  playlist_id: string | null;
+}
+
+export interface LibraryRollup {
+  watched_videos: number;
+  saved_curated_videos: number;
+  /** A video attribute, not a playlist type — belongs with the video rollups. */
+  liked_videos: number;
+}
+
+export interface Overview {
+  saved_and_forgotten: number;
+  /**
+   * Null when no Watch Later playlist exists.
+   *
+   * Distinct from a present-but-empty queue, which is `{total: 0, unwatched: 0}`.
+   * Rendering both as zeros would tell someone with no Watch Later that their
+   * queue is empty.
+   */
+  watch_later: WatchLaterDepth | null;
+  playlist_inventory: PlaylistTypeCount[];
+  rollup: LibraryRollup;
+}
+
+interface OverviewResponse {
+  data: Overview;
+  pagination: null;
+}
+
+/**
+ * Fetch the library overview aggregates.
+ *
+ * @param signal - Optional AbortSignal, combined with the internal timeout.
+ */
+export async function fetchOverview(signal?: AbortSignal): Promise<Overview> {
+  const response = await apiFetch<OverviewResponse>("/overview", {
+    ...(signal !== undefined ? { externalSignal: signal } : {}),
+  });
+  return response.data;
+}

--- a/frontend/src/components/PlaylistVideoCard.tsx
+++ b/frontend/src/components/PlaylistVideoCard.tsx
@@ -56,6 +56,7 @@ export function PlaylistVideoCard({ video }: PlaylistVideoCardProps) {
     transcript_summary,
     position,
     availability_status,
+    watched,
   } = video;
 
   // Convert 0-indexed position to 1-indexed display format
@@ -113,6 +114,20 @@ export function PlaylistVideoCard({ video }: PlaylistVideoCardProps) {
               </h3>
               <AvailabilityBadge status={availability_status} className="flex-shrink-0" />
             </div>
+
+            {/* Watched indicator (Feature 061, FR-009).
+                FR-032: the state is carried by the badge's text, not by colour
+                or icon alone, so it is available to a screen reader and to a
+                user who cannot distinguish the two colours. */}
+            <span
+              className={`inline-flex items-center px-2 py-0.5 mb-1 rounded text-xs font-medium ${
+                watched
+                  ? "bg-emerald-100 text-emerald-800"
+                  : "bg-slate-100 text-slate-700"
+              }`}
+            >
+              {watched ? "Watched" : "Unwatched"}
+            </span>
 
             {/* Channel Name */}
             <p className={`text-sm text-${colorTokens.text.secondary}`}>

--- a/frontend/src/components/StatGrid.tsx
+++ b/frontend/src/components/StatGrid.tsx
@@ -1,0 +1,128 @@
+/**
+ * StatGrid — a labelled grid of numeric figures.
+ *
+ * Extracted from `settings/AboutSection.tsx`'s `DatabaseStatsGrid` when the
+ * Overview Dashboard needed the same pattern for its inventory and its rollups
+ * (Feature 061, T055). Three call sites, so the abstraction is earned rather
+ * than anticipated.
+ *
+ * Figures are rendered as a semantic description list: the label is the term,
+ * the number is the definition. `tabular-nums` keeps digits aligned across
+ * tiles so columns of figures stay readable.
+ *
+ * A tile is interactive only when it carries an `href` (FR-025) — the
+ * distinction is structural, not a styling convention that could drift.
+ */
+
+import { Link } from "react-router-dom";
+
+export interface StatGridItem {
+  /** The term. Must read as a noun phrase — it is the accessible label. */
+  label: string;
+  value: number;
+  /**
+   * Explicit qualifying text under the figure, e.g. "System list".
+   *
+   * Carries meaning that must not depend on colour or styling alone
+   * (FR-022, FR-034).
+   */
+  note?: string;
+  /** When set the figure links here; when absent the tile is inert (FR-025). */
+  href?: string;
+  /**
+   * Accessible name for the link, when `href` is set.
+   *
+   * The visible link text is a bare number, which tells a screen-reader user
+   * nothing about where it goes.
+   */
+  linkLabel?: string;
+}
+
+interface StatGridProps {
+  items: StatGridItem[];
+  /** Visible heading; also names the list for assistive technology. */
+  heading: string;
+  /** DOM id linking the heading to the list via `aria-labelledby`. */
+  headingId: string;
+  /**
+   * Heading level, so the grid nests correctly wherever it is placed.
+   *
+   * Not cosmetic: a fixed level would make this heading a sibling of the
+   * section that contains it, breaking the document outline screen-reader
+   * users navigate by.
+   */
+  headingLevel?: "h3" | "h4";
+  /** Render placeholder tiles instead of figures. */
+  loading?: boolean;
+  /** How many placeholders to show while loading. */
+  skeletonCount?: number;
+}
+
+const TILE = "bg-slate-50 border border-slate-100 rounded-lg px-4 py-3";
+
+export function StatGrid({
+  items,
+  heading,
+  headingId,
+  headingLevel: Heading = "h3",
+  loading = false,
+  skeletonCount = 3,
+}: StatGridProps) {
+  return (
+    <div>
+      <Heading
+        id={headingId}
+        className="text-sm font-semibold text-slate-700 mb-3"
+      >
+        {heading}
+      </Heading>
+
+      {loading ? (
+        <div
+          className="grid grid-cols-2 sm:grid-cols-3 gap-3"
+          aria-busy="true"
+          data-testid={`${headingId}-loading`}
+        >
+          <span className="sr-only">Loading {heading}…</span>
+          {Array.from({ length: skeletonCount }, (_, i) => (
+            <div key={i} className={TILE} aria-hidden="true">
+              <div className="animate-pulse">
+                <div className="h-3 w-20 bg-slate-200 rounded mb-2" />
+                <div className="h-6 w-12 bg-slate-200 rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <dl
+          aria-labelledby={headingId}
+          className="grid grid-cols-2 sm:grid-cols-3 gap-3"
+        >
+          {items.map(({ label, value, note, href, linkLabel }) => (
+            <div key={label} className={TILE}>
+              <dt className="text-xs font-medium text-slate-500 mb-0.5">
+                {label}
+              </dt>
+              <dd className="text-xl font-semibold text-slate-900 tabular-nums">
+                {href ? (
+                  <Link
+                    to={href}
+                    aria-label={linkLabel ?? `${label}: ${value}`}
+                    className="text-blue-700 underline underline-offset-2 hover:text-blue-800 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+                  >
+                    {value.toLocaleString()}
+                  </Link>
+                ) : (
+                  value.toLocaleString()
+                )}
+              </dd>
+              {note ? (
+                <p className="mt-1 text-xs text-slate-500">{note}</p>
+              ) : null}
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/VideoList.tsx
+++ b/frontend/src/components/VideoList.tsx
@@ -120,6 +120,8 @@ interface VideoListProps {
   likedOnly?: boolean;
   /** Filter to videos with transcripts (Feature 027) */
   hasTranscript?: boolean;
+  /** Filter to videos saved in a curated playlist and never watched */
+  savedUnwatched?: boolean;
 }
 
 /**
@@ -136,6 +138,7 @@ export function VideoList({
   sortOrder,
   likedOnly = false,
   hasTranscript,
+  savedUnwatched,
 }: VideoListProps = {}) {
   const {
     videos,
@@ -159,6 +162,7 @@ export function VideoList({
     ...(sortBy !== undefined && { sortBy }),
     ...(sortOrder !== undefined && { sortOrder }),
     ...(hasTranscript !== undefined && { hasTranscript }),
+    ...(savedUnwatched !== undefined && { savedUnwatched }),
   });
 
   // Initial loading state

--- a/frontend/src/components/WatchedFilterTabs.tsx
+++ b/frontend/src/components/WatchedFilterTabs.tsx
@@ -1,0 +1,173 @@
+/**
+ * WatchedFilterTabs Component (Feature 061)
+ *
+ * Tri-state filter for a playlist's video list: All / Watched / Unwatched.
+ *
+ * Implements:
+ * - FR-006: three filter values, defaulting to All
+ * - FR-030: keyboard operable, selected value exposed to assistive technology
+ * - FR-035: visible focus indicator
+ *
+ * This is a small dedicated control rather than a generalization of
+ * `PlaylistFilterTabs`. That component serves one use case across four call
+ * sites and has its own substantial test suite; widening its type parameter for
+ * a second consumer would be abstracting on the second use, which the Rule of
+ * Three forbids, and would put working code at risk inside a read-only feature.
+ * Its keyboard model (arrow/Home/End with activation on move) is reproduced here
+ * deliberately, so both controls behave identically for a keyboard user.
+ */
+
+import { useEffect, useRef } from "react";
+
+import type { WatchedStatus } from "../hooks/usePlaylistVideos";
+
+interface WatchedFilterTabsProps {
+  /** Currently selected watched-status filter */
+  currentFilter: WatchedStatus;
+  /** Callback when the selection changes */
+  onFilterChange: (filter: WatchedStatus) => void;
+  /**
+   * Counts shown as badges.
+   *
+   * These come from the stats header and are the *playlist* figures — they do
+   * not change as the filter moves (FR-005b), so the badges stay stable while
+   * the list below them changes.
+   */
+  counts?: {
+    all?: number;
+    watched?: number;
+    unwatched?: number;
+  };
+  /** Optional className for custom styling */
+  className?: string;
+}
+
+const TABS: Array<{
+  id: WatchedStatus;
+  label: string;
+  ariaLabel: string;
+}> = [
+  { id: "all", label: "All", ariaLabel: "Show all videos" },
+  { id: "watched", label: "Watched", ariaLabel: "Show only watched videos" },
+  {
+    id: "unwatched",
+    label: "Unwatched",
+    ariaLabel: "Show only unwatched videos",
+  },
+];
+
+/**
+ * Tri-state watched-status filter with keyboard navigation.
+ *
+ * @example
+ * ```tsx
+ * <WatchedFilterTabs
+ *   currentFilter={watchedStatus}
+ *   onFilterChange={setWatchedStatus}
+ *   counts={{ all: 4973, watched: 2581, unwatched: 2392 }}
+ * />
+ * ```
+ */
+export function WatchedFilterTabs({
+  currentFilter,
+  onFilterChange,
+  counts,
+  className = "",
+}: WatchedFilterTabsProps) {
+  const tablistRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const tablist = tablistRef.current;
+    if (!tablist) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.matches('[role="tab"]')) return;
+
+      const tabs = Array.from(tablist.querySelectorAll('[role="tab"]'));
+      const currentIndex = tabs.indexOf(target);
+
+      let nextIndex: number | null = null;
+
+      switch (e.key) {
+        case "ArrowLeft":
+          e.preventDefault();
+          nextIndex = currentIndex > 0 ? currentIndex - 1 : tabs.length - 1;
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          nextIndex = currentIndex < tabs.length - 1 ? currentIndex + 1 : 0;
+          break;
+        case "Home":
+          e.preventDefault();
+          nextIndex = 0;
+          break;
+        case "End":
+          e.preventDefault();
+          nextIndex = tabs.length - 1;
+          break;
+      }
+
+      if (nextIndex !== null) {
+        const nextTab = tabs[nextIndex] as HTMLButtonElement;
+        nextTab.focus();
+        const filterId = nextTab.dataset.watchedStatus as WatchedStatus;
+        if (filterId) {
+          onFilterChange(filterId);
+        }
+      }
+    };
+
+    tablist.addEventListener("keydown", handleKeyDown);
+    return () => tablist.removeEventListener("keydown", handleKeyDown);
+  }, [onFilterChange]);
+
+  return (
+    <div
+      ref={tablistRef}
+      role="tablist"
+      aria-label="Filter videos by watched status"
+      className={`inline-flex items-center gap-1 ${className}`}
+    >
+      {TABS.map((tab) => {
+        const isSelected = currentFilter === tab.id;
+        const count = counts?.[tab.id];
+
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={isSelected}
+            aria-label={tab.ariaLabel}
+            data-watched-status={tab.id}
+            onClick={() => onFilterChange(tab.id)}
+            tabIndex={isSelected ? 0 : -1}
+            className={`
+              px-3 py-1.5 text-sm font-medium rounded-md transition-colors
+              focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1
+              ${
+                isSelected
+                  ? "bg-blue-600 text-white"
+                  : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+              }
+            `}
+          >
+            <span className="flex items-center gap-1.5">
+              {tab.label}
+              {count !== undefined && (
+                <span
+                  className={`text-xs tabular-nums ${
+                    isSelected ? "text-blue-100" : "text-slate-500"
+                  }`}
+                >
+                  {count.toLocaleString()}
+                </span>
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/WatchedFilterTabs.test.tsx
+++ b/frontend/src/components/__tests__/WatchedFilterTabs.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for WatchedFilterTabs (Feature 061, T028).
+ *
+ * Covers FR-006 (three values, All default), FR-030 (keyboard operable, selected
+ * value exposed to assistive technology), and FR-035 (visible focus indicator).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { WatchedFilterTabs } from "../WatchedFilterTabs";
+
+describe("WatchedFilterTabs", () => {
+  it("renders the three filter values (FR-006)", () => {
+    render(<WatchedFilterTabs currentFilter="all" onFilterChange={vi.fn()} />);
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(3);
+    expect(tabs.map((t) => t.textContent?.trim())).toEqual([
+      "All",
+      "Watched",
+      "Unwatched",
+    ]);
+  });
+
+  it("exposes the selected value to assistive technology (FR-030)", () => {
+    render(
+      <WatchedFilterTabs currentFilter="unwatched" onFilterChange={vi.fn()} />
+    );
+
+    expect(screen.getByRole("tab", { name: /show only unwatched/i })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+    expect(screen.getByRole("tab", { name: /show all videos/i })).toHaveAttribute(
+      "aria-selected",
+      "false"
+    );
+  });
+
+  it("is reachable by keyboard with only the selected tab in tab order", () => {
+    render(
+      <WatchedFilterTabs currentFilter="watched" onFilterChange={vi.fn()} />
+    );
+
+    // Roving tabindex: one stop for the whole group, arrows move within it.
+    expect(screen.getByRole("tab", { name: /only watched/i })).toHaveAttribute(
+      "tabindex",
+      "0"
+    );
+    expect(screen.getByRole("tab", { name: /all videos/i })).toHaveAttribute(
+      "tabindex",
+      "-1"
+    );
+  });
+
+  it("moves and activates with arrow keys (FR-030)", async () => {
+    const user = userEvent.setup();
+    const onFilterChange = vi.fn();
+    render(
+      <WatchedFilterTabs currentFilter="all" onFilterChange={onFilterChange} />
+    );
+
+    screen.getByRole("tab", { name: /all videos/i }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(onFilterChange).toHaveBeenCalledWith("watched");
+  });
+
+  it("wraps at both ends and supports Home/End (FR-030)", async () => {
+    const user = userEvent.setup();
+    const onFilterChange = vi.fn();
+    render(
+      <WatchedFilterTabs currentFilter="all" onFilterChange={onFilterChange} />
+    );
+
+    screen.getByRole("tab", { name: /all videos/i }).focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(onFilterChange).toHaveBeenLastCalledWith("unwatched");
+
+    await user.keyboard("{Home}");
+    expect(onFilterChange).toHaveBeenLastCalledWith("all");
+
+    await user.keyboard("{End}");
+    expect(onFilterChange).toHaveBeenLastCalledWith("unwatched");
+  });
+
+  it("activates on click", async () => {
+    const user = userEvent.setup();
+    const onFilterChange = vi.fn();
+    render(
+      <WatchedFilterTabs currentFilter="all" onFilterChange={onFilterChange} />
+    );
+
+    await user.click(screen.getByRole("tab", { name: /only unwatched/i }));
+    expect(onFilterChange).toHaveBeenCalledWith("unwatched");
+  });
+
+  it("shows playlist counts as badges", () => {
+    render(
+      <WatchedFilterTabs
+        currentFilter="all"
+        onFilterChange={vi.fn()}
+        counts={{ all: 4973, watched: 2581, unwatched: 2392 }}
+      />
+    );
+
+    // Formatted with separators; these are the playlist figures, which stay
+    // fixed as the filter moves (FR-005b).
+    expect(screen.getByRole("tab", { name: /all videos/i })).toHaveTextContent(
+      "4,973"
+    );
+    expect(screen.getByRole("tab", { name: /only unwatched/i })).toHaveTextContent(
+      "2,392"
+    );
+  });
+
+  it("declares a visible focus indicator (FR-035)", () => {
+    render(<WatchedFilterTabs currentFilter="all" onFilterChange={vi.fn()} />);
+
+    // Focus must be visible, not suppressed by outline-none alone.
+    const tab = screen.getByRole("tab", { name: /all videos/i });
+    expect(tab.className).toContain("focus:ring-2");
+  });
+});

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -15,6 +15,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 import { Sidebar } from "../Sidebar";
+import { navRoutes } from "../../../router/routes";
 
 // ---------------------------------------------------------------------------
 // Mock useNavigate (NavGroup uses it internally)
@@ -162,9 +163,11 @@ describe("Sidebar — Tags group", () => {
 });
 
 describe("Sidebar — total top-level nav item count", () => {
-  it("top-level list contains 10 entries (Videos, Transcripts group, Channels, Playlists, Entities, Tags group, Search, separator, Setup, Settings)", () => {
+  it("renders one top-level item per navRoutes entry", () => {
     renderSidebar();
-    // The outer <ul role="list"> has 10 children (6 flat routes + 2 groups + 1 separator + 2 config routes)
+    // Derived from navRoutes rather than hardcoded, so adding a destination
+    // does not require editing a magic number here as well as in routes.test.ts.
+    // The ordered contents are asserted in src/router/__tests__/routes.test.ts.
     const nav = screen.getByRole("navigation", { name: "Main navigation" });
     // The direct child ul has role="list" — query it within the nav
     const outerList = nav.querySelector("ul[role='list']");
@@ -172,6 +175,6 @@ describe("Sidebar — total top-level nav item count", () => {
     const directLiChildren = outerList
       ? Array.from(outerList.children).filter((el) => el.tagName === "LI")
       : [];
-    expect(directLiChildren).toHaveLength(10);
+    expect(directLiChildren).toHaveLength(navRoutes.length);
   });
 });

--- a/frontend/src/components/settings/AboutSection.tsx
+++ b/frontend/src/components/settings/AboutSection.tsx
@@ -19,15 +19,13 @@ import { useCallback } from "react";
 
 import { useAppInfo } from "../../hooks/useAppInfo";
 import type { DatabaseStats } from "../../api/settings";
+import { StatGrid, type StatGridItem } from "../StatGrid";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-interface StatItem {
-  label: string;
-  value: number;
-}
+type StatItem = StatGridItem;
 
 interface SyncItem {
   key: string;
@@ -245,33 +243,13 @@ function DatabaseStatsGrid({ stats }: DatabaseStatsGridProps) {
   }));
 
   return (
-    <div>
-      <h4
-        id="about-db-stats-heading"
-        className="text-sm font-semibold text-slate-700 mb-3"
-      >
-        Database Statistics
-      </h4>
-
-      <dl
-        aria-labelledby="about-db-stats-heading"
-        className="grid grid-cols-2 sm:grid-cols-3 gap-3"
-      >
-        {items.map(({ label, value }) => (
-          <div
-            key={label}
-            className="bg-slate-50 border border-slate-100 rounded-lg px-4 py-3"
-          >
-            <dt className="text-xs font-medium text-slate-500 mb-0.5">
-              {label}
-            </dt>
-            <dd className="text-xl font-semibold text-slate-900 tabular-nums">
-              {value.toLocaleString()}
-            </dd>
-          </div>
-        ))}
-      </dl>
-    </div>
+    <StatGrid
+      items={items}
+      heading="Database Statistics"
+      headingId="about-db-stats-heading"
+      headingLevel="h4"
+      skeletonCount={DB_STAT_LABELS.length}
+    />
   );
 }
 

--- a/frontend/src/hooks/useOverview.ts
+++ b/frontend/src/hooks/useOverview.ts
@@ -1,0 +1,51 @@
+/**
+ * useOverview hook — library aggregates for the Overview Dashboard (Feature 061).
+ *
+ * One request serves every card, so the figures are computed together and
+ * cannot disagree with each other.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchOverview, type Overview } from "../api/overview";
+
+/** Query key for the overview aggregates. */
+export const OVERVIEW_KEY = ["overview"] as const;
+
+interface UseOverviewReturn {
+  /** The aggregates, or undefined until the first load resolves */
+  overview: Overview | undefined;
+  /** Whether the initial load is in progress */
+  isLoading: boolean;
+  /** Whether the request failed */
+  isError: boolean;
+  /** The error, if any */
+  error: unknown;
+  /** Retry without a full page reload (FR-027c) */
+  retry: () => void;
+}
+
+/**
+ * Fetch the Overview Dashboard aggregates.
+ *
+ * @example
+ * ```tsx
+ * const { overview, isLoading, isError, retry } = useOverview();
+ * ```
+ */
+export function useOverview(): UseOverviewReturn {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: OVERVIEW_KEY,
+    queryFn: ({ signal }) => fetchOverview(signal),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  return {
+    overview: data,
+    isLoading,
+    isError,
+    error,
+    retry: () => void refetch(),
+  };
+}

--- a/frontend/src/hooks/usePlaylistVideos.ts
+++ b/frontend/src/hooks/usePlaylistVideos.ts
@@ -13,7 +13,16 @@ import type { SortOrder } from "../types/filters";
 import type {
   PlaylistVideoItem,
   PlaylistVideoListResponse,
+  PlaylistWatchStats,
 } from "../types/playlist";
+
+/**
+ * Watched-status filter values (Feature 061).
+ *
+ * Mirrors the backend `WatchedStatus` enum and the `watched_status` URL/query
+ * parameter — one name end to end, so the address and the API cannot drift.
+ */
+export type WatchedStatus = "all" | "watched" | "unwatched";
 
 /**
  * Default number of videos to fetch per page.
@@ -38,6 +47,7 @@ async function fetchPlaylistVideos(
   likedOnly?: boolean,
   hasTranscript?: boolean,
   unavailableOnly?: boolean,
+  watchedStatus?: WatchedStatus,
   signal?: AbortSignal
 ): Promise<PlaylistVideoListResponse> {
   const params = new URLSearchParams({
@@ -60,6 +70,10 @@ async function fetchPlaylistVideos(
   }
   if (unavailableOnly) {
     params.set("unavailable_only", "true");
+  }
+  // Omit at the default so the request matches the URL, which also omits it.
+  if (watchedStatus && watchedStatus !== "all") {
+    params.set("watched_status", watchedStatus);
   }
 
   // FR-004/FR-005: externalSignal combines with the internal timeout guard.
@@ -86,13 +100,26 @@ export interface UsePlaylistVideosOptions {
   hasTranscript?: boolean;
   /** Filter to show only unavailable videos */
   unavailableOnly?: boolean;
+  /** Watched-status filter: all (default), watched, or unwatched */
+  watchedStatus?: WatchedStatus;
 }
 
 interface UsePlaylistVideosReturn {
   /** All loaded video items flattened */
   videos: PlaylistVideoItem[];
-  /** Total number of videos available in the playlist */
+  /**
+   * Result count for the current view — the basis for pagination.
+   *
+   * NOT the playlist size: when `watchedStatus` is "watched" or "unwatched"
+   * this shrinks while `stats.playlist_total` stays put.
+   */
   total: number | null;
+  /**
+   * Watched breakdown for the playlist, unaffected by `watchedStatus`.
+   *
+   * Null until the first page resolves.
+   */
+  stats: PlaylistWatchStats | null;
   /** Number of videos currently loaded */
   loadedCount: number;
   /** Whether the initial load is in progress */
@@ -149,6 +176,7 @@ export function usePlaylistVideos(
     likedOnly,
     hasTranscript,
     unavailableOnly,
+    watchedStatus,
   } = options;
 
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -173,6 +201,7 @@ export function usePlaylistVideos(
       likedOnly,
       hasTranscript,
       unavailableOnly,
+      watchedStatus,
     ],
     queryFn: async ({ pageParam, signal }) => {
       // FR-004/FR-005: TanStack Query provides signal; cancelled on key change or unmount.
@@ -186,6 +215,7 @@ export function usePlaylistVideos(
         likedOnly,
         hasTranscript,
         unavailableOnly,
+        watchedStatus,
         signal
       );
     },
@@ -207,6 +237,7 @@ export function usePlaylistVideos(
   // Get total count from the last page's pagination
   const lastPage = data?.pages[data.pages.length - 1];
   const total = lastPage?.pagination?.total ?? null;
+  const stats = lastPage?.stats ?? null;
   const loadedCount = videos.length;
 
   // Memoized fetch function for intersection observer
@@ -249,6 +280,7 @@ export function usePlaylistVideos(
   return {
     videos,
     total,
+    stats,
     loadedCount,
     isLoading,
     isError,

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -46,6 +46,8 @@ interface UseVideosOptions {
   likedOnly?: boolean;
   /** Filter to videos with transcripts (Feature 027) */
   hasTranscript?: boolean;
+  /** Filter to videos saved in a curated playlist and never watched */
+  savedUnwatched?: boolean;
 }
 
 interface UseVideosReturn {
@@ -104,6 +106,7 @@ export function useVideos(options: UseVideosOptions = {}): UseVideosReturn {
     sortOrder,
     likedOnly = false,
     hasTranscript,
+    savedUnwatched,
   } = options;
 
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -118,7 +121,7 @@ export function useVideos(options: UseVideosOptions = {}): UseVideosReturn {
     fetchNextPage,
     refetch,
   } = useInfiniteQuery({
-    queryKey: ["videos", { limit, tags, canonicalTags, category, topicIds, includeUnavailable, sortBy, sortOrder, likedOnly, hasTranscript }],
+    queryKey: ["videos", { limit, tags, canonicalTags, category, topicIds, includeUnavailable, sortBy, sortOrder, likedOnly, hasTranscript, savedUnwatched }],
     queryFn: async ({ pageParam, signal }) => {
       const params = new URLSearchParams({
         offset: pageParam.toString(),
@@ -143,6 +146,7 @@ export function useVideos(options: UseVideosOptions = {}): UseVideosReturn {
       if (sortOrder) params.set('sort_order', sortOrder);
       if (likedOnly) params.set('liked_only', 'true');
       if (hasTranscript) params.set('has_transcript', 'true');
+      if (savedUnwatched) params.set('saved_unwatched', 'true');
 
       // FR-004/FR-005: Pass TanStack Query signal as externalSignal so it is
       // combined with the internal timeout guard via AbortSignal.any().

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -50,6 +50,11 @@ export function HomePage() {
   const sortOrder = (searchParams.get("sort_order") as SortOrder) || undefined;
   const likedOnly = searchParams.get("liked_only") === "true";
   const hasTranscript = searchParams.get("has_transcript") === "true";
+  // Feature 061 (FR-018d): URL-backed, using the same name as the API query
+  // parameter so the address and the request cannot drift. This is also what
+  // makes the dashboard's pre-filtered deep link possible (FR-018, FR-025) —
+  // component state would leave that link with nothing to target.
+  const savedUnwatched = searchParams.get("saved_unwatched") === "true";
 
   // Get total count for filters display (using the same hook with all filters)
   const { total } = useVideos({
@@ -74,7 +79,7 @@ export function HomePage() {
   // Scroll to top when filter or sort changes (FR-031)
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });
-  }, [tags, canonicalTags, category, topicIds, includeUnavailable, sortBy, sortOrder, likedOnly, hasTranscript]);
+  }, [tags, canonicalTags, category, topicIds, includeUnavailable, sortBy, sortOrder, likedOnly, hasTranscript, savedUnwatched]);
 
   return (
     <div className="p-6 lg:p-8">
@@ -106,6 +111,10 @@ export function HomePage() {
           {/* Boolean Filter Toggles */}
           <FilterToggle paramKey="liked_only" label="Liked only" />
           <FilterToggle paramKey="has_transcript" label="Has transcripts" />
+          <FilterToggle
+            paramKey="saved_unwatched"
+            label="Saved but never watched"
+          />
         </div>
       </section>
 
@@ -137,6 +146,7 @@ export function HomePage() {
           sortOrder={sortOrder}
           likedOnly={likedOnly}
           hasTranscript={hasTranscript}
+          savedUnwatched={savedUnwatched}
         />
       </section>
     </div>

--- a/frontend/src/pages/OverviewPage.tsx
+++ b/frontend/src/pages/OverviewPage.tsx
@@ -1,0 +1,278 @@
+/**
+ * Overview Dashboard (Feature 061, User Stories 2 and 3).
+ *
+ * Headline metric: "Saved & Forgotten" — videos saved to a curated playlist and
+ * never watched. Below it, the breakdown: Watch Later depth, an inventory of the
+ * playlist types actually present, and library-wide rollups. An additional
+ * navigation destination; it deliberately does not replace the existing landing
+ * page (FR-014a).
+ *
+ * Every figure comes from one request (FR-026), so the numbers on this page are
+ * computed together and cannot disagree with each other.
+ */
+
+import { Link } from "react-router-dom";
+
+import { ErrorState } from "../components/ErrorState";
+import { StatGrid, type StatGridItem } from "../components/StatGrid";
+import { useOverview } from "../hooks/useOverview";
+import type { Overview, PlaylistTypeCount } from "../api/overview";
+import { cardPatterns } from "../styles";
+
+/**
+ * Destination for the Saved & Forgotten metric (FR-018, FR-025).
+ *
+ * `include_unavailable=true` is required, not incidental: the dashboard figure
+ * applies no availability condition, while the videos list hides unavailable
+ * videos by default. Without it the user clicks 609 and lands on 586 — the 23
+ * saved-but-unwatched videos that have since been deleted. A video you saved
+ * and never watched is still forgotten even if it is now gone (FR-018b).
+ */
+const SAVED_FORGOTTEN_HREF =
+  "/videos?saved_unwatched=true&include_unavailable=true";
+
+/**
+ * Human labels for the playlist types we know about.
+ *
+ * Deliberately a *lookup with a fallback*, never the source of what to render.
+ * FR-021 requires the inventory to show whatever types exist in the data, so a
+ * type introduced by a future feature must still appear — humanised from its
+ * raw value rather than dropped for want of an entry here.
+ */
+const PLAYLIST_TYPE_LABELS: Record<string, string> = {
+  regular: "Curated playlists",
+  watch_later: "Watch Later",
+  history: "History",
+  liked: "Liked playlists",
+  favorites: "Favorites",
+};
+
+function playlistTypeLabel(type: string): string {
+  return (
+    PLAYLIST_TYPE_LABELS[type] ??
+    type.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase())
+  );
+}
+
+function inventoryItems(rows: PlaylistTypeCount[]): StatGridItem[] {
+  return rows.map((row) => ({
+    label: playlistTypeLabel(row.playlist_type),
+    value: row.playlist_count,
+    // FR-022, FR-034: system lists are marked with words, not styling alone —
+    // a colour or an icon carries nothing to a screen reader or in monochrome.
+    ...(row.is_system ? { note: "System list" } : {}),
+  }));
+}
+
+/**
+ * FR-024: membership is never described as watching.
+ *
+ * "Watched" is reserved for watch-history figures; membership figures say
+ * "saved" or "in playlists".
+ */
+function rollupItems(overview: Overview): StatGridItem[] {
+  return [
+    { label: "Watched videos", value: overview.rollup.watched_videos },
+    {
+      label: "Saved in curated playlists",
+      value: overview.rollup.saved_curated_videos,
+    },
+    // FR-023, FR-023a: a video attribute, so it belongs among the video
+    // rollups. A `liked` *playlist* is a different quantity from a different
+    // table and lives in the inventory above.
+    { label: "Liked videos", value: overview.rollup.liked_videos },
+  ];
+}
+
+function watchLaterItems(overview: Overview): StatGridItem[] {
+  const wl = overview.watch_later;
+  if (!wl) return [];
+
+  const unwatched: StatGridItem = {
+    label: "Unwatched",
+    value: wl.unwatched,
+    // FR-025: link only when the target is unambiguous; otherwise the figure
+    // stays inert rather than pointing somewhere whose count differs.
+    ...(wl.playlist_id
+      ? {
+          href: `/playlists/${wl.playlist_id}?watched_status=unwatched`,
+          linkLabel: `View ${wl.unwatched} unwatched videos in Watch Later`,
+        }
+      : {}),
+  };
+
+  return [{ label: "In the queue", value: wl.total }, unwatched];
+}
+
+export function OverviewPage() {
+  const { overview, isLoading, isError, retry } = useOverview();
+
+  if (isError) {
+    // FR-027b: an error must be distinguishable from a legitimately empty
+    // library, so this is not a zero card. FR-027c: retry without reload.
+    return (
+      <div className={PAGE}>
+        <OverviewHeader />
+        <ErrorState
+          title="Could not load your overview"
+          message="The library aggregates could not be retrieved."
+          onRetry={retry}
+        />
+      </div>
+    );
+  }
+
+  const pending = isLoading || !overview;
+
+  return (
+    <div className={PAGE}>
+      <OverviewHeader />
+
+      {pending ? (
+        <div
+          className={`${cardPatterns.base} p-6`}
+          aria-busy="true"
+          data-testid="overview-loading"
+        >
+          <span className="sr-only">Loading overview…</span>
+          {/* FR-027a: a loading state must not look like a zero value. */}
+          <div className="animate-pulse" aria-hidden="true">
+            <div className="h-4 w-40 bg-slate-200 rounded mb-3" />
+            <div className="h-10 w-24 bg-slate-200 rounded" />
+          </div>
+        </div>
+      ) : (
+        <Link
+          to={SAVED_FORGOTTEN_HREF}
+          className={`${cardPatterns.base} ${cardPatterns.hover} ${cardPatterns.focus} ${cardPatterns.transition} block p-6`}
+          aria-labelledby="saved-forgotten-label"
+        >
+          <dl>
+            <dt
+              id="saved-forgotten-label"
+              className="text-sm font-medium text-slate-500"
+            >
+              Saved &amp; Forgotten
+            </dt>
+            {/* FR-014: the largest figure on the page, above every other card. */}
+            <dd className="mt-1 text-5xl font-bold text-slate-900 tabular-nums">
+              {overview.saved_and_forgotten.toLocaleString()}
+            </dd>
+          </dl>
+          <p className="mt-3 text-sm text-slate-600">
+            {overview.saved_and_forgotten === 0
+              ? // FR-019: an explicit zero state, never a bare 0 to interpret.
+                "Nothing forgotten — every video you saved to a playlist has been watched."
+              : "Videos saved to a playlist you have never watched. Watch Later and History are not counted."}
+          </p>
+        </Link>
+      )}
+
+      {/* FR-027d: one column on narrow viewports, two from `md` — figures wrap
+          rather than truncate, and the grid never forces horizontal scroll. */}
+      <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
+        <section className={`${cardPatterns.base} p-6`}>
+          {pending ? (
+            <StatGrid
+              items={[]}
+              heading="Watch Later"
+              headingId="overview-watch-later"
+              loading
+              skeletonCount={2}
+            />
+          ) : overview.watch_later ? (
+            <StatGrid
+              items={watchLaterItems(overview)}
+              heading="Watch Later"
+              headingId="overview-watch-later"
+            />
+          ) : (
+            // FR-020a: absence is its own state. Zeros here would tell someone
+            // with no Watch Later that their queue is empty.
+            <div>
+              <h3
+                id="overview-watch-later"
+                className="text-sm font-semibold text-slate-700 mb-3"
+              >
+                Watch Later
+              </h3>
+              <p className="text-sm text-slate-600">
+                No Watch Later playlist found in your library.
+              </p>
+            </div>
+          )}
+        </section>
+
+        <section className={`${cardPatterns.base} p-6`}>
+          {pending ? (
+            <StatGrid
+              items={[]}
+              heading="Playlists by type"
+              headingId="overview-inventory"
+              loading
+              skeletonCount={3}
+            />
+          ) : overview.playlist_inventory.length > 0 ? (
+            <StatGrid
+              items={inventoryItems(overview.playlist_inventory)}
+              heading="Playlists by type"
+              headingId="overview-inventory"
+            />
+          ) : (
+            <div>
+              <h3
+                id="overview-inventory"
+                className="text-sm font-semibold text-slate-700 mb-3"
+              >
+                Playlists by type
+              </h3>
+              <p className="text-sm text-slate-600">
+                No playlists yet — 0 in your library.
+              </p>
+            </div>
+          )}
+        </section>
+
+        <section className={`${cardPatterns.base} p-6 md:col-span-2`}>
+          <StatGrid
+            items={pending ? [] : rollupItems(overview)}
+            heading="Library totals"
+            headingId="overview-rollup"
+            loading={pending}
+            skeletonCount={3}
+          />
+          <p className="mt-3 text-xs text-slate-500">
+            Saved and watched are independent — a video can be in a playlist
+            without ever having been watched.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Page container, matching Settings and Videos.
+ *
+ * Without this the content sits flush against the sidebar — every other page
+ * carries its own padding because the shell's content area supplies none.
+ */
+const PAGE = "p-6 lg:p-8";
+
+/**
+ * Page header, matching Settings and Videos.
+ *
+ * `h2`, not `h1`: the shell header already renders the document's single `h1`
+ * ("Chronovista", `layout/Header.tsx`). A second `h1` here would give the page
+ * two top-level headings and break the outline screen-reader users navigate by.
+ */
+function OverviewHeader() {
+  return (
+    <div className="mb-8">
+      <h2 className="text-2xl font-bold text-slate-900">Overview</h2>
+      <p className="text-slate-600 mt-1">
+        A snapshot of what you have saved and what you have actually watched.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/PlaylistDetailPage.tsx
+++ b/frontend/src/pages/PlaylistDetailPage.tsx
@@ -31,7 +31,14 @@ import { FilterToggle } from "../components/FilterToggle";
 import { LoadingState } from "../components/LoadingState";
 import { PlaylistVideoCard } from "../components/PlaylistVideoCard";
 import { SortDropdown } from "../components/SortDropdown";
-import { usePlaylistDetail, usePlaylistVideos, useUrlParamBoolean } from "../hooks";
+import { WatchedFilterTabs } from "../components/WatchedFilterTabs";
+import {
+  usePlaylistDetail,
+  usePlaylistVideos,
+  useUrlParam,
+  useUrlParamBoolean,
+} from "../hooks";
+import type { WatchedStatus } from "../hooks/usePlaylistVideos";
 import { cardPatterns } from "../styles";
 import type { PlaylistVideoSortField, SortOption, SortOrder } from "../types/filters";
 import type { PlaylistPrivacyStatus } from "../types/playlist";
@@ -307,13 +314,26 @@ export function PlaylistDetailPage() {
   const [likedOnly] = useUrlParamBoolean("liked_only");
   const [hasTranscript] = useUrlParamBoolean("has_transcript");
   const [unavailableOnly] = useUrlParamBoolean("unavailable_only");
+  // Feature 061: watched filter lives in the URL under the same name the API
+  // uses (FR-007a), so a filtered view is shareable and the dashboard's
+  // pre-filtered deep link has a target (FR-025). useUrlParam falls back to
+  // "all" for an invalid value (FR-007e) and omits the param at the default
+  // (FR-007c). Sort and the watched filter are independent params, so changing
+  // one preserves the other (FR-007d).
+  const [watchedStatus, setWatchedStatus] = useUrlParam<WatchedStatus>(
+    "watched_status",
+    "all",
+    ["all", "watched", "unwatched"] as const
+  );
 
   // Determine if any filter is active
-  const hasActiveFilter = likedOnly || hasTranscript || unavailableOnly;
+  const hasActiveFilter =
+    likedOnly || hasTranscript || unavailableOnly || watchedStatus !== "all";
 
   const {
     videos,
     total,
+    stats,
     isLoading: videosLoading,
     isError: videosError,
     hasNextPage,
@@ -326,6 +346,7 @@ export function PlaylistDetailPage() {
     likedOnly,
     hasTranscript,
     unavailableOnly,
+    watchedStatus,
   });
 
   // Description truncation state (CHK041)
@@ -563,6 +584,55 @@ export function PlaylistDetailPage() {
       <div>
         <h2 className="text-2xl font-bold text-gray-900 mb-4">Videos</h2>
 
+        {/* Watched stats header (FR-004). These three figures describe the
+            playlist under the *other* active filters and do NOT change as the
+            watched filter moves (FR-005b) — only the list and its result count
+            do. */}
+        {videosError ? (
+          <div
+            role="alert"
+            className="mb-6 p-4 bg-white border border-red-200 rounded-lg text-sm text-red-700"
+          >
+            Could not load watch statistics for this playlist.
+          </div>
+        ) : videosLoading || stats === null ? (
+          <div
+            className="mb-6 p-4 bg-white border border-gray-200 rounded-lg"
+            aria-busy="true"
+          >
+            <span className="sr-only">Loading watch statistics…</span>
+            <div className="grid grid-cols-3 gap-4" aria-hidden="true">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="animate-pulse">
+                  <div className="h-3 w-16 bg-slate-200 rounded mb-2" />
+                  <div className="h-6 w-12 bg-slate-200 rounded" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <dl className="grid grid-cols-3 gap-4 mb-6 p-4 bg-white border border-gray-200 rounded-lg">
+            <div>
+              <dt className="text-xs font-medium text-slate-500">Total</dt>
+              <dd className="text-xl font-semibold text-slate-900 tabular-nums">
+                {stats.playlist_total.toLocaleString()}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-slate-500">Watched</dt>
+              <dd className="text-xl font-semibold text-slate-900 tabular-nums">
+                {stats.watched.toLocaleString()}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-slate-500">Unwatched</dt>
+              <dd className="text-xl font-semibold text-slate-900 tabular-nums">
+                {stats.unwatched.toLocaleString()}
+              </dd>
+            </div>
+          </dl>
+        )}
+
         {/* Sort & Filter Toolbar */}
         <div className="flex flex-wrap items-center gap-4 mb-6 p-4 bg-white border border-gray-200 rounded-lg">
           <SortDropdown<PlaylistVideoSortField>
@@ -575,6 +645,20 @@ export function PlaylistDetailPage() {
           <FilterToggle paramKey="unavailable_only" label="Unavailable only" />
           <FilterToggle paramKey="liked_only" label="Liked only" />
           <FilterToggle paramKey="has_transcript" label="Has transcript" />
+          <div className="h-6 w-px bg-gray-200" aria-hidden="true" />
+          <WatchedFilterTabs
+            currentFilter={watchedStatus}
+            onFilterChange={setWatchedStatus}
+            {...(stats
+              ? {
+                  counts: {
+                    all: stats.playlist_total,
+                    watched: stats.watched,
+                    unwatched: stats.unwatched,
+                  },
+                }
+              : {})}
+          />
         </div>
 
         {/* ARIA live region announcing filtered count (FR-005) */}

--- a/frontend/src/router/__tests__/routes.test.ts
+++ b/frontend/src/router/__tests__/routes.test.ts
@@ -44,66 +44,43 @@ function findGroup(entries: NavEntry[], label: string): NavGroupRoute | undefine
 // ---------------------------------------------------------------------------
 
 describe("navRoutes — top-level structure", () => {
-  it("has exactly 10 top-level entries", () => {
-    expect(navRoutes).toHaveLength(10);
+  // Asserted as one explicit ordered list rather than per-index tests. The
+  // previous form checked navRoutes[0..6] individually, so inserting an entry
+  // renumbered every later assertion and broke 12 tests at once — the same
+  // brittleness as a mock that dispatches by call number. Order is still
+  // covered, but a deliberate change now edits one list.
+  it("has the expected top-level entries in order", () => {
+    const shape = navRoutes.map((e) =>
+      e.kind === "route"
+        ? `route:${e.path}`
+        : e.kind === "group"
+          ? `group:${e.label}`
+          : "separator"
+    );
+
+    expect(shape).toEqual([
+      // Feature 061: an ADDITIONAL destination. `/` still redirects to /videos,
+      // so the landing page is unchanged (FR-014a).
+      "route:/overview",
+      "route:/videos",
+      "group:Transcripts",
+      "route:/channels",
+      "route:/playlists",
+      "route:/entities",
+      "group:Tags",
+      "route:/search",
+      "separator",
+      "route:/onboarding",
+      "route:/settings",
+    ]);
   });
 
-  it("first entry is Videos flat route", () => {
-    const entry = navRoutes[0];
-    expect(entry?.kind).toBe("route");
-    if (entry?.kind === "route") {
-      expect(entry.path).toBe("/videos");
-      expect(entry.label).toBe("Videos");
-    }
-  });
-
-  it("second entry is the Transcripts group", () => {
-    const entry = navRoutes[1];
-    expect(entry?.kind).toBe("group");
-    if (entry?.kind === "group") {
-      expect(entry.label).toBe("Transcripts");
-    }
-  });
-
-  it("third entry is Channels flat route", () => {
-    const entry = navRoutes[2];
-    expect(entry?.kind).toBe("route");
-    if (entry?.kind === "route") {
-      expect(entry.path).toBe("/channels");
-    }
-  });
-
-  it("fourth entry is Playlists flat route", () => {
-    const entry = navRoutes[3];
-    expect(entry?.kind).toBe("route");
-    if (entry?.kind === "route") {
-      expect(entry.path).toBe("/playlists");
-    }
-  });
-
-  it("fifth entry is Entities flat route", () => {
-    const entry = navRoutes[4];
-    expect(entry?.kind).toBe("route");
-    if (entry?.kind === "route") {
-      expect(entry.path).toBe("/entities");
-    }
-  });
-
-  it("sixth entry is the Tags group", () => {
-    const entry = navRoutes[5];
-    expect(entry?.kind).toBe("group");
-    if (entry?.kind === "group") {
-      expect(entry.label).toBe("Tags");
-    }
-  });
-
-  it("seventh entry is Search flat route", () => {
-    const entry = navRoutes[6];
-    expect(entry?.kind).toBe("route");
-    if (entry?.kind === "route") {
-      expect(entry.path).toBe("/search");
-      expect(entry.label).toBe("Search");
-    }
+  it("Overview is a flat route with label and icon", () => {
+    const route = findRoute(navRoutes, "/overview");
+    expect(route).toBeDefined();
+    expect(route?.label).toBe("Overview");
+    expect(route?.tooltip).toBeTruthy();
+    expect(route?.icon).toBeDefined();
   });
 });
 
@@ -148,12 +125,16 @@ describe("navRoutes — flat NavRoute entries", () => {
 });
 
 describe("navRoutes — config section order", () => {
-  it("separator appears at index 7", () => {
-    expect(navRoutes[7]?.kind).toBe("separator");
+  // Positions are expressed relative to the separator rather than as absolute
+  // indices, so inserting a content route above it does not renumber these.
+  const separatorIndex = () => navRoutes.findIndex((e) => e.kind === "separator");
+
+  it("has exactly one separator", () => {
+    expect(navRoutes.filter((e) => e.kind === "separator")).toHaveLength(1);
   });
 
-  it("Setup route appears at index 8, after the separator", () => {
-    const entry = navRoutes[8];
+  it("Setup route appears immediately after the separator", () => {
+    const entry = navRoutes[separatorIndex() + 1];
     expect(entry?.kind).toBe("route");
     if (entry?.kind === "route") {
       expect(entry.path).toBe("/onboarding");
@@ -161,8 +142,8 @@ describe("navRoutes — config section order", () => {
     }
   });
 
-  it("Settings route appears at index 9, after Setup", () => {
-    const entry = navRoutes[9];
+  it("Settings route appears after Setup", () => {
+    const entry = navRoutes[separatorIndex() + 2];
     expect(entry?.kind).toBe("route");
     if (entry?.kind === "route") {
       expect(entry.path).toBe("/settings");

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -20,6 +20,9 @@ import { AppShell } from "../components/layout";
 import { NotFoundPage } from "../pages/NotFoundPage";
 
 // Lazy-loaded page components (downloaded on first navigation)
+const OverviewPage = lazy(() =>
+  import("../pages/OverviewPage").then((m) => ({ default: m.OverviewPage })),
+);
 const HomePage = lazy(() =>
   import("../pages/HomePage").then((m) => ({ default: m.HomePage })),
 );
@@ -149,6 +152,10 @@ export const router = createBrowserRouter([
       {
         index: true,
         element: <Navigate to="/videos" replace />,
+      },
+      {
+        path: "overview",
+        element: lazySuspense(<OverviewPage />),
       },
       {
         path: "videos",

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -74,6 +74,13 @@ export type NavEntry = NavRoute | NavGroupRoute | NavSeparator;
 export const navRoutes: NavEntry[] = [
   {
     kind: "route",
+    path: "/overview",
+    label: "Overview",
+    tooltip: "Library overview and Saved & Forgotten",
+    icon: ChartBarIcon,
+  },
+  {
+    kind: "route",
     path: "/videos",
     label: "Videos",
     tooltip: "Browse your video library",

--- a/frontend/src/tests/hooks/usePlaylistVideos.test.tsx
+++ b/frontend/src/tests/hooks/usePlaylistVideos.test.tsx
@@ -45,6 +45,7 @@ describe("usePlaylistVideos", () => {
         },
         position: 0,
         availability_status: "available",
+        watched: false,
       },
       {
         video_id: "unavail123",
@@ -62,6 +63,7 @@ describe("usePlaylistVideos", () => {
         },
         position: 1,
         availability_status: "deleted",
+        watched: false,
       },
       {
         video_id: "private456",
@@ -79,6 +81,7 @@ describe("usePlaylistVideos", () => {
         },
         position: 2,
         availability_status: "private",
+        watched: false,
       },
     ],
     pagination: {
@@ -87,6 +90,7 @@ describe("usePlaylistVideos", () => {
       offset: 0,
       has_more: false,
     },
+        stats: { playlist_total: 0, watched: 0, unwatched: 0 },
   };
 
   beforeEach(() => {
@@ -179,6 +183,7 @@ describe("usePlaylistVideos", () => {
           offset: 0,
           has_more: false,
         },
+        stats: { playlist_total: 0, watched: 0, unwatched: 0 },
       };
 
       vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(availableOnlyResponse);
@@ -297,6 +302,7 @@ describe("usePlaylistVideos", () => {
           offset: 0,
           has_more: true,
         },
+        stats: { playlist_total: 0, watched: 0, unwatched: 0 },
       };
 
       vi.mocked(apiConfig.apiFetch).mockResolvedValueOnce(responseWithMore);

--- a/frontend/src/types/playlist.ts
+++ b/frontend/src/types/playlist.ts
@@ -125,6 +125,32 @@ export interface PlaylistVideoItem {
   position: number;
   /** Content availability status */
   availability_status: string;
+  /**
+   * Whether a watch-history record exists for this video (Feature 061).
+   *
+   * Derived from watch history only — never from playlist membership. A video
+   * can sit in Watch Later and still be watched.
+   */
+  watched: boolean;
+}
+
+/**
+ * Watched/unwatched breakdown for one playlist (Feature 061).
+ *
+ * `playlist_total` is deliberately NOT called `total`: the same response also
+ * carries `pagination.total`, which is the **result count** for the current
+ * view. The two differ whenever the watched filter is not "all" — on a
+ * 4,973-video Watch Later filtered to Unwatched, `playlist_total` stays 4,973
+ * while `pagination.total` is 2,392. Both are correct; they answer different
+ * questions.
+ */
+export interface PlaylistWatchStats {
+  /** Distinct videos in the playlist under the current non-watched filters */
+  playlist_total: number;
+  /** Of those, distinct videos with a watch-history record */
+  watched: number;
+  /** Of those, distinct videos with no watch-history record */
+  unwatched: number;
 }
 
 /**
@@ -169,8 +195,10 @@ export interface PlaylistDetailResponse {
 export interface PlaylistVideoListResponse {
   /** Array of video items with playlist positions */
   data: PlaylistVideoItem[];
-  /** Pagination metadata */
+  /** Pagination metadata — `total` here is the RESULT COUNT */
   pagination: PaginationMeta;
+  /** Watched breakdown — `playlist_total` here is NOT the result count */
+  stats: PlaylistWatchStats;
 }
 
 /**

--- a/frontend/tests/components/PlaylistVideoCard.watched.test.tsx
+++ b/frontend/tests/components/PlaylistVideoCard.watched.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Watched indicator on PlaylistVideoCard (Feature 061, T063).
+ *
+ * Covers FR-009 (each row exposes its watched state) and FR-032 (that state is
+ * carried by a text alternative, never by colour or icon shape alone).
+ *
+ * FR-032 is the reason these assertions read the badge's *text* rather than its
+ * classes: a test that checked for `bg-emerald-100` would keep passing if the
+ * word were removed, which is precisely the failure the requirement forbids.
+ *
+ * Located in `tests/` rather than `src/**\/__tests__/` because it uses
+ * `renderWithProviders` (GitHub #159, research R7).
+ */
+
+import { describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+
+import { renderWithProviders } from "../test-utils";
+import { PlaylistVideoCard } from "../../src/components/PlaylistVideoCard";
+import type { PlaylistVideoItem } from "../../src/types/playlist";
+
+// No `as PlaylistVideoItem` cast: `frontend/tests/` is outside tsconfig's
+// `include`, so a cast here would be the only thing standing between a wrong
+// fixture and a confusing runtime failure — and it would lose that argument.
+// Every field is spelled out so the fixture breaks loudly if the type changes.
+function video(overrides: Partial<PlaylistVideoItem> = {}): PlaylistVideoItem {
+  return {
+    video_id: "vid1",
+    title: "A video",
+    channel_title: "A channel",
+    channel_id: "UC1",
+    upload_date: "2024-01-01T00:00:00Z",
+    duration: 120,
+    view_count: 10,
+    position: 0,
+    availability_status: "available",
+    watched: false,
+    transcript_summary: {
+      count: 0,
+      languages: [],
+      has_manual: false,
+      has_corrections: false,
+    },
+    ...overrides,
+  };
+}
+
+function render(overrides: Partial<PlaylistVideoItem> = {}) {
+  renderWithProviders(<PlaylistVideoCard video={video(overrides)} />, {
+    initialEntries: ["/playlists/PLtest"],
+  });
+}
+
+describe("PlaylistVideoCard watched indicator", () => {
+  it("labels a watched video in words (FR-009, FR-032)", () => {
+    render({ watched: true });
+    expect(screen.getByText("Watched")).toBeInTheDocument();
+    expect(screen.queryByText("Unwatched")).not.toBeInTheDocument();
+  });
+
+  it("labels an unwatched video in words (FR-009, FR-032)", () => {
+    render({ watched: false });
+    expect(screen.getByText("Unwatched")).toBeInTheDocument();
+    expect(screen.queryByText("Watched")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes the two states by text, not colour alone (FR-032)", () => {
+    render({ watched: true });
+    const watched = screen.getByText("Watched").textContent;
+
+    renderWithProviders(<PlaylistVideoCard video={video({ watched: false })} />, {
+      initialEntries: ["/playlists/PLtest"],
+    });
+    const unwatched = screen.getByText("Unwatched").textContent;
+
+    // Strip styling out of the comparison entirely: the two states must differ
+    // in their text content, which is what survives monochrome and a screen
+    // reader.
+    expect(watched).not.toEqual(unwatched);
+  });
+
+  it("still reports watched state for an unavailable video (FR-011)", () => {
+    // A deleted video you watched is still watched — watch history outlives
+    // availability, and the badge must not silently drop.
+    render({ watched: true, availability_status: "deleted" });
+    expect(screen.getByText("Watched")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/pages/OverviewPage.breakdown.test.tsx
+++ b/frontend/tests/pages/OverviewPage.breakdown.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Tests for the Overview Dashboard breakdown cards (Feature 061, T060).
+ *
+ * Covers FR-020/FR-020a (Watch Later depth and its absent state), FR-021/FR-022
+ * (inventory over types present, system lists labelled in words), FR-023/FR-023a
+ * (liked as a video attribute, not a playlist type), FR-024 (saved is never
+ * called watched), FR-025/FR-025a (deep link only when unambiguous), and
+ * FR-027/FR-027a (zero and loading states).
+ *
+ * Located in `tests/` rather than `src/**\/__tests__/` because it uses
+ * `renderWithProviders` (GitHub #159, research R7).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, within } from "@testing-library/react";
+
+import { renderWithProviders } from "../test-utils";
+import { OverviewPage } from "../../src/pages/OverviewPage";
+import { useOverview } from "../../src/hooks/useOverview";
+import type { Overview } from "../../src/api/overview";
+
+vi.mock("../../src/hooks/useOverview", () => ({
+  useOverview: vi.fn(),
+}));
+
+const mockUseOverview = vi.mocked(useOverview);
+
+function overview(patch: Partial<Overview> = {}): Overview {
+  return {
+    saved_and_forgotten: 609,
+    watch_later: { total: 4973, unwatched: 2392, playlist_id: "WL" },
+    playlist_inventory: [
+      { playlist_type: "regular", playlist_count: 290, is_system: false },
+      { playlist_type: "watch_later", playlist_count: 1, is_system: true },
+      { playlist_type: "history", playlist_count: 1, is_system: true },
+    ],
+    rollup: {
+      watched_videos: 51271,
+      saved_curated_videos: 20259,
+      liked_videos: 5830,
+    },
+    ...patch,
+  };
+}
+
+function render(patch: Partial<Overview> = {}) {
+  mockUseOverview.mockReturnValue({
+    overview: overview(patch),
+    isLoading: false,
+    isError: false,
+    error: null,
+    retry: vi.fn(),
+  });
+  renderWithProviders(<OverviewPage />);
+}
+
+/** The tile whose `<dt>` is `label`, within the grid named by `headingId`. */
+function tile(headingId: string, label: string): HTMLElement {
+  const list = document.querySelector(`dl[aria-labelledby="${headingId}"]`);
+  expect(list).not.toBeNull();
+  const term = within(list as HTMLElement).getByText(label);
+  return term.closest("div") as HTMLElement;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("OverviewPage — Watch Later depth (FR-020)", () => {
+  it("shows queue total and unwatched", () => {
+    render();
+    expect(tile("overview-watch-later", "In the queue")).toHaveTextContent(
+      "4,973"
+    );
+    expect(tile("overview-watch-later", "Unwatched")).toHaveTextContent("2,392");
+  });
+
+  it("links unwatched to the playlist pre-filtered to Unwatched (FR-025)", () => {
+    render();
+    const link = screen.getByRole("link", {
+      name: /unwatched videos in Watch Later/i,
+    });
+    expect(link.getAttribute("href")).toBe(
+      "/playlists/WL?watched_status=unwatched"
+    );
+  });
+
+  it("renders unwatched inert when the link target is ambiguous (FR-025a)", () => {
+    render({ watch_later: { total: 10, unwatched: 4, playlist_id: null } });
+
+    expect(
+      screen.queryByRole("link", { name: /unwatched videos in Watch Later/i })
+    ).not.toBeInTheDocument();
+    // The figure is still shown — it just is not interactive.
+    expect(tile("overview-watch-later", "Unwatched")).toHaveTextContent("4");
+  });
+
+  it("renders an explicit absent state, not zeros, when there is no queue (FR-020a)", () => {
+    render({ watch_later: null });
+
+    expect(screen.getByText(/no watch later playlist found/i)).toBeInTheDocument();
+    // Zeros here would read as "your queue is empty", a different fact.
+    const card = screen.getByText(/no watch later playlist found/i).closest(
+      "section"
+    ) as HTMLElement;
+    expect(within(card).queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes a present-but-empty queue with zeros", () => {
+    render({ watch_later: { total: 0, unwatched: 0, playlist_id: "WL" } });
+
+    expect(
+      screen.queryByText(/no watch later playlist found/i)
+    ).not.toBeInTheDocument();
+    expect(tile("overview-watch-later", "In the queue")).toHaveTextContent("0");
+  });
+});
+
+describe("OverviewPage — playlist inventory (FR-021, FR-022)", () => {
+  it("renders only the types present in the data", () => {
+    render();
+    const list = document.querySelector(
+      'dl[aria-labelledby="overview-inventory"]'
+    ) as HTMLElement;
+
+    expect(within(list).getByText("Curated playlists")).toBeInTheDocument();
+    expect(within(list).getByText("Watch Later")).toBeInTheDocument();
+    expect(within(list).getByText("History")).toBeInTheDocument();
+    // `favorites` exists upstream but not in the data — never a permanent zero.
+    expect(within(list).queryByText("Favorites")).not.toBeInTheDocument();
+  });
+
+  it("marks system lists with words, not styling alone (FR-022, FR-034)", () => {
+    render();
+    expect(tile("overview-inventory", "Watch Later")).toHaveTextContent(
+      "System list"
+    );
+    expect(tile("overview-inventory", "History")).toHaveTextContent(
+      "System list"
+    );
+    expect(tile("overview-inventory", "Curated playlists")).not.toHaveTextContent(
+      "System list"
+    );
+  });
+
+  it("labels an unrecognised future type instead of dropping it (FR-021)", () => {
+    render({
+      playlist_inventory: [
+        { playlist_type: "regular", playlist_count: 2, is_system: false },
+        { playlist_type: "some_new_type", playlist_count: 7, is_system: true },
+      ],
+    });
+
+    const t = tile("overview-inventory", "Some new type");
+    expect(t).toHaveTextContent("7");
+    expect(t).toHaveTextContent("System list");
+  });
+
+  it("renders an empty-library state cleanly (FR-027)", () => {
+    render({ playlist_inventory: [] });
+    expect(screen.getByText(/no playlists yet/i)).toBeInTheDocument();
+  });
+});
+
+describe("OverviewPage — rollups (FR-023, FR-023a, FR-024)", () => {
+  it("keeps saved and watched verbally distinct", () => {
+    render();
+    const list = document.querySelector(
+      'dl[aria-labelledby="overview-rollup"]'
+    ) as HTMLElement;
+
+    expect(within(list).getByText("Watched videos")).toBeInTheDocument();
+    const saved = within(list).getByText(/saved in curated playlists/i);
+    // Membership must never be described as watching (FR-024).
+    expect(saved.textContent?.toLowerCase()).not.toContain("watched");
+  });
+
+  it("places liked videos among the rollups, never in the inventory (FR-023)", () => {
+    render();
+
+    expect(tile("overview-rollup", "Liked videos")).toHaveTextContent("5,830");
+
+    const inventory = document.querySelector(
+      'dl[aria-labelledby="overview-inventory"]'
+    ) as HTMLElement;
+    expect(within(inventory).queryByText("Liked videos")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes a liked playlist count from the liked-video count (FR-023a)", () => {
+    render({
+      playlist_inventory: [
+        { playlist_type: "regular", playlist_count: 290, is_system: false },
+        { playlist_type: "liked", playlist_count: 1, is_system: true },
+      ],
+    });
+
+    // Same word, different quantities from different tables: 1 playlist vs
+    // 5,830 videos. They must not be presented as one figure.
+    expect(tile("overview-inventory", "Liked playlists")).toHaveTextContent("1");
+    expect(tile("overview-rollup", "Liked videos")).toHaveTextContent("5,830");
+  });
+
+  it("renders zero rollups as figures, not blanks (FR-027)", () => {
+    render({
+      rollup: { watched_videos: 0, saved_curated_videos: 0, liked_videos: 0 },
+    });
+    expect(tile("overview-rollup", "Watched videos")).toHaveTextContent("0");
+  });
+});
+
+describe("OverviewPage — breakdown loading state (FR-027a)", () => {
+  it("shows skeletons for every card, not zeros", () => {
+    mockUseOverview.mockReturnValue({
+      overview: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      retry: vi.fn(),
+    });
+    renderWithProviders(<OverviewPage />);
+
+    expect(
+      screen.getByTestId("overview-watch-later-loading")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("overview-inventory-loading")).toBeInTheDocument();
+    expect(screen.getByTestId("overview-rollup-loading")).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/pages/OverviewPage.test.tsx
+++ b/frontend/tests/pages/OverviewPage.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Tests for the Overview Dashboard headline (Feature 061, T048).
+ *
+ * Covers FR-014 (prominent metric), FR-018/FR-025 (links to the filtered list),
+ * FR-019 (explicit zero state), and FR-027a/b/c (loading, error, retry).
+ *
+ * Located in `tests/` rather than `src/**\/__tests__/` because it uses
+ * `renderWithProviders`: `tsconfig.json` includes only `src`, so a `src/` file
+ * importing `tests/test-utils` drags that file into the type-check program and
+ * exposes latent errors in it (GitHub #159, research R7).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders } from "../test-utils";
+import { OverviewPage } from "../../src/pages/OverviewPage";
+import { useOverview } from "../../src/hooks/useOverview";
+
+vi.mock("../../src/hooks/useOverview", () => ({
+  useOverview: vi.fn(),
+}));
+
+const mockUseOverview = vi.mocked(useOverview);
+
+function overview(savedAndForgotten: number) {
+  return {
+    saved_and_forgotten: savedAndForgotten,
+    watch_later: { total: 4973, unwatched: 2392, playlist_id: "WL" },
+    playlist_inventory: [
+      { playlist_type: "regular", playlist_count: 290, is_system: false },
+    ],
+    rollup: {
+      watched_videos: 51271,
+      saved_curated_videos: 20259,
+      liked_videos: 5830,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseOverview.mockReturnValue({
+    overview: overview(609),
+    isLoading: false,
+    isError: false,
+    error: null,
+    retry: vi.fn(),
+  });
+});
+
+describe("OverviewPage — Saved & Forgotten headline", () => {
+  it("shows the metric with its label associated (FR-014, FR-033)", () => {
+    renderWithProviders(<OverviewPage />);
+
+    const terms = Array.from(document.querySelectorAll("dl dt")).map((el) =>
+      el.textContent?.trim()
+    );
+    const values = Array.from(document.querySelectorAll("dl dd")).map((el) =>
+      el.textContent?.trim()
+    );
+
+    expect(terms).toContain("Saved & Forgotten");
+    expect(values).toContain("609");
+  });
+
+  it("titles the page with an h2, leaving the single h1 to the shell", () => {
+    renderWithProviders(<OverviewPage />);
+
+    // `layout/Header.tsx` renders the document's only `h1` ("Chronovista").
+    // A page-level `h1` here would give the rendered document two top-level
+    // headings and break the outline screen-reader users navigate by. Every
+    // mature page (Videos, Settings) uses `h2` for its title for this reason.
+    expect(
+      screen.queryByRole("heading", { level: 1 })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Overview" })
+    ).toBeInTheDocument();
+  });
+
+  it("links to the filtered list carrying include_unavailable (FR-018, FR-018b)", () => {
+    renderWithProviders(<OverviewPage />);
+
+    const link = screen.getByRole("link", { name: /saved & forgotten/i });
+    const href = link.getAttribute("href") ?? "";
+
+    expect(href).toContain("/videos");
+    expect(href).toContain("saved_unwatched=true");
+    // Without this the user clicks 609 and lands on 586 — the dashboard counts
+    // unavailable videos, the list hides them by default.
+    expect(href).toContain("include_unavailable=true");
+  });
+
+  it("renders an explicit zero state, not a bare 0 (FR-019)", () => {
+    mockUseOverview.mockReturnValue({
+      overview: overview(0),
+      isLoading: false,
+      isError: false,
+      error: null,
+      retry: vi.fn(),
+    });
+    renderWithProviders(<OverviewPage />);
+
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText(/nothing forgotten/i)).toBeInTheDocument();
+  });
+
+  it("shows a loading state distinguishable from zero (FR-027a)", () => {
+    mockUseOverview.mockReturnValue({
+      overview: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      retry: vi.fn(),
+    });
+    renderWithProviders(<OverviewPage />);
+
+    expect(screen.getByTestId("overview-loading")).toBeInTheDocument();
+    // A zero value must not be implied while loading.
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("shows an error state distinguishable from an empty library (FR-027b)", () => {
+    mockUseOverview.mockReturnValue({
+      overview: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("boom"),
+      retry: vi.fn(),
+    });
+    renderWithProviders(<OverviewPage />);
+
+    expect(screen.getByText(/could not load your overview/i)).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("offers retry without a full reload (FR-027c)", async () => {
+    const user = userEvent.setup();
+    const retry = vi.fn();
+    mockUseOverview.mockReturnValue({
+      overview: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("boom"),
+      retry,
+    });
+    renderWithProviders(<OverviewPage />);
+
+    await user.click(screen.getByRole("button", { name: /try again|retry/i }));
+    expect(retry).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/pages/PlaylistDetailPage.test.tsx
+++ b/frontend/tests/pages/PlaylistDetailPage.test.tsx
@@ -4,6 +4,7 @@
  * Covers:
  * - Sort dropdown renders 3 options with correct labels
  * - Filter toggles render (unavailable_only, liked_only, has_transcript)
+ * - Watched filter tabs render (all/watched/unwatched, Feature 061)
  * - URL state persistence on refresh
  * - Empty state messages (single-filter specific + multi-filter combined)
  * - Focus remains on control after change
@@ -110,6 +111,14 @@ function setupDefaultMocks(options: {
   mockUsePlaylistVideos.mockReturnValue({
     videos,
     total,
+    // Feature 061: the stats header. These describe the playlist and stay
+    // fixed as the watched filter moves (FR-005b), unlike `total`, which is
+    // the result count for the current view.
+    stats: {
+      playlist_total: videos.length,
+      watched: 0,
+      unwatched: videos.length,
+    },
     loadedCount: videos.length,
     isLoading,
     isError: false,

--- a/frontend/tests/pages/PlaylistDetailPage.watched.test.tsx
+++ b/frontend/tests/pages/PlaylistDetailPage.watched.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * URL persistence for the watched filter (Feature 061, T029).
+ *
+ * Covers FR-007a (the filter lives in the address under the same name the API
+ * uses), FR-007b (arriving with it pre-set renders filtered), FR-007c (the
+ * default is never written), and FR-007e (an invalid value falls back to All).
+ *
+ * This is the mechanism FR-025 depends on: the dashboard's "Watch Later
+ * unwatched" card links to this page pre-filtered, which is only possible
+ * because the filter is addressable.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, getTestLocation } from "../test-utils";
+import { PlaylistDetailPage } from "../../src/pages/PlaylistDetailPage";
+import { usePlaylistDetail, usePlaylistVideos } from "../../src/hooks";
+
+vi.mock("../../src/hooks", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/hooks")>();
+  return {
+    ...original,
+    usePlaylistDetail: vi.fn(),
+    usePlaylistVideos: vi.fn(),
+  };
+});
+
+vi.mock("../../src/components/PlaylistVideoCard", () => ({
+  PlaylistVideoCard: () => <div data-testid="video-card" />,
+}));
+
+const mockDetail = vi.mocked(usePlaylistDetail);
+const mockVideos = vi.mocked(usePlaylistVideos);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockDetail.mockReturnValue({
+    playlist: {
+      playlist_id: "PLtest",
+      title: "Test playlist",
+      description: "d",
+      video_count: 3,
+      privacy_status: "private",
+      is_linked: true,
+      playlist_type: "regular",
+      default_language: null,
+      channel_id: null,
+      published_at: null,
+      deleted_flag: false,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    retry: vi.fn(),
+  } as unknown as ReturnType<typeof usePlaylistDetail>);
+
+  mockVideos.mockReturnValue({
+    videos: [],
+    total: 1,
+    stats: { playlist_total: 3, watched: 2, unwatched: 1 },
+    loadedCount: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    retry: vi.fn(),
+    loadMoreRef: { current: null },
+  } as unknown as ReturnType<typeof usePlaylistVideos>);
+});
+
+function lastCallOptions(): Record<string, unknown> {
+  const call = mockVideos.mock.calls[mockVideos.mock.calls.length - 1];
+  return (call?.[1] ?? {}) as Record<string, unknown>;
+}
+
+describe("PlaylistDetailPage watched filter URL persistence", () => {
+  it("defaults to all and does not write the param (FR-007c)", () => {
+    renderWithProviders(<PlaylistDetailPage />, {
+      initialEntries: ["/playlists/PLtest"],
+      path: "/playlists/:playlistId",
+    });
+
+    expect(lastCallOptions().watchedStatus).toBe("all");
+    expect(getTestLocation().search).not.toContain("watched_status");
+  });
+
+  it("writes the selected value to the address (FR-007a)", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PlaylistDetailPage />, {
+      initialEntries: ["/playlists/PLtest"],
+      path: "/playlists/:playlistId",
+    });
+
+    await user.click(screen.getByRole("tab", { name: /only unwatched/i }));
+
+    // Same name the API uses, so address and request cannot drift (FR-007a).
+    expect(getTestLocation().search).toContain("watched_status=unwatched");
+  });
+
+  it("renders pre-filtered when the address already carries it (FR-007b)", () => {
+    renderWithProviders(<PlaylistDetailPage />, {
+      initialEntries: ["/playlists/PLtest?watched_status=unwatched"],
+      path: "/playlists/:playlistId",
+    });
+
+    // No interaction required — this is what makes the dashboard deep link
+    // in FR-025 possible.
+    expect(lastCallOptions().watchedStatus).toBe("unwatched");
+    expect(
+      screen.getByRole("tab", { name: /only unwatched/i })
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("falls back to all for an invalid value rather than erroring (FR-007e)", () => {
+    renderWithProviders(<PlaylistDetailPage />, {
+      initialEntries: ["/playlists/PLtest?watched_status=bogus"],
+      path: "/playlists/:playlistId",
+    });
+
+    expect(lastCallOptions().watchedStatus).toBe("all");
+    expect(screen.getByRole("tab", { name: /all videos/i })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+  });
+
+  it("preserves the sort selection when the filter changes (FR-007d)", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PlaylistDetailPage />, {
+      initialEntries: ["/playlists/PLtest?sort_by=title&sort_order=desc"],
+      path: "/playlists/:playlistId",
+    });
+
+    await user.click(screen.getByRole("tab", { name: /only watched/i }));
+
+    const search = getTestLocation().search;
+    expect(search).toContain("watched_status=watched");
+    expect(search).toContain("sort_by=title");
+    expect(search).toContain("sort_order=desc");
+  });
+
+  it("shows the stats header, unchanged by the filter (FR-004, FR-005b)", () => {
+    renderWithProviders(<PlaylistDetailPage />, {
+      initialEntries: ["/playlists/PLtest?watched_status=unwatched"],
+      path: "/playlists/:playlistId",
+    });
+
+    // "Watched" also appears as a tab label, so scope to the stats list. Each
+    // figure must sit in a <dt>/<dd> pair so the number and what it counts are
+    // programmatically associated (FR-033).
+    const terms = Array.from(document.querySelectorAll("dl dt")).map((el) =>
+      el.textContent?.trim()
+    );
+    const values = Array.from(document.querySelectorAll("dl dd")).map((el) =>
+      el.textContent?.trim()
+    );
+
+    expect(terms).toEqual(["Total", "Watched", "Unwatched"]);
+    // The playlist figures (3/2/1), NOT the filtered result count of 1 —
+    // the header does not move with the filter (FR-005b).
+    expect(values).toEqual(["3", "2", "1"]);
+  });
+
+  it("announces the filtered result count to assistive tech (FR-031)", () => {
+    renderWithProviders(<PlaylistDetailPage />, {
+      initialEntries: ["/playlists/PLtest?watched_status=unwatched"],
+      path: "/playlists/:playlistId",
+    });
+
+    // A filter change alters the result set, which must be perceivable without
+    // sight — the count lives in a polite live region rather than only in the
+    // visual list. The page carries more than one status region, so find the
+    // one that carries the count rather than assuming there is exactly one.
+    const regions = screen.getAllByRole("status");
+    const countRegion = regions.find((el) => /\d+\s+videos?/.test(el.textContent ?? ""));
+
+    expect(countRegion, "no live region announces the result count").toBeDefined();
+    expect(countRegion).toHaveAttribute("aria-live", "polite");
+    expect(countRegion?.textContent).toContain("1 video");
+    // The announcement says the list is filtered, so the number is not mistaken
+    // for the playlist's full size.
+    expect(countRegion?.textContent).toContain("filtered");
+  });
+
+  it("does not announce a stale count while results are loading (FR-031)", () => {
+    mockVideos.mockReturnValue({
+      videos: [],
+      total: null,
+      stats: null,
+      loadedCount: 0,
+      isLoading: true,
+      isError: false,
+      error: null,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      retry: vi.fn(),
+      loadMoreRef: { current: null },
+    } as unknown as ReturnType<typeof usePlaylistVideos>);
+
+    renderWithProviders(<PlaylistDetailPage />, {
+      initialEntries: ["/playlists/PLtest?watched_status=unwatched"],
+      path: "/playlists/:playlistId",
+    });
+
+    // Announcing the previous filter's total mid-load would state a number that
+    // is about to change. The loading skeleton has its own status region, so
+    // assert on the announced *text* rather than on the role's absence.
+    const announced = screen
+      .getAllByRole("status")
+      .map((el) => el.textContent ?? "")
+      .join(" ");
+
+    expect(announced).not.toMatch(/\d+\s+videos?/);
+    expect(announced).toMatch(/loading/i);
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.60.0"
+version = "0.61.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.60.0"
+__version__ = "0.61.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/main.py
+++ b/src/chronovista/api/main.py
@@ -28,6 +28,7 @@ from chronovista.api.routers import (
     health,
     images,
     onboarding,
+    overview,
     playlists,
     preferences,
     search,
@@ -254,6 +255,7 @@ async def log_requests(
 app.include_router(health.router, prefix="/api/v1", tags=["health"])
 app.include_router(channels.router, prefix="/api/v1", tags=["channels"])
 app.include_router(playlists.router, prefix="/api/v1", tags=["playlists"])
+app.include_router(overview.router, prefix="/api/v1", tags=["overview"])
 app.include_router(topics.router, prefix="/api/v1", tags=["topics"])
 app.include_router(categories.router, prefix="/api/v1", tags=["categories"])
 app.include_router(tags.router, prefix="/api/v1", tags=["tags"])

--- a/src/chronovista/api/routers/overview.py
+++ b/src/chronovista/api/routers/overview.py
@@ -1,0 +1,47 @@
+"""Overview dashboard endpoint (Feature 061).
+
+A single read-only aggregation serving every figure the dashboard displays
+(FR-026), so the cards are computed together and cannot disagree.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.api.deps import get_db, require_auth
+from chronovista.api.routers.responses import LIST_ERRORS
+from chronovista.api.schemas.overview import OverviewResponse
+from chronovista.api.schemas.responses import ApiResponse
+from chronovista.repositories.playlist_repository import get_library_overview
+
+router = APIRouter(dependencies=[Depends(require_auth)])
+
+
+@router.get(
+    "/overview",
+    response_model=ApiResponse[OverviewResponse],
+    responses=LIST_ERRORS,
+    summary="Library overview aggregates",
+)
+async def get_overview(
+    session: AsyncSession = Depends(get_db),
+) -> ApiResponse[OverviewResponse]:
+    """Return the library overview figures.
+
+    Read-only. Takes no parameters and returns aggregates rather than rows, so
+    its cost does not grow with the number of videos in the library (SC-011).
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session injected via FastAPI dependency.
+
+    Returns
+    -------
+    ApiResponse[OverviewResponse]
+        Saved & Forgotten headline, Watch Later depth (null when no such
+        playlist exists), the playlist inventory, and library rollups.
+    """
+    data = await get_library_overview(session)
+    return ApiResponse[OverviewResponse](data=OverviewResponse.model_validate(data))

--- a/src/chronovista/api/routers/playlists.py
+++ b/src/chronovista/api/routers/playlists.py
@@ -23,6 +23,7 @@ from chronovista.api.schemas.playlists import (
     PlaylistListResponse,
     PlaylistVideoListItem,
     PlaylistVideoListResponse,
+    PlaylistWatchStats,
 )
 from chronovista.api.schemas.responses import PaginationMeta
 from chronovista.api.schemas.sorting import SortOrder
@@ -36,7 +37,8 @@ from chronovista.db.models import (
 )
 from chronovista.db.models import Video as VideoDB
 from chronovista.exceptions import BadRequestError, NotFoundError
-from chronovista.models.enums import AvailabilityStatus, PlaylistType
+from chronovista.models.enums import AvailabilityStatus, PlaylistType, WatchedStatus
+from chronovista.repositories.user_video_repository import watched_video_ids
 
 router = APIRouter(dependencies=[Depends(require_auth)])
 
@@ -332,6 +334,13 @@ async def get_playlist_videos(
         False,
         description="Filter to show only unavailable videos",
     ),
+    watched_status: WatchedStatus = Query(
+        WatchedStatus.ALL,
+        description=(
+            "Filter by watched status (all, watched, unwatched). Watched-status "
+            "comes from watch history, never from playlist membership."
+        ),
+    ),
     session: AsyncSession = Depends(get_db),
 ) -> PlaylistVideoListResponse:
     """Get videos in a playlist with sorting and filtering.
@@ -361,6 +370,11 @@ async def get_playlist_videos(
         If True, only return videos with transcripts (default: False).
     unavailable_only : bool
         If True, only return unavailable videos (default: False).
+    watched_status : WatchedStatus
+        Restrict results to watched or unwatched videos (default: all). Watched
+        means a watch-history record exists; it is never inferred from playlist
+        membership. Narrows ``pagination.total`` but deliberately not ``stats``,
+        which always describes the whole playlist.
     session : AsyncSession
         Database session from dependency.
 
@@ -420,6 +434,15 @@ async def get_playlist_videos(
         )
         query = query.where(VideoDB.video_id.in_(transcript_subquery))
 
+    # Apply watched_status filter (Feature 061) — non-correlated IN-subquery,
+    # matching the liked_only pattern above. The correlated EXISTS equivalent
+    # measured 25,676 ms against production data where this measures 69 ms, for
+    # identical results (research R1).
+    if watched_status is WatchedStatus.WATCHED:
+        query = query.where(VideoDB.video_id.in_(watched_video_ids()))
+    elif watched_status is WatchedStatus.UNWATCHED:
+        query = query.where(VideoDB.video_id.not_in(watched_video_ids()))
+
     # Build count query with the same filters
     count_base_query = (
         select(PlaylistMembership)
@@ -450,6 +473,40 @@ async def get_playlist_videos(
         )
         count_base_query = count_base_query.where(
             VideoDB.video_id.in_(transcript_count_subquery)
+        )
+
+    # The stats header (FR-004) is computed from the filter context *before* the
+    # watched filter narrows it, so switching All/Watched/Unwatched changes the
+    # listed videos and the result count but never the three header figures
+    # (FR-005b). Counting DISTINCT video_id keeps it duplicate-safe (FR-002).
+    stats_subquery = count_base_query.subquery()
+    stats_result = await session.execute(
+        select(
+            func.count(func.distinct(stats_subquery.c.video_id)),
+            func.count(func.distinct(stats_subquery.c.video_id)).filter(
+                stats_subquery.c.video_id.in_(watched_video_ids())
+            ),
+        ).select_from(stats_subquery)
+    )
+    stats_total, stats_watched = stats_result.one()
+    stats = PlaylistWatchStats(
+        playlist_total=int(stats_total or 0),
+        watched=int(stats_watched or 0),
+        unwatched=int(stats_total or 0) - int(stats_watched or 0),
+    )
+
+    # Now apply the watched filter to the count query so pagination.total is the
+    # RESULT COUNT — a different quantity from stats.playlist_total (FR-005c).
+    # playlists.py rebuilds its count query by hand rather than deriving it from
+    # `query`, so the filter must be applied in both places or the list narrows
+    # while the total does not (research R8).
+    if watched_status is WatchedStatus.WATCHED:
+        count_base_query = count_base_query.where(
+            VideoDB.video_id.in_(watched_video_ids())
+        )
+    elif watched_status is WatchedStatus.UNWATCHED:
+        count_base_query = count_base_query.where(
+            VideoDB.video_id.not_in(watched_video_ids())
         )
 
     count_query = select(func.count()).select_from(count_base_query.subquery())
@@ -493,6 +550,34 @@ async def get_playlist_videos(
         corrections_result = await session.execute(corrections_query)
         videos_with_corrections = {row[0] for row in corrections_result.fetchall()}
 
+    # Which videos on this page have been watched (FR-010).
+    #
+    # Under a watched filter the answer is already settled by the WHERE clause
+    # applied above — every row on a `watched` page passed
+    # `video_id IN watched_video_ids()`, and every row on an `unwatched` page
+    # failed it. Re-asking the database would scan `user_videos` again to
+    # rediscover what the query just proved. Only the unfiltered case can hold a
+    # mix and needs the lookup.
+    #
+    # That lookup is one query per page, never one per row, mirroring the
+    # corrections batch above; it is bounded by page size, so it does not
+    # interact with R1's scaling.
+    watched_ids: set[str] = set()
+    if watched_status is WatchedStatus.WATCHED:
+        watched_ids = set(video_ids)
+    elif watched_status is WatchedStatus.UNWATCHED:
+        watched_ids = set()
+    elif video_ids:
+        watched_result = await session.execute(
+            select(UserVideo.video_id)
+            .where(
+                UserVideo.video_id.in_(video_ids),
+                UserVideo.watched_at.is_not(None),
+            )
+            .distinct()
+        )
+        watched_ids = {row[0] for row in watched_result.fetchall()}
+
     # Transform to response items
     items: list[PlaylistVideoListItem] = []
     for membership, video in rows:
@@ -514,6 +599,7 @@ async def get_playlist_videos(
                 transcript_summary=transcript_summary,
                 position=membership.position,
                 availability_status=video.availability_status,
+                watched=video.video_id in watched_ids,
             )
         )
 
@@ -525,4 +611,4 @@ async def get_playlist_videos(
         has_more=(offset + limit) < total,
     )
 
-    return PlaylistVideoListResponse(data=items, pagination=pagination)
+    return PlaylistVideoListResponse(data=items, pagination=pagination, stats=stats)

--- a/src/chronovista/api/routers/videos.py
+++ b/src/chronovista/api/routers/videos.py
@@ -64,6 +64,7 @@ from chronovista.repositories.canonical_tag_repository import (
 from chronovista.repositories.playlist_membership_repository import (
     PlaylistMembershipRepository,
 )
+from chronovista.repositories.playlist_repository import saved_forgotten_video_ids
 
 logger = logging.getLogger(__name__)
 
@@ -562,6 +563,13 @@ async def list_videos(
         SortOrder.DESC,
         description="Sort order (asc or desc)",
     ),
+    saved_unwatched: bool = Query(
+        False,
+        description=(
+            "Filter to videos saved in at least one curated playlist and never "
+            "watched (the dashboard's Saved & Forgotten set)"
+        ),
+    ),
     liked_only: bool = Query(
         False,
         description="Filter to only liked videos",
@@ -750,6 +758,14 @@ async def list_videos(
             .scalar_subquery()
         )
         query = query.where(VideoDB.video_id.in_(liked_subquery))
+
+    # Saved & Forgotten filter (Feature 061) — imports the SAME derivation the
+    # dashboard headline uses, rather than re-expressing it here, so the two
+    # figures cannot drift (FR-029b). Applied to `query` only: the count is
+    # derived from `query.subquery()` below, unlike playlists.py which rebuilds
+    # its count by hand (research R8).
+    if saved_unwatched:
+        query = query.where(VideoDB.video_id.in_(saved_forgotten_video_ids()))
 
     # T099: Execute query with timeout (FR-036: 10s timeout)
     try:

--- a/src/chronovista/api/schemas/overview.py
+++ b/src/chronovista/api/schemas/overview.py
@@ -1,0 +1,109 @@
+"""Overview dashboard response schemas (Feature 061).
+
+Read-only aggregates over the library: the Saved & Forgotten headline, Watch
+Later depth, a playlist inventory by type, and library-wide rollups. Every
+figure comes from one aggregation source (FR-026) so the cards cannot disagree
+with each other.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PlaylistTypeCount(BaseModel):
+    """One row of the playlist inventory.
+
+    Produced by grouping over the playlist types **actually present in the
+    data**, never by iterating a fixed list of known types (FR-021). That is
+    deliberate: Saved & Forgotten hardcodes ``curated == 'regular'``, so a
+    playlist type introduced later is silently excluded from it, and this
+    inventory is the only place such a type becomes visible. Rendering a fixed
+    set of types would remove the sole signal that the curated definition has
+    gone stale.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    playlist_type: str = Field(..., description="Playlist type as stored")
+    playlist_count: int = Field(..., description="Number of playlists of this type")
+    is_system: bool = Field(
+        ...,
+        description=(
+            "Whether this is a system list rather than user curation. Derived as "
+            "'type is not regular', never from a named set, so a liked or "
+            "favorites playlist is never presented as user-curated."
+        ),
+    )
+
+
+class WatchLaterDepth(BaseModel):
+    """How much is queued in Watch Later, and how much of it is unwatched."""
+
+    model_config = ConfigDict(strict=True)
+
+    total: int = Field(..., description="Distinct videos in Watch Later")
+    unwatched: int = Field(
+        ..., description="Of those, distinct videos with no watch-history record"
+    )
+    playlist_id: str | None = Field(
+        None,
+        description=(
+            "Target for the FR-025 deep link, present only when exactly one "
+            "Watch Later playlist exists. Null when the depth spans several, "
+            "since no single playlist would match the figure clicked."
+        ),
+    )
+
+
+class LibraryRollup(BaseModel):
+    """Library-wide totals.
+
+    ``saved_curated_videos`` counts what is *saved*; ``watched_videos`` counts
+    what has been *watched*. They are independent facts and the labelling must
+    keep them so (FR-024).
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    watched_videos: int = Field(
+        ..., description="Distinct videos with a watch-history record"
+    )
+    saved_curated_videos: int = Field(
+        ..., description="Distinct videos saved across curated playlists"
+    )
+    liked_videos: int = Field(
+        ...,
+        description=(
+            "Distinct videos carrying the liked attribute. A video attribute, "
+            "not a playlist type — presented among the video rollups and never "
+            "in the playlist inventory."
+        ),
+    )
+
+
+class OverviewResponse(BaseModel):
+    """Everything the Overview Dashboard displays."""
+
+    model_config = ConfigDict(strict=True)
+
+    saved_and_forgotten: int = Field(
+        ...,
+        description=(
+            "Distinct videos in at least one curated playlist with no "
+            "watch-history record. Counted once per video however many curated "
+            "playlists hold it."
+        ),
+    )
+    watch_later: WatchLaterDepth | None = Field(
+        ...,
+        description=(
+            "Watch Later depth, or null when no Watch Later playlist exists. "
+            "Null is distinct from a present-but-empty queue, which is "
+            "{total: 0, unwatched: 0} (FR-020a)."
+        ),
+    )
+    playlist_inventory: list[PlaylistTypeCount] = Field(
+        ..., description="Counts for the playlist types present in the data"
+    )
+    rollup: LibraryRollup = Field(..., description="Library-wide totals")

--- a/src/chronovista/api/schemas/playlists.py
+++ b/src/chronovista/api/schemas/playlists.py
@@ -156,6 +156,13 @@ class PlaylistVideoListItem(BaseModel):
         ...,
         description="Video availability status (included to preserve position integrity)",
     )
+    watched: bool = Field(
+        ...,
+        description=(
+            "Whether a watch-history record exists for this video. Derived from "
+            "watch history, never from playlist membership."
+        ),
+    )
 
 
 class PlaylistListResponse(BaseModel):
@@ -175,6 +182,31 @@ class PlaylistDetailResponse(BaseModel):
     data: PlaylistDetail
 
 
+class PlaylistWatchStats(BaseModel):
+    """Watched/unwatched breakdown for one playlist (Feature 061).
+
+    The field is named ``playlist_total`` rather than ``total`` on purpose. The
+    same response also carries ``pagination.total``, which is the **result
+    count** — the number of videos in the current view — and the two differ
+    whenever the watched filter is not ``all``. Under ``watched_status=unwatched``
+    on a 4,973-video Watch Later, ``playlist_total`` is 4,973 while
+    ``pagination.total`` is 2,392. Distinct names make that impossible to
+    conflate in code.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    playlist_total: int = Field(
+        ..., description="Distinct videos in the playlist under the current filters"
+    )
+    watched: int = Field(
+        ..., description="Of those, distinct videos with a watch-history record"
+    )
+    unwatched: int = Field(
+        ..., description="Of those, distinct videos with no watch-history record"
+    )
+
+
 class PlaylistVideoListResponse(BaseModel):
     """Response wrapper for playlist video list."""
 
@@ -182,3 +214,4 @@ class PlaylistVideoListResponse(BaseModel):
 
     data: list[PlaylistVideoListItem]
     pagination: PaginationMeta
+    stats: PlaylistWatchStats

--- a/src/chronovista/models/enums.py
+++ b/src/chronovista/models/enums.py
@@ -86,6 +86,18 @@ class PlaylistType(str, Enum):
     FAVORITES = "favorites"  # Legacy Favorites playlist
 
 
+class WatchedStatus(str, Enum):
+    """Watched-status filter for playlist video listings (Feature 061).
+
+    Watched-status derives solely from ``user_videos.watched_at`` and is never
+    inferred from playlist membership.
+    """
+
+    ALL = "all"
+    WATCHED = "watched"
+    UNWATCHED = "unwatched"
+
+
 # Known English system-playlist names (normalized, case-insensitive) → type.
 # Name matching is English-only by design (accepted limitation, Feature 058).
 _SYSTEM_PLAYLIST_NAMES: dict[str, PlaylistType] = {

--- a/src/chronovista/repositories/playlist_repository.py
+++ b/src/chronovista/repositories/playlist_repository.py
@@ -14,6 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from chronovista.db.models import Playlist as PlaylistDB
+from chronovista.db.models import PlaylistMembership as PlaylistMembershipDB
+from chronovista.db.models import UserVideo as UserVideoDB
 from chronovista.models.enums import PlaylistType
 from chronovista.models.playlist import (
     PlaylistAnalytics,
@@ -23,6 +25,218 @@ from chronovista.models.playlist import (
     PlaylistUpdate,
 )
 from chronovista.repositories.base import BaseSQLAlchemyRepository
+from chronovista.repositories.user_video_repository import watched_video_ids
+
+
+def saved_forgotten_video_ids() -> Any:
+    """Return a subquery of every distinct "saved & forgotten" video id.
+
+    Saved & Forgotten (Feature 061) means: the video sits in at least one
+    *curated* playlist and has no watch-history record.
+
+    **This is the single derivation of that concept.** Both the dashboard
+    headline and the videos-list filter consume it, rather than each expressing
+    it independently — FR-029b requires exactly one definition so the two
+    consumers cannot drift, and FR-029c asserts their equality as a backstop
+    rather than as the mechanism.
+
+    Two details are load-bearing:
+
+    - **"Curated" is tested positively** as ``playlist_type == 'regular'``, so
+      every other type is excluded automatically — including ``liked`` and
+      ``favorites``, which the upstream enum defines but this feature never
+      names. A negative test against a list of known system types would leak a
+      newly-introduced type into the count.
+    - **``.not_in()`` against a non-correlated, DISTINCT subquery.** Safe here
+      because ``user_videos.video_id`` and ``playlist_memberships.video_id`` are
+      both NOT NULL — a NULL anywhere in a ``NOT IN`` subquery would make it
+      return zero rows silently, reporting 0 forgotten videos as if that were a
+      real answer.
+
+    Returns
+    -------
+    Any
+        A selectable of distinct video ids, usable as
+        ``VideoDB.video_id.in_(saved_forgotten_video_ids())``.
+    """
+    return (
+        select(PlaylistMembershipDB.video_id)
+        .join(PlaylistDB, PlaylistDB.playlist_id == PlaylistMembershipDB.playlist_id)
+        .where(
+            PlaylistDB.playlist_type == PlaylistType.REGULAR.value,
+            PlaylistMembershipDB.video_id.not_in(watched_video_ids()),
+        )
+        .distinct()
+    )
+
+
+async def get_library_overview(session: AsyncSession) -> dict[str, Any]:
+    """Compute every Overview Dashboard figure.
+
+    Query shape is the whole problem here (research R1). Measured against
+    production data — 89,465 memberships, 51,271 watch rows:
+
+    - ``LEFT JOIN LATERAL (SELECT 1 FROM user_videos ... LIMIT 1)`` per
+      membership row: **50,893 ms**
+    - the CTE form below: **131 ms**
+
+    Both return identical numbers, so a test asserting only values cannot tell
+    them apart. The CTE form expresses the watched set and the distinct
+    (type, video) membership set once, then answers the depth figures with
+    conditional aggregates over a single join — no per-row subquery anywhere.
+
+    These CTEs are deliberately **not** ``MATERIALIZED``. Each is referenced once,
+    so PostgreSQL 12+ inlines them and plans across the boundary. Forcing
+    materialisation was measured against production and is *slower*: ~134 ms
+    versus ~85 ms. The win over the LATERAL form came from removing the per-row
+    correlation, not from an optimisation fence, so do not add the hint on the
+    theory that it must help.
+
+    Sequential queries, never ``asyncio.gather`` — ``AsyncSession`` raises
+    ``IllegalStateChangeError`` under concurrent use (research R2, and see the
+    note at ``api/routers/settings.py``). Keeping the figure count low matters
+    precisely because the queries cannot overlap.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session.
+
+    Returns
+    -------
+    dict[str, Any]
+        Keys: ``saved_and_forgotten``, ``watch_later`` (None when absent),
+        ``playlist_inventory``, ``rollup``.
+    """
+    watched = (
+        select(UserVideoDB.video_id.label("video_id"))
+        .where(UserVideoDB.watched_at.is_not(None))
+        .distinct()
+        .cte("watched")
+    )
+    membership = (
+        select(
+            PlaylistDB.playlist_type.label("playlist_type"),
+            PlaylistMembershipDB.video_id.label("video_id"),
+        )
+        .join(PlaylistDB, PlaylistDB.playlist_id == PlaylistMembershipDB.playlist_id)
+        .distinct()
+        .cte("membership")
+    )
+
+    regular = PlaylistType.REGULAR.value
+    watch_later_type = PlaylistType.WATCH_LATER.value
+    unwatched = watched.c.video_id.is_(None)
+
+    counts = (
+        await session.execute(
+            select(
+                func.count()
+                .filter(membership.c.playlist_type == regular)
+                .label("saved_curated_videos"),
+                func.count()
+                .filter(membership.c.playlist_type == watch_later_type)
+                .label("wl_total"),
+                func.count()
+                .filter(
+                    and_(
+                        membership.c.playlist_type == watch_later_type,
+                        unwatched,
+                    )
+                )
+                .label("wl_unwatched"),
+            ).select_from(
+                membership.outerjoin(
+                    watched, watched.c.video_id == membership.c.video_id
+                )
+            )
+        )
+    ).one()
+
+    # FR-021: group over whatever types exist. Never iterate a fixed list — this
+    # is the tripwire that makes a newly-introduced playlist type visible.
+    #
+    # `min(playlist_id)` rides along so FR-025 can deep-link Watch Later without
+    # a second round trip. It is only meaningful when the type has exactly one
+    # playlist, which is enforced where it is consumed below.
+    inventory_rows = (
+        await session.execute(
+            select(
+                PlaylistDB.playlist_type,
+                func.count(),
+                func.min(PlaylistDB.playlist_id),
+            )
+            .group_by(PlaylistDB.playlist_type)
+            .order_by(PlaylistDB.playlist_type)
+        )
+    ).all()
+
+    # FR-029b: Saved & Forgotten has **one** derivation, and this is the
+    # dashboard consuming it. Expressing it here a second time as a conditional
+    # aggregate over the membership CTE would agree numerically today and make
+    # the equality test (FR-029c) a coincidence rather than a consequence — the
+    # backstop would be doing the job the mechanism is supposed to do. The extra
+    # round trip costs ~30 ms against production, well inside the SC-010 budget.
+    saved_and_forgotten = await session.scalar(
+        select(func.count()).select_from(saved_forgotten_video_ids().subquery())
+    )
+
+    watched_videos = await session.scalar(
+        select(func.count(func.distinct(UserVideoDB.video_id))).where(
+            UserVideoDB.watched_at.is_not(None)
+        )
+    )
+    liked_videos = await session.scalar(
+        select(func.count(func.distinct(UserVideoDB.video_id))).where(
+            UserVideoDB.liked.is_(True)
+        )
+    )
+
+    # FR-020a: absence of a Watch Later playlist is distinct from an empty one.
+    watch_later_row = next(
+        (row for row in inventory_rows if row[0] == watch_later_type), None
+    )
+
+    # FR-025: the depth aggregates over every Watch Later playlist, but a link
+    # can only target one. Offer an id only when the target is unambiguous —
+    # with two such playlists the figure spans both and linking to either would
+    # send the user somewhere whose count does not match what they clicked. The
+    # frontend renders a non-interactive figure when this is null, which FR-025
+    # explicitly permits.
+    watch_later_playlist_id = (
+        str(watch_later_row[2])
+        if watch_later_row is not None and int(watch_later_row[1] or 0) == 1
+        else None
+    )
+
+    return {
+        "saved_and_forgotten": int(saved_and_forgotten or 0),
+        "watch_later": (
+            {
+                "total": int(counts.wl_total or 0),
+                "unwatched": int(counts.wl_unwatched or 0),
+                "playlist_id": watch_later_playlist_id,
+            }
+            if watch_later_row is not None
+            else None
+        ),
+        "playlist_inventory": [
+            {
+                "playlist_type": row[0],
+                "playlist_count": int(row[1] or 0),
+                # row[2] (min playlist_id) is deliberately not surfaced here;
+                # it exists only for the Watch Later deep link above.
+                # Derived, not enumerated (FR-022).
+                "is_system": row[0] != regular,
+            }
+            for row in inventory_rows
+        ],
+        "rollup": {
+            "watched_videos": int(watched_videos or 0),
+            "saved_curated_videos": int(counts.saved_curated_videos or 0),
+            "liked_videos": int(liked_videos or 0),
+        },
+    }
 
 
 class PlaylistRepository(

--- a/src/chronovista/repositories/user_video_repository.py
+++ b/src/chronovista/repositories/user_video_repository.py
@@ -29,6 +29,40 @@ from ..models.youtube_types import UserId, VideoId
 from .base import BaseSQLAlchemyRepository
 
 
+def watched_video_ids() -> Any:
+    """Return a subquery of every distinct video id that has been watched.
+
+    The single definition of "watched" for read-side filtering (Feature 061):
+    a ``user_videos`` row whose ``watched_at`` is set. Never inferred from
+    playlist membership.
+
+    Three properties, all load-bearing:
+
+    - **Non-correlated.** It references no outer query, so PostgreSQL evaluates
+      it once instead of per row. The correlated equivalent measured 25,676 ms
+      against production data where this measures 69 ms — for identical results,
+      so a test asserting only values will not catch the regression.
+    - **Duplicate-safe.** ``.distinct()`` means a video with several watch-history
+      rows contributes once, so counts cannot inflate. This does not lean on
+      Feature 060's single-identity guarantee.
+    - **Identity-agnostic.** No ``user_id`` filter, which is correct only because
+      Feature 060 guarantees exactly one identity.
+
+    Returns
+    -------
+    Any
+        A scalar subquery usable as ``VideoDB.video_id.in_(watched_video_ids())``
+        or ``.not_in(...)``. Typed loosely because SQLAlchemy's scalar-subquery
+        type is not expressible in a way mypy can narrow usefully here.
+    """
+    return (
+        select(UserVideoDB.video_id)
+        .where(UserVideoDB.watched_at.is_not(None))
+        .distinct()
+        .scalar_subquery()
+    )
+
+
 class UserVideoRepository(
     BaseSQLAlchemyRepository[
         UserVideoDB,

--- a/tests/integration/api/test_overview.py
+++ b/tests/integration/api/test_overview.py
@@ -1,0 +1,583 @@
+"""Integration tests for the Overview Dashboard aggregates.
+
+Feature 061, User Stories 2 and 3 (T030, T031, T031a, T032, T049, T050, T051).
+
+The corpus deliberately includes a playlist of a system type this feature's prose
+never names (``liked``). The upstream ``PlaylistType`` enum has five members while
+production has only three, so a "system list" check written as membership of
+``{watch_later, history}`` would pass every other test here and still render a
+``liked`` playlist as user-curated. That is the seam defect this file guards.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import (
+    Channel,
+    Playlist,
+    PlaylistMembership,
+    UserVideo,
+    Video,
+)
+from chronovista.repositories.playlist_repository import get_library_overview
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+CHANNEL = "UCoverviewtest000000000"
+T0 = datetime(2024, 1, 1, tzinfo=UTC)
+
+CURATED_A = "PLoverviewA"
+CURATED_B = "PLoverviewB"
+WATCH_LATER = "WLoverview"
+HISTORY = "HLoverview"
+LIKED = "LLoverview"
+
+# ov_multi   — in BOTH curated playlists, never watched  -> counts ONCE (FR-017)
+# ov_wlonly  — only in Watch Later, never watched        -> excluded (FR-016)
+# ov_histonly— only in History, never watched            -> excluded (FR-016)
+# ov_likedonly — only in a `liked` playlist, never watched -> excluded (FR-016/029f)
+# ov_watched — in a curated playlist AND watched         -> excluded
+#
+# The integration database is shared across test modules, so absolute totals are
+# not stable. Assertions compare the API against an INDEPENDENT query over the
+# same database — which is what SC-003 actually specifies ("equals an independent
+# count") and is stronger than pinning a constant.
+
+
+async def _add_if_absent(session: AsyncSession, pk: Any, obj: Any) -> None:
+    """Insert ``obj`` only when its primary key is not already present.
+
+    Idempotent **per row**, not per corpus. An all-or-nothing guard keyed on the
+    channel would skip every later addition once the corpus existed — and the
+    integration database is never reset, so a corpus seeded by an earlier run
+    would silently freeze this file's fixtures at their old shape.
+    """
+    found = await session.execute(select(pk).where(pk == _pk_value(obj, pk)))
+    if found.scalar_one_or_none() is None:
+        session.add(obj)
+
+
+def _pk_value(obj: Any, pk: Any) -> Any:
+    return getattr(obj, pk.key)
+
+
+async def _seed(session: AsyncSession) -> None:
+    """Seed the shared corpus; the integration DB is not reset per test or run."""
+    await _add_if_absent(
+        session,
+        Channel.channel_id,
+        Channel(channel_id=CHANNEL, title="T", description="d"),
+    )
+    videos = (
+        "ov_multi",
+        "ov_wlonly",
+        "ov_histonly",
+        "ov_likedonly",
+        "ov_watched",
+    )
+    for vid in videos:
+        await _add_if_absent(
+            session,
+            Video.video_id,
+            Video(
+                video_id=vid,
+                channel_id=CHANNEL,
+                title=vid,
+                description="d",
+                upload_date=T0,
+                duration=60,
+            ),
+        )
+
+    # Unwatched, in Watch Later, and no longer available. Its only job is to make
+    # the two availability defaults produce *different* numbers, so the test that
+    # compares the dashboard figure with the page it links to can actually fail.
+    # Without it that comparison passes under either default and proves nothing.
+    await _add_if_absent(
+        session,
+        Video.video_id,
+        Video(
+            video_id="ov_wlgone",
+            channel_id=CHANNEL,
+            title="ov_wlgone",
+            description="d",
+            upload_date=T0,
+            duration=60,
+            availability_status="deleted",
+        ),
+    )
+
+    for pid, ptype in (
+        (CURATED_A, "regular"),
+        (CURATED_B, "regular"),
+        (WATCH_LATER, "watch_later"),
+        (HISTORY, "history"),
+        (LIKED, "liked"),
+    ):
+        await _add_if_absent(
+            session,
+            Playlist.playlist_id,
+            Playlist(
+                playlist_id=pid,
+                title=pid,
+                description="d",
+                video_count=0,
+                privacy_status="private",
+                playlist_type=ptype,
+            ),
+        )
+    await session.flush()
+
+    # In two curated playlists — must contribute exactly 1 (FR-017).
+    for pid, vid, pos in (
+        (CURATED_A, "ov_multi", 0),
+        (CURATED_B, "ov_multi", 0),
+        (CURATED_A, "ov_watched", 1),
+        (WATCH_LATER, "ov_wlonly", 0),
+        (WATCH_LATER, "ov_wlgone", 1),
+        (HISTORY, "ov_histonly", 0),
+        (LIKED, "ov_likedonly", 0),
+    ):
+        found = await session.execute(
+            select(PlaylistMembership.playlist_id).where(
+                PlaylistMembership.playlist_id == pid,
+                PlaylistMembership.video_id == vid,
+            )
+        )
+        if found.scalars().first() is None:
+            session.add(PlaylistMembership(playlist_id=pid, video_id=vid, position=pos))
+
+    found = await session.execute(
+        select(UserVideo.video_id).where(UserVideo.video_id == "ov_watched")
+    )
+    if found.scalars().first() is None:
+        session.add(
+            UserVideo(
+                user_id="u_a", video_id="ov_watched", watched_at=T0, rewatch_count=0
+            )
+        )
+    await session.commit()
+
+
+async def _independent_saved_forgotten(session: AsyncSession) -> int:
+    """Count Saved & Forgotten with SQL written independently of the endpoint."""
+    result = await session.execute(
+        text(
+            """
+            SELECT count(DISTINCT pm.video_id)
+            FROM playlist_memberships pm
+            JOIN playlists p ON p.playlist_id = pm.playlist_id
+            WHERE p.playlist_type = 'regular'
+              AND NOT EXISTS (
+                SELECT 1 FROM user_videos uv
+                WHERE uv.video_id = pm.video_id AND uv.watched_at IS NOT NULL
+              )
+            """
+        )
+    )
+    return int(result.scalar_one())
+
+
+async def _is_counted(session: AsyncSession, video_id: str) -> bool:
+    """Whether one specific video falls in the Saved & Forgotten set."""
+    result = await session.execute(
+        text(
+            """
+            SELECT count(*)
+            FROM playlist_memberships pm
+            JOIN playlists p ON p.playlist_id = pm.playlist_id
+            WHERE p.playlist_type = 'regular'
+              AND pm.video_id = :vid
+              AND NOT EXISTS (
+                SELECT 1 FROM user_videos uv
+                WHERE uv.video_id = pm.video_id AND uv.watched_at IS NOT NULL
+              )
+            """
+        ),
+        {"vid": video_id},
+    )
+    return int(result.scalar_one()) > 0
+
+
+async def _overview(client: AsyncClient) -> dict:
+    with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+        mock_oauth.is_authenticated.return_value = True
+        response = await client.get("/api/v1/overview")
+    assert response.status_code == 200, response.text
+    return dict(response.json()["data"])
+
+
+async def test_saved_and_forgotten_counts_distinct_videos(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T031 / FR-015, FR-017 — a video in two curated playlists counts once."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    data = await _overview(async_client)
+    async with integration_db_session() as session:
+        expected = await _independent_saved_forgotten(session)
+        # In two curated playlists, unwatched — contributes exactly once.
+        assert await _is_counted(session, "ov_multi") is True
+
+    assert data["saved_and_forgotten"] == expected
+
+
+async def test_system_lists_are_excluded_from_saved_and_forgotten(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T031 / FR-016 — Watch Later and History never contribute."""
+    async with integration_db_session() as session:
+        await _seed(session)
+        # Unwatched and saved, but in system lists rather than curated ones.
+        assert await _is_counted(session, "ov_wlonly") is False
+        assert await _is_counted(session, "ov_histonly") is False
+        expected = await _independent_saved_forgotten(session)
+
+    data = await _overview(async_client)
+    assert data["saved_and_forgotten"] == expected
+
+
+async def test_unnamed_system_type_is_excluded_and_flagged(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T031a / T050 / FR-016, FR-022, FR-029f — the seam guard.
+
+    ``liked`` is a system type the feature's prose never enumerates. It must be
+    excluded from Saved & Forgotten and flagged ``is_system`` in the inventory,
+    both of which follow from "type is not regular" rather than from a list.
+    """
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    async with integration_db_session() as session:
+        # Unwatched and saved, but `liked` is not a curated type.
+        assert await _is_counted(session, "ov_likedonly") is False
+        expected = await _independent_saved_forgotten(session)
+
+    data = await _overview(async_client)
+    assert data["saved_and_forgotten"] == expected
+
+    by_type = {row["playlist_type"]: row for row in data["playlist_inventory"]}
+    assert by_type["liked"]["is_system"] is True, (
+        "a `liked` playlist must be flagged as a system list — deriving is_system "
+        "from {watch_later, history} would render it as user-curated"
+    )
+    assert by_type["regular"]["is_system"] is False
+
+
+async def test_inventory_reports_only_types_present(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T049 / FR-021 — grouped over the data, never a fixed list of types."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    data = await _overview(async_client)
+    types = {row["playlist_type"] for row in data["playlist_inventory"]}
+
+    # `favorites` exists in the enum but not in the data, so it must not appear
+    # as a permanent zero row.
+    assert "favorites" not in types
+    assert {"regular", "watch_later", "history", "liked"} <= types
+    assert all(row["playlist_count"] > 0 for row in data["playlist_inventory"])
+
+
+async def test_watch_later_depth(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T051 / FR-020 — total and unwatched for the queue."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    data = await _overview(async_client)
+    assert data["watch_later"] is not None
+    assert data["watch_later"]["total"] >= 1
+    assert data["watch_later"]["unwatched"] >= 1
+
+
+async def test_watch_later_exposes_a_deep_link_target_only_when_unambiguous(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T058 / FR-025 — the depth card can only link to a single playlist.
+
+    The depth aggregates over every Watch Later playlist. With exactly one, the
+    link target is unambiguous and MUST be offered. With two, the figure spans
+    both and no single playlist matches it, so the target MUST be withheld and
+    the figure rendered non-interactively.
+    """
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    # The integration database is shared and other modules seed their own Watch
+    # Later playlists, so "exactly one exists" cannot be assumed globally — it is
+    # staged here inside a transaction that is rolled back.
+    async with integration_db_session() as session:
+        try:
+            await session.execute(
+                delete(PlaylistMembership).where(
+                    PlaylistMembership.playlist_id.in_(
+                        select(Playlist.playlist_id).where(
+                            Playlist.playlist_type == "watch_later",
+                            Playlist.playlist_id != WATCH_LATER,
+                        )
+                    )
+                )
+            )
+            await session.execute(
+                delete(Playlist).where(
+                    Playlist.playlist_type == "watch_later",
+                    Playlist.playlist_id != WATCH_LATER,
+                )
+            )
+            await session.flush()
+
+            overview = await get_library_overview(session)
+            assert overview["watch_later"]["playlist_id"] == WATCH_LATER, (
+                "with exactly one Watch Later playlist the link target is "
+                "unambiguous and must be offered"
+            )
+        finally:
+            await session.rollback()
+
+    async with integration_db_session() as session:
+        try:
+            session.add(
+                Playlist(
+                    playlist_id="WLoverview2",
+                    title="second queue",
+                    description="d",
+                    video_count=0,
+                    privacy_status="private",
+                    playlist_type="watch_later",
+                )
+            )
+            await session.flush()
+
+            overview = await get_library_overview(session)
+            assert overview["watch_later"] is not None
+            assert overview["watch_later"]["playlist_id"] is None, (
+                "with two Watch Later playlists the depth spans both — linking "
+                "to either would land on a count that differs from the figure "
+                "the user clicked"
+            )
+        finally:
+            await session.rollback()
+
+
+async def test_watch_later_link_lands_on_the_permissive_availability_count(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T058 / FR-025 — clicking a number must not land on a different number.
+
+    The dashboard applies no availability condition at all. The playlist videos
+    endpoint happens to default ``include_unavailable=True``, so the link agrees
+    with the figure *without* carrying an explicit parameter — the opposite of
+    the videos-list link, where the default is restrictive and FR-018b forced one
+    on. Two endpoints, two opposite defaults, and the dashboard link is correct
+    only because of which one it happens to hit.
+
+    This pins that default rather than the resulting number, so it holds however
+    many Watch Later playlists the shared database contains: if the default ever
+    flips to False "for consistency", the link silently starts under-reporting
+    and this fails.
+    """
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    async def total(query: str) -> int:
+        with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            response = await async_client.get(
+                f"/api/v1/playlists/{WATCH_LATER}/videos?watched_status=unwatched"
+                f"&limit=1{query}"
+            )
+        assert response.status_code == 200, response.text
+        return int(response.json()["pagination"]["total"])
+
+    # Exactly the URL the dashboard links to — no availability parameter.
+    as_linked = await total("")
+    permissive = await total("&include_unavailable=true")
+    restrictive = await total("&include_unavailable=false")
+
+    assert as_linked == permissive, (
+        "the dashboard counts unavailable videos, so the page it links to must "
+        "too — otherwise the user clicks one number and lands on a smaller one"
+    )
+    # Non-vacuity: the corpus really does contain an unwatched, unavailable
+    # video in Watch Later, so the two availability modes genuinely differ.
+    # Without this the assertion above would hold under either default.
+    assert restrictive < permissive, (
+        "the corpus must distinguish the two availability modes, or this test "
+        "passes no matter which default the endpoint uses"
+    )
+
+
+async def test_absent_watch_later_is_null_not_zero(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T051 / FR-020a — no Watch Later playlist yields null, not a zero depth.
+
+    A present-but-empty queue is ``{total: 0, unwatched: 0}``. Rendering both as
+    zeros would tell someone who has no Watch Later that their queue is empty.
+
+    The integration database is shared and never reset, so the absence is staged
+    inside a transaction that is rolled back: every Watch Later playlist is
+    removed, the repository function is called on that same session so it reads
+    the uncommitted state, then the transaction is discarded.
+    """
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    async with integration_db_session() as session:
+        wl_ids = (
+            (
+                await session.execute(
+                    select(Playlist.playlist_id).where(
+                        Playlist.playlist_type == "watch_later"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert wl_ids, "precondition: the corpus has at least one Watch Later playlist"
+
+        try:
+            await session.execute(
+                delete(PlaylistMembership).where(
+                    PlaylistMembership.playlist_id.in_(wl_ids)
+                )
+            )
+            await session.execute(
+                delete(Playlist).where(Playlist.playlist_id.in_(wl_ids))
+            )
+            await session.flush()
+
+            overview = await get_library_overview(session)
+
+            assert overview["watch_later"] is None, (
+                "absence of a Watch Later playlist must be null — a zero depth "
+                "means the queue exists and is empty"
+            )
+            # The rest of the dashboard still resolves with the queue absent.
+            assert overview["saved_and_forgotten"] >= 0
+            assert all(
+                row["playlist_type"] != "watch_later"
+                for row in overview["playlist_inventory"]
+            )
+        finally:
+            await session.rollback()
+
+    # The rollback left the shared corpus intact for every other test.
+    async with integration_db_session() as session:
+        still_there = (
+            await session.execute(
+                select(func.count())
+                .select_from(Playlist)
+                .where(Playlist.playlist_type == "watch_later")
+            )
+        ).scalar_one()
+    assert still_there == len(wl_ids)
+
+
+async def test_present_but_empty_watch_later_is_zero_not_null(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T051 / FR-020a — the other side of the distinction.
+
+    Without this, ``watch_later: null`` could be returned for an existing but
+    empty queue and the test above would still pass.
+    """
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    async with integration_db_session() as session:
+        wl_ids = (
+            (
+                await session.execute(
+                    select(Playlist.playlist_id).where(
+                        Playlist.playlist_type == "watch_later"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        try:
+            # Empty the queue but keep the playlist itself.
+            await session.execute(
+                delete(PlaylistMembership).where(
+                    PlaylistMembership.playlist_id.in_(wl_ids)
+                )
+            )
+            await session.flush()
+
+            overview = await get_library_overview(session)
+
+            assert overview["watch_later"] is not None, (
+                "a playlist that exists but holds nothing is a zero depth, "
+                "never null"
+            )
+            assert overview["watch_later"]["total"] == 0
+            assert overview["watch_later"]["unwatched"] == 0
+        finally:
+            await session.rollback()
+
+
+async def test_liked_figure_is_a_video_attribute_not_a_playlist_type(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """FR-023, FR-023a — the two `liked` quantities stay distinct.
+
+    A `liked` *playlist type* counts playlists; `rollup.liked_videos` counts
+    videos carrying the liked attribute. They come from different tables and
+    must not be conflated.
+    """
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    data = await _overview(async_client)
+
+    assert "liked_videos" in data["rollup"]
+    # The inventory row counts playlists (1), not videos.
+    by_type = {row["playlist_type"]: row for row in data["playlist_inventory"]}
+    assert by_type["liked"]["playlist_count"] == 1
+
+
+async def test_dashboard_figure_and_filtered_list_agree(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T030 / FR-018b, FR-029c — the two consumers of one derivation.
+
+    They agree under the *same availability context*. The videos list hides
+    unavailable videos by default while the dashboard applies no availability
+    condition, so the comparison passes `include_unavailable=true` — which is
+    exactly what the dashboard's link must carry (FR-018).
+    """
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    data = await _overview(async_client)
+
+    with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+        mock_oauth.is_authenticated.return_value = True
+        response = await async_client.get(
+            "/api/v1/videos?saved_unwatched=true&include_unavailable=true&limit=1"
+        )
+    assert response.status_code == 200, response.text
+    list_total = response.json()["pagination"]["total"]
+
+    assert list_total == data["saved_and_forgotten"], (
+        "the dashboard headline and the filtered list must agree — they share "
+        "one derivation (FR-029b), so a mismatch means a surrounding filter "
+        "differs, not that the definition drifted"
+    )

--- a/tests/integration/api/test_playlist_watched.py
+++ b/tests/integration/api/test_playlist_watched.py
@@ -1,0 +1,290 @@
+"""Integration tests for per-playlist watched/unwatched stats and filtering.
+
+Feature 061, User Story 1 (T009, T010, T011, T011a).
+
+The central thing under test is that the response carries **two different
+counts** and that they move independently:
+
+- ``stats.playlist_total`` — the size of the playlist under the *other* filters,
+  frozen with respect to the watched filter (FR-005b)
+- ``pagination.total`` — the result count for the current view, which tracks the
+  watched filter (FR-005c)
+
+An implementation that makes these equal has broken FR-005b; one that makes the
+header shrink with the filter has broken it the other way. A spec review caught
+exactly that ambiguity, so these are asserted separately and never conflated.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import (
+    Channel,
+    Playlist,
+    PlaylistMembership,
+    UserVideo,
+    Video,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+CHANNEL = "UCwatchedtest0000000000"
+T0 = datetime(2024, 1, 1, tzinfo=UTC)
+
+# Curated playlist: 4 videos — 2 watched (one of them via a DUPLICATE pair of
+# watch rows), 2 unwatched (one of which has a row with a NULL watched_at).
+CURATED = "PLwatchedtest001"
+WATCH_LATER = "WLwatchedtest001"
+HISTORY = "HLwatchedtest001"
+EMPTY = "PLwatchedtestempty"
+
+
+async def _seed(session: AsyncSession) -> None:
+    """Seed the shared corpus once.
+
+    The integration database is not reset between tests in this suite, so this
+    is idempotent: every test calls it, and only the first one writes.
+    """
+    existing = await session.execute(
+        select(Channel.channel_id).where(Channel.channel_id == CHANNEL)
+    )
+    if existing.scalar_one_or_none() is not None:
+        return
+
+    session.add(Channel(channel_id=CHANNEL, title="T", description="d"))
+    for vid in ("vw_watched1", "vw_watched2", "vw_unwatch1", "vw_unwatch2"):
+        session.add(
+            Video(
+                video_id=vid,
+                channel_id=CHANNEL,
+                title=vid,
+                description="d",
+                upload_date=T0,
+                duration=60,
+            )
+        )
+
+    for pid, ptype in (
+        (CURATED, "regular"),
+        (WATCH_LATER, "watch_later"),
+        (HISTORY, "history"),
+        (EMPTY, "regular"),
+    ):
+        session.add(
+            Playlist(
+                playlist_id=pid,
+                title=pid,
+                description="d",
+                video_count=0,
+                privacy_status="private",
+                playlist_type=ptype,
+            )
+        )
+
+    for pos, vid in enumerate(
+        ("vw_watched1", "vw_watched2", "vw_unwatch1", "vw_unwatch2")
+    ):
+        session.add(PlaylistMembership(playlist_id=CURATED, video_id=vid, position=pos))
+    # Watch Later holds one watched and one unwatched video — the real-world
+    # case: YouTube does not remove a video from the queue once watched.
+    session.add(
+        PlaylistMembership(playlist_id=WATCH_LATER, video_id="vw_watched1", position=0)
+    )
+    session.add(
+        PlaylistMembership(playlist_id=WATCH_LATER, video_id="vw_unwatch1", position=1)
+    )
+    # History is trivially all-watched.
+    session.add(
+        PlaylistMembership(playlist_id=HISTORY, video_id="vw_watched2", position=0)
+    )
+
+    # vw_watched1 has TWO watch-history rows. FR-002: counts are per distinct
+    # video and must not inflate. Feature 060 makes this unreachable in practice,
+    # but the counting must not depend on that guarantee.
+    session.add(
+        UserVideo(user_id="u_a", video_id="vw_watched1", watched_at=T0, rewatch_count=0)
+    )
+    session.add(
+        UserVideo(user_id="u_b", video_id="vw_watched1", watched_at=T0, rewatch_count=0)
+    )
+    session.add(
+        UserVideo(user_id="u_a", video_id="vw_watched2", watched_at=T0, rewatch_count=0)
+    )
+    # A row with NO watch timestamp counts as unwatched, identical to no row.
+    session.add(
+        UserVideo(
+            user_id="u_a", video_id="vw_unwatch1", watched_at=None, rewatch_count=0
+        )
+    )
+    await session.commit()
+
+
+async def _get(client: AsyncClient, playlist: str, **params: object) -> dict:
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+        mock_oauth.is_authenticated.return_value = True
+        response = await client.get(f"/api/v1/playlists/{playlist}/videos?{qs}")
+    assert response.status_code == 200, response.text
+    return dict(response.json())
+
+
+async def test_counts_are_per_distinct_video_and_duplicate_safe(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T009 / FR-029, FR-002."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    body = await _get(async_client, CURATED, limit=50)
+    stats = body["stats"]
+
+    # 4 distinct videos; vw_watched1 has two watch rows and must count once.
+    assert stats["playlist_total"] == 4
+    assert stats["watched"] == 2
+    assert stats["unwatched"] == 2
+    assert stats["watched"] + stats["unwatched"] == stats["playlist_total"]
+
+
+async def test_each_filter_value_returns_exactly_the_right_videos(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T009 / FR-029."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    watched = await _get(async_client, CURATED, watched_status="watched", limit=50)
+    unwatched = await _get(async_client, CURATED, watched_status="unwatched", limit=50)
+
+    assert {v["video_id"] for v in watched["data"]} == {"vw_watched1", "vw_watched2"}
+    assert {v["video_id"] for v in unwatched["data"]} == {"vw_unwatch1", "vw_unwatch2"}
+    # Per-row flag (FR-009) agrees with the filter. Note this pair is weak on its
+    # own: under a filter the endpoint derives the flag *from* the filter rather
+    # than re-querying, so these can no longer disagree. The unfiltered
+    # assertion below is the one that actually tests the flag.
+    assert all(v["watched"] is True for v in watched["data"])
+    assert all(v["watched"] is False for v in unwatched["data"])
+
+
+async def test_unfiltered_page_flags_match_an_independent_query(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """FR-009 — the per-row flag is verified against the database, not the filter.
+
+    Under ``watched_status=watched|unwatched`` the endpoint knows every row's
+    state from the WHERE clause it just applied, so it does not re-query, and an
+    assertion that those rows carry the matching flag cannot fail. The unfiltered
+    page is the only one that can hold a mix, so it is the only place the flag is
+    genuinely derived — and it is checked here against watch history read
+    directly, not against anything the endpoint computed.
+    """
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    page = await _get(async_client, CURATED, limit=50)
+    assert len(page["data"]) >= 4, "the mixed corpus must actually be mixed"
+
+    async with integration_db_session() as session:
+        truth = {
+            row[0]
+            for row in (
+                await session.execute(
+                    select(UserVideo.video_id).where(UserVideo.watched_at.is_not(None))
+                )
+            ).all()
+        }
+
+    for item in page["data"]:
+        assert item["watched"] is (item["video_id"] in truth), (
+            f"{item['video_id']}: endpoint said watched={item['watched']}, "
+            f"watch history says {item['video_id'] in truth}"
+        )
+
+    # And the page really did contain both states, or the loop proved nothing.
+    states = {item["watched"] for item in page["data"]}
+    assert states == {True, False}
+
+
+async def test_header_is_frozen_while_result_count_tracks_the_filter(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T010 / FR-029a, FR-005b, FR-005c — the two quantities, asserted apart."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    expected_stats = {"playlist_total": 4, "watched": 2, "unwatched": 2}
+    expected_result_counts = {"all": 4, "watched": 2, "unwatched": 2}
+
+    for status, expected_total in expected_result_counts.items():
+        body = await _get(async_client, CURATED, watched_status=status, limit=50)
+        assert (
+            body["stats"] == expected_stats
+        ), f"header must not change with watched_status={status} (FR-005b)"
+        assert (
+            body["pagination"]["total"] == expected_total
+        ), f"result count must track watched_status={status} (FR-005c)"
+
+
+async def test_stats_narrow_with_other_filters_but_not_the_watched_filter(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T011 / FR-005a."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    # has_transcript matches nothing in this corpus, so it must narrow the header
+    # to zero — proving the stats honour filters other than watched_status.
+    narrowed = await _get(async_client, CURATED, has_transcript="true", limit=50)
+    assert narrowed["stats"]["playlist_total"] == 0
+    assert narrowed["stats"]["watched"] == 0
+    assert narrowed["stats"]["unwatched"] == 0
+
+
+async def test_behaves_identically_on_watch_later_and_history(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T011a / FR-008 — same header and filter on every playlist type."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    wl = await _get(async_client, WATCH_LATER, limit=50)
+    assert wl["stats"] == {"playlist_total": 2, "watched": 1, "unwatched": 1}
+
+    # History is trivially all-watched; its Unwatched view is empty, not an error.
+    hist = await _get(async_client, HISTORY, watched_status="unwatched", limit=50)
+    assert hist["stats"] == {"playlist_total": 1, "watched": 1, "unwatched": 0}
+    assert hist["data"] == []
+    assert hist["pagination"]["total"] == 0
+
+
+async def test_empty_playlist_renders_zeroed_header(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """T011a / FR-013."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    body = await _get(async_client, EMPTY, limit=50)
+    assert body["stats"] == {"playlist_total": 0, "watched": 0, "unwatched": 0}
+    assert body["data"] == []
+
+
+async def test_invalid_watched_status_is_rejected(
+    async_client: AsyncClient, integration_db_session
+) -> None:
+    """Enum validation — the API rejects what the UI must never send."""
+    async with integration_db_session() as session:
+        await _seed(session)
+
+    with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+        mock_oauth.is_authenticated.return_value = True
+        response = await async_client.get(
+            f"/api/v1/playlists/{CURATED}/videos?watched_status=bogus"
+        )
+    assert response.status_code == 422

--- a/tests/unit/api/routers/test_playlists.py
+++ b/tests/unit/api/routers/test_playlists.py
@@ -37,8 +37,13 @@ def _make_mock_session() -> AsyncMock:
     """
     mock_session = AsyncMock(spec=AsyncSession)
 
-    # Create a mock result that handles playlist lookup (scalar_one_or_none)
-    # and video query (all)
+    # The first execute() is always the playlist existence check; every later
+    # one is configured with a safe empty answer for each accessor the endpoint
+    # might use. Dispatching purely on call *number* made this fixture brittle:
+    # Feature 061 inserted a stats aggregate before the count query and shifted
+    # every subsequent case by one, breaking 14 tests that had nothing to do
+    # with the change. Answering by accessor instead of by position means adding
+    # a query no longer renumbers anything.
     call_count = 0
 
     async def mock_execute(query, *args, **kwargs):
@@ -48,15 +53,17 @@ def _make_mock_session() -> AsyncMock:
         result = MagicMock()
 
         if call_count == 1:
-            # First call: playlist existence check
+            # Playlist existence check
             result.scalar_one_or_none.return_value = "PLtest1234567890abcdefgh"
-        elif call_count == 2:
-            # Second call: count query
-            result.scalar.return_value = 0
-        else:
-            # Third call: main query -> empty result
-            result.all.return_value = []
+            return result
 
+        # Aggregate row, e.g. the watched stats header: (playlist_total, watched)
+        result.one.return_value = (0, 0)
+        # Scalar count query
+        result.scalar.return_value = 0
+        # Row-returning queries
+        result.all.return_value = []
+        result.fetchall.return_value = []
         return result
 
     mock_session.execute = AsyncMock(side_effect=mock_execute)

--- a/tests/unit/repositories/test_watched_video_ids.py
+++ b/tests/unit/repositories/test_watched_video_ids.py
@@ -1,0 +1,67 @@
+"""Shape tests for the shared watched-video derivation (Feature 061, T006).
+
+``watched_video_ids()`` is the single definition of "watched" on the read side.
+These tests pin the three properties it exists to guarantee — correctness,
+duplicate-safety, and the non-correlated form — because the correlated
+alternative returns *identical results* 370x slower, so no value assertion can
+distinguish them (research R1).
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy.dialects import postgresql
+
+from chronovista.repositories.user_video_repository import watched_video_ids
+
+
+def _sql() -> str:
+    """Compile the subquery to PostgreSQL SQL with whitespace collapsed."""
+    raw = str(
+        watched_video_ids().compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    return re.sub(r"\s+", " ", raw).strip().lower()
+
+
+def test_selects_video_id_from_user_videos() -> None:
+    sql = _sql()
+    assert "select" in sql
+    assert "user_videos.video_id" in sql
+    assert "from user_videos" in sql
+
+
+def test_filters_on_watched_at_not_membership() -> None:
+    """FR-001: watched-status comes from the watch timestamp, never membership."""
+    sql = _sql()
+    assert "user_videos.watched_at is not null" in sql
+    assert (
+        "playlist_membership" not in sql
+    ), "watched-status must never be derived from playlist membership"
+
+
+def test_is_distinct_so_duplicate_watch_rows_cannot_inflate() -> None:
+    """FR-002: counts must not depend on one watch-history row per video."""
+    assert "distinct" in _sql()
+
+
+def test_is_not_correlated() -> None:
+    """Research R1: the correlated form measured 25,676 ms vs 69 ms.
+
+    A correlated subquery references the outer query's tables. This one must
+    reference ``user_videos`` and nothing else, so PostgreSQL evaluates it once
+    rather than once per candidate row.
+
+    Table references are compared as whole names rather than by substring —
+    ``"videos." in sql`` is true of ``user_videos.video_id`` and would pass
+    vacuously.
+    """
+    sql = _sql()
+    qualifiers = set(re.findall(r"\b(\w+)\.\w+", sql))
+    assert qualifiers == {"user_videos"}, (
+        f"subquery references {qualifiers - {'user_videos'}} besides user_videos — "
+        "it is correlated and will be re-evaluated per row (research R1)"
+    )


### PR DESCRIPTION
## Summary

"Watched" and "saved in a playlist" are independent facts, and the UI could not tell them apart. Watched-status derives **solely** from `user_videos.watched_at` and is never inferred from playlist membership — YouTube does not remove watched videos from Watch Later, so a playlist legitimately holds a mix.

**Per-playlist (US1).** Each playlist detail page gains a `total / watched / unwatched` header and an All / Watched / Unwatched filter. The header describes the whole playlist and deliberately does **not** move with the filter, while the result count does — two quantities asserted separately, because conflating them is the easy bug. The filter lives in the address as `?watched_status=`, so a filtered view is shareable and the dashboard has something to deep-link into.

**Dashboard (US2/US3).** New `/overview` page headlined by **Saved & Forgotten** — 609 on this library — plus Watch Later depth, a playlist inventory by type, and library rollups. One request serves every figure, so the numbers cannot disagree with each other.

**API.** New `GET /api/v1/overview`; `GET /playlists/{id}/videos` gains `watched_status`, a `stats` object, and `watched: bool` per item; `GET /videos` gains `saved_unwatched`.

Read-only throughout: **no migration, no schema change, no write path, no CLI change.**

## Query shape is the whole story

Measured on production (89,465 memberships, 51,271 watch rows). Each pair returns **identical numbers**, so a test asserting only values cannot tell them apart:

| | Slow form | Shipped form |
|---|---|---|
| Playlist header | correlated `EXISTS` — **25,676 ms** | non-correlated `IN` — **69 ms** |
| Dashboard | `LEFT JOIN LATERAL` per row — **50,893 ms** | CTE form — **131 ms** |

Two follow-ons:

- The CTEs are deliberately **not** `MATERIALIZED`. Each is referenced once, so PostgreSQL inlines them and plans across the boundary. A review flagged the missing hint as a contract deviation; adding it measured **slower** (~134 ms vs ~85 ms), so the code stayed and the docstring and binding contract note were corrected instead. The win over LATERAL came from removing per-row correlation, not from an optimisation fence.
- Under a watched filter the per-page watched lookup is skipped entirely — the page's rows already satisfy the `WHERE` clause, so re-querying asks the database to rediscover what it just proved.

**Measured:** `/overview` **91–102 ms** (SC-010 budget 2 s); playlist page **50–99 ms** across all three filter values (SC-008 budget 1 s).

## Guards against the failure modes this feature invites

- **One derivation.** Saved & Forgotten is defined once and consumed by both the dashboard and the videos-list filter, so the equality test is a backstop rather than the mechanism. (A review caught the dashboard re-expressing it inline; fixed.)
- **"Curated" is tested positively** as `playlist_type = 'regular'`, so `liked` and `favorites` — types the enum defines but this feature never names — are excluded automatically. `is_system` is likewise derived as "not regular", never from a hardcoded pair. Both halves are guarded by a test that seeds a `liked` playlist.
- **The inventory is a tripwire**, produced by `GROUP BY` over whatever exists, so a playlist type introduced later becomes visible rather than silently absent.
- **The dashboard link carries `include_unavailable=true`.** The figure applies no availability condition while `/videos` hides unavailable videos by default — without it a user clicks 609 and lands on 586.
- **Duplicate-safe counting** per distinct `video_id`, not assuming one `user_videos` row per video.

## Corrections to the spec, made from real data

- **The History playlist is not "trivially all-watched."** It holds 2,997 videos of which **116 have no watch record** — the Takeout playlist export and the watch-history import are separate sources and need not agree. A non-empty Unwatched view for History is correct output, not a bug to be "fixed" by inferring watched-status from membership.
- **FR-025 was unsatisfiable as written**: it required the Watch Later figure to link to that playlist, but the contract carried no playlist id. Added, with a guard — the id is offered only when exactly one Watch Later playlist exists, since the depth spans all of them and no single playlist would match the number clicked.

## Accessibility

Keyboard-operable tablist (arrow/Home/End) with an exposed selected value; result-count changes announced through a live region; watched state carried by **text**, never colour alone; dashboard figures bound to their labels via `dl`/`dt`/`dd`; system lists marked with the words "System list". The page title is an `h2` — `layout/Header.tsx` owns the document's single `h1`, and a page-level `h1` would have given the document two top-level headings.

## Verification

- Backend **6,750 unit** + **1,231 integration** pass; frontend **166 files / 3,808** pass
- `ruff` · `black` · `mypy --strict` (241 files) · `npm run typecheck` — all clean
- `quickstart.md` executed against production: **20/20**
- Rebuilt and verified live in the container at `:8765` (health reports 0.61.0; restyle and both deep links confirmed present in the shipped bundle)
- Non-vacuity checked by mutation: availability default flipped, shortcut mislabels rows, watched badge by colour alone, count no longer announced, inventory drops unknown types, link ignores ambiguity, `is_system` from a named pair, curated as negative enumeration, WL always/never null, page title reverted to `h1` — **all caught**

## Filed during this work

- **#160** — `make quality` cannot pass and diverges from CI (redundant `isort`, plus `mypy` over `tests/`); the three actual CI gates are green
- **#161** — `user_videos` lacks an index on `video_id`; deliberately not fixed here because it needs a migration, which this feature's scope fence forbids

## Note for the reviewer

`Makefile` has an unrelated uncommitted change in my working tree (removing `test-models` / `validate-schema` targets that point at scripts which no longer exist). It is **not** part of this PR.

Versions: backend **0.61.0**, frontend **0.28.0**.
