### PR TITLE
feat(entities): intersect a set of entities, exclude entities, and discover connections (Feature 062)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,12 +82,6 @@ help:
 	@echo "  dev-migrate       - Run migrations on development database"
 	@echo "  dev-revision      - Create migration using development database"
 	@echo ""
-	@echo "Schema Validation:"
-	@echo "  test-models       - Test database models (use DEVELOPMENT_MODE=true for dev DB)"
-	@echo "  test-models-dev   - Test models using development database"
-	@echo "  validate-schema   - Validate schema with real YouTube API data"
-	@echo "  validate-schema-takeout - Validate using Takeout + API data"
-	@echo ""
 	@echo "CI/CD:"
 	@echo "  ci                - Run full CI pipeline (quality + tests)"
 	@echo "  ci-quality        - Run quality checks with CI-friendly output"
@@ -372,30 +366,6 @@ dev-full-reset: dev-db-reset dev-migrate
 	@echo "🧪 Test database: postgresql://dev_user:dev_password@localhost:5434/chronovista_integration_test"
 
 # Test database models
-test-models:
-	@echo "🧪 Testing database models..."
-	@echo "💡 Use: DEVELOPMENT_MODE=true make test-models (for development database)"
-	python scripts/test_models.py
-
-test-models-dev:
-	@echo "🧪 Testing database models with development database..."
-	DEVELOPMENT_MODE=true python scripts/test_models.py
-
-validate-schema:
-	@echo "🔍 Validating database schema with real YouTube API data..."
-	@echo "💡 This will use your development database and real YouTube API data"
-	@echo "📋 Make sure you're authenticated: poetry run chronovista auth login"
-	@echo ""
-	DEVELOPMENT_MODE=true $(POETRY_RUN) python scripts/validate_database_schema.py
-
-validate-schema-takeout:
-	@echo "🔍 Enhanced validation using Takeout data + YouTube API..."
-	@echo "💡 This combines your Google Takeout data with YouTube API data"
-	@echo "📋 Make sure you're authenticated: poetry run chronovista auth login"
-	@echo "📊 Using recommended channels from Takeout analysis"
-	@echo ""
-	DEVELOPMENT_MODE=true $(POETRY_RUN) python scripts/validate_schema_with_takeout.py
-
 # Documentation targets
 install-docs:
 	@echo "📚 Installing documentation dependencies..."

--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ See the [Architecture Overview](https://aucontraire.github.io/chronovista/archit
 
 ### Engineering Practice
 
-The codebase is governed by a versioned constitution that enforces production standards on AI-collaborated code: strict typing (mypy strict, zero `Any`), Pydantic-first modeling, the repository pattern, and explicit anti-slop constraints — minimal-diff, file and abstraction budgets, and the Rule of Three against premature abstraction.
+The codebase holds production standards for AI-collaborated code, enforced in CI: strict typing (mypy strict, zero `Any` in public APIs), Pydantic-first modeling, the repository pattern with async I/O throughout, `black` and `ruff` formatting gates, and >90% test coverage. Anti-slop constraints are explicit — minimal diffs, file and abstraction budgets, and the Rule of Three against premature abstraction.
 
-It is a living document shaped by post-mortems rather than written up front: v1.1.0 added Cross-Feature Data Contract Verification after integration bugs in Features 030–032 exposed a gap at the seam *between* features, and a multi-tier sub-agent review enforces compliance at PR time.
+The standard that took longest to learn is **cross-feature data contract verification**. A mutation that changes data ownership must be re-queried through every downstream consumer path, and a mock test for an UPDATE must inspect the SQL `SET` clause rather than the return value — a column silently absent from `SET` returns success while writing nothing. This was added after integration bugs in Features 030–032 exposed a gap at the seam *between* features, where each side was individually correct. The tests enforcing it are in `tests/unit/api/test_entity_update_sql_columns.py` and `tests/integration/api/test_entity_rename_cross_feature.py`.
 
 ## Development
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -40,6 +40,7 @@ All endpoints except `/health` require authentication. The API shares OAuth toke
 | `/videos/{id}/transcript/segments/{seg_id}/corrections/revert` | POST | Revert latest segment correction |
 | `/videos/{id}/playlists` | GET | Playlists containing video |
 | `/videos/{id}/entities` | GET | Entity mentions in video |
+| `/videos?entity_id=` | GET | Videos mentioning **all** listed entities (repeat the key; add `exclude_entity_id` and `min_evidence`) |
 | `/videos/{id}/alternative-url` | PATCH | Set alternative URL for unavailable video |
 | `/channels` | GET | List channels |
 | `/channels/{id}` | GET | Get channel details |
@@ -64,6 +65,7 @@ All endpoints except `/health` require authentication. The API shares OAuth toke
 | `/entities/{id}` | GET | Get entity details |
 | `/entities/{id}/videos` | GET | Videos mentioning entity |
 | `/entities/{id}/aliases` | POST | Add alias to entity |
+| `/entities/{id}/co-occurring` | GET | Entities sharing videos with this entity |
 | `/corrections/batch/preview` | POST | Preview batch find-replace matches |
 | `/corrections/batch/apply` | POST | Apply batch corrections to selected segments |
 | `/corrections/batch/rebuild-text` | POST | Rebuild transcript text for affected videos |

--- a/docs/architecture/frontend-architecture.md
+++ b/docs/architecture/frontend-architecture.md
@@ -164,6 +164,16 @@ Transcript segments load in batches (50 initial, then 25 per page) using `useInf
 ### Deep Link Navigation
 Search results link to specific transcript timestamps via URL parameters (`?t=90&lang=en`). The `seekToTimestamp` function uses the backend's `start_time` filter for precise segment loading without offset estimation.
 
+### Entity Type Identity — one pill, two contents
+Entity type colours live in exactly one place (`constants/entityTypes.ts`) and reach every surface through two components, chosen by what the surface is *doing*:
+
+- **`EntityTypeBadge`** puts the **type** in the pill ("Person", "Place"). Used where the type is the subject — the entities list, the entity detail header. These are the legend: they teach the convention.
+- **`EntityName`** puts the entity's **name** in the same pill, in that type's colour. Used everywhere the entity is an attribute of something else — filter pills, result rows, the appears-with panel, the video-page mention chips.
+
+Both resolve colour through a shared `entityTypeColors()` helper rather than inlining `COLORS[x] ?? FALLBACK`, because that inline expression is how a palette forks: one site forgets the fallback, or picks a different neutral.
+
+The tradeoff is deliberate and recorded: on shorthand surfaces the type is carried by colour plus visually-hidden text, so screen readers keep it everywhere but greyscale users lose the distinction away from the legend pages.
+
 ### API Client Strategy
 The project uses a hybrid approach:
 - **Orval** generates typed hooks from the OpenAPI spec for stable endpoints

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.0] - 2026-08-04
+
+### Added
+- **Entity intersection — find the videos where several entities all appear (Feature 062).** Entity filtering was single-entity only, so the library could tell you everything mentioning one person but not what two people had in **common** — the entry point to most relationship-oriented questions it can answer.
+  - **Set filter on the videos list.** "Mentions all of" accepts several entities and returns only the videos where every one of them has a qualifying mention. An AND across entities, so adding one always narrows. Sets of three and four are ordinary rather than exceptional: 7,062 videos in a real library carry three or more distinct entities. Each result row shows, per entity, its mention count and the timestamp of its **first** mention — and shows nothing rather than a misleading `0:00` when an entity appears only in a title or description and therefore has no position in time.
+  - **Exclusion.** An OR across excluded entities, in deliberate contrast to the required set's AND: a video mentioning any of them is removed regardless of how many required entities it matches. Works with an empty required set, which answers a different question — "everything that isn't about this". An entity present in both sets is rejected with an explanation rather than silently returning nothing.
+  - **Evidence scope (`min_evidence`).** A "transcript only" toggle requiring the entity was actually *said*, not merely listed in metadata. Expressed over mention **source** only, never detection method: the two are orthogonal, and every manually added or user-corrected mention is transcript-sourced, so restricting to transcript retains all of them rather than discarding the highest-trust evidence in the system. The scope applies symmetrically to exclusion — measured against production, excluding the most-mentioned entity removes 8,496 videos under the default scope and 870 under transcript-only, so applying it to one side and not the other would mean a single request in which the same video both does and does not mention an entity.
+  - **"Appears with" panel.** On each entity's detail page, the entities sharing the most videos with it. Activating one opens that exact pairing on the videos list. **The count shown equals the total landed on** — both derive from the same qualification rule *and* the same video population, which is what makes the promise hold. Loads independently of the page, since it is the slowest query in the feature and computing it synchronously would penalise precisely the well-connected entities people open most.
+  - **Relevance ordering.** Ranks by combined mention volume, tiebroken by video id so pagination cannot duplicate or drop a row. Auto-selected only when an entity filter is active *and* no sort was chosen; an explicit choice always wins.
+  - **Shareable addresses.** Required entities, exclusions and the evidence scope all live in the URL, so a filtered view survives refresh, back-navigation and copy-paste. Entity names are re-fetched from the ids on load, so a bookmarked link shows names rather than UUIDs.
+
+### Changed
+- **Entity type colours are now uniform across every surface.** One pill shape with two contents: the Entities page and entity detail header put the *type* in it (the legend that teaches the convention), and every other surface puts the entity's *name* in the same colour. The video-page mention chips previously rendered **every** entity in indigo regardless of type, directly contradicting the convention the Entities page teaches — a place, an organization and a person looked identical. The palette now has one definition point, consumed by four call sites; two components and one page previously carried private copies, one of which was missing two types and mis-cased a third.
+- `sort_by` on `GET /api/v1/videos` now carries a distinct unset state so "caller sent nothing" is distinguishable from "caller explicitly chose upload_date". Behaviour for existing callers is unchanged; the OpenAPI default moves from `"upload_date"` to a nullable schema.
+- `ApiError` now carries the server's RFC 7807 `detail`, so a rejected filter can name the value it rejected instead of showing a generic message.
+
+### Fixed
+- Entity filter changes did not refresh the videos list — the request URL was correct but the TanStack Query key omitted the entity parameters, so a cached unfiltered result was served until a hard reload. The filter-panel count had the same shape of bug from a separate call that omitted several filters entirely.
+- The "appears with" panel linked to `/?entity_id=…`, and the root is an index route whose redirect carries no query string, so every parameter was dropped on landing.
+
+
 ## [0.61.0] - 2026-08-03
 
 ### Added

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -114,6 +114,29 @@ Project-specific terminology used throughout chronovista documentation and code.
 **Diacritic Collision**
 :   A canonical tag group where raw forms differ by accents that were stripped during Tier 1 normalization. For example, "café" and "cafe" both normalize to "cafe" and get merged. The `tags collisions` command identifies these for manual review — most are correct merges, but some may need splitting.
 
+## Entity Intersection Concepts
+
+**Intersection**
+:   The set of videos in which *every* requested entity has at least one qualifying mention. An AND across entities — adding one always narrows the result. Distinct from the single-entity filter, which asks about one entity at a time.
+
+**Required entity**
+:   An entity that must be present for a video to appear in the result. Qualification and all counts are per distinct video and per distinct entity, so duplicate mention rows cannot make a video qualify for an entity it never mentions.
+
+**Excluded entity**
+:   An entity whose presence disqualifies a video, regardless of the required set. An OR across the excluded set, in deliberate contrast to the AND of the required one. Works with an empty required set, which answers "everything that isn't about this".
+
+**Evidence scope**
+:   The constraint on which mentions count toward an intersection. Expressed over mention **source** only — transcript, title, description — never detection method. The two are orthogonal: every manually added and user-corrected mention is transcript-sourced, so restricting to transcript retains all of them rather than discarding the highest-trust evidence in the system. Exposed as `min_evidence`, named for the graded confidence threshold it may later become.
+
+**Qualifying mention**
+:   A mention satisfying the active evidence scope. One definition applied to both sides of a filter: under a restricted scope, a video whose only mention of an excluded entity falls outside that scope is not disqualified.
+
+**Relevance ordering**
+:   Ranking by combined mention volume across the requested entities, tiebroken by video id so the order is total and pagination cannot duplicate or drop a row. Auto-selected when an entity filter is active and no sort was chosen; an explicit choice is never overridden. Favours longer videos, which is accepted as the honest reading of "most about these entities".
+
+**Co-occurrence**
+:   The count of distinct videos two entities share, powering the "appears with" panel. Computed over the same video population the videos list shows, so the count displayed equals the total of the intersection it opens.
+
 ## Transcript Correction Concepts
 
 **Transcript Correction**

--- a/docs/user-guide/entity-intersection.md
+++ b/docs/user-guide/entity-intersection.md
@@ -1,0 +1,126 @@
+# Find what entities have in common
+
+Filter your library to the videos where **several entities all appear**, exclude the ones you don't want, and discover connections you didn't know to look for.
+
+## Overview
+
+Entity filtering used to be single-entity only: you could browse everything mentioning one person, but not ask what two people have in **common**. That question is the entry point to most relationship-oriented things a library can tell you — which episodes cover both a person and a place, which conversations bring two guests together, which videos discuss a topic without ever mentioning the obvious counterpart.
+
+This guide covers three things:
+
+- Filtering the videos list to an **intersection** of entities
+- **Excluding** entities to cut noise out of a result
+- Following the **"appears with"** panel to find connections
+
+Everything here is read-only. Nothing you do changes a mention, an entity, or a video.
+
+## Filter to an intersection
+
+On the **Videos** page, open the filter panel and use **Mentions all of**.
+
+1. Type at least two characters into the entity search.
+2. Pick an entity. The list narrows immediately.
+3. Add another. It narrows further.
+
+The filter is an **AND**: a video qualifies only if *every* entity you list has at least one mention in it. Adding entities always shrinks the result, never grows it.
+
+Each result row shows what it matched:
+
+```
+Knowledge Graph or Vector Database... Which is Better?
+GraphRAG (23)   from 5:43     Knowledge Graph (22)   from 1:39
+```
+
+The number in parentheses is how many times that entity is mentioned in that video. The timestamp is the **first** mention, so you can jump straight to the part you want. An entity mentioned only in a video's title or description has no timestamp — nothing is shown rather than a misleading `0:00`.
+
+!!! tip "Results are ranked by relevance"
+    With an entity filter active and no sort chosen, results order by total mentions across your chosen entities — the videos most *about* them first. Pick any sort yourself and your choice is kept; it is never overridden.
+
+## Exclude entities
+
+**Excluding** is the disambiguation tool. Use it when one entity keeps dragging in videos about something else.
+
+Add entities under **Excluding**. A video mentioning *any* excluded entity is removed, regardless of how many required entities it matches. Exclusion is an **OR** — the opposite of the required set.
+
+Exclusion works on its own, with no required entities at all. That answers a different and useful question: *"show me everything that isn't about this."*
+
+An entity cannot be both required and excluded. The request is rejected with an explanation rather than silently returning nothing.
+
+## Restrict to transcript mentions
+
+Mentions come from three places: the **transcript**, the video **title**, and the **description**. By default all three count.
+
+Tick **Transcript only** to require that the entity was actually *said*, not merely listed in metadata. This is the difference between a video that discusses someone and a video that tagged them.
+
+!!! note "Manual corrections always survive this filter"
+    Every mention you added or corrected by hand is transcript-sourced, so restricting to transcript keeps all of them. It never discards your own work — that would invert the point of the setting.
+
+## Follow the "appears with" panel
+
+Open any entity's detail page and scroll to **Appears with**. It lists the entities sharing the most videos with this one:
+
+```
+Palestine        3296 videos
+Iran             1474 videos
+Hamas            1301 videos
+```
+
+Click any of them and you land on the videos list filtered to **both** entities — that exact set of shared videos. The number in the panel and the number you land on are the same number, by construction.
+
+This is the discovery path: you don't need to know what to search for. Open an entity you care about, see what it keeps company with, and follow whatever surprises you.
+
+If **Transcript only** is active, the panel honours it and carries it forward, so the count and the page it opens are computed under one definition.
+
+## Share a filtered view
+
+Everything lives in the page address — required entities, exclusions, and the transcript-only setting. Copy the URL and it reproduces the same result set, ordering, and total:
+
+```
+/videos?entity_id=<id>&entity_id=<id>&min_evidence=transcript
+```
+
+It survives refresh and back-navigation, so browser history works the way you expect.
+
+## Reading the colours
+
+Entities are colour-coded by type, and the convention is the same everywhere:
+
+| Where | The pill contains |
+|---|---|
+| **Entities** page, entity detail header | The **type** — "Person", "Place" — this is the legend |
+| Everywhere else | The entity's **name**, in that type's colour |
+
+The Entities page is where the convention is taught; every other surface applies it. Screen readers are told the type on every surface regardless of which form is shown.
+
+## Via the REST API
+
+The same capability is available directly. See the [REST API guide](rest-api.md) for the full parameter list.
+
+```bash
+# Videos mentioning BOTH entities
+curl "http://localhost:8765/api/v1/videos?entity_id=<id-a>&entity_id=<id-b>"
+
+# ...excluding a third, transcript mentions only
+curl "http://localhost:8765/api/v1/videos?entity_id=<id-a>&exclude_entity_id=<id-c>&min_evidence=transcript"
+
+# What appears alongside an entity
+curl "http://localhost:8765/api/v1/entities/<id>/co-occurring"
+```
+
+## Limits and edge cases
+
+- **Ten entities per set.** Required and excluded are counted separately, and both count toward the videos list's overall filter cap.
+- **An intersection matching nothing** shows an empty state that tells you so, distinct from an error and from an unfiltered library.
+- **Duplicates are harmless.** Asking for the same entity twice is treated as asking once.
+- **Unavailable videos** are excluded by default, as everywhere else. Tick *Show unavailable content* to include them; entity matching itself is unaffected by availability.
+- **Mentions, not tags.** The intersection works on entity *mentions*. A tag associating an entity with a video is not an utterance and carries no timestamp, so it does not qualify.
+
+## What this doesn't do yet
+
+**Temporal proximity** — "both entities discussed within 30 seconds of each other" — is not available. It is the strongest form of this query and it is computable from data already stored, so it may arrive later. The per-entity timestamps this feature exposes are exactly what such a filter would need.
+
+## See also
+
+- [Work with transcripts](transcripts.md) — where transcript mentions come from
+- [Correct transcripts](corrections.md) — fixing a misheard name so its mentions are found
+- [Analyze topics](topic-analytics.md) — the other axis for slicing your library

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -143,7 +143,20 @@ export async function apiFetch<T>(
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      throw createApiError(null, response);
+      // Read the problem-details body before discarding the response, so a
+      // client-correctable rejection can say WHICH value was rejected.
+      // Best-effort: a non-JSON or empty body simply leaves `detail` unset.
+      let detail: string | undefined;
+      try {
+        const body = (await response.clone().json()) as { detail?: unknown };
+        if (typeof body.detail === "string") {
+          detail = body.detail;
+        }
+      } catch {
+        detail = undefined;
+      }
+      const apiError = createApiError(null, response);
+      throw detail === undefined ? apiError : { ...apiError, detail };
     }
 
     // HTTP 204 No Content (and 205 Reset Content) have no body.

--- a/frontend/src/api/entityMentions.ts
+++ b/frontend/src/api/entityMentions.ts
@@ -870,3 +870,45 @@ export async function getScanJob(
   });
   return res.data;
 }
+
+// ---------------------------------------------------------------------------
+// Appears-with panel (Feature 062, US3)
+// ---------------------------------------------------------------------------
+
+/** An entity sharing videos with the subject entity. */
+export interface CooccurringEntity {
+  entity_id: string;
+  entity_type: string;
+  canonical_name: string;
+  /**
+   * Distinct videos in which both entities have a qualifying mention.
+   *
+   * Equals the videos list's `pagination.total` for the same pair under the
+   * same evidence scope (FR-024b) — so the number shown here and the number
+   * landed on after clicking are the same number.
+   */
+  shared_video_count: number;
+}
+
+/**
+ * Fetch the entities co-occurring with a subject entity.
+ *
+ * @param entityId - UUID of the subject entity
+ * @param limit - Maximum partners to return (server-bounded)
+ * @param minEvidence - Evidence scope; must match the surrounding view's
+ * @param signal - Abort signal, so a scope change discards an in-flight result
+ */
+export async function fetchCooccurringEntities(
+  entityId: string,
+  limit: number,
+  minEvidence?: "transcript",
+  signal?: AbortSignal
+): Promise<CooccurringEntity[]> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (minEvidence) params.set("min_evidence", minEvidence);
+  const res = await apiFetch<{ data: CooccurringEntity[] }>(
+    `/entities/${entityId}/co-occurring?${params.toString()}`,
+    signal ? { externalSignal: signal } : {}
+  );
+  return res.data;
+}

--- a/frontend/src/components/EntityMentionsPanel.tsx
+++ b/frontend/src/components/EntityMentionsPanel.tsx
@@ -24,6 +24,8 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
+import { entityTypeColors } from "../constants/entityTypes";
+
 import type { VideoEntitySummary } from "../api/entityMentions";
 import { useEntitySearch } from "../hooks/useEntitySearch";
 import {
@@ -65,8 +67,15 @@ export interface EntityMentionsPanelProps {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Human-readable label for each entity_type value from the backend. */
-const ENTITY_TYPE_LABELS: Record<string, string> = {
+/**
+ * PLURAL section headings for this panel's grouped layout.
+ *
+ * Deliberately separate from `constants/entityTypes`' singular badge labels —
+ * these title a group ("People"), those name one entity's type ("Person"). The
+ * COLOURS come from the shared constant, so the convention taught on the
+ * entities page holds here too (FR-025, FR-029).
+ */
+const ENTITY_TYPE_SECTION_LABELS: Record<string, string> = {
   person: "People",
   organization: "Organizations",
   place: "Places",
@@ -90,7 +99,7 @@ const ENTITY_TYPE_ORDER = [
 ];
 
 function getTypeLabel(entityType: string): string {
-  return ENTITY_TYPE_LABELS[entityType] ?? entityType;
+  return ENTITY_TYPE_SECTION_LABELS[entityType] ?? entityType;
 }
 
 /** Group entity summaries by entity_type. */
@@ -813,17 +822,16 @@ function EntityChip({
         <Link
           to={`/entities/${entity.entity_id}`}
           onClick={handleClick}
-          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-full hover:bg-indigo-100 hover:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium border rounded-full hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors ${
+            entityTypeColors(entity.entity_type)
+          }`}
           aria-label={buildAriaLabel(entity)}
         >
           <span>{entity.canonical_name}</span>
 
           {/* Transcript mention tally — hidden when mention_count is 0 */}
           {entity.mention_count > 0 && (
-            <span
-              className="text-xs font-normal text-indigo-500"
-              aria-hidden="true"
-            >
+            <span className="text-xs font-normal opacity-70" aria-hidden="true">
               ({entity.mention_count})
             </span>
           )}

--- a/frontend/src/components/EntityMultiSelect.tsx
+++ b/frontend/src/components/EntityMultiSelect.tsx
@@ -1,0 +1,244 @@
+/**
+ * EntityMultiSelect — multi-select entity picker for the videos list filter panel.
+ *
+ * Feature 062. Models itself on `TagAutocomplete` rather than on
+ * `batch/EntityAutocomplete`, deliberately:
+ *
+ * `EntityAutocomplete` is driven by a `searchText` prop supplied by the parent
+ * correction field — it does not own its query — and it links exactly one
+ * entity. A filter picker owns its input and holds a set. Bending one component
+ * to serve both would thread a mode flag through every branch and create the
+ * second code path that later diverges. Leaving it untouched is also the
+ * strongest possible form of "do not regress the batch surface" (FR-039).
+ *
+ * What IS shared is the data layer: `useEntitySearch` (300 ms debounce,
+ * 2-character minimum) backs both.
+ *
+ * Accessibility follows the ARIA combobox pattern already used by
+ * `TagAutocomplete`: role="combobox" with aria-expanded and
+ * aria-autocomplete="list", a role="listbox" of role="option" items, and
+ * aria-activedescendant for keyboard navigation.
+ */
+
+import { useEffect, useId, useRef, useState } from "react";
+
+import { EntityName } from "./EntityName";
+import { useEntitySearch } from "../hooks/useEntitySearch";
+
+export interface SelectedEntity {
+  /** Named entity UUID. */
+  entity_id: string;
+  /** Canonical display name. */
+  canonical_name: string;
+  /** Entity type, for the badge. */
+  entity_type: string;
+}
+
+interface EntityMultiSelectProps {
+  /** Currently selected entities. */
+  selected: SelectedEntity[];
+  /** Called when an entity is added. */
+  onSelect: (entity: SelectedEntity) => void;
+  /** Called when an entity is removed, by entity_id. */
+  onRemove: (entityId: string) => void;
+  /** Maximum selectable; the input disables at the ceiling. */
+  max: number;
+  /** Visible label for the input. */
+  label: string;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** Ids already chosen in the sibling set, which cannot be chosen here. */
+  unavailableIds?: string[];
+  /** Optional container className. */
+  className?: string;
+}
+
+export function EntityMultiSelect({
+  selected,
+  onSelect,
+  onRemove,
+  max,
+  label,
+  placeholder = "Search entities…",
+  unavailableIds = [],
+  className = "",
+}: EntityMultiSelectProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputId = useId();
+  const listboxId = useId();
+  const descriptionId = useId();
+
+  const { entities, isLoading, isBelowMinChars } = useEntitySearch(inputValue);
+
+  const atCeiling = selected.length >= max;
+  const selectedIds = new Set(selected.map((e) => e.entity_id));
+  const blockedIds = new Set([...selectedIds, ...unavailableIds]);
+  const options = entities.filter((e) => !blockedIds.has(e.entity_id));
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  function commit(index: number) {
+    const option = options[index];
+    if (!option || atCeiling) return;
+    onSelect({
+      entity_id: option.entity_id,
+      canonical_name: option.canonical_name,
+      entity_type: option.entity_type,
+    });
+    setInputValue("");
+    setIsOpen(false);
+    setHighlightedIndex(-1);
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (!isOpen || options.length === 0) {
+      if (event.key === "Escape") setIsOpen(false);
+      return;
+    }
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setHighlightedIndex((i) => (i + 1) % options.length);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setHighlightedIndex((i) => (i <= 0 ? options.length - 1 : i - 1));
+        break;
+      case "Enter":
+        event.preventDefault();
+        if (highlightedIndex >= 0) commit(highlightedIndex);
+        break;
+      case "Escape":
+        event.preventDefault();
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+        break;
+      default:
+        break;
+    }
+  }
+
+  const showSuggestions = isOpen && !isBelowMinChars && !atCeiling;
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`.trim()}>
+      <label
+        htmlFor={inputId}
+        className="block text-sm font-medium text-slate-700 mb-1"
+      >
+        {label}
+      </label>
+
+      {selected.length > 0 && (
+        <ul
+          role="list"
+          aria-label={`Selected: ${label}`}
+          className="flex flex-wrap gap-1.5 mb-2"
+        >
+          {selected.map((entity) => (
+            <li key={entity.entity_id} role="listitem">
+              <EntityName
+                name={entity.canonical_name}
+                entityType={entity.entity_type}
+                onRemove={() => onRemove(entity.entity_id)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <input
+        id={inputId}
+        type="text"
+        role="combobox"
+        aria-expanded={showSuggestions && options.length > 0}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-describedby={descriptionId}
+        {...(highlightedIndex >= 0 && options[highlightedIndex]
+          ? {
+              "aria-activedescendant": `${listboxId}-${options[highlightedIndex].entity_id}`,
+            }
+          : {})}
+        value={inputValue}
+        disabled={atCeiling}
+        placeholder={atCeiling ? `Maximum ${max} reached` : placeholder}
+        onChange={(e) => {
+          setInputValue(e.target.value);
+          setIsOpen(true);
+          setHighlightedIndex(-1);
+        }}
+        onFocus={() => setIsOpen(true)}
+        onKeyDown={handleKeyDown}
+        className={`w-full rounded-lg border px-4 py-2.5 text-base text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+          atCeiling
+            ? 'cursor-not-allowed border-gray-300 bg-gray-100'
+            : 'border-gray-300 bg-white'
+        }`}
+      />
+
+      <p id={descriptionId} className="mt-1 text-xs text-slate-500">
+        {atCeiling
+          ? `Maximum ${max} reached. Remove one to add another.`
+          : `Type at least 2 characters. ${selected.length} of ${max} selected.`}
+      </p>
+
+      {showSuggestions && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          aria-label={`${label} suggestions`}
+          className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-gray-300 bg-white shadow-lg"
+        >
+          {isLoading && (
+            <li className="px-2 py-1.5 text-sm text-slate-500">Searching…</li>
+          )}
+          {!isLoading && options.length === 0 && (
+            <li className="px-2 py-1.5 text-sm text-slate-500">
+              No matching entities
+            </li>
+          )}
+          {!isLoading &&
+            options.map((option, index) => (
+              <li
+                key={option.entity_id}
+                id={`${listboxId}-${option.entity_id}`}
+                role="option"
+                aria-selected={index === highlightedIndex}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  commit(index);
+                }}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                className={`flex cursor-pointer items-center gap-2 px-2 py-1.5 text-sm ${
+                  index === highlightedIndex ? "bg-indigo-50" : ""
+                }`}
+              >
+                <EntityName
+                  name={option.canonical_name}
+                  entityType={option.entity_type}
+                  className="truncate"
+                />
+              </li>
+            ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/EntityName.tsx
+++ b/frontend/src/components/EntityName.tsx
@@ -1,0 +1,108 @@
+import {
+  ENTITY_TYPE_FALLBACK_LABEL,
+  ENTITY_TYPE_LABELS,
+  entityTypeColors,
+} from "../constants/entityTypes";
+
+interface EntityNameProps {
+  /** Canonical display name — this is what the pill contains. */
+  name: string;
+  /** Raw entity_type value; supplies the pill's colour. */
+  entityType: string | null | undefined;
+  /**
+   * When given, renders a dismiss control INSIDE the pill.
+   *
+   * Inside rather than beside: a pill wrapped in a second bordered box with the
+   * × outside it reads as two elements for one thing. The selected-tag pills
+   * put their dismiss inside, and matching them keeps the filter panel coherent.
+   */
+  onRemove?: (() => void) | undefined;
+  /**
+   * Mention tally, rendered as `(N)` inside the pill.
+   *
+   * Matches the video detail page's entity chips, which have always shown the
+   * count this way. Keeping one convention means a reader who learns it in one
+   * place reads it everywhere.
+   */
+  count?: number | undefined;
+  /** Optional extra classes for layout at the call site. */
+  className?: string;
+}
+
+/**
+ * An entity's NAME in a type-coloured pill — the shorthand treatment.
+ *
+ * The project uses one pill shape with two possible contents, and which one
+ * appears depends on whether the surface is *teaching* the convention or
+ * *applying* it:
+ *
+ * - **Legend surfaces** — the entities list, the entity detail header — put the
+ *   TYPE in the pill ("Person", "Technical Term") via `EntityTypeBadge`. That
+ *   is where a reader learns indigo means person and emerald means place.
+ * - **Every other surface** — appears-with, result rows, the filter picker —
+ *   puts the NAME in the pill, in the same colour. Repeating the type label
+ *   beside every name is noise once the convention is known; the colour
+ *   carries it, and the legend pages are where it was learned.
+ *
+ * The type is still announced to screen readers as visually-hidden text, so it
+ * is never lost to assistive technology. It IS lost in greyscale on these
+ * surfaces — the deliberate trade recorded in FR-027a.
+ */
+export function EntityName({
+  name,
+  entityType,
+  onRemove,
+  count,
+  className = "",
+}: EntityNameProps) {
+  const key = entityType ?? "";
+  const colorClasses = entityTypeColors(entityType);
+  const typeLabel =
+    ENTITY_TYPE_LABELS[key] ?? (key === "" ? ENTITY_TYPE_FALLBACK_LABEL : key);
+
+  const spacing = onRemove ? "gap-1.5 ps-3 pe-1.5 py-1" : "px-2.5 py-0.5";
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border text-xs font-medium ${spacing} ${colorClasses} ${className}`.trim()}
+    >
+      <span className="sr-only">{typeLabel}: </span>
+      {name}
+      {count !== undefined && (
+        <>
+          {/* Spoken in full, shown in shorthand: a screen reader saying
+              "open paren three close paren" helps nobody. */}
+          <span className="sr-only">
+            , {count} mention{count === 1 ? "" : "s"}
+          </span>
+          <span className="ms-1 font-normal opacity-70" aria-hidden="true">
+            ({count})
+          </span>
+        </>
+      )}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${name}`}
+          className="inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-current"
+        >
+          <svg
+            className="h-3 w-3"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/EntityTypeBadge.tsx
+++ b/frontend/src/components/EntityTypeBadge.tsx
@@ -1,0 +1,57 @@
+import {
+  ENTITY_TYPE_FALLBACK_LABEL,
+  ENTITY_TYPE_LABELS,
+  entityTypeColors,
+} from "../constants/entityTypes";
+
+/** Badge sizes in use. `sm` matches the entities list, `md` the detail page. */
+type EntityTypeBadgeSize = "sm" | "md";
+
+const SIZE_CLASSES: Record<EntityTypeBadgeSize, string> = {
+  sm: "px-2.5 py-0.5 text-xs",
+  md: "px-3 py-1 text-sm",
+};
+
+interface EntityTypeBadgeProps {
+  /** Raw entity_type value from the API. Unrecognised values fall back. */
+  entityType: string | null | undefined;
+  /** Visual size. Defaults to the compact list size. */
+  size?: EntityTypeBadgeSize;
+  /** Optional extra classes for layout at the call site (margins, etc.). */
+  className?: string;
+}
+
+/**
+ * Type badge for a named entity.
+ *
+ * Colour and label both come from `constants/entityTypes`, so every surface
+ * renders the same entity identically (FR-025) and the palette has exactly one
+ * definition point (FR-029). The label is always rendered as text, never
+ * conveyed by colour alone, so the type survives greyscale, colour-blindness,
+ * and screen readers (FR-027, SC-010).
+ *
+ * **Fallback preserves prior behaviour.** An unrecognised but non-empty type
+ * displays the raw value rather than a generic word: the entities list has
+ * always done that, and it tells a reader what the data actually says instead
+ * of hiding it. Only a missing type falls back to a generic label, since there
+ * is nothing to show (FR-028).
+ */
+export function EntityTypeBadge({
+  entityType,
+  size = "sm",
+  className = "",
+}: EntityTypeBadgeProps) {
+  const key = entityType ?? "";
+  const colorClasses = entityTypeColors(entityType);
+  const label =
+    ENTITY_TYPE_LABELS[key] ?? (key === "" ? ENTITY_TYPE_FALLBACK_LABEL : key);
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border font-medium ${SIZE_CLASSES[size]} ${colorClasses} ${className}`.trim()}
+      aria-label={`Entity type: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/FilterPills.tsx
+++ b/frontend/src/components/FilterPills.tsx
@@ -43,6 +43,7 @@
  */
 
 import { useRef, useId, useState, useEffect } from 'react';
+import { entityTypeColors } from '../constants/entityTypes';
 import { filterColors } from '../styles/tokens';
 
 /**
@@ -58,7 +59,14 @@ const MAX_FILTER_TEXT_LENGTH = 25;
 const MAX_CANONICAL_TAG_TEXT_LENGTH = 25;
 
 /** Supported filter pill types. */
-export type FilterPillType = 'tag' | 'category' | 'topic' | 'boolean' | 'canonical_tag';
+export type FilterPillType =
+  | 'tag'
+  | 'category'
+  | 'topic'
+  | 'boolean'
+  | 'canonical_tag'
+  | 'entity'
+  | 'excluded_entity';
 
 export interface FilterPill {
   /** Type of filter (determines color scheme) */
@@ -75,6 +83,15 @@ export interface FilterPill {
    * When alias_count = 1 or omitted, no variation badge is shown.
    */
   aliasCount?: number | undefined;
+  /**
+   * Entity type, for 'entity' and 'excluded_entity' pills only.
+   *
+   * When present the pill takes its colour from the shared entity palette
+   * rather than the generic filter palette, so an entity looks the same here
+   * as it does everywhere else (FR-025). The required/excluded distinction is
+   * then carried by the symbol and the spoken prefix, not by hue (FR-030).
+   */
+  entityType?: string | undefined;
 }
 
 export interface FilterPillsProps {
@@ -108,6 +125,24 @@ function truncateText(text: string, maxLength: number): string {
 /**
  * Gets the appropriate emoji icon for a filter type.
  */
+/**
+ * Human-readable prefix announced to screen readers before the pill label.
+ *
+ * Only the compound slugs are mapped. 'tag', 'topic', and 'category' already
+ * read as English when spoken, and existing suites assert on them verbatim;
+ * 'excluded_entity' does not, and FR-030 requires the required/excluded
+ * distinction to reach a screen reader — the icon that carries it visually is
+ * aria-hidden, so the text is the only channel that survives.
+ */
+const FILTER_TYPE_SR_LABELS: Partial<Record<FilterPillType, string>> = {
+  entity: 'Required entity',
+  excluded_entity: 'Excluded entity',
+};
+
+function filterTypeSrLabel(type: FilterPillType): string {
+  return FILTER_TYPE_SR_LABELS[type] ?? type;
+}
+
 function getFilterIcon(type: FilterPillType): string {
   switch (type) {
     case 'tag':
@@ -120,6 +155,14 @@ function getFilterIcon(type: FilterPillType): string {
       return '\u{2705}';
     case 'canonical_tag':
       return '\u{1F3F7}\uFE0F';
+    // Feature 062: required vs excluded must be distinguishable by something
+    // other than colour, since entity pills already carry entity-type colour
+    // (FR-030). These two symbols differ in greyscale and are announced
+    // distinctly by screen readers.
+    case 'entity':
+      return '\u{1F3AF}';
+    case 'excluded_entity':
+      return '\u{1F6AB}';
   }
 }
 
@@ -278,6 +321,14 @@ export function FilterPills({
         {/* gap-2 = 8px minimum spacing between interactive elements (T094) */}
         {filters.map((filter, index) => {
           const colorScheme = filterColors[filter.type];
+          // Entity pills use the shared entity palette (Tailwind classes)
+          // instead of the generic filter palette (inline hex). Branching here
+          // rather than duplicating the palette in hex keeps FR-029's single
+          // definition point intact.
+          const entityClasses =
+            filter.entityType !== undefined
+              ? entityTypeColors(filter.entityType)
+              : null;
           const maxLength =
             filter.type === 'canonical_tag'
               ? MAX_CANONICAL_TAG_TEXT_LENGTH
@@ -300,12 +351,18 @@ export function FilterPills({
             <div
               key={`${filter.type}-${filter.value}`}
               role="listitem"
-              className="inline-flex items-center gap-1.5 px-3 py-2 sm:py-1.5 min-h-[44px] sm:min-h-0 rounded-full text-sm font-medium border transition-colors"
-              style={{
-                backgroundColor: colorScheme.background,
-                color: colorScheme.text,
-                borderColor: colorScheme.border,
-              }}
+              className={`inline-flex items-center gap-1.5 px-3 py-2 sm:py-1.5 min-h-[44px] sm:min-h-0 rounded-full text-sm font-medium border transition-colors ${
+                entityClasses ?? ''
+              }`.trim()}
+              style={
+                entityClasses
+                  ? undefined
+                  : {
+                      backgroundColor: colorScheme.background,
+                      color: colorScheme.text,
+                      borderColor: colorScheme.border,
+                    }
+              }
               title={isTruncated ? tooltipText : undefined}
             >
               {/* Filter icon */}
@@ -313,7 +370,9 @@ export function FilterPills({
 
               {/* Filter label */}
               <span className="inline-flex items-baseline gap-1">
-                <span className="sr-only">{filter.type}: </span>
+                <span className="sr-only">
+                  {filterTypeSrLabel(filter.type)}:{' '}
+                </span>
                 <span>{displayText}</span>
                 {/* Variation badge: "{N} var." shown only when alias_count > 1 */}
                 {showVariationBadge && (
@@ -333,9 +392,11 @@ export function FilterPills({
                 }}
                 type="button"
                 onClick={() => handleRemoveWithFocus(filter.type, filter.value, index)}
-                aria-label={`Remove ${filter.type} filter: ${filter.label}`}
+                aria-label={`Remove ${filterTypeSrLabel(
+                  filter.type
+                )} filter: ${filter.label}`}
                 className="inline-flex items-center justify-center min-w-[44px] min-h-[44px] sm:min-w-[24px] sm:min-h-[24px] -my-2 sm:my-0 -me-2 sm:me-0 rounded-full hover:bg-black/10 dark:hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
-                style={{ color: colorScheme.text }}
+                style={entityClasses ? undefined : { color: colorScheme.text }}
               >
                 <svg
                   className="w-4 h-4 sm:w-3 sm:h-3"

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -7,6 +7,7 @@ import { Link } from "react-router-dom";
 import { cardPatterns, colorTokens } from "../styles";
 import type { VideoListItem } from "../types/video";
 import { AvailabilityBadge } from "./AvailabilityBadge";
+import { EntityName } from "./EntityName";
 import { isVideoUnavailable } from "../utils/availability";
 import { API_BASE_URL } from "../api/config";
 
@@ -177,6 +178,43 @@ export function VideoCard({ video }: VideoCardProps) {
         {/* View Count */}
         <span>{formatViewCount(view_count)}</span>
       </div>
+
+      {/* Per-entity evidence (Feature 062, FR-008a).
+
+          Rendered only when an entity filter is active. `entity_matches` is
+          null with no filter and an EMPTY array for an exclusion-only filter,
+          and neither should draw a section. */}
+      {video.entity_matches != null && video.entity_matches.length > 0 && (
+        <div className={`mt-3 pt-3 border-t border-${colorTokens.border}`}>
+          <ul className="flex flex-wrap gap-x-3 gap-y-1.5 text-sm">
+            {video.entity_matches.map((match) => (
+              <li
+                key={match.entity_id}
+                className="inline-flex items-center gap-1.5"
+              >
+                <EntityName
+                  name={match.canonical_name}
+                  entityType={match.entity_type}
+                  count={match.mention_count}
+                />
+                {/* Omitted entirely — never rendered as 0:00 — when the entity
+                    appears only in the title or description and therefore has
+                    no position in time. */}
+                {match.first_timestamp !== null && (
+                  <span
+                    className="text-slate-400"
+                    aria-label={`First mentioned at ${formatDuration(
+                      Math.floor(match.first_timestamp)
+                    )}`}
+                  >
+                    {`from ${formatDuration(Math.floor(match.first_timestamp))}`}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {/* Transcript Info */}
       {transcript_summary.count > 0 && (

--- a/frontend/src/components/VideoFilters.tsx
+++ b/frontend/src/components/VideoFilters.tsx
@@ -58,6 +58,10 @@
  */
 
 import { useSearchParams } from 'react-router-dom';
+
+import { EntityMultiSelect } from './EntityMultiSelect';
+import { fetchEntityDetail } from '../api/entityMentions';
+import type { SelectedEntity } from './EntityMultiSelect';
 import { useEffect, useState, useId, useRef, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -99,9 +103,22 @@ function calculateTotalFilters(
   tags: string[],
   category: string | null,
   topicIds: string[],
-  canonicalTags: string[]
+  canonicalTags: string[],
+  entityIds: string[] = [],
+  excludedEntityIds: string[] = []
 ): number {
-  return tags.length + (category ? 1 : 0) + topicIds.length + canonicalTags.length;
+  // Entities count toward the global cap on the same terms as every other
+  // filter type (FR-002d). The backend enforces this in
+  // _validate_filter_limits; if the panel omitted them it would understate the
+  // total and let the user build a request the API then rejects.
+  return (
+    tags.length +
+    (category ? 1 : 0) +
+    topicIds.length +
+    canonicalTags.length +
+    entityIds.length +
+    excludedEntityIds.length
+  );
 }
 
 /**
@@ -181,15 +198,85 @@ export function VideoFilters({
    * Maps normalized_form → { canonical_form, alias_count }.
    * Populated on autocomplete selection and bookmark hydration.
    */
+  // Entity display names for pill labels. The URL carries ids only, so a
+  // restored address shows the id until the user re-picks — the same tradeoff
+  // canonical tags already make with displayNameCache below.
+  const [entityNameCache, setEntityNameCache] = useState<
+    Map<string, SelectedEntity>
+  >(new Map());
+
   const [displayNameCache, setDisplayNameCache] = useState<
     Map<string, CanonicalTagCacheEntry>
   >(new Map());
 
   // Calculate filter counts (include boolean filters in active count)
-  const totalFilters = calculateTotalFilters(tags, category, topicIds, canonicalTags);
+  const totalFilters = calculateTotalFilters(
+    tags,
+    category,
+    topicIds,
+    canonicalTags,
+    searchParams.getAll('entity_id'),
+    searchParams.getAll('exclude_entity_id')
+  );
   const booleanFilterCount = (likedOnly ? 1 : 0) + (hasTranscript ? 1 : 0);
   const hasActiveFilters = totalFilters > 0 || booleanFilterCount > 0;
   const approachingLimit = isApproachingLimit(tags, category, topicIds, canonicalTags);
+
+  /**
+   * Hydrate entity display names for entity_id / exclude_entity_id URL params.
+   *
+   * The address carries ids, not names, so a bookmarked or shared link arrives
+   * with nothing to label the pills — they would read as raw UUIDs, which tells
+   * the user nothing about what their own filter is doing. Same bookmark
+   * scenario the canonical tags solve below, same shape of fix.
+   */
+  useEffect(() => {
+    const missing = [
+      ...searchParams.getAll('entity_id'),
+      ...searchParams.getAll('exclude_entity_id'),
+    ].filter((id) => !entityNameCache.has(id));
+    if (missing.length === 0) return;
+
+    let cancelled = false;
+    void Promise.all(
+      missing.map(async (entityId) => {
+        try {
+          const detail = await fetchEntityDetail(entityId);
+          // Validate before caching. An unexpected or malformed response would
+          // otherwise put `undefined` in the pill label, which crashes the
+          // whole FilterPills render — one bad entity taking down every filter
+          // the user has active.
+          if (typeof detail?.canonical_name !== 'string' || !detail.canonical_name) {
+            return null;
+          }
+          return {
+            entity_id: entityId,
+            canonical_name: detail.canonical_name,
+            entity_type:
+              typeof detail.entity_type === 'string' ? detail.entity_type : 'other',
+          } satisfies SelectedEntity;
+        } catch {
+          // A deleted or malformed id leaves the pill showing the raw value
+          // rather than failing the panel — the API rejects the query itself
+          // and the list surfaces that separately (FR-016a).
+          return null;
+        }
+      })
+    ).then((resolved) => {
+      if (cancelled) return;
+      const found = resolved.filter((e): e is SelectedEntity => e !== null);
+      if (found.length === 0) return;
+      setEntityNameCache((prev) => {
+        const next = new Map(prev);
+        found.forEach((entity) => next.set(entity.entity_id, entity));
+        return next;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParams, entityNameCache]);
 
   /**
    * Hydrate display names for canonical_tag URL params on page load (bookmark scenario).
@@ -463,6 +550,12 @@ export function VideoFilters({
       case 'topic':
         handleTopicRemove(value);
         break;
+      case 'entity':
+        removeEntity('entity_id')(value);
+        break;
+      case 'excluded_entity':
+        removeEntity('exclude_entity_id')(value);
+        break;
       case 'boolean': {
         // Remove the boolean URL param (e.g., liked_only, has_transcript)
         const newParams = new URLSearchParams(searchParams);
@@ -474,11 +567,89 @@ export function VideoFilters({
   };
 
   // Build filter pills data (including boolean pills for Feature 027 and canonical_tag pills for US2)
+  // ---------------------------------------------------------------------
+  // Entity intersection (Feature 062)
+  // ---------------------------------------------------------------------
+  //
+  // Display names are cached the same way canonical tags are: the URL carries
+  // ids, and a restored address has no names until the user re-picks. The
+  // cache is populated on selection and read back for the pill label.
+  // Deduplicated on read, matching the API: requesting the same entity twice
+  // is idempotent there (Edge Cases), so a hand-edited or double-appended link
+  // must not consume two slots here either — otherwise the panel's "N of 10"
+  // drifts from the ceiling the server actually enforces.
+  const entityIds = Array.from(new Set(searchParams.getAll('entity_id')));
+  const excludedEntityIds = Array.from(
+    new Set(searchParams.getAll('exclude_entity_id'))
+  );
+  const transcriptOnly = searchParams.get('min_evidence') === 'transcript';
+
+  const selectedEntities: SelectedEntity[] = entityIds.map(
+    (id) =>
+      entityNameCache.get(id) ?? {
+        entity_id: id,
+        canonical_name: id,
+        entity_type: 'other',
+      }
+  );
+  const selectedExcludedEntities: SelectedEntity[] = excludedEntityIds.map(
+    (id) =>
+      entityNameCache.get(id) ?? {
+        entity_id: id,
+        canonical_name: id,
+        entity_type: 'other',
+      }
+  );
+
+  const addEntity = (key: 'entity_id' | 'exclude_entity_id') => (
+    entity: SelectedEntity
+  ) => {
+    setEntityNameCache((prev) => new Map(prev).set(entity.entity_id, entity));
+    const newParams = new URLSearchParams(searchParams);
+    newParams.append(key, entity.entity_id);
+    setSearchParams(newParams);
+  };
+
+  const removeEntity = (key: 'entity_id' | 'exclude_entity_id') => (
+    entityId: string
+  ) => {
+    const newParams = new URLSearchParams(searchParams);
+    const remaining = newParams.getAll(key).filter((id) => id !== entityId);
+    newParams.delete(key);
+    remaining.forEach((id) => newParams.append(key, id));
+    setSearchParams(newParams);
+  };
+
+  const handleTranscriptOnlyToggle = (next: boolean) => {
+    const newParams = new URLSearchParams(searchParams);
+    if (next) {
+      newParams.set('min_evidence', 'transcript');
+    } else {
+      newParams.delete('min_evidence');
+    }
+    setSearchParams(newParams);
+  };
+
   const filterPills = [
     ...tags.map((tag) => ({
       type: 'tag' as const,
       value: tag,
       label: tag,
+    })),
+    // Entity pills (Feature 062). Required and excluded are separate pill
+    // types so they are distinguishable by symbol and text, not colour alone
+    // (FR-030) — both already carry entity-type colour.
+    ...selectedEntities.map((entity) => ({
+      type: 'entity' as const,
+      value: entity.entity_id,
+      label: entity.canonical_name,
+      entityType: entity.entity_type,
+    })),
+    ...selectedExcludedEntities.map((entity) => ({
+      type: 'excluded_entity' as const,
+      value: entity.entity_id,
+      label: entity.canonical_name,
+      entityType: entity.entity_type,
     })),
     // Canonical tag pills (US2): use display name cache, fall back to normalized form
     ...canonicalTags.map((normalizedForm) => {
@@ -539,6 +710,51 @@ export function VideoFilters({
             onTagRemove={handleCanonicalTagRemove}
             maxTags={FILTER_LIMITS.MAX_TAGS}
           />
+        </div>
+
+        {/* Entity intersection picker (Feature 062, FR-006a) */}
+        <div className="w-full">
+          <EntityMultiSelect
+            selected={selectedEntities}
+            onSelect={addEntity('entity_id')}
+            onRemove={removeEntity('entity_id')}
+            max={FILTER_LIMITS.MAX_ENTITIES}
+            label="Mentions all of"
+            placeholder="Search entities…"
+            unavailableIds={excludedEntityIds}
+          />
+        </div>
+
+        {/* Entity exclusion (Feature 062, FR-013) */}
+        <div className="w-full">
+          <EntityMultiSelect
+            selected={selectedExcludedEntities}
+            onSelect={addEntity('exclude_entity_id')}
+            onRemove={removeEntity('exclude_entity_id')}
+            max={FILTER_LIMITS.MAX_ENTITIES}
+            label="Excluding"
+            placeholder="Search entities to exclude…"
+            unavailableIds={entityIds}
+          />
+        </div>
+
+        {/* Evidence scope — exactly ONE affordance in this release (FR-020b).
+            A general scope selector waits for a graded confidence model. */}
+        <div className="w-full flex items-end">
+          <label className="flex items-center gap-2 text-sm text-slate-700">
+            <input
+              type="checkbox"
+              checked={transcriptOnly}
+              onChange={(e) => handleTranscriptOnlyToggle(e.target.checked)}
+              className="rounded border-slate-300"
+            />
+            <span>
+              Transcript only
+              <span className="block text-xs text-slate-500">
+                Excludes title and description mentions
+              </span>
+            </span>
+          </label>
         </div>
 
         {/* Category Dropdown */}

--- a/frontend/src/components/VideoList.tsx
+++ b/frontend/src/components/VideoList.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useVideos } from "../hooks/useVideos";
+import type { ApiError } from "../types/video";
 import { EmptyState } from "./EmptyState";
 import { ErrorState } from "./ErrorState";
 import { LoadingState } from "./LoadingState";
@@ -122,6 +123,12 @@ interface VideoListProps {
   hasTranscript?: boolean;
   /** Filter to videos saved in a curated playlist and never watched */
   savedUnwatched?: boolean;
+  /** Required entity UUIDs — AND logic across all of them (Feature 062) */
+  entityIds?: string[];
+  /** Excluded entity UUIDs — a video mentioning ANY is removed (Feature 062) */
+  excludedEntityIds?: string[];
+  /** Restrict which mentions qualify; omit for all three sources (Feature 062) */
+  minEvidence?: "transcript" | undefined;
 }
 
 /**
@@ -129,6 +136,9 @@ interface VideoListProps {
  * Includes infinite scroll with Intersection Observer and fallback Load More button.
  */
 export function VideoList({
+  entityIds = [],
+  excludedEntityIds = [],
+  minEvidence,
   tags = [],
   canonicalTags = [],
   category = null,
@@ -153,6 +163,9 @@ export function VideoList({
     retry,
     loadMoreRef,
   } = useVideos({
+    entityIds,
+    excludedEntityIds,
+    ...(minEvidence !== undefined && { minEvidence }),
     tags,
     canonicalTags,
     category,
@@ -174,13 +187,80 @@ export function VideoList({
     );
   }
 
-  // Error state
+  // A 4xx rejection is the user's filter being unacceptable, not the page
+  // being broken. FR-016a: present it as a RECOVERABLE state that names the
+  // offending value and leaves the rest of the filter intact, rather than the
+  // retry-oriented ErrorState, which offers an action that cannot help --
+  // retrying an invalid request just fails again.
+  // `error` is typed `unknown` by the hook, so narrow before reading it
+  // rather than asserting a shape the runtime may not have.
+  const apiError: ApiError | null =
+    error !== null && typeof error === "object" ? (error as ApiError) : null;
+  const rejectionStatus = apiError?.status;
+  const isRejection =
+    isError &&
+    rejectionStatus !== undefined &&
+    rejectionStatus >= 400 &&
+    rejectionStatus < 500;
+
+  if (isRejection) {
+    return (
+      <div
+        role="alert"
+        className="rounded-lg border border-amber-200 bg-amber-50 p-6"
+        data-testid="filter-rejected"
+      >
+        <h3 className="text-sm font-semibold text-amber-900">
+          This filter can&apos;t be applied
+        </h3>
+        <p className="mt-1 text-sm text-amber-800">
+          {apiError?.detail ??
+            "One of the active filters was rejected. Remove it to continue."}
+        </p>
+        <p className="mt-2 text-xs text-amber-700">
+          Your other filters are still active — remove the offending one from
+          the filter pills above.
+        </p>
+      </div>
+    );
+  }
+
+  // Error state — genuine failures, where retrying is a sensible offer.
   if (isError) {
     return <ErrorState error={error} onRetry={retry} />;
   }
 
-  // Empty state
+  // Empty state. FR-012 requires the filtered-empty case to be
+  // distinguishable from an error AND from an unfiltered library: "no videos
+  // at all" and "no videos matching these entities" are different facts and
+  // suggest different next actions.
   if (videos.length === 0) {
+    const hasEntityFilter =
+      entityIds.length > 0 || excludedEntityIds.length > 0;
+    if (hasEntityFilter) {
+      return (
+        <div
+          role="status"
+          className="rounded-lg border border-slate-200 bg-white p-12 text-center"
+          data-testid="empty-intersection"
+        >
+          <h3 className="text-sm font-semibold text-slate-800">
+            No videos mention all of these entities
+          </h3>
+          <p className="mt-1 text-sm text-slate-600">
+            {entityIds.length > 1
+              ? "Each entity you add narrows the result. Try removing one."
+              : "Try a different entity, or widen the evidence scope."}
+          </p>
+          {minEvidence === "transcript" && (
+            <p className="mt-2 text-xs text-slate-500">
+              Transcript-only is active — title and description mentions are
+              being excluded.
+            </p>
+          )}
+        </div>
+      );
+    }
     return <EmptyState />;
   }
 

--- a/frontend/src/components/batch/EntityAutocomplete.tsx
+++ b/frontend/src/components/batch/EntityAutocomplete.tsx
@@ -30,6 +30,7 @@
 
 import { useState, useRef, useEffect, useId } from "react";
 import { useEntitySearch } from "../../hooks/useEntitySearch";
+import { ENTITY_TYPE_LABELS } from "../../constants/entityTypes";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -69,16 +70,11 @@ export interface EntityAutocompleteProps {
 // Entity type badge label map
 // ---------------------------------------------------------------------------
 
-const ENTITY_TYPE_LABELS: Record<string, string> = {
-  person: "Person",
-  organization: "Organization",
-  place: "Place",
-  event: "Event",
-  work: "Work",
-  technical_term: "Technical term",
-};
-
 function entityTypeLabel(type: string): string {
+  // Was a private map here, missing `concept` and `other` entirely and
+  // spelling technical_term as "Technical term" against the shared
+  // constant's "Technical Term" — a live divergence from the convention the
+  // entities page teaches. FR-029 wants one definition point.
   return ENTITY_TYPE_LABELS[type] ?? type;
 }
 

--- a/frontend/src/components/entity/CooccurringPanel.tsx
+++ b/frontend/src/components/entity/CooccurringPanel.tsx
@@ -1,0 +1,161 @@
+/**
+ * CooccurringPanel — "appears with" on the entity detail page (Feature 062, US3).
+ *
+ * Discovery without knowing what to search for: shows which entities share the
+ * most videos with the subject, and opens any pairing as an intersection.
+ *
+ * The count each row shows equals the total of the page it opens (FR-024b), so
+ * the panel never promises a number the destination contradicts.
+ */
+
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { EntityName } from "../EntityName";
+import {
+  COOCCURRING_PAGE_SIZE,
+  useCooccurringEntities,
+} from "../../hooks/useCooccurringEntities";
+
+/** Server-enforced ceiling; reveal-more stops here (FR-023a). */
+const MAX_COOCCURRING = 50;
+
+interface CooccurringPanelProps {
+  /** The subject entity. */
+  entityId: string;
+  /**
+   * Evidence scope of the surrounding view. The panel must compute under the
+   * same scope it carries forward, or the count shown and the intersection it
+   * opens will disagree (FR-024a).
+   */
+  minEvidence?: "transcript" | undefined;
+  className?: string;
+}
+
+export function CooccurringPanel({
+  entityId,
+  minEvidence,
+  className = "",
+}: CooccurringPanelProps) {
+  const [limit, setLimit] = useState(COOCCURRING_PAGE_SIZE);
+  const { partners, isLoading, isError } = useCooccurringEntities(
+    entityId,
+    limit,
+    minEvidence
+  );
+
+  /**
+   * Address scheme shared with the videos list, not a parallel one (FR-022).
+   *
+   * Targets `/videos` explicitly, NOT `/`. The root is an index route that
+   * redirects with `<Navigate to="/videos" replace />`, and that redirect
+   * carries no query string — linking to `/?entity_id=…` silently lands on an
+   * unfiltered videos page with every parameter dropped.
+   */
+  function intersectionHref(partnerId: string): string {
+    const params = new URLSearchParams();
+    params.append("entity_id", entityId);
+    params.append("entity_id", partnerId);
+    if (minEvidence) params.set("min_evidence", minEvidence);
+    return `/videos?${params.toString()}`;
+  }
+
+  return (
+    <section
+      className={`rounded-lg border border-slate-200 bg-white p-4 ${className}`.trim()}
+      aria-labelledby="cooccurring-heading"
+      data-testid="cooccurring-panel"
+    >
+      <h2
+        id="cooccurring-heading"
+        className="mb-3 text-sm font-semibold text-slate-800"
+      >
+        Appears with
+      </h2>
+
+      {/* Loading state, distinct from empty and from error (FR-036). */}
+      {isLoading && (
+        <p
+          role="status"
+          className="text-sm text-slate-500"
+          data-testid="cooccurring-loading"
+        >
+          Finding related entities…
+        </p>
+      )}
+
+      {/* A panel failure degrades to a panel-level error and leaves the
+          surrounding page usable (FR-038). It deliberately does not raise. */}
+      {!isLoading && isError && (
+        <p
+          role="alert"
+          className="text-sm text-amber-800"
+          data-testid="cooccurring-error"
+        >
+          Couldn&apos;t load related entities. The rest of this page is
+          unaffected.
+        </p>
+      )}
+
+      {!isLoading && !isError && partners.length === 0 && (
+        <div role="status" data-testid="cooccurring-empty">
+          <p className="text-sm text-slate-600">
+            Nothing else appears alongside this entity yet.
+          </p>
+          {/* An empty result under a restricted scope is a different fact from
+              one empty under every scope, and suggests a different action
+              (FR-024d). */}
+          {minEvidence === "transcript" && (
+            <p className="mt-1 text-xs text-slate-500">
+              Transcript-only is active — title and description mentions are
+              being excluded. Turning it off may reveal connections.
+            </p>
+          )}
+        </div>
+      )}
+
+      {!isLoading && !isError && partners.length > 0 && (
+        <>
+          <ul className="space-y-1">
+            {partners.map((partner) => (
+              <li key={partner.entity_id}>
+                <Link
+                  to={intersectionHref(partner.entity_id)}
+                  className="flex items-center justify-between gap-2 rounded px-2 py-1.5 text-sm hover:bg-slate-50"
+                >
+                  <EntityName
+                    name={partner.canonical_name}
+                    entityType={partner.entity_type}
+                    className="min-w-0 truncate"
+                  />
+                  <span className="shrink-0 text-slate-500">
+                    {partner.shared_video_count}{" "}
+                    {partner.shared_video_count === 1 ? "video" : "videos"}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          {/* Reveal-more requests a further tranche of the same size, bounded
+              by the ceiling the endpoint enforces (FR-023, FR-023a). Hidden
+              once the list is short of the requested limit, since that means
+              there is nothing further to reveal. */}
+          {partners.length >= limit && limit < MAX_COOCCURRING && (
+            <button
+              type="button"
+              onClick={() =>
+                setLimit((current) =>
+                  Math.min(current + COOCCURRING_PAGE_SIZE, MAX_COOCCURRING)
+                )
+              }
+              className="mt-2 text-sm text-indigo-700 hover:underline"
+            >
+              Show more
+            </button>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/constants/entityTypes.ts
+++ b/frontend/src/constants/entityTypes.ts
@@ -49,6 +49,32 @@ export const ENTITY_TYPE_COLORS: Record<string, string> = {
   other: "bg-slate-100 text-slate-700 border-slate-200",
 };
 
+/**
+ * Neutral badge treatment for an unrecognised or missing entity_type.
+ *
+ * Defined here so it has exactly one definition point (FR-029). It was
+ * previously inlined identically at each call site, which is how a palette
+ * forks.
+ */
+export const ENTITY_TYPE_FALLBACK_COLOR =
+  "bg-slate-100 text-slate-700 border-slate-200";
+
+/** Label shown for an unrecognised or missing entity_type. */
+export const ENTITY_TYPE_FALLBACK_LABEL = "Unknown";
+
+/**
+ * Pill colour classes for an entity type, with the neutral fallback applied.
+ *
+ * The `ENTITY_TYPE_COLORS[x] ?? ENTITY_TYPE_FALLBACK_COLOR` resolution was
+ * being written out at each call site, which is how a palette forks: one site
+ * forgets the fallback, or picks a different neutral. FR-029 wants one
+ * definition point for the fallback as well as for the colours.
+ */
+export function entityTypeColors(entityType: string | null | undefined): string {
+  return ENTITY_TYPE_COLORS[entityType ?? ""] ?? ENTITY_TYPE_FALLBACK_COLOR;
+}
+
+
 // ---------------------------------------------------------------------------
 // Tabs
 // ---------------------------------------------------------------------------

--- a/frontend/src/hooks/useCooccurringEntities.ts
+++ b/frontend/src/hooks/useCooccurringEntities.ts
@@ -1,0 +1,50 @@
+/**
+ * useCooccurringEntities — data for the appears-with panel (Feature 062, US3).
+ *
+ * Fetches independently of the entity detail page's initial render (FR-037).
+ * This is the feature's slowest query — roughly ten times the intersection
+ * itself — so computing it synchronously would dominate load time for exactly
+ * the entities users open most: the well-connected ones. That is the
+ * difference between a panel that arrives a moment later and a page that feels
+ * broken.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchCooccurringEntities } from "../api/entityMentions";
+import type { CooccurringEntity } from "../api/entityMentions";
+
+/** Default bound; matches the server default (FR-023). */
+export const COOCCURRING_PAGE_SIZE = 12;
+
+interface UseCooccurringEntitiesReturn {
+  partners: CooccurringEntity[];
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+}
+
+export function useCooccurringEntities(
+  entityId: string | undefined,
+  limit: number = COOCCURRING_PAGE_SIZE,
+  minEvidence?: "transcript"
+): UseCooccurringEntitiesReturn {
+  const { data, isLoading, isError, error } = useQuery({
+    // minEvidence is part of the key, so changing the scope starts a NEW query
+    // rather than reusing the old one's data. Combined with the abort signal
+    // below, an in-flight result computed under the previous scope is
+    // discarded instead of being rendered against the new one (FR-024c).
+    queryKey: ["cooccurringEntities", entityId ?? null, limit, minEvidence ?? null],
+    queryFn: ({ signal }) =>
+      fetchCooccurringEntities(entityId as string, limit, minEvidence, signal),
+    enabled: Boolean(entityId),
+    staleTime: 60 * 1000,
+  });
+
+  return {
+    partners: data ?? [],
+    isLoading,
+    isError,
+    error,
+  };
+}

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -44,6 +44,12 @@ interface UseVideosOptions {
   sortOrder?: SortOrder;
   /** Filter to liked videos only (Feature 027) */
   likedOnly?: boolean;
+  /** Required entity UUIDs — AND logic across all of them (Feature 062) */
+  entityIds?: string[];
+  /** Excluded entity UUIDs — a video mentioning ANY is removed (Feature 062) */
+  excludedEntityIds?: string[];
+  /** Restrict which mentions qualify; omit for all three sources (Feature 062) */
+  minEvidence?: "transcript" | undefined;
   /** Filter to videos with transcripts (Feature 027) */
   hasTranscript?: boolean;
   /** Filter to videos saved in a curated playlist and never watched */
@@ -105,6 +111,9 @@ export function useVideos(options: UseVideosOptions = {}): UseVideosReturn {
     sortBy,
     sortOrder,
     likedOnly = false,
+    entityIds = [],
+    excludedEntityIds = [],
+    minEvidence,
     hasTranscript,
     savedUnwatched,
   } = options;
@@ -121,7 +130,29 @@ export function useVideos(options: UseVideosOptions = {}): UseVideosReturn {
     fetchNextPage,
     refetch,
   } = useInfiniteQuery({
-    queryKey: ["videos", { limit, tags, canonicalTags, category, topicIds, includeUnavailable, sortBy, sortOrder, likedOnly, hasTranscript, savedUnwatched }],
+    // EVERY input the queryFn reads must appear here. React Query caches on
+    // this key alone, so a filter missing from it produces a stale result that
+    // only corrects on a hard reload — the queryFn builds the right URL but is
+    // never re-invoked.
+    queryKey: [
+      "videos",
+      {
+        limit,
+        tags,
+        canonicalTags,
+        category,
+        topicIds,
+        includeUnavailable,
+        sortBy,
+        sortOrder,
+        likedOnly,
+        hasTranscript,
+        savedUnwatched,
+        entityIds,
+        excludedEntityIds,
+        minEvidence,
+      },
+    ],
     queryFn: async ({ pageParam, signal }) => {
       const params = new URLSearchParams({
         offset: pageParam.toString(),
@@ -147,6 +178,10 @@ export function useVideos(options: UseVideosOptions = {}): UseVideosReturn {
       if (likedOnly) params.set('liked_only', 'true');
       if (hasTranscript) params.set('has_transcript', 'true');
       if (savedUnwatched) params.set('saved_unwatched', 'true');
+      // Repeated keys, matching tag / canonical_tag / topic_id above.
+      entityIds.forEach(id => params.append('entity_id', id));
+      excludedEntityIds.forEach(id => params.append('exclude_entity_id', id));
+      if (minEvidence) params.set('min_evidence', minEvidence);
 
       // FR-004/FR-005: Pass TanStack Query signal as externalSignal so it is
       // combined with the internal timeout guard via AbortSignal.any().

--- a/frontend/src/pages/EntitiesPage.tsx
+++ b/frontend/src/pages/EntitiesPage.tsx
@@ -23,9 +23,8 @@ import { SkipLink } from "../components/SkipLink";
 import { CreateEntityModal } from "../components/entity/CreateEntityModal";
 import { useEntities } from "../hooks/useEntityMentions";
 import type { EntityListItem } from "../api/entityMentions";
+import { EntityTypeBadge } from "../components/EntityTypeBadge";
 import {
-  ENTITY_TYPE_LABELS,
-  ENTITY_TYPE_COLORS,
   ENTITY_TYPE_TABS,
 } from "../constants/entityTypes";
 
@@ -43,15 +42,6 @@ const SORT_OPTIONS: Array<{ value: string; label: string }> = [
   { value: "name", label: "Name (A-Z)" },
 ];
 
-function getTypeBadgeClass(entityType: string): string {
-  return (
-    ENTITY_TYPE_COLORS[entityType] ?? "bg-slate-100 text-slate-700 border-slate-200"
-  );
-}
-
-function getTypeLabel(entityType: string): string {
-  return ENTITY_TYPE_LABELS[entityType] ?? entityType;
-}
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -110,11 +100,7 @@ function EntityCard({ entity }: { entity: EntityListItem }) {
       aria-label={`${entity.canonical_name} — ${entity.mention_count} mention${entity.mention_count === 1 ? "" : "s"} in ${entity.video_count} video${entity.video_count === 1 ? "" : "s"}`}
     >
       {/* Type badge */}
-      <span
-        className={`inline-flex items-center px-2.5 py-0.5 text-xs font-medium rounded-full border mb-3 ${getTypeBadgeClass(entity.entity_type)}`}
-      >
-        {getTypeLabel(entity.entity_type)}
-      </span>
+      <EntityTypeBadge entityType={entity.entity_type} className="mb-3" />
 
       {/* Entity name */}
       <h3 className="text-base font-semibold text-gray-900 mb-2 line-clamp-2">

--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -17,7 +17,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 
-import { ENTITY_TYPE_LABELS, ENTITY_TYPE_COLORS } from "../constants/entityTypes";
+import { CooccurringPanel } from "../components/entity/CooccurringPanel";
+import { EntityTypeBadge } from "../components/EntityTypeBadge";
 import {
   useEntityVideos,
   useDeleteManualAssociation,
@@ -49,15 +50,7 @@ interface NamedEntityDetailResponse {
 // Helper functions
 // ---------------------------------------------------------------------------
 
-function getTypeLabel(entityType: string): string {
-  return ENTITY_TYPE_LABELS[entityType] ?? entityType;
-}
 
-function getTypeBadgeClass(entityType: string): string {
-  return (
-    ENTITY_TYPE_COLORS[entityType] ?? "bg-slate-100 text-slate-700 border-slate-200"
-  );
-}
 
 /** Format a timestamp in seconds to MM:SS display. */
 function formatTimestamp(seconds: number): string {
@@ -1250,12 +1243,7 @@ export function EntityDetailPage() {
           canonicalName={entity.canonical_name}
           description={entity.description}
           typeBadge={
-            <span
-              className={`inline-flex items-center px-3 py-1 text-sm font-medium rounded-full border ${getTypeBadgeClass(entity.entity_type)}`}
-              aria-label={`Entity type: ${getTypeLabel(entity.entity_type)}`}
-            >
-              {getTypeLabel(entity.entity_type)}
-            </span>
+            <EntityTypeBadge entityType={entity.entity_type} size="md" />
           }
         />
 
@@ -1424,6 +1412,20 @@ export function EntityDetailPage() {
             </select>
           </div>
         </div>
+
+        {/* Appears-with panel (Feature 062, US3).
+
+            Rendered unconditionally rather than gated on the video list's
+            loading state, and fetching through its own query — it must not
+            block this page's initial render (FR-037). It is the feature's
+            slowest query, so making the page wait on it would penalise
+            exactly the entities users open most. A failure inside it degrades
+            to a panel-level message and leaves this page usable (FR-038). */}
+        {entityId && (
+          <div className="mb-6">
+            <CooccurringPanel entityId={entityId} />
+          </div>
+        )}
 
         {/* Loading skeleton for video list — T067: dropdown stays interactive */}
         {videosLoading && (

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -15,6 +15,7 @@ import { FilterToggle } from "../components/FilterToggle";
 import { SkipLink } from "../components/SkipLink";
 import { useVideos } from "../hooks/useVideos";
 import type { VideoSortField, SortOrder, SortOption } from "../types/filters";
+import { FILTER_LIMITS } from "../types/filters";
 
 /**
  * Sort options for the Videos page.
@@ -56,7 +57,31 @@ export function HomePage() {
   // component state would leave that link with nothing to target.
   const savedUnwatched = searchParams.get("saved_unwatched") === "true";
 
+  // Entity intersection (Feature 062). Repeated keys, matching tag/topic.
+  //
+  // FR-002c: an address carrying more entities than the ceiling is trimmed to
+  // the ceiling rather than silently truncated server-side or failing the whole
+  // restoration. The client never issues an over-ceiling request; the API
+  // rejects rather than clamps, because clamping would answer a different
+  // question than the one asked.
+  const rawEntityIds = searchParams.getAll("entity_id");
+  const rawExcludedEntityIds = searchParams.getAll("exclude_entity_id");
+  const entityIds = rawEntityIds.slice(0, FILTER_LIMITS.MAX_ENTITIES);
+  const excludedEntityIds = rawExcludedEntityIds.slice(
+    0,
+    FILTER_LIMITS.MAX_ENTITIES
+  );
+  const droppedEntityCount =
+    rawEntityIds.length -
+    entityIds.length +
+    (rawExcludedEntityIds.length - excludedEntityIds.length);
+  const minEvidence =
+    searchParams.get("min_evidence") === "transcript" ? "transcript" : undefined;
+
   // Get total count for filters display (using the same hook with all filters)
+  // Same filter set as the list below — this call drives the panel's count,
+  // and a count computed under different filters than the rows it describes is
+  // the exact internal inconsistency FR-007 forbids.
   const { total } = useVideos({
     tags,
     canonicalTags,
@@ -66,6 +91,11 @@ export function HomePage() {
     sortBy,
     sortOrder,
     likedOnly,
+    hasTranscript,
+    savedUnwatched,
+    entityIds,
+    excludedEntityIds,
+    ...(minEvidence !== undefined && { minEvidence }),
   });
 
   // Set page title
@@ -126,6 +156,24 @@ export function HomePage() {
         <VideoFilters videoCount={total} />
       </section>
 
+      {/*
+        FR-002c: a restored address over the ceiling is trimmed rather than
+        silently truncated. Reporting what was dropped is the difference
+        between a filter the user can reason about and one that quietly
+        answers a different question.
+      */}
+      {droppedEntityCount > 0 && (
+        <div
+          role="status"
+          className="mb-4 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+        >
+          {`Showing the first ${FILTER_LIMITS.MAX_ENTITIES} entities per set — `}
+          {`${droppedEntityCount} more from the link ${
+            droppedEntityCount === 1 ? "was" : "were"
+          } not applied.`}
+        </div>
+      )}
+
       {/* ARIA live region for count announcement (FR-005) */}
       <div role="status" aria-live="polite" className="sr-only">
         {total !== null && `Showing ${total} video${total !== 1 ? "s" : ""}`}
@@ -147,6 +195,9 @@ export function HomePage() {
           likedOnly={likedOnly}
           hasTranscript={hasTranscript}
           savedUnwatched={savedUnwatched}
+          entityIds={entityIds}
+          excludedEntityIds={excludedEntityIds}
+          {...(minEvidence !== undefined && { minEvidence })}
         />
       </section>
     </div>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -107,9 +107,23 @@ export function HomePage() {
   }, []);
 
   // Scroll to top when filter or sort changes (FR-031)
+  //
+  // These must be JOINED, not listed as arrays. `searchParams.getAll()` returns
+  // a fresh array on every render, and React compares deps by identity — so
+  // depending on the arrays directly made this effect run on EVERY render, not
+  // only when a filter changed. The re-render that an infinite-scroll page
+  // triggers was enough to fire it, yanking the reader from wherever they had
+  // scrolled back up to the top. NUL is the separator because it cannot occur
+  // in a tag or an id, so ["a,b"] and ["a","b"] stay distinguishable.
+  const tagKey = tags.join("\0");
+  const canonicalTagKey = canonicalTags.join("\0");
+  const topicIdKey = topicIds.join("\0");
+  const entityKey = entityIds.join("\0");
+  const excludedEntityKey = excludedEntityIds.join("\0");
+
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });
-  }, [tags, canonicalTags, category, topicIds, includeUnavailable, sortBy, sortOrder, likedOnly, hasTranscript, savedUnwatched]);
+  }, [tagKey, canonicalTagKey, category, topicIdKey, includeUnavailable, sortBy, sortOrder, likedOnly, hasTranscript, savedUnwatched, entityKey, excludedEntityKey, minEvidence]);
 
   return (
     <div className="p-6 lg:p-8">

--- a/frontend/src/pages/__tests__/EntityDetailPage.cooccurring.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.cooccurring.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * EntityDetailPage — appears-with panel integration (Feature 062, US3, T064).
+ *
+ * Asserts the two properties FR-037 and FR-038 are about: the panel does not
+ * block the page's initial render, and a panel failure leaves the page usable.
+ *
+ * The panel is the feature's slowest query — roughly ten times the
+ * intersection itself. Computing it synchronously would dominate load time for
+ * exactly the entities users open most, the well-connected ones. These tests
+ * pin that it does not.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { EntityDetailPage } from "../EntityDetailPage";
+
+vi.mock("../../hooks/useEntityMentions", () => ({
+  useEntityVideos: vi.fn(),
+  useVideoEntities: vi.fn(() => ({
+    entities: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+  useDeleteManualAssociation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    isSuccess: false,
+  })),
+  useScanEntity: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: null,
+    reset: vi.fn(),
+  })),
+  useScanVideoEntities: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: null,
+    reset: vi.fn(),
+  })),
+  useUpdateEntity: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    isSuccess: false,
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+  };
+});
+
+// The page's PhoneticVariantsSection reads through the globally-mocked
+// useQuery and expects an array. Stubbing it keeps these tests focused on the
+// appears-with panel, matching the sibling suites' approach.
+vi.mock("../../components/corrections/PhoneticVariantsSection", () => ({
+  PhoneticVariantsSection: () => <section aria-label="Phonetic variants stub" />,
+}));
+
+const cooccurringMock = vi.fn();
+vi.mock("../../hooks/useCooccurringEntities", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../hooks/useCooccurringEntities")
+  >("../../hooks/useCooccurringEntities");
+  return {
+    ...actual,
+    useCooccurringEntities: (...args: unknown[]) => cooccurringMock(...args),
+  };
+});
+
+import { useQuery } from "@tanstack/react-query";
+import { useEntityVideos } from "../../hooks/useEntityMentions";
+
+const mockEntity = {
+  entity_id: "entity-uuid-062",
+  canonical_name: "Ada Lovelace",
+  entity_type: "person",
+  description: "Fixture entity.",
+  status: "active",
+  mention_count: 42,
+  video_count: 3,
+  aliases: [] as { alias_name: string; alias_type: string; occurrence_count: number }[],
+};
+
+const defaultUseEntityVideos = {
+  videos: [],
+  total: null,
+  pagination: null,
+  isLoading: false,
+  isError: false,
+  error: null,
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  fetchNextPage: vi.fn(),
+  loadMoreRef: { current: null },
+};
+
+function renderPage(entityId = "entity-uuid-062") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/entities/${entityId}`]}>
+        <Routes>
+          <Route path="/entities/:entityId" element={<EntityDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(useQuery).mockReturnValue({
+    data: mockEntity,
+    isLoading: false,
+    isError: false,
+    error: null,
+    status: "success",
+    isFetching: false,
+    isPending: false,
+    isSuccess: true,
+    isRefetching: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isPaused: false,
+    isPlaceholderData: false,
+    isStale: false,
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    fetchStatus: "idle" as const,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isInitialLoading: false,
+    isEnabled: true,
+    refetch: vi.fn(),
+    promise: Promise.resolve(mockEntity),
+  } as ReturnType<typeof useQuery>);
+
+  vi.mocked(useEntityVideos).mockReturnValue(defaultUseEntityVideos);
+});
+
+describe("EntityDetailPage — appears-with panel (Feature 062)", () => {
+  it("renders the entity's own content while the panel is still loading (FR-037)", () => {
+    cooccurringMock.mockReturnValue({
+      partners: [],
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+    renderPage();
+
+    // The page's primary content is present even though the panel has not
+    // resolved — the panel is not on the critical render path.
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByTestId("cooccurring-loading")).toBeInTheDocument();
+  });
+
+  it("leaves the page usable when the panel fails (FR-038)", () => {
+    cooccurringMock.mockReturnValue({
+      partners: [],
+      isLoading: false,
+      isError: true,
+      error: new Error("panel exploded"),
+    });
+    renderPage();
+
+    // A panel-level error, not a page-level one.
+    expect(screen.getByTestId("cooccurring-error")).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+  });
+
+  it("mounts the panel with the entity from the route", () => {
+    cooccurringMock.mockReturnValue({
+      partners: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    renderPage();
+
+    expect(screen.getByTestId("cooccurring-panel")).toBeInTheDocument();
+    expect(cooccurringMock).toHaveBeenCalledWith(
+      "entity-uuid-062",
+      expect.any(Number),
+      undefined
+    );
+  });
+
+  it("renders partners once they arrive", () => {
+    cooccurringMock.mockReturnValue({
+      partners: [
+        {
+          entity_id: "partner-1",
+          entity_type: "place",
+          canonical_name: "Bletchley Park",
+          shared_video_count: 7,
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    renderPage();
+
+    expect(screen.getByText("Bletchley Park")).toBeInTheDocument();
+    expect(screen.getByText("7 videos")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -318,6 +318,24 @@ export const filterColors = {
     /** Medium orange border (#FDBA74) */
     border: '#FDBA74',
   },
+  /**
+   * Entity pills draw their colour from the shared entity palette
+   * (`constants/entityTypes`), not from here — an entity must look the same in
+   * a filter pill as it does everywhere else (FR-025). These two entries were
+   * added and then never rendered, because entity pills always carry an
+   * `entityType`. Kept only as a type-total fallback for a pill that somehow
+   * arrives without one.
+   */
+  entity: {
+    background: '#E0E7FF',
+    text: '#3730A3',
+    border: '#C7D2FE',
+  },
+  excluded_entity: {
+    background: '#FFE4E6',
+    text: '#9F1239',
+    border: '#FECDD3',
+  },
   /** Boolean filter colors - slate/gray scheme with 7.0:1+ contrast (Feature 027) */
   boolean: {
     /** Light slate background (#F1F5F9) */

--- a/frontend/src/tests/components/CooccurringPanel.test.tsx
+++ b/frontend/src/tests/components/CooccurringPanel.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * CooccurringPanel — appears-with panel states and behaviour (Feature 062, US3).
+ *
+ * Covers the four states FR-036/FR-038 require to be distinct (loading, empty,
+ * scope-restricted empty, error), the reveal-more bound (FR-023/FR-023a), and
+ * the address scheme the panel hands to the videos list (FR-022, FR-024a).
+ *
+ * Kept under `src/tests/` so it is typechecked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { CooccurringPanel } from '../../components/entity/CooccurringPanel';
+
+const hookMock = vi.fn();
+vi.mock('../../hooks/useCooccurringEntities', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../hooks/useCooccurringEntities')
+  >('../../hooks/useCooccurringEntities');
+  return {
+    ...actual,
+    useCooccurringEntities: (...args: unknown[]) => hookMock(...args),
+  };
+});
+
+const SUBJECT = '11111111-1111-4111-8111-111111111111';
+const PARTNER = '22222222-2222-4222-8222-222222222222';
+
+function partner(overrides: Record<string, unknown> = {}) {
+  return {
+    entity_id: PARTNER,
+    entity_type: 'organization',
+    canonical_name: 'Analytical Engine',
+    shared_video_count: 261,
+    ...overrides,
+  };
+}
+
+function state(overrides: Record<string, unknown> = {}) {
+  return {
+    partners: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function renderPanel(props: Record<string, unknown> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <CooccurringPanel entityId={SUBJECT} {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('CooccurringPanel (Feature 062, US3)', () => {
+  beforeEach(() => {
+    hookMock.mockReset();
+  });
+
+  describe('states are distinct (FR-036, FR-038)', () => {
+    it('shows a loading state that is neither empty nor error', () => {
+      hookMock.mockReturnValue(state({ isLoading: true }));
+      renderPanel();
+
+      expect(screen.getByTestId('cooccurring-loading')).toBeInTheDocument();
+      expect(screen.queryByTestId('cooccurring-empty')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('cooccurring-error')).not.toBeInTheDocument();
+    });
+
+    it('renders a clean empty state, not an error (FR-024)', () => {
+      hookMock.mockReturnValue(state({ partners: [] }));
+      renderPanel();
+
+      expect(screen.getByTestId('cooccurring-empty')).toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('distinguishes an empty result under a restricted scope (FR-024d)', () => {
+      // "Nothing co-occurs" and "nothing co-occurs UNDER THIS SCOPE" are
+      // different facts and suggest different actions.
+      hookMock.mockReturnValue(state({ partners: [] }));
+      renderPanel({ minEvidence: 'transcript' });
+
+      expect(screen.getByText(/Transcript-only is active/)).toBeInTheDocument();
+      expect(screen.getByText(/may reveal connections/)).toBeInTheDocument();
+    });
+
+    it('does not mention the scope when none is active', () => {
+      hookMock.mockReturnValue(state({ partners: [] }));
+      renderPanel();
+
+      expect(screen.queryByText(/Transcript-only is active/)).not.toBeInTheDocument();
+    });
+
+    it('degrades to a panel-level error, leaving the page usable (FR-038)', () => {
+      hookMock.mockReturnValue(state({ isError: true, error: new Error('boom') }));
+      renderPanel();
+
+      const error = screen.getByTestId('cooccurring-error');
+      expect(error).toBeInTheDocument();
+      expect(error).toHaveTextContent(/rest of this page is unaffected/i);
+      // The panel still renders its own heading — it has not taken the page
+      // down with it.
+      expect(screen.getByText('Appears with')).toBeInTheDocument();
+    });
+  });
+
+  describe('partner rows', () => {
+    it('shows each partner name, type-coloured, with its shared-video count', () => {
+      hookMock.mockReturnValue(state({ partners: [partner()] }));
+      const { container } = renderPanel();
+
+      expect(screen.getByText('Analytical Engine')).toBeInTheDocument();
+      expect(screen.getByText('261 videos')).toBeInTheDocument();
+
+      // The type is carried by the NAME's colour, not a separate chip — a chip
+      // beside every row made the panel busy. The type still reaches screen
+      // readers through visually-hidden text.
+      expect(screen.getByText('Organization:')).toHaveClass('sr-only');
+      const name = container.querySelector('.text-violet-700');
+      expect(name).not.toBeNull();
+      expect(name).toHaveTextContent('Analytical Engine');
+    });
+
+    it('singularises a count of one', () => {
+      hookMock.mockReturnValue(
+        state({ partners: [partner({ shared_video_count: 1 })] })
+      );
+      renderPanel();
+
+      expect(screen.getByText('1 video')).toBeInTheDocument();
+    });
+  });
+
+  describe('address scheme (FR-022, FR-024a)', () => {
+    it('links to the two-entity intersection using repeated entity_id keys', () => {
+      hookMock.mockReturnValue(state({ partners: [partner()] }));
+      renderPanel();
+
+      const href = screen.getByRole('link').getAttribute('href') ?? '';
+      const params = new URLSearchParams(href.split('?')[1]);
+      // Both entities present, as repeated keys — the same scheme the videos
+      // list reads, not a parallel one.
+      expect(params.getAll('entity_id')).toEqual([SUBJECT, PARTNER]);
+    });
+
+    it('targets /videos, not the root', () => {
+      // The root is an index route that redirects with
+      // `<Navigate to="/videos" replace />`, and that redirect carries NO
+      // query string. Linking to `/?entity_id=…` therefore lands on an
+      // unfiltered videos page with every parameter silently dropped — the
+      // href looks correct on hover and the destination is wrong.
+      //
+      // This assertion exists because the params-only test above passed
+      // while the feature was broken: it checked what the link carried and
+      // never checked where it pointed.
+      hookMock.mockReturnValue(state({ partners: [partner()] }));
+      renderPanel();
+
+      const href = screen.getByRole('link').getAttribute('href') ?? '';
+      expect(href.split('?')[0]).toBe('/videos');
+    });
+
+    it('carries the active evidence scope forward', () => {
+      // Otherwise the panel computes under one definition and the page it
+      // opens computes under another, and the counts disagree.
+      hookMock.mockReturnValue(state({ partners: [partner()] }));
+      renderPanel({ minEvidence: 'transcript' });
+
+      const href = screen.getByRole('link').getAttribute('href') ?? '';
+      expect(new URLSearchParams(href.split('?')[1]).get('min_evidence')).toBe(
+        'transcript'
+      );
+    });
+
+    it('omits the scope parameter when none is active', () => {
+      hookMock.mockReturnValue(state({ partners: [partner()] }));
+      renderPanel();
+
+      const href = screen.getByRole('link').getAttribute('href') ?? '';
+      expect(new URLSearchParams(href.split('?')[1]).has('min_evidence')).toBe(
+        false
+      );
+    });
+  });
+
+  describe('reveal more (FR-023, FR-023a)', () => {
+    it('offers reveal-more only when the list filled the requested bound', () => {
+      // Fewer partners than requested means there is nothing further to show.
+      hookMock.mockReturnValue(state({ partners: [partner()] }));
+      renderPanel();
+
+      expect(
+        screen.queryByRole('button', { name: 'Show more' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('requests a further tranche of the same size when revealed', async () => {
+      const user = userEvent.setup();
+      const full = Array.from({ length: 12 }, (_, i) =>
+        partner({ entity_id: `p${i}`, canonical_name: `Partner ${i}` })
+      );
+      hookMock.mockReturnValue(state({ partners: full }));
+      renderPanel();
+
+      await user.click(screen.getByRole('button', { name: 'Show more' }));
+
+      await waitFor(() => {
+        // Second positional argument is the limit.
+        const limits = hookMock.mock.calls.map((call) => call[1]);
+        expect(limits).toContain(24);
+      });
+    });
+
+    it('passes the subject id and scope through to the hook', () => {
+      hookMock.mockReturnValue(state({ partners: [] }));
+      renderPanel({ minEvidence: 'transcript' });
+
+      expect(hookMock).toHaveBeenCalledWith(SUBJECT, 12, 'transcript');
+    });
+  });
+});

--- a/frontend/src/tests/components/EntityAutocomplete.test.tsx
+++ b/frontend/src/tests/components/EntityAutocomplete.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * EntityAutocomplete — batch-correction single-select surface (FR-039).
+ *
+ * Feature 062 needed a multi-select entity picker for the videos list filter
+ * panel. It got a NEW component (`EntityMultiSelect`) rather than a
+ * generalisation of this one, because this component does not own its query —
+ * its input is driven by a `searchText` prop from the parent correction field —
+ * and it links exactly one entity.
+ *
+ * So the strongest form of "do not regress the batch surface" is that this file
+ * was never edited. These tests pin the contract anyway: the next person
+ * tempted to fold the two components together will find out here rather than in
+ * production.
+ *
+ * There were no tests for this component before Feature 062.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { EntityAutocomplete } from '../../components/batch/EntityAutocomplete';
+import type { EntityOption } from '../../components/batch/EntityAutocomplete';
+
+const RESULTS = [
+  {
+    entity_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    canonical_name: 'Noam Chomsky',
+    entity_type: 'person',
+  },
+  {
+    entity_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    canonical_name: 'Chomsky Hierarchy',
+    entity_type: 'technical_term',
+  },
+];
+
+vi.mock('../../hooks/useEntitySearch', () => ({
+  useEntitySearch: (search: string) => ({
+    entities: search.trim().length >= 2 ? RESULTS : [],
+    isLoading: false,
+    isBelowMinChars: search.trim().length < 2,
+    isError: false,
+  }),
+}));
+
+const SELECTED: EntityOption = {
+  id: RESULTS[0]!.entity_id,
+  name: RESULTS[0]!.canonical_name,
+  type: 'person',
+};
+
+describe('EntityAutocomplete — batch correction contract (FR-039)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('parent-driven query', () => {
+    it('takes its search text from the parent, not from its own state', () => {
+      // This is the property that makes it unsuitable as a filter picker: the
+      // input reflects the correction field the user is editing elsewhere.
+      render(
+        <EntityAutocomplete
+          searchText="Chomsky"
+          selectedEntity={null}
+          onEntitySelect={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('combobox')).toHaveValue('Chomsky');
+    });
+
+    it('shows suggestions once the parent text reaches the minimum length', () => {
+      render(
+        <EntityAutocomplete
+          searchText="Ch"
+          selectedEntity={null}
+          onEntitySelect={vi.fn()}
+        />
+      );
+      expect(screen.getByText('Noam Chomsky')).toBeInTheDocument();
+    });
+
+    it('shows none below the minimum length', () => {
+      render(
+        <EntityAutocomplete
+          searchText="C"
+          selectedEntity={null}
+          onEntitySelect={vi.fn()}
+        />
+      );
+      expect(screen.queryByText('Noam Chomsky')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('single selection', () => {
+    it('reports the chosen entity to the parent', async () => {
+      const user = userEvent.setup();
+      const onEntitySelect = vi.fn();
+      render(
+        <EntityAutocomplete
+          searchText="Chomsky"
+          selectedEntity={null}
+          onEntitySelect={onEntitySelect}
+        />
+      );
+
+      await user.click(screen.getByText('Noam Chomsky'));
+
+      expect(onEntitySelect).toHaveBeenCalledTimes(1);
+      expect(onEntitySelect.mock.calls[0]?.[0]).toMatchObject({
+        id: RESULTS[0]!.entity_id,
+        name: 'Noam Chomsky',
+      });
+    });
+
+    it('renders exactly one selection, never a set', () => {
+      // The contract this component keeps and EntityMultiSelect deliberately
+      // does not: one entity, cleared with null rather than removed by id.
+      render(
+        <EntityAutocomplete
+          searchText=""
+          selectedEntity={SELECTED}
+          onEntitySelect={vi.fn()}
+        />
+      );
+      expect(screen.getAllByText('Noam Chomsky')).toHaveLength(1);
+    });
+
+    it('clears with null rather than an id', async () => {
+      const user = userEvent.setup();
+      const onEntitySelect = vi.fn();
+      render(
+        <EntityAutocomplete
+          searchText=""
+          selectedEntity={SELECTED}
+          onEntitySelect={onEntitySelect}
+        />
+      );
+
+      const clear = screen
+        .getAllByRole('button')
+        .find((button) => /unlink|remove|clear/i.test(button.getAttribute('aria-label') ?? ''));
+      expect(clear).toBeDefined();
+      await user.click(clear!);
+
+      expect(onEntitySelect).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('batch-specific affordances', () => {
+    it('disables every control when the parent says so', () => {
+      render(
+        <EntityAutocomplete
+          searchText="Chomsky"
+          selectedEntity={null}
+          onEntitySelect={vi.fn()}
+          disabled
+        />
+      );
+      expect(screen.getByRole('combobox')).toBeDisabled();
+    });
+
+    it('surfaces the replacement-text mismatch warning', () => {
+      // `hasMismatch` exists only for the correction workflow — the replacement
+      // text no longer matches the linked entity's name. A filter picker has no
+      // such concept, which is the clearest sign these are two components.
+      render(
+        <EntityAutocomplete
+          searchText="Chomskey"
+          selectedEntity={SELECTED}
+          onEntitySelect={vi.fn()}
+          hasMismatch
+        />
+      );
+      expect(screen.getByText(/match/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/tests/components/EntityTypeBadge.test.tsx
+++ b/frontend/src/tests/components/EntityTypeBadge.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * EntityTypeBadge and EntityName — entity type identity (Feature 062, US4).
+ *
+ * Two treatments, deliberately:
+ *
+ * - `EntityTypeBadge` draws the type explicitly, for surfaces where the type
+ *   IS the subject: the entities list, the entity detail header.
+ * - `EntityName` colours the name and hides the type in screen-reader text,
+ *   for dense surfaces where a chip beside every row is noise.
+ *
+ * Both consume `constants/entityTypes`, so the palette has exactly one
+ * definition point (FR-029) and no surface can fork it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { EntityTypeBadge } from '../../components/EntityTypeBadge';
+import { EntityName } from '../../components/EntityName';
+import {
+  ENTITY_TYPE_COLORS,
+  ENTITY_TYPE_LABELS,
+  ENTITY_TYPE_FALLBACK_COLOR,
+} from '../../constants/entityTypes';
+
+const ALL_TYPES = [
+  'person',
+  'organization',
+  'place',
+  'event',
+  'work',
+  'technical_term',
+  'concept',
+  'other',
+] as const;
+
+describe('EntityTypeBadge (FR-025, FR-026, FR-027, FR-028)', () => {
+  it.each(ALL_TYPES)('renders %s with its established colour and label', (type) => {
+    const { container } = render(<EntityTypeBadge entityType={type} />);
+    const badge = container.firstElementChild;
+
+    // Colour comes from the shared constant — asserted against the constant
+    // itself, so a hardcoded copy anywhere would diverge and fail.
+    for (const cls of ENTITY_TYPE_COLORS[type]!.split(' ')) {
+      expect(badge).toHaveClass(cls);
+    }
+    // And the type is ALSO in text, so it survives colour removal (FR-027).
+    expect(badge).toHaveTextContent(ENTITY_TYPE_LABELS[type]!);
+  });
+
+  it('covers every type the constants define, with no extras', () => {
+    // Guards against a ninth type being added to the palette without this
+    // suite noticing (FR-026: none added, none changed).
+    expect(Object.keys(ENTITY_TYPE_COLORS).sort()).toEqual([...ALL_TYPES].sort());
+  });
+
+  it('falls back to the neutral treatment for an unrecognised type (FR-028)', () => {
+    const { container } = render(<EntityTypeBadge entityType="not_a_real_type" />);
+    const badge = container.firstElementChild;
+
+    for (const cls of ENTITY_TYPE_FALLBACK_COLOR.split(' ')) {
+      expect(badge).toHaveClass(cls);
+    }
+    // Shows the raw value rather than a generic word: that is what the
+    // entities list has always done, and it tells a reader what the data
+    // actually says instead of hiding it.
+    expect(badge).toHaveTextContent('not_a_real_type');
+  });
+
+  it('falls back without breaking layout for a missing type', () => {
+    const { container } = render(<EntityTypeBadge entityType={null} />);
+    const badge = container.firstElementChild;
+
+    expect(badge).toHaveTextContent('Unknown');
+    // Layout classes still applied — the badge does not collapse.
+    expect(badge).toHaveClass('inline-flex');
+  });
+
+  it('offers both sizes in use without changing the colour', () => {
+    const { container: small } = render(
+      <EntityTypeBadge entityType="person" size="sm" />
+    );
+    const { container: medium } = render(
+      <EntityTypeBadge entityType="person" size="md" />
+    );
+
+    expect(small.firstElementChild).toHaveClass('text-xs');
+    expect(medium.firstElementChild).toHaveClass('text-sm');
+    expect(small.firstElementChild).toHaveClass('text-indigo-700');
+    expect(medium.firstElementChild).toHaveClass('text-indigo-700');
+  });
+
+  it('identifies the type with all colour stripped (SC-010)', () => {
+    // The strongest form: remove every class, and the type must still be
+    // readable from text alone.
+    const { container } = render(<EntityTypeBadge entityType="technical_term" />);
+    container.querySelectorAll('*').forEach((el) => el.removeAttribute('class'));
+    expect(container.textContent).toContain('Technical Term');
+  });
+});
+
+describe('EntityName — the NAME in a type-coloured pill (FR-025, FR-029)', () => {
+  it.each(ALL_TYPES)('gives %s the same full pill colours as the badge', (type) => {
+    const { container: named } = render(
+      <EntityName name="Ada Lovelace" entityType={type} />
+    );
+    const { container: badged } = render(<EntityTypeBadge entityType={type} />);
+
+    // Background, text AND border all match the badge's — this is the same
+    // pill, differing only in what it contains. Asserting the whole triplet is
+    // the point: colouring only the text would look like a different element.
+    for (const cls of ENTITY_TYPE_COLORS[type]!.split(' ')) {
+      expect(named.firstElementChild).toHaveClass(cls);
+      expect(badged.firstElementChild).toHaveClass(cls);
+    }
+    expect(named.firstElementChild).toHaveClass('rounded-full');
+  });
+
+  it('puts the NAME in the pill, not the type', () => {
+    // The distinction between the legend treatment and the shorthand one.
+    const { container } = render(
+      <EntityName name="Ada Lovelace" entityType="person" />
+    );
+    // Clone and strip the visually-hidden node, so this measures what a
+    // sighted reader actually sees rather than the DOM's full textContent.
+    const clone = container.firstElementChild!.cloneNode(true) as HTMLElement;
+    clone.querySelectorAll('.sr-only').forEach((el) => el.remove());
+
+    expect(clone.textContent).toContain('Ada Lovelace');
+    expect(clone.textContent).not.toContain('Person');
+  });
+
+  it('keeps the type available to screen readers', () => {
+    render(<EntityName name="Ada Lovelace" entityType="person" />);
+    expect(screen.getByText('Person:')).toHaveClass('sr-only');
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+  });
+
+  it('falls back to the neutral pill for an unrecognised type', () => {
+    const { container } = render(
+      <EntityName name="Mystery" entityType="not_a_real_type" />
+    );
+    for (const cls of ENTITY_TYPE_FALLBACK_COLOR.split(' ')) {
+      expect(container.firstElementChild).toHaveClass(cls);
+    }
+  });
+
+  it('shows a mention tally as (N) inside the pill', () => {
+    // One convention across the app: the video detail page's entity chips have
+    // always shown counts this way, so a reader who learns it there reads it
+    // on the videos list too.
+    render(<EntityName name="Ada Lovelace" entityType="person" count={13} />);
+    expect(screen.getByText('(13)')).toBeInTheDocument();
+  });
+
+  it('speaks the tally in full rather than as punctuation', () => {
+    // A screen reader reading "open paren thirteen close paren" helps nobody,
+    // so the shorthand is aria-hidden and a spoken form sits beside it.
+    render(<EntityName name="Ada Lovelace" entityType="person" count={13} />);
+    expect(screen.getByText('(13)')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText(', 13 mentions')).toHaveClass('sr-only');
+  });
+
+  it('singularises a tally of one', () => {
+    render(<EntityName name="Ada Lovelace" entityType="person" count={1} />);
+    expect(screen.getByText(', 1 mention')).toBeInTheDocument();
+  });
+
+  it('draws no tally when no count is given', () => {
+    // The filter-panel pills carry no count; an empty "()" would be noise.
+    const { container } = render(
+      <EntityName name="Ada Lovelace" entityType="person" />
+    );
+    expect(container.textContent).not.toContain('(');
+  });
+
+  it('renders the same entity identically wherever it appears (SC-009)', () => {
+    // Two independent renders of the same entity must be indistinguishable.
+    // This is what makes the colour convention learnable: it only teaches
+    // anything if it is the same everywhere.
+    const { container: first } = render(
+      <EntityName name="Israel" entityType="place" />
+    );
+    const { container: second } = render(
+      <EntityName name="Israel" entityType="place" />
+    );
+    expect(first.firstElementChild?.className).toBe(
+      second.firstElementChild?.className
+    );
+  });
+});

--- a/frontend/src/tests/components/FilterPills.entity.test.tsx
+++ b/frontend/src/tests/components/FilterPills.entity.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * FilterPills — required vs excluded entity distinction (Feature 062, FR-030).
+ *
+ * Entity pills already carry entity-TYPE colour, so colour cannot also carry
+ * the required/excluded distinction — two signals competing for one channel.
+ * FR-030 therefore requires a non-colour property: a distinct symbol and a
+ * distinct textual prefix, surviving greyscale and reaching a screen reader.
+ *
+ * These tests assert on the DOM text and the symbol rather than on class names,
+ * because a class-name assertion would pass even if both pills rendered
+ * identically to someone who cannot perceive the colour.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { FilterPills } from '../../components/FilterPills';
+
+const REQUIRED = {
+  type: 'entity' as const,
+  value: '11111111-1111-4111-8111-111111111111',
+  label: 'Ada Lovelace',
+};
+const EXCLUDED = {
+  type: 'excluded_entity' as const,
+  value: '22222222-2222-4222-8222-222222222222',
+  label: 'Analytical Engine',
+};
+
+function renderPills() {
+  return render(
+    <FilterPills filters={[REQUIRED, EXCLUDED]} onRemove={() => {}} />
+  );
+}
+
+describe('FilterPills — entity required/excluded distinction (FR-030)', () => {
+  it('announces a distinct human-readable prefix for each', () => {
+    const { container } = renderPills();
+    const srTexts = Array.from(container.querySelectorAll('span.sr-only')).map(
+      (el) => el.textContent?.trim() ?? ''
+    );
+
+    expect(srTexts).toContain('Required entity:');
+    expect(srTexts).toContain('Excluded entity:');
+    // The raw enum slug must not reach a listener.
+    expect(srTexts.join(' ')).not.toContain('excluded_entity');
+  });
+
+  it('gives each pill a distinct symbol that survives greyscale', () => {
+    const { container } = renderPills();
+    const pills = Array.from(container.querySelectorAll('[role="listitem"]'));
+    expect(pills).toHaveLength(2);
+
+    const symbols = pills.map(
+      (pill) => pill.querySelector('[aria-hidden="true"]')?.textContent ?? ''
+    );
+    expect(symbols[0]).not.toBe('');
+    expect(symbols[1]).not.toBe('');
+    // Different glyphs, so the distinction does not depend on hue at all.
+    expect(symbols[0]).not.toBe(symbols[1]);
+  });
+
+  it('distinguishes the remove controls by name, not by position alone', () => {
+    renderPills();
+    expect(
+      screen.getByRole('button', {
+        name: 'Remove Required entity filter: Ada Lovelace',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Remove Excluded entity filter: Analytical Engine',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('remains distinguishable with all colour stripped from the markup', () => {
+    // The strongest form of the requirement: remove every class attribute, so
+    // no styling of any kind survives, and confirm the two pills are still
+    // tellable apart from their text content alone.
+    const { container } = renderPills();
+    container.querySelectorAll('*').forEach((el) => el.removeAttribute('class'));
+
+    const pills = Array.from(container.querySelectorAll('[role="listitem"]'));
+    const [first, second] = pills.map((p) => p.textContent ?? '');
+
+    expect(first).not.toBe(second);
+    expect(first).toContain('Required entity');
+    expect(second).toContain('Excluded entity');
+  });
+});

--- a/frontend/src/tests/components/VideoFilters.entity.test.tsx
+++ b/frontend/src/tests/components/VideoFilters.entity.test.tsx
@@ -1,0 +1,280 @@
+/**
+ * VideoFilters — entity intersection filter (Feature 062).
+ *
+ * Covers the panel half of US1/US2: selecting required and excluded entities,
+ * the selection ceiling, pill rendering, and the transcript-only toggle.
+ *
+ * Placed under `src/tests/` alongside the sibling VideoFilters suites rather
+ * than under `frontend/tests/`. Only tests importing `tests/test-utils` need
+ * the latter; `tsconfig.json` includes just `src`, so a test kept here is
+ * typechecked by `npm run typecheck` and one moved there is not.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { VideoFilters } from '../../components/VideoFilters';
+import { FILTER_LIMITS } from '../../types/filters';
+
+// ---------------------------------------------------------------------------
+// Mocks — the panel's sibling data sources, not the subject of these tests
+// ---------------------------------------------------------------------------
+
+vi.mock('../../hooks/useCategories', () => ({
+  useCategories: () => ({
+    categories: [{ category_id: '10', name: 'Gaming', assignable: true }],
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../hooks/useTopics', () => ({
+  useTopics: () => ({ topics: [], isLoading: false, isError: false, error: null }),
+}));
+
+vi.mock('../../hooks/useOnlineStatus', () => ({
+  useOnlineStatus: () => true,
+}));
+
+const ADA = {
+  entity_id: '11111111-1111-4111-8111-111111111111',
+  canonical_name: 'Ada Lovelace',
+  entity_type: 'person',
+};
+const ENGINE = {
+  entity_id: '22222222-2222-4222-8222-222222222222',
+  canonical_name: 'Analytical Engine',
+  entity_type: 'work',
+};
+const ENTITIES = [ADA, ENGINE];
+
+vi.mock('../../hooks/useEntitySearch', () => ({
+  useEntitySearch: (search: string) => ({
+    entities: search.trim().length >= 2 ? ENTITIES : [],
+    isLoading: false,
+    isBelowMinChars: search.trim().length < 2,
+    isError: false,
+  }),
+}));
+
+function renderFilters(initialEntries: string[] = ['/']) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <VideoFilters />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('VideoFilters — entity intersection (Feature 062)', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [], pagination: { total: 0 } }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe('selection', () => {
+    it('renders a required and an excluded entity picker', () => {
+      renderFilters();
+      expect(screen.getByLabelText('Mentions all of')).toBeInTheDocument();
+      expect(screen.getByLabelText('Excluding')).toBeInTheDocument();
+    });
+
+    it('adds a chosen entity to the URL as a repeated entity_id key', async () => {
+      const user = userEvent.setup();
+      renderFilters();
+
+      await user.type(screen.getByLabelText('Mentions all of'), 'ada');
+      await user.click(await screen.findByText('Ada Lovelace'));
+
+      // The name renders twice by design — once as the picker's selected chip
+      // and once as a filter pill — so assert on the chip's remove control,
+      // which is unique and is also the affordance that makes the selection
+      // reversible.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Remove Ada Lovelace' })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('offers suggestions only at two characters or more', async () => {
+      const user = userEvent.setup();
+      renderFilters();
+
+      await user.type(screen.getByLabelText('Mentions all of'), 'a');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+
+      await user.type(screen.getByLabelText('Mentions all of'), 'd');
+      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('does not offer an entity already chosen in the opposite set', async () => {
+      const user = userEvent.setup();
+      // Ada is already EXCLUDED, so she must not appear as a required option:
+      // the two sets must stay disjoint, and the API rejects an overlap (FR-016).
+      renderFilters([`/?exclude_entity_id=${ADA.entity_id}`]);
+
+      await user.type(screen.getByLabelText('Mentions all of'), 'ada');
+      const listbox = await screen.findByRole('listbox');
+      expect(listbox).not.toHaveTextContent('Ada Lovelace');
+      expect(listbox).toHaveTextContent('Analytical Engine');
+    });
+  });
+
+  describe('selection ceiling (FR-002a, FR-002b)', () => {
+    it('explains the limit and disables input at the ceiling', () => {
+      const atCeiling = Array.from(
+        { length: FILTER_LIMITS.MAX_ENTITIES },
+        (_, index) =>
+          `entity_id=00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
+      ).join('&');
+      renderFilters([`/?${atCeiling}`]);
+
+      const input = screen.getByLabelText('Mentions all of');
+      expect(input).toBeDisabled();
+      expect(
+        screen.getByText(
+          `Maximum ${FILTER_LIMITS.MAX_ENTITIES} reached. Remove one to add another.`
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('applies the ceiling to each set separately, not to their sum', () => {
+      // Nine required plus nine excluded is eighteen entities, and NEITHER set
+      // is at its own ceiling of ten. A ceiling applied to the combined size
+      // would wrongly disable both inputs here.
+      const nine = (key: string) =>
+        Array.from(
+          { length: 9 },
+          (_, i) => `${key}=00000000-0000-4000-8000-${String(i).padStart(12, '0')}`
+        ).join('&');
+      renderFilters([`/?${nine('entity_id')}&${nine('exclude_entity_id')}`]);
+
+      expect(screen.getByLabelText('Mentions all of')).not.toBeDisabled();
+      expect(screen.getByLabelText('Excluding')).not.toBeDisabled();
+    });
+  });
+
+  describe('filter pills', () => {
+    it('renders required and excluded entities as distinct pill types', () => {
+      renderFilters([
+        `/?entity_id=${ADA.entity_id}&exclude_entity_id=${ENGINE.entity_id}`,
+      ]);
+      // Both ids appear as pills; the labels fall back to the id until the
+      // user re-picks, since the URL carries ids rather than names.
+      const pills = screen.getAllByRole('listitem');
+      expect(pills.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('address round-trip (FR-011, FR-011a, FR-017, SC-006)', () => {
+    it('restores required entities, an exclusion, and a scope from one URL', async () => {
+      // The shareable-link contract: everything needed to reproduce a result
+      // lives in the address. A parameter that the panel writes but does not
+      // read back produces a link that works for the sender and not for the
+      // recipient — which is worse than not being shareable at all.
+      renderFilters([
+        `/?entity_id=${ADA.entity_id}&entity_id=${ENGINE.entity_id}` +
+          `&exclude_entity_id=00000000-0000-4000-8000-000000000009` +
+          `&min_evidence=transcript`,
+      ]);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Type at least 2 characters. 2 of 10 selected.')
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText('Type at least 2 characters. 1 of 10 selected.')
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText(/Transcript only/)).toBeChecked();
+    });
+
+    it('keeps required and excluded sets distinct on restore', async () => {
+      // Both sets are repeated keys on the same address; reading one into the
+      // other would silently invert the user's intent.
+      renderFilters([
+        `/?entity_id=${ADA.entity_id}&exclude_entity_id=${ENGINE.entity_id}`,
+      ]);
+
+      // One in each set, not two in either — so both pickers report exactly
+      // one selection, which is what two matches of this text means.
+      await waitFor(() => {
+        expect(
+          screen.getAllByText('Type at least 2 characters. 1 of 10 selected.')
+        ).toHaveLength(2);
+      });
+    });
+
+    it('restores an exclusion-only address', async () => {
+      // FR-015: exclusion works with an empty required set, so the address
+      // must round-trip that shape too.
+      renderFilters([`/?exclude_entity_id=${ENGINE.entity_id}`]);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Type at least 2 characters. 0 of 10 selected.')
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText('Type at least 2 characters. 1 of 10 selected.')
+      ).toBeInTheDocument();
+    });
+
+    it('treats a duplicated entity id in the address as one selection', async () => {
+      // Requesting the same entity twice is idempotent (Edge Cases); a
+      // hand-edited or double-appended link must not consume two slots.
+      renderFilters([
+        `/?entity_id=${ADA.entity_id}&entity_id=${ADA.entity_id}`,
+      ]);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Mentions all of')).toBeInTheDocument();
+      });
+      // The API deduplicates; the panel must not report two selections for one
+      // entity, or the ceiling count would drift from what the server enforces.
+      expect(
+        screen.getByText('Type at least 2 characters. 1 of 10 selected.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('evidence scope (FR-020b)', () => {
+    it('offers exactly one scope affordance, a transcript-only toggle', () => {
+      renderFilters();
+      expect(screen.getByLabelText(/Transcript only/)).toBeInTheDocument();
+      // A general scope selector waits for a graded confidence model; there
+      // must be no source dropdown alongside it.
+      expect(screen.queryByLabelText(/evidence scope/i)).not.toBeInTheDocument();
+    });
+
+    it('reflects an active transcript-only scope from the address', () => {
+      renderFilters(['/?min_evidence=transcript']);
+      expect(screen.getByLabelText(/Transcript only/)).toBeChecked();
+    });
+
+    it('is unchecked when no scope is requested, meaning all three sources', () => {
+      renderFilters();
+      expect(screen.getByLabelText(/Transcript only/)).not.toBeChecked();
+    });
+  });
+});

--- a/frontend/src/tests/components/VideoList.entity.test.tsx
+++ b/frontend/src/tests/components/VideoList.entity.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * VideoList / VideoCard — entity intersection result rendering (Feature 062).
+ *
+ * Covers the result half of US1: per-entity evidence on each row (FR-008a),
+ * the empty state distinguishable from an error and from an unfiltered library
+ * (FR-012), and a rejected filter presented as recoverable rather than as a
+ * dead end (FR-016a).
+ *
+ * Kept under `src/tests/` so it is typechecked — see the note in
+ * VideoFilters.entity.test.tsx.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { VideoList } from '../../components/VideoList';
+import type { VideoListItem } from '../../types/video';
+
+vi.mock('../../hooks/useOnlineStatus', () => ({
+  useOnlineStatus: () => true,
+}));
+
+const useVideosMock = vi.fn();
+vi.mock('../../hooks/useVideos', () => ({
+  useVideos: (...args: unknown[]) => useVideosMock(...args),
+}));
+
+function makeVideo(overrides: Partial<VideoListItem> = {}): VideoListItem {
+  return {
+    video_id: 'vid00000001',
+    title: 'Fixture Video',
+    channel_id: 'UC00000000000000000001',
+    channel_title: 'Fixture Channel',
+    upload_date: '2024-05-01T00:00:00Z',
+    duration: 610,
+    view_count: 100,
+    transcript_summary: {
+      count: 0,
+      languages: [],
+      has_manual: false,
+      has_corrections: false,
+    },
+    tags: [],
+    category_id: null,
+    category_name: null,
+    topics: [],
+    availability_status: 'available',
+    ...overrides,
+  } as VideoListItem;
+}
+
+function baseHookReturn(overrides: Record<string, unknown> = {}) {
+  return {
+    videos: [],
+    total: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    retry: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    loadMoreRef: { current: null },
+    ...overrides,
+  };
+}
+
+function renderList(props: Record<string, unknown> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <VideoList {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('VideoList — entity intersection (Feature 062)', () => {
+  beforeEach(() => {
+    useVideosMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('per-entity evidence (FR-008a)', () => {
+    it('shows each required entity with its mention count and first timestamp', () => {
+      useVideosMock.mockReturnValue(
+        baseHookReturn({
+          videos: [
+            makeVideo({
+              entity_matches: [
+                {
+                  entity_id: 'e1',
+                  entity_type: 'person',
+                  canonical_name: 'Ada Lovelace',
+                  mention_count: 3,
+                  first_timestamp: 65,
+                },
+              ],
+              total_mentions: 3,
+            }),
+          ],
+          total: 1,
+        })
+      );
+      renderList({ entityIds: ['e1'] });
+
+      expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+      // Shown as `(3)` inside the pill, matching the video detail page's
+      // entity chips; spoken in full so a screen reader is not left reading
+      // punctuation.
+      expect(screen.getByText('(3)')).toBeInTheDocument();
+      expect(screen.getByText(', 3 mentions')).toHaveClass('sr-only');
+      expect(screen.getByText('from 1:05')).toBeInTheDocument();
+    });
+
+    it('omits the timestamp entirely when the entity has none', () => {
+      // An entity present only in the title or description has no segment and
+      // therefore no position in time. Rendering 0:00 would assert it was
+      // mentioned at the very start, which is a different and false claim.
+      useVideosMock.mockReturnValue(
+        baseHookReturn({
+          videos: [
+            makeVideo({
+              entity_matches: [
+                {
+                  entity_id: 'e1',
+                  entity_type: 'place',
+                  canonical_name: 'Bletchley',
+                  mention_count: 1,
+                  first_timestamp: null,
+                },
+              ],
+              total_mentions: 1,
+            }),
+          ],
+          total: 1,
+        })
+      );
+      renderList({ entityIds: ['e1'] });
+
+      expect(screen.getByText('Bletchley')).toBeInTheDocument();
+      expect(screen.getByText('(1)')).toBeInTheDocument();
+      // Singular when the count is one, in the spoken form.
+      expect(screen.getByText(', 1 mention')).toHaveClass('sr-only');
+      expect(screen.queryByText(/^from /)).not.toBeInTheDocument();
+      expect(screen.queryByText('0:00')).not.toBeInTheDocument();
+    });
+
+    it('draws no entity section when no entity filter is active', () => {
+      useVideosMock.mockReturnValue(
+        baseHookReturn({
+          videos: [makeVideo({ entity_matches: null, total_mentions: null })],
+          total: 1,
+        })
+      );
+      renderList();
+      expect(screen.queryByText(/mentions?$/)).not.toBeInTheDocument();
+    });
+
+    it('draws no entity section for an exclusion-only filter', () => {
+      // entity_matches is present-and-EMPTY here, which marks an active filter
+      // with no required entities. An empty section header would be noise.
+      useVideosMock.mockReturnValue(
+        baseHookReturn({
+          videos: [makeVideo({ entity_matches: [], total_mentions: 0 })],
+          total: 1,
+        })
+      );
+      renderList({ excludedEntityIds: ['e9'] });
+      expect(screen.queryByText(/mentions?$/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty state (FR-012)', () => {
+    it('distinguishes an empty intersection from an empty library', () => {
+      useVideosMock.mockReturnValue(baseHookReturn({ videos: [], total: 0 }));
+      renderList({ entityIds: ['e1', 'e2'] });
+
+      expect(screen.getByTestId('empty-intersection')).toBeInTheDocument();
+      expect(
+        screen.getByText('No videos mention all of these entities')
+      ).toBeInTheDocument();
+      // And it suggests the action that actually helps at this set size.
+      expect(screen.getByText(/Try removing one/)).toBeInTheDocument();
+    });
+
+    it('mentions the active scope when transcript-only is narrowing results', () => {
+      useVideosMock.mockReturnValue(baseHookReturn({ videos: [], total: 0 }));
+      renderList({ entityIds: ['e1'], minEvidence: 'transcript' });
+
+      expect(screen.getByText(/Transcript-only is active/)).toBeInTheDocument();
+    });
+
+    it('falls back to the ordinary empty state with no entity filter', () => {
+      useVideosMock.mockReturnValue(baseHookReturn({ videos: [], total: 0 }));
+      renderList();
+
+      expect(screen.queryByTestId('empty-intersection')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('rejected filter (FR-016a)', () => {
+    it('presents a 400 as recoverable, naming the offending value', () => {
+      useVideosMock.mockReturnValue(
+        baseHookReturn({
+          isError: true,
+          error: {
+            type: 'unknown',
+            message: 'An unexpected error occurred.',
+            status: 400,
+            detail: 'Unknown entity id(s): 11111111-1111-4111-8111-111111111111.',
+          },
+        })
+      );
+      renderList({ entityIds: ['11111111-1111-4111-8111-111111111111'] });
+
+      const panel = screen.getByTestId('filter-rejected');
+      expect(panel).toBeInTheDocument();
+      // The server's explanation must survive to the user; the generic
+      // type-keyed message cannot say WHICH value was rejected.
+      expect(panel).toHaveTextContent('11111111-1111-4111-8111-111111111111');
+      expect(panel).toHaveTextContent(/other filters are still active/i);
+    });
+
+    it('does not offer retry for a rejection, since retrying cannot help', () => {
+      useVideosMock.mockReturnValue(
+        baseHookReturn({
+          isError: true,
+          error: { type: 'unknown', message: 'x', status: 400 },
+        })
+      );
+      renderList({ entityIds: ['e1'] });
+
+      expect(screen.getByTestId('filter-rejected')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /retry|try again/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('still shows the ordinary error state for a server failure', () => {
+      // A 500 IS worth retrying, so it must not be absorbed into the
+      // recoverable-filter panel.
+      useVideosMock.mockReturnValue(
+        baseHookReturn({
+          isError: true,
+          error: { type: 'server', message: 'boom', status: 500 },
+        })
+      );
+      renderList({ entityIds: ['e1'] });
+
+      expect(screen.queryByTestId('filter-rejected')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('parameter pass-through', () => {
+    it('forwards entity filters to the videos query', () => {
+      useVideosMock.mockReturnValue(baseHookReturn({ videos: [], total: 0 }));
+      renderList({
+        entityIds: ['e1', 'e2'],
+        excludedEntityIds: ['e3'],
+        minEvidence: 'transcript',
+      });
+
+      expect(useVideosMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityIds: ['e1', 'e2'],
+          excludedEntityIds: ['e3'],
+          minEvidence: 'transcript',
+        })
+      );
+    });
+  });
+});

--- a/frontend/src/tests/hooks/useVideos.entity.test.ts
+++ b/frontend/src/tests/hooks/useVideos.entity.test.ts
@@ -1,0 +1,167 @@
+/**
+ * useVideos — entity intersection parameters (Feature 062).
+ *
+ * The centrepiece is the **cache-key** test. React Query caches on the query
+ * key alone, so a filter that reaches the request URL but is missing from the
+ * key produces a result that looks right on first load and then never updates:
+ * changing the filter serves the previous answer from cache, and only a hard
+ * reload appears to "fix" it. That shipped once here — the entity params were
+ * appended to the URL but omitted from the key — and it is invisible to any
+ * test that checks a single request in isolation.
+ *
+ * @module tests/hooks/useVideos.entity
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+import { useVideos } from "../../hooks/useVideos";
+import type { VideoListResponse } from "../../types/video";
+import * as apiConfig from "../../api/config";
+
+vi.mock("../../api/config", () => ({
+  apiFetch: vi.fn(),
+  API_BASE_URL: "http://localhost:8765/api/v1",
+  API_TIMEOUT: 10000,
+}));
+
+const mockResponse: VideoListResponse = {
+  data: [],
+  pagination: { total: 0, limit: 25, offset: 0, has_more: false },
+};
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function newClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+/** Last URL passed to apiFetch. */
+function lastUrl(): string {
+  const calls = vi.mocked(apiConfig.apiFetch).mock.calls;
+  return String(calls[calls.length - 1]?.[0] ?? "");
+}
+
+describe("useVideos — entity filter parameters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(apiConfig.apiFetch).mockResolvedValue(mockResponse);
+  });
+
+  describe("request construction", () => {
+    it("sends required entities as repeated entity_id keys", async () => {
+      const queryClient = newClient();
+      renderHook(() => useVideos({ entityIds: ["e1", "e2"] }), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => expect(apiConfig.apiFetch).toHaveBeenCalled());
+      const params = new URLSearchParams(lastUrl().split("?")[1]);
+      expect(params.getAll("entity_id")).toEqual(["e1", "e2"]);
+    });
+
+    it("sends excluded entities as repeated exclude_entity_id keys", async () => {
+      const queryClient = newClient();
+      renderHook(() => useVideos({ excludedEntityIds: ["x1", "x2"] }), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => expect(apiConfig.apiFetch).toHaveBeenCalled());
+      const params = new URLSearchParams(lastUrl().split("?")[1]);
+      expect(params.getAll("exclude_entity_id")).toEqual(["x1", "x2"]);
+    });
+
+    it("sends min_evidence only when a scope is requested", async () => {
+      const withScope = newClient();
+      renderHook(() => useVideos({ entityIds: ["e1"], minEvidence: "transcript" }), {
+        wrapper: createWrapper(withScope),
+      });
+      await waitFor(() => expect(apiConfig.apiFetch).toHaveBeenCalled());
+      expect(new URLSearchParams(lastUrl().split("?")[1]).get("min_evidence")).toBe(
+        "transcript"
+      );
+
+      vi.clearAllMocks();
+      const noScope = newClient();
+      renderHook(() => useVideos({ entityIds: ["e1"] }), {
+        wrapper: createWrapper(noScope),
+      });
+      await waitFor(() => expect(apiConfig.apiFetch).toHaveBeenCalled());
+      expect(new URLSearchParams(lastUrl().split("?")[1]).has("min_evidence")).toBe(
+        false
+      );
+    });
+
+    it("omits entity params entirely when no entity filter is active", async () => {
+      const queryClient = newClient();
+      renderHook(() => useVideos({}), { wrapper: createWrapper(queryClient) });
+
+      await waitFor(() => expect(apiConfig.apiFetch).toHaveBeenCalled());
+      const params = new URLSearchParams(lastUrl().split("?")[1]);
+      expect(params.has("entity_id")).toBe(false);
+      expect(params.has("exclude_entity_id")).toBe(false);
+    });
+  });
+
+  describe("cache key covers every entity parameter", () => {
+    /**
+     * Each case changes ONE entity parameter on a shared QueryClient and
+     * asserts a second request is issued. If the parameter is missing from the
+     * query key, React Query answers from cache and `apiFetch` is never called
+     * again — the exact stale-until-reload bug this guards.
+     */
+    it.each([
+      ["required entities", { entityIds: ["a"] }, { entityIds: ["a", "b"] }],
+      [
+        "excluded entities",
+        { excludedEntityIds: ["a"] },
+        { excludedEntityIds: ["a", "b"] },
+      ],
+      [
+        "evidence scope",
+        { entityIds: ["a"] },
+        { entityIds: ["a"], minEvidence: "transcript" as const },
+      ],
+    ])("refetches when %s change", async (_label, first, second) => {
+      const queryClient = newClient();
+      const wrapper = createWrapper(queryClient);
+
+      const { rerender } = renderHook((props: Parameters<typeof useVideos>[0]) => useVideos(props), {
+        wrapper,
+        initialProps: first,
+      });
+      await waitFor(() => expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1));
+
+      rerender(second);
+      await waitFor(() => expect(apiConfig.apiFetch).toHaveBeenCalledTimes(2));
+
+      // And the second request actually carries the new filter, so the refetch
+      // is meaningful rather than an identical repeat.
+      expect(lastUrl()).not.toBe(
+        String(vi.mocked(apiConfig.apiFetch).mock.calls[0]?.[0] ?? "")
+      );
+    });
+
+    it("does NOT refetch when nothing relevant changed", async () => {
+      // The counterweight: a key containing something volatile would refetch
+      // constantly and make the test above pass for the wrong reason.
+      const queryClient = newClient();
+      const wrapper = createWrapper(queryClient);
+
+      const { rerender } = renderHook(
+        (props: Parameters<typeof useVideos>[0]) => useVideos(props),
+        { wrapper, initialProps: { entityIds: ["a"] } }
+      );
+      await waitFor(() => expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1));
+
+      rerender({ entityIds: ["a"] });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(apiConfig.apiFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/tests/pages/HomePage.scroll.test.tsx
+++ b/frontend/src/tests/pages/HomePage.scroll.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * HomePage — scroll-to-top fires on filter CHANGE, not on every render (FR-031).
+ *
+ * `searchParams.getAll()` returns a fresh array on every render. Listing those
+ * arrays as effect dependencies made the scroll-to-top effect run on every
+ * render rather than when a filter changed — and HomePage re-renders whenever
+ * the shared videos query gains a page, because its own `useVideos` call (for
+ * the filter panel's total) subscribes to the same cache entry that infinite
+ * scroll appends to.
+ *
+ * The user-visible result: scroll down far enough to load another page and the
+ * page smoothly yanks itself back to the top. Reproduced at ~118,000px of
+ * scroll depth before the fix.
+ *
+ * These tests pin both halves — it must NOT fire on a bare re-render, and it
+ * must STILL fire when a filter actually changes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { HomePage } from "../../pages/HomePage";
+
+vi.mock("../../hooks/useCategories", () => ({
+  useCategories: () => ({
+    categories: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../../hooks/useTopics", () => ({
+  useTopics: () => ({
+    topics: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../../hooks/useVideos", () => ({
+  useVideos: vi.fn(() => ({
+    videos: [],
+    total: 0,
+    loadedCount: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    retry: vi.fn(),
+    loadMoreRef: { current: null },
+  })),
+}));
+
+function renderWithProviders(
+  ui: React.ReactElement,
+  { initialEntries = ["/"] } = {}
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("HomePage — scroll-to-top trigger (FR-031)", () => {
+  let scrollTo: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scrollTo = vi
+      .spyOn(window, "scrollTo")
+      .mockImplementation(() => undefined) as unknown as ReturnType<
+      typeof vi.spyOn
+    >;
+  });
+
+  afterEach(() => {
+    scrollTo.mockRestore();
+  });
+
+  describe("does not fire on a re-render with unchanged filters", () => {
+    it("stays put when nothing changed", () => {
+      const { rerender } = renderWithProviders(<HomePage />);
+      scrollTo.mockClear(); // ignore the mount call
+
+      // A re-render is exactly what an arriving infinite-scroll page causes.
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <MemoryRouter>
+            <HomePage />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+
+      expect(scrollTo).not.toHaveBeenCalled();
+    });
+
+    it("stays put with array-valued filters active", () => {
+      // The array params are the ones whose identity churned: tag,
+      // canonical_tag, topic_id, entity_id, exclude_entity_id.
+      const url =
+        "/?tag=a&canonical_tag=b&topic_id=/m/04rlf&entity_id=11111111-1111-4111-8111-111111111111&exclude_entity_id=22222222-2222-4222-8222-222222222222";
+      const { rerender } = renderWithProviders(<HomePage />, {
+        initialEntries: [url],
+      });
+      scrollTo.mockClear();
+
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <MemoryRouter initialEntries={[url]}>
+            <HomePage />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+
+      expect(scrollTo).not.toHaveBeenCalled();
+    });
+
+    it("stays put across several consecutive re-renders", () => {
+      // One page arriving is one re-render; a long scroll is many.
+      const { rerender } = renderWithProviders(<HomePage />, {
+        initialEntries: ["/?tag=news"],
+      });
+      scrollTo.mockClear();
+
+      for (let i = 0; i < 5; i++) {
+        rerender(
+          <QueryClientProvider client={new QueryClient()}>
+            <MemoryRouter initialEntries={["/?tag=news"]}>
+              <HomePage />
+            </MemoryRouter>
+          </QueryClientProvider>
+        );
+      }
+
+      expect(scrollTo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("still fires when a filter actually changes (FR-031)", () => {
+    it("scrolls to top when a filter is toggled", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<HomePage />);
+      scrollTo.mockClear();
+
+      await user.click(
+        screen.getByRole("checkbox", { name: /Show unavailable content/i })
+      );
+
+      await waitFor(() => {
+        expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+      });
+    });
+  });
+});

--- a/frontend/src/types/filters.ts
+++ b/frontend/src/types/filters.ts
@@ -118,6 +118,15 @@ export const FILTER_LIMITS = {
   MAX_TOPICS: 10,
   /** Maximum number of categories (always 1 - single selection) */
   MAX_CATEGORIES: 1,
+  /**
+   * Maximum entities per set (Feature 062, FR-002a).
+   *
+   * Applied SEPARATELY to the required and excluded sets, matching MAX_TAGS
+   * for interface consistency. Note MAX_TOTAL below still binds across all
+   * filter types, so this per-set ceiling is a sub-cap and is not always
+   * reachable.
+   */
+  MAX_ENTITIES: 10,
   /** Maximum total number of filters across all types */
   MAX_TOTAL: 15,
 } as const;

--- a/frontend/src/types/video.ts
+++ b/frontend/src/types/video.ts
@@ -33,6 +33,26 @@ export interface TopicSummary {
 /**
  * Video item as returned by the list API endpoint.
  */
+/**
+ * One required entity's evidence within a qualifying video (Feature 062).
+ */
+export interface VideoEntityMatch {
+  /** Named entity UUID. */
+  entity_id: string;
+  /** Entity type, carried so the badge renders without a second lookup. */
+  entity_type: string;
+  /** Canonical display name. */
+  canonical_name: string;
+  /** Qualifying mentions of this entity in this video. */
+  mention_count: number;
+  /**
+   * Earliest transcript position in seconds, or null when the entity appears
+   * only in the title or description — those have no segment and therefore
+   * no time. Null must render as absent, never as 0:00.
+   */
+  first_timestamp: number | null;
+}
+
 export interface VideoListItem {
   /** 11-character YouTube video ID */
   video_id: string;
@@ -56,6 +76,17 @@ export interface VideoListItem {
   category_id: string | null;
   /** Human-readable category name */
   category_name: string | null;
+  /**
+   * Per-required-entity evidence (Feature 062).
+   *
+   * Null when no entity filter of either kind is active, so pre-existing
+   * callers see an unchanged shape. Present and EMPTY for an exclusion-only
+   * filter, which IS an active filter. Otherwise one element per required
+   * entity.
+   */
+  entity_matches?: VideoEntityMatch[] | null;
+  /** Qualifying mentions summed across required entities; the relevance key. */
+  total_mentions?: number | null;
   /** Associated topics with hierarchy */
   topics: TopicSummary[];
   /** Content availability status */
@@ -164,4 +195,14 @@ export interface ApiError {
   type: ApiErrorType;
   message: string;
   status?: number | undefined;
+  /**
+   * Server-supplied explanation from the RFC 7807 problem-details body.
+   *
+   * The generic `message` above is keyed off the error TYPE and cannot name
+   * what actually went wrong. When the API rejects a request for a reason the
+   * user can act on — an entity id it does not recognise, a limit it exceeded
+   * — that reason arrives here, so the UI can present a recoverable state
+   * rather than a dead end (Feature 062, FR-016a).
+   */
+  detail?: string | undefined;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
       - Work with transcripts: user-guide/transcripts.md
       - Correct transcripts: user-guide/corrections.md
       - Analyze topics: user-guide/topic-analytics.md
+      - Find entity intersections: user-guide/entity-intersection.md
       - CLI workflows: user-guide/cli-overview.md
       - Run the REST API: user-guide/rest-api.md
       - Deploy with Docker: guides/migrating-to-docker.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.61.0"
+version = "0.62.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.61.0"
+__version__ = "0.62.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -24,6 +24,8 @@ from sqlalchemy.orm import selectinload
 from chronovista.api.deps import get_db, require_auth
 from chronovista.api.schemas.entity_mentions import (
     ClassifyTagRequest,
+    CooccurringEntitiesResponse,
+    CooccurringEntity,
     CreateEntityAliasRequest,
     CreateEntityRequest,
     DuplicateCheckResponse,
@@ -62,6 +64,7 @@ from chronovista.models.enums import (
     DiscoveryMethod,
     EntityAliasType,
     EntityType,
+    EvidenceScope,
     TagStatus,
 )
 from chronovista.models.named_entity import NamedEntityCreate
@@ -96,6 +99,11 @@ router = APIRouter(dependencies=[Depends(require_auth)])
 
 # Module-level repository / service instantiation (singleton pattern)
 _mention_repo = EntityMentionRepository()
+
+# Ceiling for the appears-with panel (FR-023a). The default of 12 fills a
+# column without scrolling; this bound exists so "reveal more" cannot walk the
+# list to an unbounded size on a hub entity with hundreds of partners.
+MAX_COOCCURRING_LIMIT = 50
 _alias_repo = EntityAliasRepository()
 _entity_repo = NamedEntityRepository()
 _normalizer = TagNormalizationService()
@@ -630,6 +638,87 @@ async def get_entity_detail(
             "exclusion_patterns": list(entity.exclusion_patterns or []),
         }
     }
+
+
+@router.get(
+    "/entities/{entity_id}/co-occurring",
+    response_model=CooccurringEntitiesResponse,
+    status_code=200,
+    summary="Entities that share videos with this entity",
+)
+async def get_cooccurring_entities(
+    entity_id: str = Path(..., description="Named entity UUID"),
+    limit: int = Query(
+        default=12,
+        ge=1,
+        le=MAX_COOCCURRING_LIMIT,
+        description=(
+            "Maximum partners to return. Bounded rather than unbounded: a "
+            "handful of entities co-occur with hundreds of others, and an "
+            "unbounded list would be unusable and slow (FR-023a)."
+        ),
+    ),
+    min_evidence: EvidenceScope = Query(
+        EvidenceScope.ANY,
+        description=(
+            "Which mentions count as co-occurrence. Must match the scope of "
+            "the surrounding view, or the count shown and the intersection it "
+            "opens will disagree (FR-024a)."
+        ),
+    ),
+    session: AsyncSession = Depends(get_db),
+) -> CooccurringEntitiesResponse:
+    """Get the entities most often appearing alongside this one.
+
+    Powers the "appears with" panel on the entity detail page. Each partner's
+    ``shared_video_count`` equals the total the videos list reports when
+    filtered to that pair under the same evidence scope (FR-024b).
+
+    Parameters
+    ----------
+    entity_id : str
+        Named entity UUID (string representation).
+    limit : int
+        Maximum partners returned, bounded by ``MAX_COOCCURRING_LIMIT``
+        (default 12).
+    min_evidence : EvidenceScope
+        Evidence scope to compute co-occurrence under.
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    CooccurringEntitiesResponse
+        Partners ordered by shared-video count descending, tiebroken by id.
+
+    Raises
+    ------
+    NotFoundError
+        If the entity does not exist (404).
+    """
+    try:
+        parsed_entity_id = uuid.UUID(entity_id)
+    except ValueError as exc:
+        raise NotFoundError(resource_type="Entity", identifier=entity_id) from exc
+
+    entity_exists = await session.execute(
+        select(NamedEntityDB.id).where(NamedEntityDB.id == parsed_entity_id)
+    )
+    if not entity_exists.scalar_one_or_none():
+        raise NotFoundError(resource_type="Entity", identifier=entity_id)
+
+    partners = await _mention_repo.get_cooccurring_entities(
+        session,
+        entity_id=parsed_entity_id,
+        limit=limit,
+        evidence_scope=min_evidence,
+    )
+
+    # An entity with no co-occurrences returns an empty list, not an error
+    # (FR-024): "nothing appears alongside this" is an answer, not a failure.
+    return CooccurringEntitiesResponse(
+        data=[CooccurringEntity(**partner) for partner in partners]
+    )
 
 
 @router.get(

--- a/src/chronovista/api/routers/videos.py
+++ b/src/chronovista/api/routers/videos.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any
+from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Path, Query, Request
 from fastapi.responses import JSONResponse
@@ -33,6 +34,7 @@ from chronovista.api.schemas.videos import (
     TranscriptSummary,
     VideoDetail,
     VideoDetailResponse,
+    VideoEntityMatch,
     VideoListItem,
     VideoListResponse,
     VideoListResponseWithWarnings,
@@ -40,6 +42,9 @@ from chronovista.api.schemas.videos import (
     VideoPlaylistsResponse,
     VideoRecoveryResponse,
     VideoRecoveryResultData,
+)
+from chronovista.db.models import (
+    NamedEntity as NamedEntityDB,
 )
 from chronovista.db.models import (
     TopicCategory,
@@ -57,10 +62,11 @@ from chronovista.exceptions import (
     ConflictError,
     NotFoundError,
 )
-from chronovista.models.enums import AvailabilityStatus
+from chronovista.models.enums import AvailabilityStatus, EvidenceScope
 from chronovista.repositories.canonical_tag_repository import (
     CanonicalTagRepository,
 )
+from chronovista.repositories.entity_mention_repository import EntityMentionRepository
 from chronovista.repositories.playlist_membership_repository import (
     PlaylistMembershipRepository,
 )
@@ -78,6 +84,9 @@ class VideoSortField(str, Enum):
 
     UPLOAD_DATE = "upload_date"
     TITLE = "title"
+    RELEVANCE = "relevance"  # Feature 062: ordering comes from the entity
+    # qualification subquery, not a VideoDB column, so it is deliberately
+    # absent from _VIDEO_SORT_COLUMN_MAP below.
 
 
 # Mapping from VideoSortField enum to actual SQLAlchemy column references.
@@ -92,6 +101,9 @@ MAX_TAGS = 10
 MAX_CANONICAL_TAGS = 10
 MAX_TOPICS = 10
 MAX_TOTAL_FILTERS = 15
+# Feature 062: applied SEPARATELY to the required and excluded sets (FR-002a),
+# while both sets also count toward MAX_TOTAL_FILTERS above (FR-002d).
+MAX_ENTITIES = 10
 
 # Rate limiting configuration (T097)
 # In-memory rate limiter - requests per minute per client
@@ -223,6 +235,8 @@ def _validate_filter_limits(
     canonical_tags: list[str],
     topic_ids: list[str],
     category: str | None,
+    entity_ids: list[UUID] | None = None,
+    excluded_entity_ids: list[UUID] | None = None,
 ) -> None:
     """
     Validate filter limits per FR-034.
@@ -289,9 +303,37 @@ def _validate_filter_limits(
             },
         )
 
-    # Check total filter count
+    # Entity ceilings (Feature 062). Applied to each set SEPARATELY rather than
+    # to their combined size (FR-002a): requiring five entities and excluding
+    # five is two five-item decisions, not one ten-item one.
+    required = entity_ids or []
+    excluded = excluded_entity_ids or []
+    for field, values in (("entity_id", required), ("exclude_entity_id", excluded)):
+        if len(values) > MAX_ENTITIES:
+            raise BadRequestError(
+                message=(
+                    f"Maximum {MAX_ENTITIES} entities allowed per set, "
+                    f"received {len(values)}. "
+                    f"Remove {len(values) - MAX_ENTITIES} to continue."
+                ),
+                details={
+                    "field": field,
+                    "max_allowed": MAX_ENTITIES,
+                    "received": len(values),
+                    "excess": len(values) - MAX_ENTITIES,
+                },
+            )
+
+    # Check total filter count. Entities count toward the global cap on the
+    # same terms as every other filter type (FR-002d), so the per-set ceiling
+    # above is a sub-cap: with other filters active, neither set reaches 10.
     total_filters = (
-        len(tags) + len(canonical_tags) + len(topic_ids) + (1 if category else 0)
+        len(tags)
+        + len(canonical_tags)
+        + len(topic_ids)
+        + (1 if category else 0)
+        + len(required)
+        + len(excluded)
     )
     if total_filters > MAX_TOTAL_FILTERS:
         raise BadRequestError(
@@ -555,9 +597,14 @@ async def list_videos(
         False,
         description="Include unavailable records in results",
     ),
-    sort_by: VideoSortField = Query(
-        VideoSortField.UPLOAD_DATE,
-        description="Sort field (upload_date or title)",
+    sort_by: VideoSortField | None = Query(
+        None,
+        description=(
+            "Sort field (upload_date, title, or relevance). Defaults to "
+            "upload_date. Left unset here rather than defaulted at the "
+            "parameter layer so the endpoint can distinguish 'caller sent "
+            "nothing' from 'caller explicitly chose upload_date' (FR-009e)."
+        ),
     ),
     sort_order: SortOrder = Query(
         SortOrder.DESC,
@@ -573,6 +620,34 @@ async def list_videos(
     liked_only: bool = Query(
         False,
         description="Filter to only liked videos",
+    ),
+    # Entity intersection (Feature 062). Repeated keys, matching the binding
+    # already used by tag / canonical_tag / topic_id (research R4).
+    entity_id: list[UUID] = Query(
+        default=[],
+        description=(
+            "Required entity UUID(s) - AND logic. A video qualifies only if "
+            "EVERY listed entity has at least one qualifying mention. Max 10."
+        ),
+    ),
+    exclude_entity_id: list[UUID] = Query(
+        default=[],
+        description=(
+            "Excluded entity UUID(s). A video mentioning ANY of these is "
+            "removed regardless of required matches. Max 10."
+        ),
+    ),
+    min_evidence: EvidenceScope = Query(
+        EvidenceScope.ANY,
+        description=(
+            "Which mentions qualify. 'any' counts transcript, title, and "
+            "description; 'transcript' restricts to transcript-sourced "
+            "mentions, which inherently retains every human-added mention. "
+            "Accepted and ignored when no entity filter is present, since "
+            "there is nothing being qualified — unlike sort_by=relevance, "
+            "which rejects under the same condition because it would have to "
+            "invent an ordering it cannot compute."
+        ),
     ),
     limit: int = Query(20, ge=1, le=100, description="Items per page"),
     offset: int = Query(0, ge=0, description="Pagination offset"),
@@ -646,8 +721,91 @@ async def list_videos(
     # T100: Performance logging - start timing
     query_start_time = time.perf_counter()
 
-    # Validate filter limits (FR-034)
-    _validate_filter_limits(tag, canonical_tag, topic_id, category)
+    # FR-009e: apply the sort default here rather than at the parameter layer,
+    # so "unset" stays distinguishable from an explicit choice of the same
+    # value. Feature 062 needs that distinction to auto-select relevance only
+    # when the caller expressed no preference (FR-009b).
+    # FR-009b: relevance is auto-selected when an entity filter is active AND
+    # the caller expressed no preference. FR-009c: an explicit choice is never
+    # overridden. The unset state (FR-009e) is what makes the distinction
+    # possible -- a default applied at the parameter layer would make
+    # "sent nothing" indistinguishable from "explicitly chose upload_date".
+    if sort_by is not None:
+        effective_sort_by = sort_by
+    elif entity_id:
+        effective_sort_by = VideoSortField.RELEVANCE
+    else:
+        effective_sort_by = VideoSortField.UPLOAD_DATE
+    if effective_sort_by is VideoSortField.RELEVANCE and not entity_id:
+        # Relevance ranks by mention volume across the required entities, so it
+        # has no meaning without a required set (FR-009d).
+        raise BadRequestError(
+            message=(
+                "sort_by=relevance requires at least one entity filter. "
+                "Add an entity to sort by relevance, or choose another sort."
+            ),
+            details={"field": "sort_by", "invalid_value": "relevance"},
+        )
+
+    # Deduplicate the entity sets before anything counts or queries them.
+    # Requesting an entity twice is idempotent and must not raise the
+    # qualification bar or consume two slots against the ceiling.
+    required_entity_ids = list(dict.fromkeys(entity_id))
+    excluded_entity_ids = list(dict.fromkeys(exclude_entity_id))
+
+    # Validate filter limits (FR-034, and FR-002a/FR-002d for entities)
+    _validate_filter_limits(
+        tag,
+        canonical_tag,
+        topic_id,
+        category,
+        required_entity_ids,
+        excluded_entity_ids,
+    )
+
+    # The two entity sets must be disjoint. Rejected with the offending entity
+    # named, never a silently empty result (FR-016).
+    overlap = set(required_entity_ids) & set(excluded_entity_ids)
+    if overlap:
+        raise BadRequestError(
+            message=(
+                "An entity cannot be both required and excluded: "
+                f"{', '.join(str(e) for e in sorted(overlap, key=str))}."
+            ),
+            details={
+                "field": "entity_id",
+                "conflicting_entity_ids": [str(e) for e in sorted(overlap, key=str)],
+            },
+        )
+
+    # Unknown entity ids are rejected, not ignored-with-a-warning like this
+    # endpoint's other multi-value filters. The divergence is deliberate
+    # (FR-016b): the entity filter is conjunctive, so silently dropping a
+    # required entity BROADENS the result -- a three-entity intersection
+    # quietly answered as a two-entity one returns more videos, presenting a
+    # wrong answer confidently. Dropping a disjunct narrows visibly instead.
+    all_entity_ids = required_entity_ids + excluded_entity_ids
+    if all_entity_ids:
+        known = set(
+            (
+                await session.execute(
+                    select(NamedEntityDB.id).where(NamedEntityDB.id.in_(all_entity_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        unknown = [e for e in all_entity_ids if e not in known]
+        if unknown:
+            raise BadRequestError(
+                message=(
+                    "Unknown entity id(s): " f"{', '.join(str(e) for e in unknown)}."
+                ),
+                details={
+                    "field": "entity_id",
+                    "unknown_entity_ids": [str(e) for e in unknown],
+                },
+            )
 
     # Validate filter values and collect warnings (FR-042 through FR-045)
     all_warnings: list[FilterWarning] = []
@@ -767,6 +925,25 @@ async def list_videos(
     if saved_unwatched:
         query = query.where(VideoDB.video_id.in_(saved_forgotten_video_ids()))
 
+    # Entity intersection (Feature 062). Both mutate `query`, so the count
+    # derived from `query.subquery()` below inherits them automatically -- the
+    # same guarantee every other filter here already has (FR-033, research R9).
+    # Building a parallel query or a hand-rolled count would produce correct
+    # rows with a wrong total, which no row-inspecting test detects.
+    entity_repo = EntityMentionRepository()
+    qualification = None
+    if required_entity_ids:
+        qualification = entity_repo.build_entity_qualification_subquery(
+            required_entity_ids, min_evidence
+        )
+        query = query.join(qualification, VideoDB.video_id == qualification.c.video_id)
+
+    if excluded_entity_ids:
+        excluded_videos = entity_repo.build_entity_exclusion_subquery(
+            excluded_entity_ids, min_evidence
+        )
+        query = query.where(VideoDB.video_id.notin_(excluded_videos))
+
     # T099: Execute query with timeout (FR-036: 10s timeout)
     try:
 
@@ -780,11 +957,20 @@ async def list_videos(
             total = total_result.scalar() or 0
 
             # Apply sorting (Feature 027) with deterministic secondary sort (FR-029)
-            sort_column = _VIDEO_SORT_COLUMN_MAP[sort_by]
-            if sort_order == SortOrder.ASC:
-                order_clause = sort_column.asc()
+            # Relevance orders by the joined qualification subquery's mention
+            # total, not a VideoDB column, which is why RELEVANCE is
+            # deliberately absent from _VIDEO_SORT_COLUMN_MAP. The guard
+            # earlier guarantees `qualification` exists whenever it is active.
+            ascending = sort_order == SortOrder.ASC
+            if effective_sort_by is VideoSortField.RELEVANCE:
+                assert qualification is not None
+                relevance_col = qualification.c.total_mentions
+                order_clause = (
+                    relevance_col.asc() if ascending else relevance_col.desc()
+                )
             else:
-                order_clause = sort_column.desc()
+                sort_col = _VIDEO_SORT_COLUMN_MAP[effective_sort_by]
+                order_clause = sort_col.asc() if ascending else sort_col.desc()
             paginated_query = (
                 query.order_by(order_clause, VideoDB.video_id.asc())
                 .offset(offset)
@@ -853,6 +1039,19 @@ async def list_videos(
         )
 
     # Transform to response items with classification data
+    # Per-entity evidence for the RETURNED PAGE ONLY (research R1). This is the
+    # single place transcript_segments is joined; doing it before pagination
+    # instead returns byte-identical output at roughly 8x the cost, a
+    # regression no value-based assertion can detect. Only timing can.
+    page_entity_matches: dict[str, list[dict[str, Any]]] = {}
+    if required_entity_ids:
+        page_entity_matches = await entity_repo.get_page_entity_matches(
+            session,
+            video_ids=[v.video_id for v in videos],
+            entity_ids=required_entity_ids,
+            evidence_scope=min_evidence,
+        )
+
     items: list[VideoListItem] = []
     for video in videos:
         transcript_summary = build_transcript_summary(
@@ -860,6 +1059,34 @@ async def list_videos(
             has_corrections=video.video_id in videos_with_corrections,
         )
         channel_title = video.channel.title if video.channel else None
+
+        # Entity intersection fields (Feature 062). None when no entity filter
+        # of either kind is active, so existing callers see an unchanged shape;
+        # present-and-empty for an exclusion-only filter, which IS an active
+        # filter (FR-015a).
+        video_entity_matches: list[VideoEntityMatch] | None = None
+        video_total_mentions: int | None = None
+        if required_entity_ids or excluded_entity_ids:
+            raw_matches = page_entity_matches.get(video.video_id, [])
+            # Ordered by the caller's required-set sequence. Without this the
+            # order is whatever the GROUP BY returned, so per-entity badges on
+            # one video can reorder between requests and two pages of one
+            # result set can present the same entities differently. The
+            # co-occurrence query got a tiebreak for exactly this reason; this
+            # path needs the same determinism.
+            by_id = {m["entity_id"]: m for m in raw_matches}
+            raw_matches = [by_id[eid] for eid in required_entity_ids if eid in by_id]
+            video_entity_matches = [
+                VideoEntityMatch(
+                    entity_id=m["entity_id"],
+                    entity_type=m["entity_type"],
+                    canonical_name=m["canonical_name"],
+                    mention_count=m["mention_count"],
+                    first_timestamp=m["first_timestamp"],
+                )
+                for m in raw_matches
+            ]
+            video_total_mentions = sum(m.mention_count for m in video_entity_matches)
 
         # Extract tags
         video_tags = [t.tag for t in video.tags] if video.tags else []
@@ -898,6 +1125,8 @@ async def list_videos(
                 category_name=category_name,
                 topics=topics_list,
                 availability_status=video.availability_status,
+                entity_matches=video_entity_matches,
+                total_mentions=video_total_mentions,
             )
         )
 

--- a/src/chronovista/api/schemas/entity_mentions.py
+++ b/src/chronovista/api/schemas/entity_mentions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Literal
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -774,3 +775,42 @@ class ScanJobResponse(BaseModel):
     model_config = ConfigDict(strict=True)
 
     data: ScanJobData
+
+
+class CooccurringEntity(BaseModel):
+    """An entity that shares videos with the subject entity (Feature 062).
+
+    Attributes
+    ----------
+    entity_id : UUID
+        The co-occurring partner.
+    entity_type : str
+        Carried so the badge renders without a second lookup (FR-031).
+    canonical_name : str
+        Display name.
+    shared_video_count : int
+        Distinct videos in which BOTH entities have a qualifying mention.
+
+        This MUST equal the ``pagination.total`` the videos list returns when
+        filtered to the same pair under the same evidence scope (FR-024b). The
+        two derive from the same qualification rule, but only agree if both
+        also apply the same video population -- the videos list excludes
+        unavailable videos by default, so this count must too. Showing "261
+        shared videos" and then landing on a page that says 258 is the same
+        class of defect as two endpoints disagreeing about a video count.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    entity_id: UUID
+    entity_type: str
+    canonical_name: str
+    shared_video_count: int
+
+
+class CooccurringEntitiesResponse(BaseModel):
+    """Response envelope for the appears-with panel."""
+
+    model_config = ConfigDict(strict=True)
+
+    data: list[CooccurringEntity]

--- a/src/chronovista/api/schemas/videos.py
+++ b/src/chronovista/api/schemas/videos.py
@@ -1,6 +1,7 @@
 """Video API response schemas."""
 
 from datetime import datetime
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -18,6 +19,36 @@ class TranscriptSummary(BaseModel):
     languages: list[str]  # Available language codes (BCP-47)
     has_manual: bool  # Any manual/CC transcripts?
     has_corrections: bool = False  # Any segments with user corrections?
+
+
+class VideoEntityMatch(BaseModel):
+    """One required entity's evidence within a qualifying video (Feature 062).
+
+    Attributes
+    ----------
+    entity_id : UUID
+        The required entity this evidence belongs to.
+    entity_type : str
+        Entity type, carried so a client can render the type badge without a
+        second lookup per entity (FR-031).
+    canonical_name : str
+        Display name for the badge label.
+    mention_count : int
+        Qualifying mentions of this entity in this video, respecting the
+        active evidence scope.
+    first_timestamp : float | None
+        Earliest transcript position, in seconds. ``None`` when the entity
+        appears only in the title or description, which have no segment and
+        therefore no time (FR-008).
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    entity_id: UUID
+    entity_type: str
+    canonical_name: str
+    mention_count: int
+    first_timestamp: float | None = None
 
 
 class VideoListItem(BaseModel):
@@ -74,6 +105,34 @@ class VideoListItem(BaseModel):
         default_factory=list, description="Associated topics"
     )
     availability_status: str = Field(..., description="Video availability status")
+
+    # Entity intersection fields (Feature 062).
+    #
+    # These live on the *item* rather than on the response wrappers because
+    # both VideoListResponse and VideoListResponseWithWarnings wrap
+    # list[VideoListItem]. Carrying them here makes it structurally impossible
+    # for one response shape to expose them and the other not, which is what
+    # FR-007a requires: entity data must not be lost because an unrelated
+    # filter emitted a warning.
+    #
+    # None (not []) when no entity filter of either kind is active, so existing
+    # callers see an unchanged shape. An exclusion-only filter IS active and
+    # yields an empty list with total_mentions 0 (FR-015a).
+    entity_matches: list[VideoEntityMatch] | None = Field(
+        default=None,
+        description=(
+            "Per-required-entity evidence. One element per required entity "
+            "(FR-003a); empty for an exclusion-only filter; null when no "
+            "entity filter is active."
+        ),
+    )
+    total_mentions: int | None = Field(
+        default=None,
+        description=(
+            "Qualifying mentions summed across required entities; the "
+            "relevance sort key."
+        ),
+    )
 
 
 class VideoListResponse(ApiResponse[list[VideoListItem]]):

--- a/src/chronovista/models/enums.py
+++ b/src/chronovista/models/enums.py
@@ -404,6 +404,27 @@ class MentionSource(str, Enum):
     DESCRIPTION = "description"
 
 
+class EvidenceScope(str, Enum):
+    """Which mentions qualify toward an entity intersection.
+
+    Expressed over mention **source** only, never detection method (FR-020d).
+    The two are orthogonal: every manually added and user-corrected mention is
+    transcript-sourced, so restricting to ``TRANSCRIPT`` retains all of them
+    rather than excluding the highest-trust evidence in the system.
+
+    Named for what it will become, but a graded confidence model MUST arrive as
+    a separate parameter rather than as new members here. A confidence
+    threshold and a mention source are two dimensions; admitting both into one
+    enum is precisely the defect recorded in GitHub #172, where
+    ``?source=`` accepts three mention sources, one detection method, and one
+    relation that is not a mention at all. The name is stable so saved
+    addresses survive (FR-020); the vocabulary stays one-dimensional (FR-020d).
+    """
+
+    ANY = "any"
+    TRANSCRIPT = "transcript"
+
+
 class TaskStatus(str, Enum):
     """Status of a background task."""
 

--- a/src/chronovista/repositories/entity_mention_repository.py
+++ b/src/chronovista/repositories/entity_mention_repository.py
@@ -8,10 +8,14 @@ for the entity_mentions table.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from typing import Any
 
 from sqlalchemy import (
+    ScalarSelect,
+    Select,
     String,
+    Subquery,
     and_,
     delete,
     distinct,
@@ -56,7 +60,12 @@ from chronovista.db.models import (
 )
 from chronovista.exceptions import APIValidationError, ConflictError, NotFoundError
 from chronovista.models.entity_mention import EntityMentionCreate
-from chronovista.models.enums import EntityAliasType
+from chronovista.models.enums import (
+    AvailabilityStatus,
+    EntityAliasType,
+    EvidenceScope,
+    MentionSource,
+)
 from chronovista.repositories.base import BaseSQLAlchemyRepository
 from chronovista.services.tag_normalization import TagNormalizationService
 
@@ -948,6 +957,333 @@ class EntityMentionRepository(
         paginated = sorted_results[offset : offset + limit]
 
         return paginated, filtered_total if source_filter is not None else total_count
+
+    def build_entity_qualification_subquery(
+        self,
+        entity_ids: Sequence[uuid.UUID],
+        evidence_scope: EvidenceScope = EvidenceScope.ANY,
+    ) -> Subquery:
+        """
+        Build the qualification subquery for an entity intersection.
+
+        Produces ``(video_id, total_mentions)`` for exactly those videos in
+        which **every** requested entity has at least one qualifying mention.
+
+        Duplicate-safe by construction. ``entity_mentions`` holds multiple rows
+        per ``(entity_id, video_id)`` by design -- across sources, and within a
+        source. Qualification counts *distinct* entity ids, so row multiplicity
+        can neither make a video qualify for an entity it does not mention nor
+        raise the bar for one it does (FR-003, FR-004).
+
+        ``transcript_segments`` is deliberately NOT joined here. Joining it
+        before pagination returns byte-identical results at roughly eight times
+        the cost (research R1). Timestamps are fetched for the returned page
+        only, by :meth:`get_page_entity_matches`.
+
+        Parameters
+        ----------
+        entity_ids : Sequence[uuid.UUID]
+            Required entities. Deduplicated internally, so requesting the same
+            entity twice is idempotent and does not raise the bar.
+        evidence_scope : EvidenceScope
+            Which mentions qualify. ``ANY`` accepts all three sources;
+            ``TRANSCRIPT`` restricts to transcript-sourced mentions, which
+            inherently retains every human-added mention (FR-020c).
+
+        Returns
+        -------
+        Subquery
+            Joinable subquery exposing ``video_id`` and ``total_mentions``.
+        """
+        distinct_ids = list(dict.fromkeys(entity_ids))
+        stmt = select(
+            EntityMentionDB.video_id.label("video_id"),
+            # Raw row count, deliberately NOT count(distinct(segment_id)) as
+            # get_video_entity_summary uses. Each row is a distinct mention
+            # event -- a different segment, or the same entity in the title AND
+            # the transcript -- and relevance ranks by mention VOLUME. The two
+            # fields are both called a mention count and are computed
+            # differently on purpose; see FR-009 and research R3.
+            func.count().label("total_mentions"),
+        ).where(EntityMentionDB.entity_id.in_(distinct_ids))
+
+        if evidence_scope is EvidenceScope.TRANSCRIPT:
+            stmt = stmt.where(
+                EntityMentionDB.mention_source == MentionSource.TRANSCRIPT.value
+            )
+
+        return (
+            stmt.group_by(EntityMentionDB.video_id)
+            .having(
+                func.count(distinct(EntityMentionDB.entity_id)) == len(distinct_ids)
+            )
+            .subquery()
+        )
+
+    def build_entity_exclusion_subquery(
+        self,
+        entity_ids: Sequence[uuid.UUID],
+        evidence_scope: EvidenceScope = EvidenceScope.ANY,
+    ) -> ScalarSelect[str]:
+        """
+        Build the set of video ids disqualified by an excluded-entity filter.
+
+        A video mentioning **any** of the excluded entities is disqualified,
+        regardless of how many required entities it matches (FR-014). This is
+        OR semantics, in deliberate contrast to the AND semantics of
+        qualification.
+
+        The evidence scope is applied symmetrically with qualification: under
+        ``TRANSCRIPT``, a video whose only mention of an excluded entity is in
+        its title is **not** disqualified, because that mention does not
+        qualify. "Qualifying mention" is one definition, and applying it to one
+        side of the filter but not the other would mean the same video both
+        does and does not mention the entity within a single request.
+
+        Parameters
+        ----------
+        entity_ids : Sequence[uuid.UUID]
+            Excluded entities. Deduplicated internally.
+        evidence_scope : EvidenceScope
+            Which mentions count as mentioning. Must match the scope used for
+            qualification.
+
+        Returns
+        -------
+        ScalarSelect[str]
+            Scalar subquery of ``video_id`` suitable for ``notin_()``.
+        """
+        stmt = select(EntityMentionDB.video_id).where(
+            EntityMentionDB.entity_id.in_(list(dict.fromkeys(entity_ids)))
+        )
+        if evidence_scope is EvidenceScope.TRANSCRIPT:
+            stmt = stmt.where(
+                EntityMentionDB.mention_source == MentionSource.TRANSCRIPT.value
+            )
+        return stmt.distinct().scalar_subquery()
+
+    def build_cooccurrence_query(
+        self,
+        entity_id: uuid.UUID,
+        limit: int = 12,
+        evidence_scope: EvidenceScope = EvidenceScope.ANY,
+    ) -> Select[Any]:
+        """
+        Return the entities sharing the most videos with ``entity_id``.
+
+        Powers the appears-with panel (US3). Ordered by shared-video count
+        descending, tiebroken by partner id ascending -- the tiebreak makes a
+        bounded list deterministic, so two partners with equal counts cannot
+        swap between requests and make the panel look unstable (R5).
+
+        **Availability is not incidental here.** The count this returns is
+        promised to equal the videos list's ``pagination.total`` for the same
+        pair (FR-024b), and that list excludes unavailable videos by default.
+        Counting every shared video would inflate this figure -- measured
+        against production, one popular pair differs by nine -- and the user
+        would be shown one number and land on another. The join to ``videos``
+        below is what keeps the promise.
+
+        Parameters
+        ----------
+        entity_id : uuid.UUID
+            The subject entity.
+        limit : int
+            Maximum partners to return.
+        evidence_scope : EvidenceScope
+            Which mentions count as co-occurrence. Must match the scope the
+            surrounding view is using, or the panel and the intersection it
+            opens will disagree (FR-024a).
+
+        Returns
+        -------
+        Select[Any]
+            The unexecuted statement, so callers and tests can inspect it.
+        """
+        # The scope narrows the SUBJECT's videos before the partner select is
+        # built, so both sides of the co-occurrence are computed under one
+        # definition. Chained rather than rebuilt: two copies of this column
+        # list would let the scoped and unscoped forms drift apart silently.
+        subject_videos = select(EntityMentionDB.video_id).where(
+            EntityMentionDB.entity_id == entity_id
+        )
+        if evidence_scope is EvidenceScope.TRANSCRIPT:
+            subject_videos = subject_videos.where(
+                EntityMentionDB.mention_source == MentionSource.TRANSCRIPT.value
+            )
+
+        partner = select(
+            EntityMentionDB.entity_id.label("partner_id"),
+            func.count(distinct(EntityMentionDB.video_id)).label("shared"),
+        ).where(
+            EntityMentionDB.entity_id != entity_id,
+            EntityMentionDB.video_id.in_(subject_videos),
+        )
+        if evidence_scope is EvidenceScope.TRANSCRIPT:
+            partner = partner.where(
+                EntityMentionDB.mention_source == MentionSource.TRANSCRIPT.value
+            )
+
+        # Restrict to the same video population the videos list uses, so the
+        # count shown equals the count landed on (FR-024b).
+        available = select(VideoDB.video_id).where(
+            VideoDB.availability_status == AvailabilityStatus.AVAILABLE
+        )
+        partner = partner.where(EntityMentionDB.video_id.in_(available))
+
+        grouped = partner.group_by(EntityMentionDB.entity_id).subquery()
+
+        stmt = (
+            select(
+                grouped.c.partner_id,
+                grouped.c.shared,
+                NamedEntityDB.canonical_name,
+                NamedEntityDB.entity_type,
+            )
+            .join(NamedEntityDB, NamedEntityDB.id == grouped.c.partner_id)
+            .order_by(grouped.c.shared.desc(), grouped.c.partner_id.asc())
+            .limit(limit)
+        )
+
+        return stmt
+
+    async def get_cooccurring_entities(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: uuid.UUID,
+        limit: int = 12,
+        evidence_scope: EvidenceScope = EvidenceScope.ANY,
+    ) -> list[dict[str, Any]]:
+        """
+        Execute :meth:`build_cooccurrence_query` and shape the rows.
+
+        The query is built separately so it can be compiled and inspected
+        without a database. The ordering tiebreak that keeps a bounded list
+        stable (R5) cannot be verified from returned rows -- Postgres happens
+        to return small groups in ascending-id order whether or not the
+        ``ORDER BY`` asks for it -- so the only way to assert it is to look at
+        the statement.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        entity_id : uuid.UUID
+            The subject entity.
+        limit : int
+            Maximum partners to return.
+        evidence_scope : EvidenceScope
+            Which mentions count as co-occurrence.
+
+        Returns
+        -------
+        list[dict[str, Any]]
+            Dicts with ``entity_id``, ``entity_type``, ``canonical_name``, and
+            ``shared_video_count``.
+        """
+        result = await session.execute(
+            self.build_cooccurrence_query(entity_id, limit, evidence_scope)
+        )
+        return [
+            {
+                "entity_id": row.partner_id,
+                "entity_type": row.entity_type,
+                "canonical_name": row.canonical_name,
+                "shared_video_count": row.shared,
+            }
+            for row in result
+        ]
+
+    async def get_page_entity_matches(
+        self,
+        session: AsyncSession,
+        *,
+        video_ids: Sequence[str],
+        entity_ids: Sequence[uuid.UUID],
+        evidence_scope: EvidenceScope = EvidenceScope.ANY,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """
+        Fetch per-entity evidence for the videos on the returned page only.
+
+        This is the sole place ``transcript_segments`` is joined. Restricting
+        it to the page (at most ``limit`` videos) rather than the full
+        qualifying set is the 806 ms -> 98 ms optimization recorded in research
+        R1, and the two steps must not be recombined.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        video_ids : Sequence[str]
+            Videos on the page being returned. Pass only the page.
+        entity_ids : Sequence[uuid.UUID]
+            Required entities, matching the qualification subquery.
+        evidence_scope : EvidenceScope
+            Must match the scope used for qualification, or counts will
+            disagree with the set they describe.
+
+        Returns
+        -------
+        dict[str, list[dict[str, Any]]]
+            Keyed by ``video_id``. Each value holds one dict per required
+            entity with ``entity_id``, ``entity_type``, ``canonical_name``,
+            ``mention_count``, and ``first_timestamp`` (``None`` when the
+            entity appears only in the title or description).
+        """
+        if not video_ids or not entity_ids:
+            return {}
+
+        stmt = (
+            select(
+                EntityMentionDB.video_id,
+                EntityMentionDB.entity_id,
+                NamedEntityDB.canonical_name,
+                NamedEntityDB.entity_type,
+                func.count().label("mention_count"),
+                func.min(TranscriptSegmentDB.start_time).label("first_timestamp"),
+            )
+            .join(NamedEntityDB, NamedEntityDB.id == EntityMentionDB.entity_id)
+            # Outer join: segment_id is nullable, since title and description
+            # mentions have no segment and therefore no timestamp.
+            .outerjoin(
+                TranscriptSegmentDB,
+                TranscriptSegmentDB.id == EntityMentionDB.segment_id,
+            )
+            .where(
+                EntityMentionDB.video_id.in_(list(video_ids)),
+                EntityMentionDB.entity_id.in_(list(dict.fromkeys(entity_ids))),
+            )
+            .group_by(
+                EntityMentionDB.video_id,
+                EntityMentionDB.entity_id,
+                NamedEntityDB.canonical_name,
+                NamedEntityDB.entity_type,
+            )
+        )
+
+        if evidence_scope is EvidenceScope.TRANSCRIPT:
+            stmt = stmt.where(
+                EntityMentionDB.mention_source == MentionSource.TRANSCRIPT.value
+            )
+
+        result = await session.execute(stmt)
+        matches: dict[str, list[dict[str, Any]]] = {}
+        for row in result:
+            matches.setdefault(row.video_id, []).append(
+                {
+                    "entity_id": row.entity_id,
+                    "entity_type": row.entity_type,
+                    "canonical_name": row.canonical_name,
+                    "mention_count": row.mention_count,
+                    "first_timestamp": (
+                        float(row.first_timestamp)
+                        if row.first_timestamp is not None
+                        else None
+                    ),
+                }
+            )
+        return matches
 
     async def get_combined_video_count(
         self,

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -20,6 +20,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from chronovista.api.deps import get_db
 from chronovista.api.main import app
+from chronovista.api.routers.canonical_tags import (
+    _request_counts as _canonical_tags_request_counts,
+)
+from chronovista.api.routers.videos import (
+    _filter_request_counts as _videos_request_counts,
+)
 from chronovista.auth.oauth_service import YouTubeOAuthService
 from chronovista.config.settings import get_settings
 from chronovista.db.models import Base
@@ -75,6 +81,26 @@ def integration_test_db_url():
             "postgresql+asyncpg://dev_user:dev_password@localhost:5434/chronovista_integration_test",
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def reset_api_rate_limit_counters() -> None:
+    """Clear every router's in-memory rate-limit counter before each test.
+
+    The counters are module-level ``defaultdict(list)`` state that survives
+    between tests, so requests accumulate across an entire session. Individual
+    tests stay well under the limits; a *suite* does not. Once the window fills,
+    every subsequent test hitting that endpoint gets a 429 — and the failures
+    land on whichever tests happen to run last, not on whichever test made the
+    requests. That is a confusing, order-dependent failure that passes when the
+    file is run alone.
+
+    ``test_canonical_tags_router.py`` already resets its own router's counter
+    for this reason. Doing it here covers every endpoint and every test file,
+    so the next suite to grow past a limit does not rediscover this.
+    """
+    _videos_request_counts.clear()
+    _canonical_tags_request_counts.clear()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import asyncio
 import os
-from collections.abc import AsyncGenerator, Awaitable
+from collections.abc import AsyncGenerator, Awaitable, Generator
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -81,6 +82,28 @@ def integration_test_db_url():
             "postgresql+asyncpg://dev_user:dev_password@localhost:5434/chronovista_integration_test",
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def authenticated_by_default() -> Generator[None, None, None]:
+    """Treat the API as authenticated unless a test says otherwise.
+
+    Every router except health sits behind ``require_auth``, which calls
+    ``youtube_oauth.is_authenticated()`` — a real check against OAuth token
+    files on disk. That makes the result environment-dependent: it passes on a
+    developer machine that has logged in and returns 401 in CI, which has no
+    tokens. A test suite whose outcome depends on the developer's login state
+    is not testing anything reliably.
+
+    Individual tests already patch this per-request to assert their endpoint is
+    protected. Those patches are context managers, so they nest over this and
+    still win inside their ``with`` block — which is why this is a patch rather
+    than a ``dependency_overrides`` entry. Overriding the dependency would
+    bypass ``require_auth`` entirely and silently break every 401 test.
+    """
+    with patch("chronovista.api.deps.youtube_oauth") as mock_oauth:
+        mock_oauth.is_authenticated.return_value = True
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/api/test_entity_cooccurrence.py
+++ b/tests/integration/api/test_entity_cooccurrence.py
@@ -1,0 +1,364 @@
+"""
+Integration tests for the appears-with panel endpoint (Feature 062, US3).
+
+The centrepiece is the **equality contract** (FR-024b, SC-008a): the count the
+panel shows for a partner must equal the ``pagination.total`` the videos list
+returns for that pair. Both derive from the same qualification rule, so they
+agree by construction -- but only if they also apply the same evidence scope
+AND the same video population. The videos list excludes unavailable videos by
+default; a co-occurrence count that ignored availability would be inflated, and
+a user would be shown one number and land on another.
+
+The plan named this the third-highest risk in the feature and said to assert
+it rather than assume it. That is what this module does.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import EntityMention as EntityMentionDB
+from chronovista.db.models import NamedEntity as NamedEntityDB
+from chronovista.db.models import Video as VideoDB
+from tests.factories.named_entity_orm_factory import create_named_entity_db
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+# Without this, async tests are silently skipped under coverage.
+pytestmark = pytest.mark.asyncio
+
+_CHANNEL_ID = "UCec062co000000000000001"
+_PREFIX = "ec062co"
+_LANG = "en"
+_VIDEOS = [f"{_PREFIX}_v{n}" for n in range(1, 6)]
+
+
+async def _cleanup(session: AsyncSession) -> None:
+    await session.execute(
+        delete(EntityMentionDB).where(EntityMentionDB.video_id.in_(_VIDEOS))
+    )
+    await session.execute(
+        delete(NamedEntityDB).where(
+            NamedEntityDB.canonical_name_normalized.like(f"{_PREFIX} %")
+        )
+    )
+    await session.execute(delete(VideoDB).where(VideoDB.video_id.in_(_VIDEOS)))
+    await session.execute(delete(ChannelDB).where(ChannelDB.channel_id == _CHANNEL_ID))
+    await session.commit()
+
+
+@pytest.fixture
+async def seed(
+    integration_session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Seed a subject entity with partners of differing strength.
+
+    ===== =========================================================== =========
+    Video Mentions                                                    Available
+    ===== =========================================================== =========
+    v1    subject, alpha, beta                                        yes
+    v2    subject, alpha                                              yes
+    v3    subject, alpha (alpha in DESCRIPTION -- scope-sensitive)     yes
+    v4    subject, gamma                                              **no**
+    v5    delta only -- never shares with the subject                  yes
+    ===== =========================================================== =========
+
+    So under ``any``: alpha shares 3, beta 1, gamma 0 (its only shared video is
+    unavailable). Under ``transcript``: alpha shares 2, because v3's alpha
+    mention is description-sourced.
+
+    v4 is the availability trap. A co-occurrence count that ignored
+    availability would report gamma as sharing 1 video, and the intersection it
+    opens would report 0.
+    """
+    ids = {name: uuid.uuid4() for name in ("subject", "alpha", "gamma", "delta")}
+    # beta and epsilon get FIXED, ordered ids and are inserted in REVERSE id
+    # order below. Natural (insertion) order therefore disagrees with the
+    # contract's ascending-id tiebreak, so a test on their relative position
+    # can actually detect the tiebreak's removal. With random uuid4s the two
+    # orders coincide about half the time and the assertion proves nothing.
+    ids["beta"] = uuid.UUID(int=0x0EC062C0_0000_4000_8000_000000000001)
+    ids["epsilon"] = uuid.UUID(int=0x0EC062C0_0000_4000_8000_00000000FFFF)
+
+    async with integration_session_factory() as session:
+        await _cleanup(session)
+        session.add(ChannelDB(channel_id=_CHANNEL_ID, title="EC062 Channel"))
+        for index, vid in enumerate(_VIDEOS):
+            session.add(
+                VideoDB(
+                    video_id=vid,
+                    channel_id=_CHANNEL_ID,
+                    title=f"EC062 {vid}",
+                    description="co-occurrence fixture",
+                    upload_date=datetime(2024, 7, 1, tzinfo=UTC),
+                    duration=300,
+                    # v4 (index 3) is deliberately unavailable.
+                    availability_status="unavailable" if index == 3 else "available",
+                )
+            )
+        for name, entity_id in ids.items():
+            session.add(
+                create_named_entity_db(
+                    id=entity_id,
+                    canonical_name=f"{_PREFIX.title()} {name.title()}",
+                    canonical_name_normalized=f"{_PREFIX} {name}",
+                    entity_type="person",
+                    description="fixture",
+                )
+            )
+        await session.commit()
+
+        def mention(
+            entity: str, video: str, source: str = "transcript"
+        ) -> EntityMentionDB:
+            return EntityMentionDB(
+                id=uuid.UUID(bytes=uuid7().bytes),
+                entity_id=ids[entity],
+                segment_id=None,
+                video_id=video,
+                language_code=_LANG,
+                mention_text=f"{_PREFIX} {entity}",
+                detection_method="rule_match",
+                mention_source=source,
+            )
+
+        for row in [
+            mention("subject", _VIDEOS[0]),
+            mention("alpha", _VIDEOS[0]),
+            # epsilon FIRST, though its id sorts after beta's -- see the id
+            # assignment above. The tiebreak must reorder them.
+            mention("epsilon", _VIDEOS[0]),
+            mention("beta", _VIDEOS[0]),
+            mention("subject", _VIDEOS[1]),
+            mention("alpha", _VIDEOS[1]),
+            mention("subject", _VIDEOS[2]),
+            mention("alpha", _VIDEOS[2], source="description"),
+            mention("subject", _VIDEOS[3]),
+            mention("gamma", _VIDEOS[3]),
+            mention("delta", _VIDEOS[4]),
+        ]:
+            session.add(row)
+        await session.commit()
+
+    yield {"ids": ids}
+
+    async with integration_session_factory() as session:
+        await _cleanup(session)
+
+
+class TestEqualityContract:
+    """FR-024b, SC-008, SC-008a -- the promise the panel makes."""
+
+    @pytest.mark.parametrize("scope", ["any", "transcript"])
+    async def test_panel_count_equals_intersection_total(
+        self, async_client: AsyncClient, seed: dict[str, Any], scope: str
+    ) -> None:
+        """Every partner's count equals the total of the pair it opens.
+
+        Verified under BOTH scopes, because the failure mode is scope drift:
+        a panel computing under one definition while the intersection computes
+        under another agrees on the default and diverges everywhere else.
+        """
+        subject = seed["ids"]["subject"]
+        panel = await async_client.get(
+            f"/api/v1/entities/{subject}/co-occurring?min_evidence={scope}"
+        )
+        assert panel.status_code == 200
+        partners = panel.json()["data"]
+        assert partners, "fixture must produce at least one partner"
+
+        for partner in partners:
+            intersection = await async_client.get(
+                f"/api/v1/videos?entity_id={subject}"
+                f"&entity_id={partner['entity_id']}"
+                f"&min_evidence={scope}&limit=1"
+            )
+            assert intersection.status_code == 200
+            assert partner["shared_video_count"] == (
+                intersection.json()["pagination"]["total"]
+            ), (
+                f"panel says {partner['shared_video_count']} shared videos with "
+                f"{partner['canonical_name']} under scope={scope}, but the "
+                f"intersection it opens reports "
+                f"{intersection.json()['pagination']['total']}"
+            )
+
+    async def test_unavailable_shared_video_is_excluded_from_the_count(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """The availability trap, asserted directly.
+
+        gamma shares exactly one video with the subject, and that video is
+        unavailable. Counting it would inflate the panel and break the equality
+        contract, because the videos list would return zero for that pair.
+        """
+        subject = seed["ids"]["subject"]
+        gamma = seed["ids"]["gamma"]
+        panel = await async_client.get(f"/api/v1/entities/{subject}/co-occurring")
+        listed = {p["entity_id"] for p in panel.json()["data"]}
+        assert str(gamma) not in listed
+
+
+class TestPartnerRanking:
+    """R5 -- bounded, ordered, deterministic."""
+
+    async def test_partners_ordered_by_shared_count_descending(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        subject = seed["ids"]["subject"]
+        response = await async_client.get(f"/api/v1/entities/{subject}/co-occurring")
+        counts = [p["shared_video_count"] for p in response.json()["data"]]
+        assert counts == sorted(counts, reverse=True)
+
+    async def test_tied_partners_are_ordered_by_id_ascending(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """The tiebreak makes a bounded list deterministic (R5).
+
+        beta and epsilon each share exactly one video, so the count alone
+        cannot order them. Without the ``entity_id`` tiebreak the database is
+        free to return either first, and a "reveal more" page could repeat or
+        skip one.
+
+        **This test confirms the rule holds; it cannot prove the ORDER BY is
+        what makes it hold.** At this fixture size Postgres returns the group
+        in ascending-id order anyway -- verified by removing the tiebreak and
+        watching this still pass, even with the tied pair given fixed ids and
+        inserted in reverse. The structural assertion in
+        ``tests/unit/repositories/test_entity_qualification_properties.py``
+        covers the gap by inspecting the compiled SQL directly.
+        """
+        subject = seed["ids"]["subject"]
+        beta, epsilon = str(seed["ids"]["beta"]), str(seed["ids"]["epsilon"])
+
+        response = await async_client.get(f"/api/v1/entities/{subject}/co-occurring")
+        returned = [p["entity_id"] for p in response.json()["data"]]
+
+        tied_in_order = [e for e in returned if e in {beta, epsilon}]
+        assert tied_in_order == sorted([beta, epsilon]), (
+            "partners with equal shared counts must be ordered by entity_id "
+            "ascending; got " + str(tied_in_order)
+        )
+
+    async def test_ordering_is_repeatable_across_requests(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        subject = seed["ids"]["subject"]
+        first = await async_client.get(f"/api/v1/entities/{subject}/co-occurring")
+        second = await async_client.get(f"/api/v1/entities/{subject}/co-occurring")
+        assert [p["entity_id"] for p in first.json()["data"]] == [
+            p["entity_id"] for p in second.json()["data"]
+        ]
+
+    async def test_entity_type_travels_with_each_partner(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """FR-031 -- the badge renders without a lookup per partner."""
+        subject = seed["ids"]["subject"]
+        response = await async_client.get(f"/api/v1/entities/{subject}/co-occurring")
+        for partner in response.json()["data"]:
+            assert partner["entity_type"] == "person"
+            assert partner["canonical_name"]
+
+    async def test_limit_bounds_the_list(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        subject = seed["ids"]["subject"]
+        response = await async_client.get(
+            f"/api/v1/entities/{subject}/co-occurring?limit=1"
+        )
+        assert len(response.json()["data"]) == 1
+
+
+class TestEvidenceScope:
+    """FR-024a -- the panel honours the surrounding view's scope."""
+
+    async def test_transcript_scope_narrows_shared_counts(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """alpha shares three videos under `any`, two under `transcript`.
+
+        v3's alpha mention is description-sourced, so it stops counting when
+        the scope tightens.
+        """
+        subject = seed["ids"]["subject"]
+        alpha = str(seed["ids"]["alpha"])
+
+        def count_for(payload: dict[str, Any]) -> int:
+            return next(
+                p["shared_video_count"]
+                for p in payload["data"]
+                if p["entity_id"] == alpha
+            )
+
+        any_scope = await async_client.get(f"/api/v1/entities/{subject}/co-occurring")
+        transcript = await async_client.get(
+            f"/api/v1/entities/{subject}/co-occurring?min_evidence=transcript"
+        )
+        assert count_for(any_scope.json()) == 3
+        assert count_for(transcript.json()) == 2
+
+
+class TestEdgeCases:
+    """FR-024, FR-023a."""
+
+    async def test_entity_with_no_co_occurrences_returns_empty_not_error(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """ "Nothing appears alongside this" is an answer, not a failure."""
+        delta = seed["ids"]["delta"]
+        response = await async_client.get(f"/api/v1/entities/{delta}/co-occurring")
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    async def test_unknown_entity_is_404(self, async_client: AsyncClient) -> None:
+        response = await async_client.get(
+            f"/api/v1/entities/{uuid.uuid4()}/co-occurring"
+        )
+        assert response.status_code == 404
+
+    async def test_malformed_entity_id_is_404(self, async_client: AsyncClient) -> None:
+        response = await async_client.get("/api/v1/entities/not-a-uuid/co-occurring")
+        assert response.status_code == 404
+
+    async def test_limit_above_maximum_is_rejected(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """FR-023a: bounded by a stated rule, never served unbounded."""
+        subject = seed["ids"]["subject"]
+        response = await async_client.get(
+            f"/api/v1/entities/{subject}/co-occurring?limit=10000"
+        )
+        assert response.status_code == 422
+
+    async def test_zero_limit_is_rejected(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        subject = seed["ids"]["subject"]
+        response = await async_client.get(
+            f"/api/v1/entities/{subject}/co-occurring?limit=0"
+        )
+        assert response.status_code == 422
+
+    async def test_subject_never_lists_itself(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """An entity co-occurs with itself in every video it appears in.
+
+        Including it would put a meaningless row at the top of every panel and
+        link to a one-entity "intersection".
+        """
+        subject = seed["ids"]["subject"]
+        response = await async_client.get(f"/api/v1/entities/{subject}/co-occurring")
+        assert str(subject) not in {p["entity_id"] for p in response.json()["data"]}

--- a/tests/integration/api/test_entity_rename_cross_feature.py
+++ b/tests/integration/api/test_entity_rename_cross_feature.py
@@ -1,6 +1,7 @@
 """Cross-feature integration test for an entity rename (Feature 057, T010).
 
-Per the constitution's Cross-Feature Data Contract Verification: after an
+A mutation that changes an entity's identity must be verified through every
+downstream consumer path, not only at its source: after an
 identity-changing rename, re-query every consumer of the entity's name and
 assert the NEW name appears everywhere it should — list, detail, search,
 entity->videos, and video->entities (the last for an entity that has a manual

--- a/tests/integration/api/test_playlists_integration.py
+++ b/tests/integration/api/test_playlists_integration.py
@@ -596,7 +596,7 @@ class TestPlaylistTypeApi:
 
 
 class TestCrossFeaturePlaylistType:
-    """Feature 058 constitution gates: import→classify→re-query, and that
+    """Feature 058 cross-feature gates: import→classify→re-query, and that
     playlist_type mutation does not touch watched-status."""
 
     async def test_import_watch_later_classifies_and_surfaces_via_api(

--- a/tests/integration/api/test_videos_entity_filter.py
+++ b/tests/integration/api/test_videos_entity_filter.py
@@ -1,0 +1,812 @@
+"""
+Integration tests for the entity intersection filter on the videos list (Feature 062).
+
+Covers FR-032 (intersections of two, three, and four entities), FR-033 (the
+count-parity seam), FR-003a (per-entity match cardinality), FR-020a/FR-020c
+(evidence scope), and FR-005 (read-only).
+
+The integration database is never reset between runs, so every assertion here
+compares against an INDEPENDENT query over this module's own seeded rows rather
+than an absolute constant. Anything else would pass on a clean database and
+drift the moment another module seeds a video.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import EntityMention as EntityMentionDB
+from chronovista.db.models import NamedEntity as NamedEntityDB
+from chronovista.db.models import TranscriptSegment as TranscriptSegmentDB
+from chronovista.db.models import Video as VideoDB
+from chronovista.db.models import VideoTranscript as VideoTranscriptDB
+from tests.factories.named_entity_orm_factory import create_named_entity_db
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+# CRITICAL: without this, async tests are silently skipped under coverage and
+# report a false low number. This repo has hit exactly that.
+pytestmark = pytest.mark.asyncio
+
+_CHANNEL_ID = "UCei062ef000000000000001"  # <= 24 chars
+_LANG = "en"
+_PREFIX = "ei062ef"
+_VIDEOS = [f"{_PREFIX}_v{n}" for n in range(1, 6)]  # <= 20 chars each
+
+
+async def _cleanup(session: AsyncSession) -> None:
+    """Remove this module's rows so reruns start from a known state."""
+    await session.execute(
+        delete(EntityMentionDB).where(EntityMentionDB.video_id.in_(_VIDEOS))
+    )
+    await session.execute(
+        delete(NamedEntityDB).where(
+            NamedEntityDB.canonical_name.like(f"{_PREFIX.title()}%")
+        )
+    )
+    await session.execute(
+        delete(TranscriptSegmentDB).where(TranscriptSegmentDB.video_id.in_(_VIDEOS))
+    )
+    await session.execute(
+        delete(VideoTranscriptDB).where(VideoTranscriptDB.video_id.in_(_VIDEOS))
+    )
+    await session.execute(delete(VideoDB).where(VideoDB.video_id.in_(_VIDEOS)))
+    await session.execute(delete(ChannelDB).where(ChannelDB.channel_id == _CHANNEL_ID))
+    await session.commit()
+
+
+@pytest.fixture
+async def seed(
+    integration_session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Seed five videos with deliberately overlapping entity sets.
+
+    The distribution is chosen so each requirement has a case that would fail
+    if the implementation were wrong in a specific way:
+
+    ===== ================================================================
+    Video Mentions
+    ===== ================================================================
+    v1    e1 x3 transcript (DUPLICATE rows), e2, e3, e4 -- all four
+    v2    e1, e2, e3 transcript; e4 transcript via detection_method=manual
+    v3    e1 transcript, e2 DESCRIPTION -- scope-sensitive
+    v4    e1 only -- must never appear in any intersection
+    v5    e1 TITLE only, e2 transcript -- scope-sensitive, null timestamp
+    ===== ================================================================
+
+    So under ``any``: {e1,e2} = v1,v2,v3,v5 (4); {e1,e2,e3} = v1,v2 (2);
+    {e1,e2,e3,e4} = v1,v2 (2). Under ``transcript``: {e1,e2} = v1,v2 (2),
+    because v3's e2 is description-sourced and v5's e1 is title-sourced.
+    """
+    ids = {name: uuid.uuid4() for name in ("e1", "e2", "e3", "e4")}
+
+    async with integration_session_factory() as session:
+        await _cleanup(session)
+        session.add(ChannelDB(channel_id=_CHANNEL_ID, title="EI062 Test Channel"))
+        for vid in _VIDEOS:
+            session.add(
+                VideoDB(
+                    video_id=vid,
+                    channel_id=_CHANNEL_ID,
+                    title=f"EI062 {vid}",
+                    description="entity intersection fixture",
+                    upload_date=datetime(2024, 5, 1, tzinfo=UTC),
+                    duration=300,
+                )
+            )
+        await session.commit()
+
+        # One transcript + segment per video, so transcript mentions have a
+        # real segment_id and therefore a real first_timestamp.
+        segment_ids: dict[str, int] = {}
+        for vid in _VIDEOS:
+            session.add(
+                VideoTranscriptDB(
+                    video_id=vid,
+                    language_code=_LANG,
+                    transcript_text="fixture transcript",
+                    transcript_type="MANUAL",
+                    download_reason="USER_REQUEST",
+                    is_cc=False,
+                    is_auto_synced=False,
+                    track_kind="standard",
+                )
+            )
+        await session.commit()
+
+        for index, vid in enumerate(_VIDEOS):
+            segment = TranscriptSegmentDB(
+                video_id=vid,
+                language_code=_LANG,
+                text="fixture segment",
+                start_time=float(index * 10),
+                duration=5.0,
+                end_time=float(index * 10 + 5),
+                sequence_number=0,
+                has_correction=False,
+            )
+            session.add(segment)
+            await session.commit()
+            segment_ids[vid] = segment.id
+
+        for name, entity_id in ids.items():
+            session.add(
+                create_named_entity_db(
+                    id=entity_id,
+                    canonical_name=f"{_PREFIX.title()} {name.upper()}",
+                    canonical_name_normalized=f"{_PREFIX} {name}",
+                    entity_type="person",
+                    description="fixture",
+                )
+            )
+        await session.commit()
+
+        def mention(
+            entity: str,
+            video: str,
+            source: str = "transcript",
+            method: str = "rule_match",
+        ) -> EntityMentionDB:
+            return EntityMentionDB(
+                id=uuid.UUID(bytes=uuid7().bytes),
+                entity_id=ids[entity],
+                # Only transcript mentions have a segment; title and
+                # description mentions have none, hence a null timestamp.
+                segment_id=segment_ids[video] if source == "transcript" else None,
+                video_id=video,
+                language_code=_LANG,
+                mention_text=f"{_PREFIX} {entity}",
+                detection_method=method,
+                mention_source=source,
+            )
+
+        rows = [
+            # v1 — all four entities; e1 appears THREE times (duplicate rows).
+            mention("e1", _VIDEOS[0]),
+            mention("e1", _VIDEOS[0]),
+            mention("e1", _VIDEOS[0]),
+            mention("e2", _VIDEOS[0]),
+            mention("e3", _VIDEOS[0]),
+            mention("e4", _VIDEOS[0]),
+            # v2 — three by rule, e4 added manually. Manual mentions are
+            # transcript-sourced, so they must survive min_evidence=transcript.
+            mention("e1", _VIDEOS[1]),
+            mention("e2", _VIDEOS[1]),
+            mention("e3", _VIDEOS[1]),
+            mention("e4", _VIDEOS[1], method="manual"),
+            # v3 — e2 only in the description.
+            mention("e1", _VIDEOS[2]),
+            mention("e2", _VIDEOS[2], source="description"),
+            # v4 — e1 alone; must never satisfy a multi-entity intersection.
+            mention("e1", _VIDEOS[3]),
+            # v5 — e1 only in the title (null timestamp), e2 in transcript.
+            mention("e1", _VIDEOS[4], source="title"),
+            mention("e2", _VIDEOS[4]),
+        ]
+        for row in rows:
+            session.add(row)
+        await session.commit()
+
+    yield {"ids": ids, "videos": _VIDEOS}
+
+    async with integration_session_factory() as session:
+        await _cleanup(session)
+
+
+def _params(entity_ids: list[uuid.UUID], **extra: str) -> str:
+    parts = [f"entity_id={e}" for e in entity_ids]
+    parts += [f"{k}={v}" for k, v in extra.items()]
+    return "&".join(parts)
+
+
+class TestIntersectionCorrectness:
+    """FR-032, SC-002, SC-004 — intersections of two, three, and four."""
+
+    async def test_two_entity_intersection(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """Exactly the videos where BOTH entities appear, under the default scope."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}"
+        )
+        assert response.status_code == 200
+        returned = {v["video_id"] for v in response.json()["data"]}
+        assert returned == {_VIDEOS[0], _VIDEOS[1], _VIDEOS[2], _VIDEOS[4]}
+        # v4 mentions only e1 and must never qualify.
+        assert _VIDEOS[3] not in returned
+
+    async def test_three_entity_intersection_narrows(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """Adding a third required entity narrows rather than widens (SC-002)."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2'], ids['e3']], limit='50')}"
+        )
+        returned = {v["video_id"] for v in response.json()["data"]}
+        assert returned == {_VIDEOS[0], _VIDEOS[1]}
+
+    async def test_four_entity_intersection(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """Four required entities behave identically to two (FR-002)."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2'], ids['e3'], ids['e4']], limit='50')}"
+        )
+        returned = {v["video_id"] for v in response.json()["data"]}
+        assert returned == {_VIDEOS[0], _VIDEOS[1]}
+
+    async def test_duplicate_mention_rows_do_not_affect_qualification(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """SC-004: v1 holds three e1 rows and still qualifies exactly once.
+
+        The count must reflect the true multiplicity (3) while qualification
+        stays per distinct entity. A formulation that joined per entity would
+        return v1 three times.
+        """
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}"
+        )
+        rows = [v for v in response.json()["data"] if v["video_id"] == _VIDEOS[0]]
+        assert len(rows) == 1
+        e1_match = next(
+            m for m in rows[0]["entity_matches"] if m["entity_id"] == str(ids["e1"])
+        )
+        assert e1_match["mention_count"] == 3
+        assert rows[0]["total_mentions"] == 4  # 3 x e1 + 1 x e2
+
+    async def test_requesting_same_entity_twice_is_idempotent(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """Duplicate ids must not raise the qualification bar."""
+        ids = seed["ids"]
+        once = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}"
+        )
+        twice = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2'], ids['e1']], limit='50')}"
+        )
+        assert twice.json()["pagination"]["total"] == once.json()["pagination"]["total"]
+
+
+class TestPerEntityMatchShape:
+    """FR-003a, FR-008, FR-031 — the per-video entity evidence."""
+
+    async def test_match_count_equals_required_set_size(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """Every returned row carries exactly one entry per required entity."""
+        ids = seed["ids"]
+        for required in ([ids["e1"], ids["e2"]], [ids["e1"], ids["e2"], ids["e3"]]):
+            response = await async_client.get(
+                f"/api/v1/videos?{_params(required, limit='50')}"
+            )
+            for video in response.json()["data"]:
+                assert len(video["entity_matches"]) == len(required)
+
+    async def test_match_order_follows_the_requested_sequence(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """Per-entity evidence is ordered by the caller's required set.
+
+        Without this the order is whatever the GROUP BY happened to return, so
+        badges on one video can reorder between requests and two pages of one
+        result set can present the same entities differently. The co-occurrence
+        query carries an explicit tiebreak for the same reason.
+        """
+        ids = seed["ids"]
+        forward = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2'], ids['e3']], limit='50')}"
+        )
+        reversed_ = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e3'], ids['e2'], ids['e1']], limit='50')}"
+        )
+
+        for video in forward.json()["data"]:
+            assert [m["entity_id"] for m in video["entity_matches"]] == [
+                str(ids["e1"]),
+                str(ids["e2"]),
+                str(ids["e3"]),
+            ]
+        # Reversing the request reverses the response, proving the order is
+        # driven by the caller rather than incidentally stable.
+        for video in reversed_.json()["data"]:
+            assert [m["entity_id"] for m in video["entity_matches"]] == [
+                str(ids["e3"]),
+                str(ids["e2"]),
+                str(ids["e1"]),
+            ]
+
+    async def test_entity_type_present_without_extra_lookup(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """FR-031: type identity travels with the match."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}"
+        )
+        for video in response.json()["data"]:
+            for match in video["entity_matches"]:
+                assert match["entity_type"] == "person"
+                assert match["canonical_name"]
+
+    async def test_title_only_mention_has_null_timestamp(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """FR-008: an entity with no segment has no time -- null, not zero."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}"
+        )
+        v5 = next(v for v in response.json()["data"] if v["video_id"] == _VIDEOS[4])
+        e1_match = next(
+            m for m in v5["entity_matches"] if m["entity_id"] == str(ids["e1"])
+        )
+        assert e1_match["first_timestamp"] is None
+
+    async def test_transcript_mention_has_a_timestamp(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """The null above must be meaningful, not the only outcome."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}"
+        )
+        v1 = next(v for v in response.json()["data"] if v["video_id"] == _VIDEOS[0])
+        e1_match = next(
+            m for m in v1["entity_matches"] if m["entity_id"] == str(ids["e1"])
+        )
+        assert e1_match["first_timestamp"] == 0.0
+
+
+class TestCountParitySeam:
+    """FR-033, SC-003 — the feature's highest-risk seam.
+
+    A filter that reaches the result set but not the reported total produces
+    correct rows with a wrong count, which no row-inspecting assertion detects.
+    Each test here compares the reported total against an INDEPENDENT count.
+    """
+
+    async def test_total_matches_independent_count(
+        self,
+        async_client: AsyncClient,
+        seed: dict[str, Any],
+        integration_session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='1')}"
+        )
+        async with integration_session_factory() as session:
+            qualifying = (
+                select(EntityMentionDB.video_id)
+                .where(EntityMentionDB.entity_id.in_([ids["e1"], ids["e2"]]))
+                .group_by(EntityMentionDB.video_id)
+                .having(func.count(func.distinct(EntityMentionDB.entity_id)) == 2)
+                .subquery()
+            )
+            expected = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(VideoDB)
+                    .join(qualifying, VideoDB.video_id == qualifying.c.video_id)
+                    .where(VideoDB.availability_status == "available")
+                )
+            ).scalar()
+        assert response.json()["pagination"]["total"] == expected
+
+    async def test_total_respects_evidence_scope_not_only_entity_ids(
+        self,
+        async_client: AsyncClient,
+        seed: dict[str, Any],
+        integration_session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """The scope must reach the COUNT query, not only the result query.
+
+        This is the specific failure FR-033 names: applying `min_evidence` to
+        the rows but not the total yields a page whose count describes a
+        different set than the one listed.
+        """
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='1', min_evidence='transcript')}"
+        )
+        async with integration_session_factory() as session:
+            qualifying = (
+                select(EntityMentionDB.video_id)
+                .where(
+                    EntityMentionDB.entity_id.in_([ids["e1"], ids["e2"]]),
+                    EntityMentionDB.mention_source == "transcript",
+                )
+                .group_by(EntityMentionDB.video_id)
+                .having(func.count(func.distinct(EntityMentionDB.entity_id)) == 2)
+                .subquery()
+            )
+            expected = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(VideoDB)
+                    .join(qualifying, VideoDB.video_id == qualifying.c.video_id)
+                    .where(VideoDB.availability_status == "available")
+                )
+            ).scalar()
+        assert response.json()["pagination"]["total"] == expected
+        # And it must genuinely differ from the unscoped total, or this test
+        # would pass even if the scope were ignored everywhere.
+        unscoped = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='1')}"
+        )
+        assert (
+            response.json()["pagination"]["total"]
+            < unscoped.json()["pagination"]["total"]
+        )
+
+
+class TestEvidenceScope:
+    """FR-020a, FR-020c — what counts as a qualifying mention."""
+
+    async def test_default_scope_accepts_all_three_sources(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """FR-020a: with no scope requested, title and description qualify."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}"
+        )
+        returned = {v["video_id"] for v in response.json()["data"]}
+        assert _VIDEOS[2] in returned  # e2 is description-sourced
+        assert _VIDEOS[4] in returned  # e1 is title-sourced
+
+    async def test_transcript_scope_excludes_other_sources(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50', min_evidence='transcript')}"
+        )
+        returned = {v["video_id"] for v in response.json()["data"]}
+        assert returned == {_VIDEOS[0], _VIDEOS[1]}
+
+    async def test_transcript_scope_retains_manual_mentions(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """FR-020c: every human-added mention is transcript-sourced.
+
+        Excluding them would invert the parameter's intent -- restricting to
+        stronger evidence would discard the strongest evidence in the system.
+        v2's e4 mention was added with detection_method='manual'.
+        """
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e4']], limit='50', min_evidence='transcript')}"
+        )
+        returned = {v["video_id"] for v in response.json()["data"]}
+        assert _VIDEOS[1] in returned
+
+
+class TestExclusion:
+    """FR-014, FR-015a, SC-007."""
+
+    async def test_excluded_entity_removes_its_videos(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1']], limit='50')}"
+            f"&exclude_entity_id={ids['e3']}"
+        )
+        returned = {v["video_id"] for v in response.json()["data"]}
+        assert _VIDEOS[0] not in returned  # v1 mentions e3
+        assert _VIDEOS[1] not in returned  # v2 mentions e3
+        assert _VIDEOS[3] in returned  # v4 has e1 only
+
+    async def test_exclusion_only_filter_returns_present_and_empty_fields(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """FR-015a: exclusion-only IS an active filter."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?exclude_entity_id={ids['e3']}&limit=1"
+        )
+        row = response.json()["data"][0]
+        assert row["entity_matches"] == []
+        assert row["total_mentions"] == 0
+
+    async def test_no_entity_filter_leaves_fields_null(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """Existing callers must see an unchanged response shape."""
+        response = await async_client.get("/api/v1/videos?limit=1")
+        row = response.json()["data"][0]
+        assert row["entity_matches"] is None
+        assert row["total_mentions"] is None
+
+
+class TestRelevanceOrdering:
+    """FR-009b, FR-009c — auto-selection and user override."""
+
+    async def test_relevance_auto_selected_when_sort_unset(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """FR-009b: v1 carries four qualifying mentions and must rank first."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}"
+        )
+        totals = [v["total_mentions"] for v in response.json()["data"]]
+        assert totals == sorted(totals, reverse=True)
+        assert response.json()["data"][0]["video_id"] == _VIDEOS[0]
+
+    async def test_explicit_sort_is_never_overridden(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """FR-009c: user choice wins even when an entity filter is active."""
+        ids = seed["ids"]
+        response = await async_client.get(
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}"
+            "&sort_by=title&sort_order=asc"
+        )
+        titles = [v["title"] for v in response.json()["data"]]
+        assert titles == sorted(titles)
+
+
+class TestFilterComposition:
+    """FR-010, SC-011 — the entity filter composes with EVERY existing filter.
+
+    Checked exhaustively rather than by sample. One unchecked combination is
+    where a silent drop hides: a filter that stops being applied when an entity
+    filter is present returns MORE videos than it should, and every assertion
+    about the rows themselves still passes because the rows that are there are
+    correct. Only comparing against the filter applied alone catches it.
+
+    Each case asserts two things:
+
+    1. The combination is a subset of the entity filter alone (or of the other
+       filter alone) — so neither side was dropped.
+    2. Where the fixture makes it possible, the combination is strictly smaller
+       than the entity filter alone — so the other filter did something.
+    """
+
+    async def test_composes_with_every_existing_filter(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        ids = seed["ids"]
+        entity_only = f"entity_id={ids['e1']}&limit=50"
+
+        baseline = await async_client.get(f"/api/v1/videos?{entity_only}")
+        baseline_ids = {v["video_id"] for v in baseline.json()["data"]}
+        assert baseline_ids, "fixture must produce a non-empty baseline"
+
+        # Every filter the videos list accepts, paired with the entity filter.
+        # `include_unavailable` is the one that legitimately WIDENS, so it is
+        # asserted separately below.
+        combinations = {
+            "channel_id": f"channel_id={_CHANNEL_ID}",
+            "tag": "tag=nonexistent-ei062-tag",
+            "canonical_tag": "canonical_tag=nonexistent-ei062-tag",
+            "topic_id": "topic_id=/m/nonexistent",
+            "category": "category=25",
+            "has_transcript": "has_transcript=true",
+            "liked_only": "liked_only=true",
+            "saved_unwatched": "saved_unwatched=true",
+            "uploaded_after": "uploaded_after=2030-01-01T00:00:00",
+            "uploaded_before": "uploaded_before=2000-01-01T00:00:00",
+        }
+
+        for label, param in combinations.items():
+            response = await async_client.get(f"/api/v1/videos?{entity_only}&{param}")
+            assert response.status_code in (
+                200,
+                400,
+            ), f"{label} + entity filter returned {response.status_code}"
+            if response.status_code != 200:
+                continue
+
+            combined_ids = {v["video_id"] for v in response.json()["data"]}
+            # The entity filter must still be applied: nothing may appear that
+            # the entity filter alone did not return.
+            assert combined_ids <= baseline_ids, (
+                f"combining with {label} returned videos the entity filter "
+                f"alone did not: {combined_ids - baseline_ids}. The entity "
+                f"filter was dropped."
+            )
+
+    async def test_directly_applied_filters_still_narrow(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """The other half: the SECOND filter must not be dropped either.
+
+        A subset assertion alone passes if the second filter is ignored, so
+        each case here uses a value the fixture cannot satisfy — the result
+        must be empty.
+
+        **Only filters applied DIRECTLY belong here.** ``tag``,
+        ``canonical_tag``, ``topic_id`` and ``category`` are validated first
+        (Feature 020, FR-042–FR-044): an unrecognised value is ignored and
+        reported in ``warnings``, not applied. For those, "impossible value"
+        correctly yields the unfiltered result, so asserting emptiness would
+        test the wrong mechanism. They are covered by the subset assertion
+        above and by the warning-shape test below.
+        """
+        ids = seed["ids"]
+        entity_only = f"entity_id={ids['e1']}&limit=50"
+
+        impossible = {
+            "channel_id": "channel_id=UCzzzzzzzzzzzzzzzzzzzzzz",
+            "uploaded_after": "uploaded_after=2035-01-01T00:00:00",
+            "uploaded_before": "uploaded_before=1990-01-01T00:00:00",
+            "liked_only": "liked_only=true",
+            "saved_unwatched": "saved_unwatched=true",
+        }
+
+        for label, param in impossible.items():
+            response = await async_client.get(f"/api/v1/videos?{entity_only}&{param}")
+            assert response.status_code == 200, f"{label}: {response.status_code}"
+            assert response.json()["pagination"]["total"] == 0, (
+                f"{label} should have excluded every fixture video, but "
+                f"{response.json()['pagination']['total']} remained — the "
+                f"filter was silently dropped when combined with an entity "
+                f"filter."
+            )
+
+    async def test_validated_filters_keep_their_ignore_and_warn_behaviour(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """An unrecognised tag/topic/category is ignored, not applied.
+
+        That predates this feature and must survive it. The entity filter
+        rejects unknown ids instead (FR-016b), and the two conventions have to
+        coexist in one request without either changing the other.
+        """
+        ids = seed["ids"]
+        entity_only = await async_client.get(
+            f"/api/v1/videos?entity_id={ids['e1']}&limit=50"
+        )
+        with_bogus_tag = await async_client.get(
+            f"/api/v1/videos?entity_id={ids['e1']}&tag=no-such-tag-ei062&limit=50"
+        )
+
+        assert with_bogus_tag.status_code == 200
+        # The bogus tag changed nothing; the entity filter still applies.
+        assert (
+            with_bogus_tag.json()["pagination"]["total"]
+            == entity_only.json()["pagination"]["total"]
+        )
+        # And the response says so rather than silently pretending.
+        assert with_bogus_tag.json().get("warnings")
+
+    async def test_include_unavailable_widens_rather_than_narrows(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """The one filter that legitimately grows the result.
+
+        Availability is orthogonal to qualification (Edge Cases): an
+        unavailable video that mentions the entity still qualifies, it is just
+        hidden by default.
+        """
+        ids = seed["ids"]
+        default = await async_client.get(
+            f"/api/v1/videos?entity_id={ids['e1']}&limit=50"
+        )
+        widened = await async_client.get(
+            f"/api/v1/videos?entity_id={ids['e1']}&include_unavailable=true&limit=50"
+        )
+        assert (
+            widened.json()["pagination"]["total"]
+            >= default.json()["pagination"]["total"]
+        )
+
+    async def test_composes_with_sort_and_pagination(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """Sorting and paging are filters' quiet neighbours.
+
+        A page-2 request that silently dropped the entity filter would return
+        unrelated videos, and a total that ignored it would promise more pages
+        than exist.
+        """
+        ids = seed["ids"]
+        required = f"entity_id={ids['e1']}&entity_id={ids['e2']}"
+
+        page1 = await async_client.get(
+            f"/api/v1/videos?{required}&sort_by=title&sort_order=asc&limit=2&offset=0"
+        )
+        page2 = await async_client.get(
+            f"/api/v1/videos?{required}&sort_by=title&sort_order=asc&limit=2&offset=2"
+        )
+        unpaged = await async_client.get(f"/api/v1/videos?{required}&limit=50")
+
+        all_ids = {v["video_id"] for v in unpaged.json()["data"]}
+        paged_ids = {v["video_id"] for v in page1.json()["data"]} | {
+            v["video_id"] for v in page2.json()["data"]
+        }
+        assert paged_ids <= all_ids
+        # Totals agree across pages and with the unpaged request.
+        assert (
+            page1.json()["pagination"]["total"]
+            == page2.json()["pagination"]["total"]
+            == unpaged.json()["pagination"]["total"]
+        )
+
+    async def test_exclusion_composes_with_the_other_filters_too(
+        self, async_client: AsyncClient, seed: dict[str, Any]
+    ) -> None:
+        """SC-011 covers the excluded set as well as the required one."""
+        ids = seed["ids"]
+        # Scope BOTH sides to this module's channel. An unscoped exclusion-only
+        # query spans the whole library, so its first page is arbitrary and a
+        # subset assertion against it would compare two unrelated pages rather
+        # than two filters.
+        base = await async_client.get(
+            f"/api/v1/videos?channel_id={_CHANNEL_ID}&limit=50"
+        )
+        base_ids = {v["video_id"] for v in base.json()["data"]}
+
+        combined = await async_client.get(
+            f"/api/v1/videos?exclude_entity_id={ids['e3']}"
+            f"&channel_id={_CHANNEL_ID}&limit=50"
+        )
+        combined_ids = {v["video_id"] for v in combined.json()["data"]}
+
+        assert combined_ids < base_ids, "the exclusion did not narrow the set"
+        assert _VIDEOS[0] not in combined_ids  # v1 mentions e3
+        assert _VIDEOS[1] not in combined_ids  # v2 mentions e3
+        assert _VIDEOS[3] in combined_ids  # v4 has e1 only, survives
+
+
+class TestReadOnly:
+    """FR-005, Constitution VI — the feature must never write."""
+
+    async def test_exercising_every_path_mutates_nothing(
+        self,
+        async_client: AsyncClient,
+        seed: dict[str, Any],
+        integration_session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ids = seed["ids"]
+
+        async def counts() -> dict[str, int]:
+            async with integration_session_factory() as session:
+                return {
+                    "mentions": (
+                        await session.execute(
+                            select(func.count()).select_from(EntityMentionDB)
+                        )
+                    ).scalar()
+                    or 0,
+                    "entities": (
+                        await session.execute(
+                            select(func.count()).select_from(NamedEntityDB)
+                        )
+                    ).scalar()
+                    or 0,
+                    "videos": (
+                        await session.execute(select(func.count()).select_from(VideoDB))
+                    ).scalar()
+                    or 0,
+                }
+
+        before = await counts()
+        for url in (
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']], limit='50')}",
+            f"/api/v1/videos?{_params([ids['e1']], limit='5', min_evidence='transcript')}",
+            f"/api/v1/videos?exclude_entity_id={ids['e3']}&limit=5",
+            f"/api/v1/videos?{_params([ids['e1'], ids['e2']])}&sort_by=title",
+        ):
+            assert (await async_client.get(url)).status_code == 200
+        assert await counts() == before

--- a/tests/integration/test_identity_dedup.py
+++ b/tests/integration/test_identity_dedup.py
@@ -2,8 +2,8 @@
 
 Real-DB proof that the merge is lossless, idempotent, and preserves the
 watched-video set that downstream watch-based metrics (e.g. the "Saved &
-Forgotten" dashboard, feature 059) depend on — the constitution-mandated
-cross-feature mutation-impact re-query.
+Forgotten" dashboard, feature 059) depend on — the cross-feature
+mutation-impact re-query.
 """
 
 from __future__ import annotations

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -11,6 +11,7 @@ import pytest
 # Import integration fixtures to make them available to performance tests
 # These need to be in module scope for pytest to discover them as fixtures
 from tests.integration.api.conftest import (
+    async_client,
     integration_db_engine,
     integration_db_schema_setup,
     integration_db_session,
@@ -21,6 +22,7 @@ from tests.integration.api.conftest import (
 
 # Re-export fixtures so pytest discovers them
 __all__ = [
+    "async_client",
     "integration_db_engine",
     "integration_db_schema_setup",
     "integration_db_session",

--- a/tests/performance/test_entity_intersection_performance.py
+++ b/tests/performance/test_entity_intersection_performance.py
@@ -1,0 +1,287 @@
+"""
+Performance tests for the entity intersection filter (Feature 062).
+
+Success criteria tested:
+- SC-005 / FR-035: first page with per-entity counts under 2 seconds, at any
+  permitted required-set size -- including the selection ceiling, not merely a
+  typical two or three.
+
+**Why this file exists at all.** Research R1 measured two formulations of the
+qualification query 8.2x apart -- 806 ms versus 98 ms -- returning *identical*
+output. No value-based assertion can tell them apart. R9 then integrated the
+fast shape into the videos-list query by joining an aggregate subquery, and
+recorded that the integrated form was *reasoned* to preserve the win but had
+never been measured. This is where that obligation is discharged on every run.
+
+**What these timings do and do not prove.** The seeded corpus here is small by
+design, so the absolute numbers are not the feature's real-world latency -- the
+authoritative measurement is recorded in ``research.md`` against production
+(152k mentions). What this file catches is a *shape* regression: joining
+``transcript_segments`` before pagination, or rebuilding the count by hand,
+degrades superlinearly and shows up here long before it becomes a 2-second
+user-facing problem. The budget is asserted as a ceiling, not as a baseline to
+match, per the spec's assumption that production figures are anchors rather
+than constants under test.
+
+Run with: pytest tests/performance/ -v -m performance
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import EntityMention as EntityMentionDB
+from chronovista.db.models import NamedEntity as NamedEntityDB
+from chronovista.db.models import Video as VideoDB
+from chronovista.models.enums import EvidenceScope
+from chronovista.repositories.entity_mention_repository import EntityMentionRepository
+from tests.factories.named_entity_orm_factory import create_named_entity_db
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.performance]
+
+_BUDGET_SECONDS = 2.0
+_CHANNEL_ID = "UCep062pf000000000000001"
+_PREFIX = "ep062pf"
+_VIDEO_COUNT = 150
+_ENTITY_COUNT = 12  # >= the selection ceiling of 10, so the ceiling is testable
+_VIDEO_IDS = [f"{_PREFIX}_v{n:04d}" for n in range(_VIDEO_COUNT)]
+
+
+# Function-scoped: `integration_session_factory` is itself function-scoped, so
+# a module-scoped fixture cannot consume it. Reseeding per test costs a second
+# or so and keeps each measurement independent of the ones before it.
+@pytest.fixture
+async def perf_seed(
+    integration_session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Seed a corpus dense enough that a shape regression is measurable.
+
+    Every video mentions the first four entities, so a four-way intersection
+    still returns the full set rather than collapsing to nothing -- an
+    intersection that returns zero rows is fast for the wrong reason and would
+    hide exactly the regression this file exists to catch.
+    """
+    entity_ids = [uuid.uuid4() for _ in range(_ENTITY_COUNT)]
+
+    async with integration_session_factory() as session:
+        await _cleanup(session, entity_ids)
+        session.add(ChannelDB(channel_id=_CHANNEL_ID, title="EP062 Perf Channel"))
+        session.add_all(
+            VideoDB(
+                video_id=vid,
+                channel_id=_CHANNEL_ID,
+                title=f"EP062 perf {vid}",
+                description="performance fixture",
+                upload_date=datetime(2024, 6, 1, tzinfo=UTC),
+                duration=600,
+            )
+            for vid in _VIDEO_IDS
+        )
+        session.add_all(
+            create_named_entity_db(
+                id=eid,
+                canonical_name=f"{_PREFIX.title()} P{index}",
+                canonical_name_normalized=f"{_PREFIX} p{index}",
+                entity_type="person",
+                description="perf fixture",
+            )
+            for index, eid in enumerate(entity_ids)
+        )
+        await session.commit()
+
+        mentions = []
+        for index, vid in enumerate(_VIDEO_IDS):
+            # First four entities in every video; the rest spread out, so
+            # larger required sets narrow realistically.
+            present = list(entity_ids[:4]) + [
+                entity_ids[4 + (index % (_ENTITY_COUNT - 4))]
+            ]
+            for eid in present:
+                # Duplicate rows per (entity, video) -- the real corpus has
+                # them, and a fan-out bug shows up here as a timing cliff.
+                #
+                # Description-sourced with DISTINCT mention_text: the schema
+                # permits duplicates per source only where its partial unique
+                # index allows. uq_entity_mentions_description keys on
+                # (entity_id, video_id, mention_source, mention_text), so
+                # varying the text is how a description mention legitimately
+                # repeats. Title mentions cannot repeat at all.
+                for occurrence in range(3):
+                    mentions.append(
+                        EntityMentionDB(
+                            id=uuid.UUID(bytes=uuid7().bytes),
+                            entity_id=eid,
+                            segment_id=None,
+                            video_id=vid,
+                            language_code="en",
+                            mention_text=f"{_PREFIX} mention {occurrence}",
+                            detection_method="rule_match",
+                            mention_source="description",
+                        )
+                    )
+        session.add_all(mentions)
+        await session.commit()
+
+    yield {"entity_ids": entity_ids, "mention_count": len(mentions)}
+
+    async with integration_session_factory() as session:
+        await _cleanup(session, entity_ids)
+
+
+async def _cleanup(session: AsyncSession, entity_ids: list[uuid.UUID]) -> None:
+    """Remove this module's rows.
+
+    Entities are deleted by NAME, not by the ids passed in: the integration
+    database is never reset between runs, and each run generates fresh uuid4s
+    while the canonical names stay deterministic. Deleting by id would leave
+    the previous run's rows behind and the next run would collide on
+    ``uq_named_entity_canonical``.
+    """
+    await session.execute(
+        delete(EntityMentionDB).where(EntityMentionDB.video_id.in_(_VIDEO_IDS))
+    )
+    await session.execute(
+        delete(NamedEntityDB).where(
+            NamedEntityDB.canonical_name_normalized.like(f"{_PREFIX} p%")
+        )
+    )
+    await session.execute(delete(VideoDB).where(VideoDB.video_id.in_(_VIDEO_IDS)))
+    await session.execute(delete(ChannelDB).where(ChannelDB.channel_id == _CHANNEL_ID))
+    await session.commit()
+
+
+class TestIntersectionLatency:
+    """SC-005 / FR-035 -- the budget holds across the permitted range."""
+
+    @pytest.mark.parametrize("set_size", [2, 3, 4, 10])
+    async def test_first_page_within_budget(
+        self,
+        async_client: AsyncClient,
+        perf_seed: dict[str, Any],
+        set_size: int,
+    ) -> None:
+        """The budget applies at ANY permitted set size, not just a typical one.
+
+        ``set_size=10`` is the selection ceiling. SC-005 originally bounded
+        only "up to four", which left five through ten unspecified -- the gap
+        this parametrisation closes.
+        """
+        params = "&".join(f"entity_id={e}" for e in perf_seed["entity_ids"][:set_size])
+        start = time.perf_counter()
+        response = await async_client.get(f"/api/v1/videos?{params}&limit=20")
+        elapsed = time.perf_counter() - start
+
+        assert response.status_code == 200
+        assert elapsed < _BUDGET_SECONDS, (
+            f"N={set_size} took {elapsed:.2f}s against a {_BUDGET_SECONDS}s budget. "
+            "The most likely cause is a query-shape regression -- "
+            "transcript_segments joined before pagination, or the count "
+            "rebuilt by hand instead of derived from the filtered query."
+        )
+
+    async def test_counting_does_not_dominate(
+        self, async_client: AsyncClient, perf_seed: dict[str, Any]
+    ) -> None:
+        """The pagination count must stay cheap relative to the page itself.
+
+        The count derives from the same filtered query object, so it should
+        cost a fraction of the request. If it ever approaches the full request
+        time, someone has rebuilt it separately -- which is also how the count
+        silently stops matching the rows.
+        """
+        params = "&".join(f"entity_id={e}" for e in perf_seed["entity_ids"][:2])
+        start = time.perf_counter()
+        first_page = await async_client.get(f"/api/v1/videos?{params}&limit=20")
+        page_time = time.perf_counter() - start
+
+        start = time.perf_counter()
+        single = await async_client.get(f"/api/v1/videos?{params}&limit=1")
+        single_time = time.perf_counter() - start
+
+        assert first_page.status_code == single.status_code == 200
+        # Both requests pay the same count; the 20-row page additionally pays
+        # enrichment. Neither should be an order of magnitude off the other.
+        assert single_time < page_time * 5 + 0.5
+
+
+class TestCooccurrencePanelLatency:
+    """SC-012 -- the appears-with panel is the feature's slowest query.
+
+    Measured against production it is roughly ten times the intersection
+    itself (923 ms worst case, R5), which is why FR-037 requires it to load
+    independently of the entity detail page's initial render. A regression here
+    would not fail the page; it would make the page feel broken for precisely
+    the entities users open most -- the well-connected ones.
+    """
+
+    async def test_panel_within_budget_for_the_most_connected_entity(
+        self, async_client: AsyncClient, perf_seed: dict[str, Any]
+    ) -> None:
+        """The first seeded entity appears in every video, so it is the hub."""
+        hub = perf_seed["entity_ids"][0]
+        start = time.perf_counter()
+        response = await async_client.get(f"/api/v1/entities/{hub}/co-occurring")
+        elapsed = time.perf_counter() - start
+
+        assert response.status_code == 200
+        assert response.json()["data"], "hub entity must have partners"
+        assert elapsed < _BUDGET_SECONDS, (
+            f"appears-with panel took {elapsed:.2f}s against a "
+            f"{_BUDGET_SECONDS}s budget (SC-012)"
+        )
+
+    async def test_raising_the_limit_does_not_change_the_cost_class(
+        self, async_client: AsyncClient, perf_seed: dict[str, Any]
+    ) -> None:
+        """The bound caps the RESULT, not the work.
+
+        Grouping and counting scans the same rows either way, so a much larger
+        limit should not multiply the time. If it does, the bound is being
+        applied after materialising something it should not have.
+        """
+        hub = perf_seed["entity_ids"][0]
+
+        start = time.perf_counter()
+        await async_client.get(f"/api/v1/entities/{hub}/co-occurring?limit=1")
+        small = time.perf_counter() - start
+
+        start = time.perf_counter()
+        await async_client.get(f"/api/v1/entities/{hub}/co-occurring?limit=50")
+        large = time.perf_counter() - start
+
+        assert large < small * 5 + 0.5, f"limit=1 {small:.3f}s vs limit=50 {large:.3f}s"
+
+
+class TestQueryShape:
+    """The regression no timing threshold reliably catches.
+
+    R1's slow formulation returned identical output. On a small fixture it may
+    even be fast enough to pass a 2-second budget, so the shape is asserted
+    structurally here rather than left to the clock alone.
+    """
+
+    async def test_qualification_never_joins_transcript_segments(
+        self, perf_seed: dict[str, Any]
+    ) -> None:
+        """Timestamps are fetched for the returned page only (R1)."""
+        repo = EntityMentionRepository()
+        subquery = repo.build_entity_qualification_subquery(
+            perf_seed["entity_ids"][:3], EvidenceScope.ANY
+        )
+        sql = str(subquery.element.compile()).lower()
+        assert "transcript_segments" not in sql
+        assert "count(distinct" in sql

--- a/tests/unit/api/routers/test_videos.py
+++ b/tests/unit/api/routers/test_videos.py
@@ -8,6 +8,7 @@ include_unavailable, tag, category, topic_id).
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
@@ -106,12 +107,22 @@ class TestVideoSortFieldEnum:
         """Verify title enum value matches API parameter."""
         assert VideoSortField.TITLE.value == "title"
 
-    def test_enum_has_exactly_two_members(self) -> None:
-        """Verify enum has only upload_date and title (no date_added)."""
+    def test_enum_holds_exactly_the_supported_sorts(self) -> None:
+        """Verify the enum holds exactly the supported sorts, and no date_added.
+
+        The count is not the point -- the guard is that no ``date_added`` member
+        appears. The frontend label "Date Added" maps to ``upload_date``
+        (FR-017), so a separate member would silently duplicate it. Asserted
+        explicitly here rather than implied by a member count, which Feature
+        062 legitimately changed by adding ``relevance``.
+        """
         members = list(VideoSortField)
-        assert len(members) == 2
-        assert VideoSortField.UPLOAD_DATE in members
-        assert VideoSortField.TITLE in members
+        assert set(members) == {
+            VideoSortField.UPLOAD_DATE,
+            VideoSortField.TITLE,
+            VideoSortField.RELEVANCE,
+        }
+        assert not any(member.value == "date_added" for member in members)
 
     def test_is_string_enum(self) -> None:
         """Verify VideoSortField is a str enum for FastAPI query param parsing."""
@@ -140,6 +151,157 @@ class TestDefaultSort:
         body = response.json()
         assert "data" in body
         assert "pagination" in body
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Unset-vs-explicit sort, and the relevance guard (Feature 062)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSortUnsetState:
+    """``sort_by`` carries a distinct unset state (FR-009e).
+
+    The parameter default moved off the signature and into the body so the
+    endpoint can tell "caller sent nothing" from "caller explicitly chose
+    upload_date". Feature 062 needs that distinction to auto-select relevance
+    only when the caller expressed no preference (FR-009b). These tests pin the
+    externally visible half of it: existing callers must see no change.
+    """
+
+    async def test_omitting_sort_by_still_succeeds(
+        self, async_client: AsyncClient
+    ) -> None:
+        """No sort_by behaves exactly as it did when the default was on the param."""
+        response = await async_client.get("/api/v1/videos")
+        assert response.status_code == 200
+
+    async def test_explicit_upload_date_still_succeeds(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Explicitly requesting the former default is still accepted."""
+        response = await async_client.get("/api/v1/videos?sort_by=upload_date")
+        assert response.status_code == 200
+
+    async def test_relevance_without_entity_filter_is_rejected(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Relevance has no meaning without a required entity set.
+
+        Must be a 400 that explains itself -- not a 422 from enum validation,
+        and emphatically not a 500 from an unmapped sort column. ``RELEVANCE``
+        is deliberately absent from ``_VIDEO_SORT_COLUMN_MAP`` because its
+        ordering comes from the entity qualification subquery, so an unguarded
+        request would raise KeyError.
+        """
+        response = await async_client.get("/api/v1/videos?sort_by=relevance")
+        assert response.status_code == 400
+        assert "relevance" in response.text.lower()
+
+    async def test_unknown_sort_value_still_422(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Adding an enum member must not turn unknown values into 400s."""
+        response = await async_client.get("/api/v1/videos?sort_by=not_a_sort")
+        assert response.status_code == 422
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Entity filter validation (Feature 062)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestEntityFilterValidation:
+    """Every rejection the entity filter can produce.
+
+    Each of these is a 400 rather than a silently-empty 200 or an ignored
+    filter. That diverges from this endpoint's convention for tag / topic /
+    category, which ignore unrecognised values and report them in ``warnings``.
+    The divergence is deliberate (FR-016b): the entity filter is CONJUNCTIVE,
+    so silently dropping a required entity BROADENS the result -- a
+    three-entity intersection quietly answered as a two-entity one returns
+    more videos, presenting a wrong answer confidently. Dropping one value
+    from an OR-filter narrows instead, which is self-evident to the user.
+    """
+
+    async def test_unknown_entity_id_is_rejected(
+        self, async_client: AsyncClient
+    ) -> None:
+        """FR-016b: never a silent empty result."""
+        unknown = uuid.uuid4()
+        response = await async_client.get(f"/api/v1/videos?entity_id={unknown}")
+        assert response.status_code == 400
+        assert str(unknown) in response.text
+
+    async def test_unknown_excluded_entity_id_is_rejected(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Exclusion gets the same treatment as inclusion."""
+        unknown = uuid.uuid4()
+        response = await async_client.get(f"/api/v1/videos?exclude_entity_id={unknown}")
+        assert response.status_code == 400
+
+    async def test_required_and_excluded_overlap_is_rejected(
+        self, async_client: AsyncClient
+    ) -> None:
+        """FR-016: an entity cannot be both required and excluded.
+
+        Checked before entity existence, so the conflict is reported even for
+        ids that do not exist -- the request is incoherent either way.
+        """
+        same = uuid.uuid4()
+        response = await async_client.get(
+            f"/api/v1/videos?entity_id={same}&exclude_entity_id={same}"
+        )
+        assert response.status_code == 400
+        assert str(same) in response.text
+
+    async def test_required_set_over_ceiling_is_rejected(
+        self, async_client: AsyncClient
+    ) -> None:
+        """FR-002a/FR-002b: explained, not silently truncated."""
+        params = "&".join(f"entity_id={uuid.uuid4()}" for _ in range(11))
+        response = await async_client.get(f"/api/v1/videos?{params}")
+        assert response.status_code == 400
+        assert "10" in response.text
+
+    async def test_excluded_set_over_ceiling_is_rejected(
+        self, async_client: AsyncClient
+    ) -> None:
+        """The ceiling applies to each set SEPARATELY (FR-002a)."""
+        params = "&".join(f"exclude_entity_id={uuid.uuid4()}" for _ in range(11))
+        response = await async_client.get(f"/api/v1/videos?{params}")
+        assert response.status_code == 400
+
+    async def test_ten_per_set_is_within_the_per_set_ceiling(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Ten required and ten excluded is twenty entities in one request.
+
+        Each set is inside its own ceiling of 10 (FR-002a), so the per-set rule
+        does not reject it -- but both sets count toward the global filter cap
+        of 15 (FR-002d), which does. The request must fail on the GLOBAL limit,
+        naming it, rather than on a per-set limit neither set exceeded.
+        """
+        params = "&".join(
+            [f"entity_id={uuid.uuid4()}" for _ in range(10)]
+            + [f"exclude_entity_id={uuid.uuid4()}" for _ in range(10)]
+        )
+        response = await async_client.get(f"/api/v1/videos?{params}")
+        assert response.status_code == 400
+        assert "15" in response.text
+
+    async def test_unrecognised_min_evidence_is_rejected(
+        self, async_client: AsyncClient
+    ) -> None:
+        """FR-018a: rejected, never silently defaulted.
+
+        422 rather than 400: an enum-typed parameter rejects at the validation
+        layer, which is what this endpoint already does for an unknown
+        ``sort_by``. FR-018a requires rejection with an explanation, not a
+        particular status code.
+        """
+        response = await async_client.get("/api/v1/videos?min_evidence=bogus")
+        assert response.status_code == 422
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/api/test_entity_update_sql_columns.py
+++ b/tests/unit/api/test_entity_update_sql_columns.py
@@ -1,8 +1,9 @@
 """
 Mock SQL-column (SET-clause) test for entity edits (Feature 057, T008; INV-1).
 
-The constitution's Cross-Feature Data Contract Verification requires that an
-entity name change writes BOTH ``canonical_name`` and
+A test for an UPDATE must inspect the SQL SET clause, not merely the return
+value — a column silently absent from SET returns success while writing
+nothing. An entity name change must write BOTH ``canonical_name`` and
 ``canonical_name_normalized`` (never one without the other), and that a
 description change writes ``description``.
 

--- a/tests/unit/models/test_app_identity.py
+++ b/tests/unit/models/test_app_identity.py
@@ -22,7 +22,7 @@ class TestAppIdentitySource:
         assert AppIdentitySource.LOCAL_CONSTANT.value == "local_constant"
 
     def test_is_str_enum(self) -> None:
-        # (str, Enum) for JSON-serialization safety (constitution II)
+        # (str, Enum) for JSON-serialization safety
         assert isinstance(AppIdentitySource.CHANNEL, str)
 
 

--- a/tests/unit/repositories/test_entity_qualification_properties.py
+++ b/tests/unit/repositories/test_entity_qualification_properties.py
@@ -1,0 +1,144 @@
+"""
+Property-based tests for entity intersection qualification (Feature 062).
+
+FR-003 and FR-004 state the invariant this feature is most exposed to:
+``entity_mentions`` holds multiple rows per ``(entity_id, video_id)`` by design
+-- across sources, and within a source per issue #106 -- so qualification must
+depend only on WHICH distinct entities are present, never on how many rows each
+one has.
+
+Example-based tests check the multiplicities someone thought of. These check
+arbitrary ones. The property is enforced in two places, and both are asserted
+here: the requested ids are deduplicated before the bar is set, and the bar is
+counted over ``DISTINCT entity_id`` rather than raw rows.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from chronovista.models.enums import EvidenceScope
+from chronovista.repositories.entity_mention_repository import EntityMentionRepository
+
+_REPO = EntityMentionRepository()
+
+# A pool of fixed ids so hypothesis can construct lists with real repetition;
+# drawing fresh uuid4s would make duplicates vanishingly unlikely and the
+# property would go untested while appearing to pass.
+_POOL = [uuid.UUID(int=n) for n in range(1, 9)]
+
+
+def _compiled(entity_ids: list[uuid.UUID], scope: EvidenceScope) -> str:
+    subquery = _REPO.build_entity_qualification_subquery(entity_ids, scope)
+    return str(
+        subquery.element.compile(compile_kwargs={"literal_binds": True})
+    ).replace("\n", " ")
+
+
+@given(
+    ids=st.lists(st.sampled_from(_POOL), min_size=1, max_size=20),
+    scope=st.sampled_from(list(EvidenceScope)),
+)
+def test_bar_is_set_from_distinct_ids_only(
+    ids: list[uuid.UUID], scope: EvidenceScope
+) -> None:
+    """The HAVING bar equals the number of DISTINCT requested entities.
+
+    If the bar were set from ``len(ids)``, requesting the same entity twice
+    would demand two distinct matches and the intersection would silently
+    collapse to empty -- a wrong answer returned confidently.
+    """
+    sql = _compiled(ids, scope)
+    assert f"= {len(set(ids))}" in sql
+
+
+@given(ids=st.lists(st.sampled_from(_POOL), min_size=1, max_size=20))
+def test_repetition_does_not_change_the_query(ids: list[uuid.UUID]) -> None:
+    """A list and its deduplicated form produce identical SQL.
+
+    This is the strongest statement of FR-003's requesting-side half: row
+    multiplicity in the REQUEST cannot influence the result at all.
+    """
+    deduped = list(dict.fromkeys(ids))
+    assert _compiled(ids, EvidenceScope.ANY) == _compiled(deduped, EvidenceScope.ANY)
+
+
+@given(ids=st.lists(st.sampled_from(_POOL), min_size=1, max_size=20))
+def test_qualification_counts_distinct_entities_not_rows(
+    ids: list[uuid.UUID],
+) -> None:
+    """The stored-side half: the bar counts DISTINCT entity_id.
+
+    Counting raw rows would let a single entity mentioned N times satisfy an
+    N-entity intersection -- a video would qualify for entities it never
+    mentions. Asserted against the compiled SQL because no fixture can
+    enumerate every multiplicity a real corpus produces.
+    """
+    sql = _compiled(ids, EvidenceScope.ANY).lower()
+    assert "count(distinct" in sql
+
+
+@given(ids=st.lists(st.sampled_from(_POOL), min_size=1, max_size=20))
+def test_transcript_scope_always_constrains_source(ids: list[uuid.UUID]) -> None:
+    """Scope is expressed over mention SOURCE only, never detection method.
+
+    FR-020d: the two are orthogonal, and every human-added mention is
+    transcript-sourced. A scope that filtered on detection_method would discard
+    the highest-trust evidence in the system.
+    """
+    sql = _compiled(ids, EvidenceScope.TRANSCRIPT).lower()
+    assert "mention_source" in sql
+    assert "detection_method" not in sql
+
+
+@given(ids=st.lists(st.sampled_from(_POOL), min_size=1, max_size=20))
+def test_qualification_never_joins_transcript_segments(
+    ids: list[uuid.UUID],
+) -> None:
+    """Research R1: the timestamp join must stay off the qualification query.
+
+    Joining ``transcript_segments`` before pagination returns byte-identical
+    output at roughly eight times the cost, so no value-based assertion can
+    detect the regression. This one can, because it inspects the shape.
+    """
+    sql = _compiled(ids, EvidenceScope.ANY).lower()
+    assert "transcript_segments" not in sql
+
+
+def test_cooccurrence_ordering_carries_the_id_tiebreak() -> None:
+    """The appears-with ordering must be total, not merely count-descending.
+
+    R5 makes the ``entity_id`` tiebreak contractual: without it, two partners
+    with equal shared counts may swap between requests, so a bounded list looks
+    unstable and a reveal-more page can repeat or skip a partner.
+
+    Asserted against the COMPILED statement, because a row-based test cannot
+    detect the tiebreak's removal -- Postgres returns small groups in
+    ascending-id order whether or not the ORDER BY asks for it, so the
+    integration test passes either way. Same class of problem as R1's two query
+    shapes returning identical output: only inspecting the query separates them.
+    """
+    stmt = _REPO.build_cooccurrence_query(uuid.UUID(int=1), 12, EvidenceScope.ANY)
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+
+    order_clause = sql.split("order by", 1)[1]
+    assert "desc" in order_clause, "partners must be ranked by shared count"
+    assert "asc" in order_clause, (
+        "ordering must carry the entity_id tiebreak (R5); count DESC alone is "
+        "not a total order and leaves tied partners free to swap"
+    )
+
+
+def test_cooccurrence_restricts_to_the_available_video_population() -> None:
+    """FR-024b holds only if the panel counts the same videos the list shows.
+
+    The videos list excludes unavailable videos by default. A co-occurrence
+    count over every shared video would be inflated, and the user would be
+    shown one number and land on another.
+    """
+    stmt = _REPO.build_cooccurrence_query(uuid.UUID(int=1), 12, EvidenceScope.ANY)
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+    assert "videos" in sql and "availability_status" in sql

--- a/tests/unit/repositories/test_user_video_repository_merge.py
+++ b/tests/unit/repositories/test_user_video_repository_merge.py
@@ -2,7 +2,8 @@
 
 Mock strategy: ``MagicMock(spec=AsyncSession)`` with ``AsyncMock`` execute —
 we capture and compile the emitted statements to inspect the SET/DELETE shape,
-not just return values (constitution: Cross-Feature Data Contract Verification).
+not just return values — a column absent from SET returns success while
+writing nothing.
 
 NOTE: the substring assertions below are coupled to SQLAlchemy's compiler output
 (e.g. ``liked=(user_videos.liked or (select``) and a SQLAlchemy version bump can


### PR DESCRIPTION
Closes #165

Entity filtering was single-entity only. You could browse everything mentioning one person, but not ask what two people had in **common** — the entry point to most relationship-oriented questions a library can answer.

## What this adds

**Intersection.** "Mentions all of" takes a set of entities and returns only the videos where every one has a qualifying mention. Sets of three and four are ordinary rather than exceptional — 7,062 videos in the production library carry three or more distinct entities. Each result row shows per-entity mention counts and the first mention's timestamp, omitted entirely rather than rendered as `0:00` when an entity appears only in a title or description and therefore has no position in time.

**Exclusion.** An OR across excluded entities, in deliberate contrast to the required set's AND: any match removes the video regardless of how many required entities it has. Works with an empty required set, which answers a different and useful question — *"everything that isn't about this."*

**Appears with.** On each entity's detail page, the entities sharing the most videos with it. Activating one opens that exact pairing on the videos list. **The count shown equals the count landed on**, because both derive from the same qualification rule *and* the same video population.

**Evidence scope.** A transcript-only toggle requiring the entity was actually *said*, not merely listed in metadata.

Read-only throughout. No schema change, no migration, no new dependency.

## The decisions worth reviewing

**Query shape is load-bearing.** Qualification is `GROUP BY video_id HAVING count(DISTINCT entity_id) = N`, joined into the existing videos-list query as an aggregate subquery so `pagination.total` *inherits* the filter rather than needing it applied twice. `transcript_segments` is joined only for the returned page — recombining those steps produces **byte-identical output at roughly eight times the cost**, which no value-based assertion can detect. Only timing separates them, which is why there is a performance test that hits the real endpoint rather than a reconstruction.

**Evidence scope applies symmetrically to exclusion.** "Qualifying mention" is one definition; applying it to the required set but not the excluded set would produce a request in which the same video both does and does not mention an entity. The effect is large: measured against production, excluding the most-mentioned entity removes **8,496** videos under the default scope and **870** under transcript-only. Recorded as FR-014a so it reads as a choice rather than an artifact.

**Scope is expressed over mention source only, never detection method.** The two are orthogonal — every hand-added and user-corrected mention is transcript-sourced, so restricting to transcript retains all of them rather than discarding the highest-trust evidence in the system. This deliberately avoids repeating #172, where one parameter conflates three dimensions.

**Unknown entity ids are rejected, not ignored.** This diverges from the endpoint's convention for tag/topic/category, which ignore unrecognised values and warn. The justification is conjunction: silently dropping a *required* entity **broadens** the result — a three-entity intersection quietly answered as a two-entity one returns more videos, presenting a wrong answer confidently. Dropping one value from an OR-filter narrows visibly instead.

## Entity type colours are now uniform

One pill shape, two contents. The entities list and entity detail header hold the **type** — that is the legend that teaches the convention. Everywhere else holds the entity's **name** in that type's colour.

The video-page mention chips previously rendered **every entity in indigo regardless of type**, so a place, an organization and a person looked identical — directly contradicting the convention the entities page teaches. The palette now has one definition point consumed by four call sites; two components and a page carried private copies, one of which was missing two types and mis-cased a third.

Tradeoff, stated rather than buried: away from the legend surfaces the type is carried by colour plus screen-reader-only text, so assistive technology keeps it everywhere but greyscale users lose the distinction. Recorded as FR-027a.

## Testing

| | |
|---|---|
| Backend | **6,836** passing |
| Frontend | **3,900** passing |
| Gates | black, ruff, mypy --strict, tsc — all clean |

Adversarial validation ran against the **production database** after every phase, comparing each result to an independent SQL count rather than to the same code path:

- Two-entity total vs independent count: **3296 = 3296**
- Equality contract (panel vs intersection): **3296 = 3296**
- Latency N=2 / N=3 / N=4: **0.238s / 0.240s / 0.219s** against a 2s budget
- Appears-with on the worst-case hub: **0.106s**

Key tests are mutation-verified — the fix is reverted and the test is confirmed to fail. That caught two of my own tests asserting less than they claimed: one "ordering is stable" test passed with the tiebreak removed, and one link test checked the query string while never checking where the link pointed.

## Bugs found and fixed during review

- **Filter changes did not refresh the list.** The request URL was correct but the TanStack Query key omitted the entity parameters, so a cached unfiltered result was served until a hard reload. Regression test added.
- **The appears-with link dropped every parameter.** It targeted `/`, whose index route redirects with `<Navigate to="/videos" replace />` — and that redirect carries no query string.
- **Malformed API data crashed the whole filter panel.** Name hydration cached whatever came back, putting `undefined` in a pill label and taking down every active filter.
- **The panel count was computed under different filters than the rows it described.**
- Non-deterministic `entity_matches` ordering; an `Any` return type; a duplicated select branch.

## Deliberately out of scope

**Temporal proximity** — "both entities within N seconds" — is the strongest form of this query and is computable from data already stored. Deferred so the first release ships, and explicitly not foreclosed: the per-entity timestamps this feature exposes are exactly what it would need.

Related follow-ups filed separately: #172 (source/detection-method conflation on an existing endpoint) and #173 (query protections are per-endpoint rather than per-router).

## Review notes

Three commits, separable on purpose:

1. `92a7177` — test docstrings made self-contained (6 files, **zero assertions changed** — a two-line review)
2. `201c647` — dead make targets removed and README Engineering Practice rewritten
3. `af568f7` — the feature

The first two are unrelated cleanup that would otherwise have ridden along inside the feature diff.
