### PR TITLE
fix(entities): make the entity scan button rebuild instead of adding

### DIFF
--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -1076,14 +1076,27 @@ export function EntityDetailPage() {
       scanTimerRef.current = null;
     }
     scanMutation.mutate(
-      { entityId, options: { sources: ["transcript", "title", "description"] } },
+      {
+        entityId,
+        options: {
+          sources: ["transcript", "title", "description"],
+          // Always a full rebuild, never incremental. An incremental scan only
+          // ADDS, so any subtractive edit — removing an alias, adding an
+          // exclusion pattern — leaves the mentions it should have retracted
+          // in place, and the user sees a scan "succeed" while the wrong
+          // matches survive. The delete is scoped to detection_method
+          // 'rule_match', so manual and correction-derived mentions are
+          // untouched, and the whole delete-and-rebuild is one transaction.
+          full_rescan: true,
+        },
+      },
       {
         onSuccess: (data) => {
           const { mentions_found, unique_videos } = data.data;
           const msg =
             mentions_found === 0
-              ? "No new mentions found."
-              : `Found ${mentions_found.toLocaleString()} new mention${mentions_found === 1 ? "" : "s"} across ${unique_videos.toLocaleString()} video${unique_videos === 1 ? "" : "s"}.`;
+              ? "No mentions found for this entity."
+              : `Rebuilt ${mentions_found.toLocaleString()} mention${mentions_found === 1 ? "" : "s"} across ${unique_videos.toLocaleString()} video${unique_videos === 1 ? "" : "s"}.`;
           setScanMessage(msg);
           setScanMessageType("success");
           scanTimerRef.current = setTimeout(() => {
@@ -1298,13 +1311,21 @@ export function EntityDetailPage() {
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
                   />
                 </svg>
-                Scanning...
-                <span className="sr-only">Scanning for mentions...</span>
+                Rescanning...
+                <span className="sr-only">Rebuilding mentions for this entity...</span>
               </>
             ) : (
-              "Scan for Mentions"
+              "Rescan Mentions"
             )}
           </button>
+
+          {!scanMutation.isPending && (
+            <p className="text-sm text-slate-500">
+              Rebuilds every detected mention from the entity's current aliases
+              and exclusion patterns. Mentions you added or corrected by hand
+              are kept.
+            </p>
+          )}
 
           {scanMutation.isPending && (
             <p

--- a/frontend/src/pages/__tests__/EntityDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.test.tsx
@@ -13,13 +13,13 @@
  * - "All N videos loaded" message at end of list
  * - Loads more videos when hasNextPage is true (via hook)
  *
- * Coverage (Feature 052, T008 — Scan for Mentions button):
- * - Renders "Scan for Mentions" button
- * - Button is disabled and shows "Scanning..." during pending state
+ * Coverage (Feature 052, T008 — Rescan Mentions button):
+ * - Renders "Rescan Mentions" button
+ * - Button is disabled and shows "Rescanning..." during pending state
  * - Button has aria-busy="true" during pending state
  * - Button has title tooltip "A scan is already running" during pending state
  * - Success message with mention/video counts appears after scan
- * - Zero-result success message "No new mentions found." appears
+ * - Zero-result success message "No mentions found for this entity." appears
  * - Error message appears and uses role="alert" for persistence
  * - Scan button triggers the mutation when clicked
  */
@@ -578,24 +578,78 @@ describe("EntityDetailPage", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Scan for Mentions button (Feature 052, T008)
+  // Rescan Mentions button (Feature 052, T008)
   // ---------------------------------------------------------------------------
 
-  describe("Scan for Mentions button", () => {
-    it("renders a 'Scan for Mentions' button in the entity header", () => {
+  describe("Rescan Mentions button", () => {
+    it("renders a 'Rescan Mentions' button in the entity header", () => {
       renderPage();
       expect(
-        screen.getByRole("button", { name: /scan for mentions/i })
+        screen.getByRole("button", { name: /rescan mentions/i })
+      ).toBeInTheDocument();
+    });
+
+    it("always requests a full rebuild, never an incremental scan", () => {
+      // The behaviour, as opposed to the label. An incremental scan only ADDS
+      // mentions, so any subtractive edit — removing an alias, adding an
+      // exclusion pattern, and later enabling case-sensitivity — leaves the
+      // matches it should have retracted in place. The scan then reports
+      // success while the wrong mentions survive, which is worse than an
+      // error. Renaming the button would pass every other test in this file.
+      const mockMutate = vi.fn();
+      vi.mocked(useScanEntity).mockReturnValue({
+        mutate: mockMutate,
+        isPending: false,
+        isError: false,
+        error: null,
+        data: undefined,
+        reset: vi.fn(),
+        mutateAsync: vi.fn(),
+        isSuccess: false,
+        isIdle: true,
+        status: "idle",
+        variables: undefined,
+        context: undefined,
+        failureCount: 0,
+        failureReason: null,
+        isPaused: false,
+        submittedAt: 0,
+      } as ReturnType<typeof useScanEntity>);
+
+      renderPage();
+      fireEvent.click(screen.getByRole("button", { name: /rescan mentions/i }));
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      const [variables] = mockMutate.mock.calls[0] as [
+        { options?: { full_rescan?: boolean; sources?: string[] } },
+      ];
+      expect(variables.options?.full_rescan).toBe(true);
+      // All three sources, or a "rebuild" silently skips two of them.
+      expect(variables.options?.sources).toEqual([
+        "transcript",
+        "title",
+        "description",
+      ]);
+    });
+
+    it("tells the user hand-curated mentions survive the rebuild", () => {
+      // The delete is scoped to detection_method='rule_match', so manual and
+      // correction-derived mentions are preserved — but nobody can infer that
+      // from a button labelled "Rescan", and the cost of guessing wrong is
+      // that they never press it.
+      renderPage();
+      expect(
+        screen.getByText(/added or corrected by hand are kept/i)
       ).toBeInTheDocument();
     });
 
     it("button is enabled in idle state", () => {
       renderPage();
-      const button = screen.getByRole("button", { name: /scan for mentions/i });
+      const button = screen.getByRole("button", { name: /rescan mentions/i });
       expect(button).not.toBeDisabled();
     });
 
-    it("button is disabled and shows 'Scanning...' text when isPending is true", () => {
+    it("button is disabled and shows 'Rescanning...' text when isPending is true", () => {
       vi.mocked(useScanEntity).mockReturnValue({
         mutate: vi.fn(),
         isPending: true,
@@ -677,7 +731,7 @@ describe("EntityDetailPage", () => {
 
     it("button does not have title tooltip in idle state", () => {
       renderPage();
-      const button = screen.getByRole("button", { name: /scan for mentions/i });
+      const button = screen.getByRole("button", { name: /rescan mentions/i });
       expect(button).not.toHaveAttribute("title");
     });
 
@@ -704,7 +758,7 @@ describe("EntityDetailPage", () => {
 
       renderPage("entity-uuid-001");
 
-      const button = screen.getByRole("button", { name: /scan for mentions/i });
+      const button = screen.getByRole("button", { name: /rescan mentions/i });
       fireEvent.click(button);
 
       expect(mockMutate).toHaveBeenCalledOnce();
@@ -718,7 +772,7 @@ describe("EntityDetailPage", () => {
       // Simulate the component having received scan result data by rendering
       // with a mutate that immediately calls onSuccess in the click handler.
       // We verify the component shows success message text patterns that match
-      // the actual implementation strings: "Found N new mention(s) across M video(s)."
+      // the actual implementation strings: "Rebuilt N mention(s) across M video(s)."
       const mockMutate = vi.fn().mockImplementation((_vars, callbacks) => {
         // Simulate an immediate onSuccess callback
         callbacks?.onSuccess?.({
@@ -755,13 +809,13 @@ describe("EntityDetailPage", () => {
 
       renderPage();
 
-      const button = screen.getByRole("button", { name: /scan for mentions/i });
+      const button = screen.getByRole("button", { name: /rescan mentions/i });
       fireEvent.click(button);
 
-      expect(screen.getByText(/found 7 new mentions across 3 videos/i)).toBeInTheDocument();
+      expect(screen.getByText(/rebuilt 7 mentions across 3 videos/i)).toBeInTheDocument();
     });
 
-    it("success message 'No new mentions found.' appears when scan returns zero results", () => {
+    it("success message 'No mentions found for this entity.' appears when scan returns zero results", () => {
       const mockMutate = vi.fn().mockImplementation((_vars, callbacks) => {
         callbacks?.onSuccess?.({
           data: {
@@ -797,10 +851,10 @@ describe("EntityDetailPage", () => {
 
       renderPage();
 
-      const button = screen.getByRole("button", { name: /scan for mentions/i });
+      const button = screen.getByRole("button", { name: /rescan mentions/i });
       fireEvent.click(button);
 
-      expect(screen.getByText(/no new mentions found/i)).toBeInTheDocument();
+      expect(screen.getByText(/no mentions found for this entity/i)).toBeInTheDocument();
     });
 
     it("success message uses role='status' for polite announcement", () => {
@@ -839,7 +893,7 @@ describe("EntityDetailPage", () => {
 
       renderPage();
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan mentions/i }));
 
       const statusEl = screen.getByRole("status");
       expect(statusEl).toBeInTheDocument();
@@ -871,7 +925,7 @@ describe("EntityDetailPage", () => {
 
       renderPage();
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan mentions/i }));
 
       const alertEl = screen.getByRole("alert");
       expect(alertEl).toBeInTheDocument();
@@ -904,7 +958,7 @@ describe("EntityDetailPage", () => {
 
       renderPage();
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan mentions/i }));
 
       expect(screen.getByRole("alert")).toHaveTextContent(/entity not found/i);
     });
@@ -935,7 +989,7 @@ describe("EntityDetailPage", () => {
 
       renderPage();
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan mentions/i }));
 
       expect(screen.getByRole("alert")).toHaveTextContent(/already running/i);
     });
@@ -968,7 +1022,7 @@ describe("EntityDetailPage", () => {
 
       renderPage();
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan mentions/i }));
 
       expect(screen.getByRole("alert")).toHaveTextContent(
         "Database connection lost during scan"


### PR DESCRIPTION
## Problem

The scan button on the entity detail page ran an **incremental** scan. Incremental only ever **adds** mentions, so any subtractive edit leaves the matches it should have retracted in place — and the scan then reports success while the wrong mentions survive, which is worse than an error.

| Change to an entity | Incremental | Full |
|---|---|---|
| Add an alias | works | works |
| **Remove an alias** | **leaves stale mentions** | correct |
| **Add an exclusion pattern** | **leaves stale mentions** | correct |
| New videos synced | works | works |

**Six entities already carry exclusion patterns**, so this is a live defect, not a latent one.

## Why unconditional rather than an option

**Incremental buys nothing.** Transcript segments are not indexed by entity, so an incremental scan still walks all 1.65M of them. The only saving is a dedup lookup instead of a delete — no meaningful difference in cost, against a meaningful difference in correctness.

**A full rebuild is safe.** The delete and the entire rebuild run in one transaction with a single commit at the end (`entity_mention_scan_service.py`, `# 5. Commit all work`). A scan that fails or is interrupted rolls back completely — there is no window where an entity has been emptied but not repopulated.

**Hand-curated work survives.** The delete is scoped to `detection_method='rule_match'`. On the current corpus that preserves 394 `manual` and 1,255 `user_correction` mentions, verified across the full rescans run while investigating #176.

So there is no state in which a user should prefer the incremental behaviour, and a `full_rescan` checkbox would only ask them to reason about a choice with one correct answer.

## Changes

- Always sends `full_rescan: true` alongside all three sources
- Button relabelled **"Rescan Mentions"** (pending state: "Rescanning...")
- Success copy: *"Found N new mentions"* → *"Rebuilt N mentions"*; zero-case *"No new mentions found."* → *"No mentions found for this entity."*
- A line under the button states that hand-curated mentions are kept — true, but not something anyone would infer from a button labelled "Rescan", and the cost of guessing wrong is never pressing it

**No confirmation dialog.** The operation is atomic, deterministic from the entity's current configuration, and preserves hand-curated work. A modal would add friction without protecting against anything. (There is also no shared confirm component in this codebase; the only such flow is MergeTags' bespoke wizard, for a genuinely irreversible merge.)

## Tests

Renaming a button would pass every existing test in the file, so the new tests assert the **payload**, not the label:

- `always requests a full rebuild, never an incremental scan` — inspects the mutation variables for `full_rescan: true` and all three sources
- `tells the user hand-curated mentions survive the rebuild`

Mutation-checked: removing `full_rescan: true` fails the first test.

Existing tests updated for the new wording.

## Verification

- **176 files / 3,908 frontend tests pass**, 19 skipped; `npm run typecheck` clean
- Verified in the browser against real data — button and helper text render, and the intercepted POST body is exactly:

```json
{"sources":["transcript","title","description"],"full_rescan":true}
```

(The request was stubbed at the fetch layer so no real scan was launched.)

## Relationship to #177

Unblocks it. A case-sensitivity toggle is inert without a rebuild — flipping it and running an incremental scan would delete nothing, leaving the user to conclude the feature is broken. Landing this separately means #177 only has to add the flag and the toggle.

Frontend only. No API change — `ScanRequest.full_rescan` already existed and was already plumbed to the dispatcher; the UI simply never sent it.
