### PR TITLE
fix(entities): store mention_context for transcript and title mentions

### DIFF
--- a/src/chronovista/services/entity_mention_scan_service.py
+++ b/src/chronovista/services/entity_mention_scan_service.py
@@ -883,10 +883,11 @@ class EntityMentionScanService:
                     continue
                 seen_entities.add(entity_id)
 
-            # Extract context snippet for description mentions
-            context: str | None = None
-            if mention_source == MentionSource.DESCRIPTION:
-                context = self._extract_context_snippet(text, m_start, m_end)
+            # Context is the evidence a reviewer judges a match by, so every
+            # source stores it — not only description. `text` is the raw
+            # (unfolded) source and m_start/m_end are already mapped back to
+            # raw offsets above, so the snippet reads as it was written.
+            context = self._extract_context_snippet(text, m_start, m_end)
 
             mention = EntityMentionCreate(
                 entity_id=entity_id,
@@ -1302,6 +1303,13 @@ class EntityMentionScanService:
                     confidence=1.0,
                     match_start=m_start,
                     match_end=m_end,
+                    # A transcript mention is recoverable via segment_id, but
+                    # only by joining and re-slicing by offset. Storing the
+                    # snippet is what makes a match reviewable in place — and
+                    # transcript is the largest source by a wide margin.
+                    mention_context=self._extract_context_snippet(
+                        effective_text, m_start, m_end
+                    ),
                 )
                 new_mentions.append(mention)
 

--- a/tests/unit/services/test_entity_mention_scan_service.py
+++ b/tests/unit/services/test_entity_mention_scan_service.py
@@ -3032,3 +3032,72 @@ class TestTranscriptMentionContext:
         assert context is not None
         assert "México" in context
         assert "discutió" in context
+
+
+class TestScanUsesCorrectedTranscriptText:
+    """The scan reads corrected transcript text where a correction exists.
+
+    This governs both what gets matched and — since #176 — what is stored as
+    ``mention_context``. A snippet taken from the original text while offsets
+    were computed against the corrected text would be silently garbled, and
+    only on corrected segments.
+
+    The unit tests above fake ``effective_text`` directly, so the CASE
+    expression that produces it is invisible to them. This asserts the emitted
+    SQL, which is the only layer where that decision is actually made.
+    """
+
+    async def test_query_selects_corrected_text_when_a_correction_exists(self) -> None:
+        captured: dict[str, object] = {}
+
+        async def _capture(stmt: object) -> object:
+            captured["stmt"] = stmt
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        session = AsyncMock()
+        session.execute = _capture
+
+        svc = _build_service(MagicMock())
+        await svc._fetch_segment_batch(
+            session,
+            video_ids=None,
+            language_code=None,
+            batch_size=10,
+            offset=0,
+        )
+
+        sql = str(captured["stmt"])
+        assert "has_correction" in sql
+        assert "corrected_text" in sql
+        # Corrected text must be preferred, with the original as the fallback
+        # branch — not the other way around.
+        assert "THEN transcript_segments.corrected_text" in sql
+        assert "ELSE transcript_segments.text" in sql
+
+    async def test_query_skips_segments_whose_correction_is_empty(self) -> None:
+        # A correction flagged but blank would otherwise yield an empty
+        # effective_text, dropping real mentions rather than surfacing them.
+        captured: dict[str, object] = {}
+
+        async def _capture(stmt: object) -> object:
+            captured["stmt"] = stmt
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        session = AsyncMock()
+        session.execute = _capture
+
+        svc = _build_service(MagicMock())
+        await svc._fetch_segment_batch(
+            session,
+            video_ids=None,
+            language_code=None,
+            batch_size=10,
+            offset=0,
+        )
+
+        sql = str(captured["stmt"])
+        assert "corrected_text IS NULL" in sql or "corrected_text = ''" in sql

--- a/tests/unit/services/test_entity_mention_scan_service.py
+++ b/tests/unit/services/test_entity_mention_scan_service.py
@@ -2942,3 +2942,93 @@ class TestDiacriticFoldingMetadata:
         m = mentions[0]
         assert desc[m.match_start : m.match_end] == "México"
         assert m.mention_text == "México"
+
+
+class TestTranscriptMentionContext:
+    """Transcript mentions carry a context snippet (#176).
+
+    Context is the evidence a reviewer judges a match by. Transcript is the
+    largest source in a real corpus, and it stored NULL for every row — so the
+    mentions most in need of review were the ones that could not be reviewed.
+
+    A transcript mention is recoverable through ``segment_id``, but only by
+    joining and re-slicing by offset. These tests pin that the snippet is
+    stored in place.
+    """
+
+    @staticmethod
+    def _pattern(name: str) -> object:
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
+
+        return _EntityPattern(
+            entity_id=_make_uuid(),
+            canonical_name=name,
+            entity_type="person",
+            pg_pattern=re.escape(name),
+            alias_names=[name],
+        )
+
+    async def _scan_one(self, text: str, name: str) -> list:
+        pattern = self._pattern(name)
+        seg = _make_segment_row(effective_text=text)
+
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=_scalars_execute([]))
+
+        svc = _build_service(MagicMock())
+        mentions, _, _, _, _ = await svc._scan_batch(
+            session,
+            batch_rows=[seg],
+            patterns=[pattern],
+            full_rescan=False,
+            dry_run=False,
+            limit=None,
+            current_preview_count=0,
+        )
+        return mentions
+
+    async def test_transcript_mention_stores_context(self) -> None:
+        mentions = await self._scan_one(
+            "Earlier today Tesla announced a new car in Berlin", "Tesla"
+        )
+
+        assert len(mentions) == 1
+        assert mentions[0].mention_context is not None
+        assert "Tesla" in mentions[0].mention_context
+
+    async def test_context_includes_surrounding_text_not_just_the_match(self) -> None:
+        # The whole point: the snippet must show what was said AROUND the
+        # match, or it adds nothing over mention_text.
+        mentions = await self._scan_one(
+            "Earlier today Tesla announced a new car in Berlin", "Tesla"
+        )
+
+        context = mentions[0].mention_context
+        assert context is not None
+        assert "Earlier today" in context
+        assert "announced a new car" in context
+
+    async def test_context_is_bounded(self) -> None:
+        # ~75 chars either side plus the match, so a long segment does not
+        # store the entire transcript on every row.
+        long_text = ("filler word " * 60) + "Tesla" + (" trailing word" * 60)
+        mentions = await self._scan_one(long_text, "Tesla")
+
+        context = mentions[0].mention_context
+        assert context is not None
+        assert len(context) < 200
+        assert len(context) < len(long_text)
+
+    async def test_context_preserves_accents_from_the_raw_text(self) -> None:
+        # Matching folds diacritics, but the stored snippet must read as it
+        # was written — folded text would show "Mexico" where "México" was
+        # said, which is a different claim about the source.
+        mentions = await self._scan_one(
+            "Hoy en México se discutió el acuerdo comercial", "Mexico"
+        )
+
+        assert len(mentions) == 1
+        context = mentions[0].mention_context
+        assert context is not None
+        assert "México" in context
+        assert "discutió" in context

--- a/tests/unit/services/test_scan_metadata.py
+++ b/tests/unit/services/test_scan_metadata.py
@@ -198,7 +198,11 @@ class TestScanMetadataTitle:
         assert mention.segment_id is None
         assert mention.video_id == "vid00100001"
         assert mention.mention_text == "Noam Chomsky"
-        assert mention.mention_context is None  # No context for title mentions
+        # Title mentions carry context too (#176). Previously this asserted
+        # None, which pinned the omission rather than a decision: a reviewer
+        # judging a match needs the surrounding text whatever the source.
+        assert mention.mention_context is not None
+        assert "Noam Chomsky" in mention.mention_context
 
     async def test_t014_title_scan_applies_exclusion_patterns(self) -> None:
         """T014: Title scanning with exclusion pattern 'New Mexico' skips


### PR DESCRIPTION
Closes #176.

## Problem

`mention_context` was populated for description mentions only. Transcript and title stored `NULL` for every row — **114,397 mentions on a real corpus, 67% of all rule-matched mentions**, with no stored evidence of why they matched.

| Source | With context (before) | Total |
|---|---|---|
| description | 56,380 | 56,380 (100%) |
| title | **0** | 25,961 (0%) |
| transcript | **0** | 88,436 (0%) |

## Change

`_extract_context_snippet` was already generic — it takes text plus match offsets. The metadata path had both in hand and was gated by an explicit `MentionSource.DESCRIPTION` condition. The transcript path never called it, despite holding the segment text and both offsets at the point of match.

Both now extract. Two lines of behaviour change; the rest is tests.

## The subtle part

The scan folds diacritics before matching, then maps offsets back to the raw text. The snippet is taken from the **raw** text with those **raw** offsets, so it reads as written — `"Perú"`, not `"Peru"`.

Passing the folded text would compile, type-check, and pass every other test in the suite while quietly misquoting the source. `test_context_preserves_accents_from_the_raw_text` pins it.

## Tests

Four new transcript tests: context is stored, it includes surrounding text rather than just the match, it stays bounded (<200 chars, so a long segment does not store a whole transcript per row), and it preserves accents.

Mutation-checked — removing the transcript change fails all four.

One existing test asserted `mention_context is None` for title mentions. That pinned the omission rather than a decision, so it now asserts the snippet is present and contains the match.

## Verification

- **6,782 unit tests pass**, 15 skipped
- `ruff`, `black --check`, `mypy --strict` clean

## Notes

- **No migration.** The column exists from Feature 054. Existing rows stay `NULL` until an `entities scan --full` backfills them — worth a changelog line.
- **Frontend follow-up needed.** The API surfaces this to the UI as `description_context`, documented as *"Only present when `description` is in sources; null otherwise"* ([EntityDetailPage.tsx:315](../blob/master/frontend/src/pages/EntityDetailPage.tsx#L315)). So the newly populated transcript and title context has no route to the UI yet. This PR unblocks the data; surfacing it means renaming that field to something source-neutral and rendering it per source. Filed separately rather than widened here.
- Prerequisite for #177 (per-alias case sensitivity) — reviewing ambiguous matches requires the evidence this stores.
