### PR TITLE
feat(entities): per-alias case-sensitive matching

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.0] - 2026-08-05
+
+Entity curation. Everything here serves one workflow: seeing why a mention matched, deciding it was wrong, and rebuilding without it.
+
+### Added
+- **Per-alias case-sensitive matching (#177).** An alias that is also an ordinary English word matches every occurrence of that word, and exclusion patterns cannot close the set — the word appears in arbitrary constructions. A **Match case** switch on each alias row restricts that one alias to its exact capitalisation.
+  - **Per-alias, and deliberately not a rule.** Measured on real data, one entity's lowercase occurrences were almost entirely the common noun, while another's were mostly the person — automatic transcription had simply failed to capitalise a proper noun. The two want *opposite* settings and nothing in the schema predicts which, so a heuristic like "case-sensitive when the alias is a dictionary word" would get the second one backwards. Only a human reading the mention contexts can decide, which is why #176 is a prerequisite rather than a convenience.
+  - **Defaults to off**, exactly how every alias has always matched. No backfill, and no existing alias changes meaning on upgrade.
+  - **Toggling rebuilds mentions**, because matching rules are applied when a scan runs. Without that the switch would appear to do nothing.
+  - New `PATCH /api/v1/entities/{entity_id}/aliases/{alias_id}`. Alias responses gain `id` and `case_sensitive`.
+
+### Fixed
+- **Transcript and title mentions had no stored context (#176).** `mention_context` was populated for description mentions only — **114,397 mentions on a real corpus, 67% of all rule-matched mentions**, with no record of why they matched. Judging one meant re-fetching the segment or video and re-slicing by offset, which blocked curation generally and blocked it hardest where it was needed most. The snippet comes from the *corrected* transcript where a correction exists, and preserves accents: it reads as written, so `"México"` is never quoted back as `"Mexico"`. Existing rows stay `NULL` until an `entities scan --full` backfills them.
+- **The entity scan button added mentions instead of rebuilding them (#179).** An incremental scan only ever adds, so removing an alias or adding an exclusion pattern left the matches it should have retracted in place — and the scan then reported success while the wrong mentions survived. It now always rebuilds, which is also free: transcript segments are not indexed by entity, so an incremental scan walks all of them anyway. Renamed **Rescan Mentions**, with a line stating that hand-curated mentions are kept — true, since the delete is scoped to machine-detected matches.
+- **The browser drew a second dropdown over every combobox (#175).** Four components declared the ARIA combobox pattern without `autoComplete="off"`, so the browser's form-history dropdown stacked on top of the component's own suggestion list — two competing lists over one input, with the native one replaying previously typed values on a surface the app cannot style or clear.
+
 ## [0.62.0] - 2026-08-04
 
 ### Added

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -114,6 +114,23 @@ Project-specific terminology used throughout chronovista documentation and code.
 **Diacritic Collision**
 :   A canonical tag group where raw forms differ by accents that were stripped during Tier 1 normalization. For example, "café" and "cafe" both normalize to "cafe" and get merged. The `tags collisions` command identifies these for manual review — most are correct merges, but some may need splitting.
 
+## Entity Curation Concepts
+
+**Alias**
+:   An alternative surface form for an entity — nickname, abbreviation, translation, former name. Matched alongside the canonical name when scanning. Aliases are what make detection work and also what makes it over-match.
+
+**Mention context**
+:   The ~150 characters of surrounding text stored with each machine-detected mention. It is the only basis for judging whether a match was correct, because the matched text alone cannot distinguish a name from an identical ordinary word. Taken from the *corrected* transcript where a correction exists, with accents preserved as written.
+
+**Case-sensitive alias**
+:   An alias restricted to its exact capitalisation, set per alias and defaulting to off. Useful where casing separates a name from the ordinary word it collides with — but only where the stored contexts show that it does. Automatic transcription drops capitalisation from proper nouns often enough that lowercase occurrences are frequently the name rather than the word, in which case enabling it discards real mentions.
+
+**Exclusion pattern**
+:   A phrase that suppresses a match when it overlaps one. Suited to a handful of known collocations; unsuited to an alias that is simply an ordinary word, since the constructions it appears in cannot be enumerated.
+
+**Full rescan**
+:   Deleting and regenerating an entity's machine-detected mentions. Required after any *subtractive* rule change, because an incremental scan only adds and never retracts what an earlier rule matched. Mentions added or corrected by hand are never touched.
+
 ## Entity Intersection Concepts
 
 **Intersection**

--- a/docs/user-guide/entity-curation.md
+++ b/docs/user-guide/entity-curation.md
@@ -1,0 +1,123 @@
+# Fix an entity that matches the wrong things
+
+Entity detection is rule-based: a name and its aliases are matched against
+transcripts, titles and descriptions. When an alias collides with ordinary
+language, that produces mentions the entity never earned.
+
+This guide covers the loop for fixing it — **see the evidence, decide, rebuild**
+— and, importantly, when *not* to reach for each tool.
+
+## Recognising the problem
+
+The signal is a mention count that looks too high for how often the subject
+actually comes up, especially for an entity whose short name is also a word:
+*Hope*, *Faith*, *Grace*, *Will*, *Summer*, *Justice*, *Destiny*.
+
+Open the entity's detail page and look at the videos it claims. If titles appear
+that have nothing to do with the subject, the alias is over-matching.
+
+## Step 1 — read the evidence
+
+Every machine-detected mention stores a **context snippet**: roughly 150
+characters of the surrounding text. That snippet is the whole basis for the
+decision, because the matched text alone cannot distinguish a name from a word —
+both are the same string.
+
+```sql
+SELECT mention_text, mention_source, mention_context
+FROM entity_mentions
+WHERE entity_id = '<entity-uuid>'
+  AND detection_method = 'rule_match'
+ORDER BY random() LIMIT 20;
+```
+
+Sample rather than skim, and sample from **transcripts specifically** — they are
+usually the largest source, and they behave differently from titles.
+
+!!! note "Contexts are stored from the corrected transcript"
+    Where a segment has a correction, the snippet comes from the corrected text,
+    so what you read is what the app displays. Accents are preserved as written.
+
+## Step 2 — choose the right tool
+
+Three tools, and picking the wrong one costs you real mentions.
+
+### Exclusion patterns — for a handful of known phrases
+
+Good when the false positives cluster into a few recognisable collocations —
+a place name that contains the entity name, a fixed idiom.
+
+Bad when the alias is simply an ordinary word. You cannot enumerate every
+construction English will put it in, and a pattern list that is *nearly*
+complete still leaks.
+
+### Match case — for an alias where capitalisation separates the two senses
+
+The **Match case** switch on an alias row restricts that one alias to its exact
+capitalisation. It applies to that alias only; the entity's other aliases and its
+canonical name are unaffected.
+
+**Check the evidence before using it.** Whether case is a reliable discriminator
+differs per entity, and it is not predictable from the alias text:
+
+| What the contexts show | Right call |
+|---|---|
+| lowercase occurrences are nearly all the ordinary word | **Match case** removes a lot of noise cheaply |
+| lowercase occurrences are mostly the subject, just uncapitalised | **Leave it off** — you would discard real mentions |
+
+The second case is common and easy to miss. Automatic transcription drops
+capitalisation from proper nouns often enough that in a real library, one entity
+had 36 lowercase occurrences of which only 3 were genuinely the ordinary word —
+turning on Match case there would have lost far more than it saved.
+
+### Removing the alias — when it earns nothing
+
+If nearly every match is wrong and the subject is reliably named some other way,
+delete the alias. Check first how many mentions use it: if the short form is how
+people actually refer to the subject, removing it discards most of your coverage.
+
+## Step 3 — rebuild
+
+**Changing a rule does not change existing mentions.** Matching is applied when a
+scan runs, and an incremental scan only *adds* — it never retracts what an
+earlier rule matched. So any subtractive change needs a full rebuild.
+
+Press **Rescan Mentions** on the entity detail page. It always rebuilds rather
+than adding, so there is no mode to choose. Toggling **Match case** triggers it
+for you.
+
+From the CLI, for one entity:
+
+```bash
+chronovista entities scan --full --entity-id <entity-uuid> \
+  --sources transcript,title,description
+```
+
+!!! tip "Your own work is safe"
+    A rebuild deletes and regenerates **machine-detected** mentions only.
+    Mentions you added by hand, and those derived from your transcript
+    corrections, are untouched. The delete and the rebuild also run in one
+    transaction, so an interrupted scan leaves the entity exactly as it was.
+
+Expect minutes rather than seconds: transcript segments are not indexed by
+entity, so even a single-entity rescan reads all of them.
+
+## Step 4 — confirm
+
+Re-read the contexts from Step 1. The false positives should be gone and the
+genuine mentions still present — the second half matters as much as the first,
+since a rule that removes everything is not an improvement.
+
+## What this doesn't solve
+
+**A name that is genuinely ambiguous in the same casing** — two different people
+with the same name, or a word used as both a name and a noun with identical
+capitalisation. Neither exclusion patterns nor case sensitivity separates those,
+because the text really is identical. Those need manual review of individual
+mentions.
+
+## See also
+
+- [Find entity intersections](entity-intersection.md) — querying entities once they are accurate
+- [Correct transcripts](corrections.md) — fixing a misheard name so its mentions are found at all
+- [Run the REST API](rest-api.md) — doing any of this programmatically

--- a/docs/user-guide/entity-intersection.md
+++ b/docs/user-guide/entity-intersection.md
@@ -121,6 +121,7 @@ curl "http://localhost:8765/api/v1/entities/<id>/co-occurring"
 
 ## See also
 
+- [Fix an over-matching entity](entity-curation.md) — when an entity claims videos it shouldn't
 - [Work with transcripts](transcripts.md) — where transcript mentions come from
 - [Correct transcripts](corrections.md) — fixing a misheard name so its mentions are found
 - [Analyze topics](topic-analytics.md) — the other axis for slicing your library

--- a/docs/user-guide/rest-api.md
+++ b/docs/user-guide/rest-api.md
@@ -519,6 +519,45 @@ curl -X POST http://localhost:8000/api/v1/entities \
   -d '{"name": "Noam Chomsky", "entity_type": "person", "aliases": ["Chomsky", "N. Chomsky"]}'
 ```
 
+#### Alias Matching Behaviour
+
+An alias that is also an ordinary word matches every occurrence of that word.
+Setting `case_sensitive` restricts that one alias to its exact capitalisation.
+
+```bash
+# Match this alias only at its exact casing
+curl -X PATCH http://localhost:8000/api/v1/entities/01936c8a-1234-7000-8000-000000000001/aliases/01936c8a-5678-7000-8000-000000000002 \
+  -H "Content-Type: application/json" \
+  -d '{"case_sensitive": true}'
+
+# Back to matching any casing
+curl -X PATCH http://localhost:8000/api/v1/entities/01936c8a-1234-7000-8000-000000000001/aliases/01936c8a-5678-7000-8000-000000000002 \
+  -H "Content-Type: application/json" \
+  -d '{"case_sensitive": false}'
+```
+
+The flag defaults to `false` and applies to a single alias — an entity's other
+aliases, and its canonical name, are unaffected.
+
+!!! warning "The change takes effect on the next rescan"
+    Matching rules are applied when a scan runs, so the flag alone does not
+    alter existing mentions. Follow it with a **full** rescan of the entity:
+
+    ```bash
+    curl -X POST http://localhost:8000/api/v1/entities/01936c8a-1234-7000-8000-000000000001/scan \
+      -H "Content-Type: application/json" \
+      -d '{"sources": ["transcript", "title", "description"], "full_rescan": true}'
+    ```
+
+    An incremental scan (`full_rescan: false`) only *adds* mentions, so it would
+    never retract the ones the previous rule matched.
+
+Whether case is the right discriminator differs per alias and is not
+predictable from the alias text — decide it by reading the `mention_context`
+of existing mentions, since automatic transcription drops capitalisation from
+proper nouns often enough that lowercase occurrences are frequently the name
+rather than the ordinary word.
+
 #### Recover Video Metadata
 
 ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.29.0",
+  "version": "0.30.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/entityMentions.ts
+++ b/frontend/src/api/entityMentions.ts
@@ -98,10 +98,17 @@ export interface EntityVideoResponse {
 
 /** Summary of a single alias for a named entity (genuine aliases only — asr_error excluded). */
 export interface EntityAliasSummary {
+  /** Alias identifier — needed to address a single alias for update. */
+  id: string;
   alias_name: string;
   /** name_variant | abbreviation | nickname | translated_name | former_name */
   alias_type: string;
   occurrence_count: number;
+  /**
+   * When true this alias matches only its exact casing. False (the default)
+   * matches any casing, which is how every alias has always behaved.
+   */
+  case_sensitive: boolean;
 }
 
 /** A single item in the entity list response. */
@@ -288,6 +295,46 @@ export async function createEntityAlias(
     `/entities/${entityId}/aliases`,
     {
       method: "POST",
+      body: JSON.stringify(body),
+    }
+  );
+  return res.data;
+}
+
+/** Request body for PATCH /api/v1/entities/{entity_id}/aliases/{alias_id} */
+export interface UpdateEntityAliasRequest {
+  case_sensitive: boolean;
+}
+
+/** Response envelope for PATCH /api/v1/entities/{entity_id}/aliases/{alias_id} */
+export interface UpdateEntityAliasResponse {
+  data: EntityAliasSummary;
+}
+
+/**
+ * Sets whether an alias matches case-sensitively.
+ *
+ * The change does not retroactively alter existing mentions — matching rules
+ * are applied when a scan runs, so callers must follow this with a full
+ * rescan of the entity for it to take effect.
+ *
+ * @param entityId - UUID of the named entity that owns the alias
+ * @param aliasId - UUID of the alias to update
+ * @param caseSensitive - New matching behaviour
+ * @returns The updated EntityAliasSummary
+ * @throws ApiError with status 404 if the entity or alias is not found, or if
+ *   the alias does not belong to that entity
+ */
+export async function updateEntityAlias(
+  entityId: string,
+  aliasId: string,
+  caseSensitive: boolean
+): Promise<EntityAliasSummary> {
+  const body: UpdateEntityAliasRequest = { case_sensitive: caseSensitive };
+  const res = await apiFetch<UpdateEntityAliasResponse>(
+    `/entities/${entityId}/aliases/${aliasId}`,
+    {
+      method: "PATCH",
       body: JSON.stringify(body),
     }
   );

--- a/frontend/src/components/corrections/__tests__/PhoneticVariantsSection.test.tsx
+++ b/frontend/src/components/corrections/__tests__/PhoneticVariantsSection.test.tsx
@@ -324,9 +324,11 @@ describe("PhoneticVariantsSection", () => {
 
   it("calls createEntityAlias with correct args when Register as Alias is clicked", async () => {
     mockedCreateEntityAlias.mockResolvedValueOnce({
+      id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
       alias_name: "chomski",
       alias_type: "name_variant",
       occurrence_count: 1,
+      case_sensitive: false,
     });
     const match = makePhoneticMatch({
       original_text: "chomski",
@@ -352,9 +354,11 @@ describe("PhoneticVariantsSection", () => {
 
   it("shows 'Registered' checkmark state after successful alias creation", async () => {
     mockedCreateEntityAlias.mockResolvedValueOnce({
+      id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
       alias_name: "chomski",
       alias_type: "name_variant",
       occurrence_count: 1,
+      case_sensitive: false,
     });
     const match = makePhoneticMatch({ original_text: "chomski" });
     mockedUsePhoneticMatches.mockReturnValue(makeSuccessHook([match]));

--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -27,7 +27,7 @@ import {
 } from "../hooks/useEntityMentions";
 import { apiFetch } from "../api/config";
 import type { EntityDetail, EntityAliasSummary, UpdateEntityRequest } from "../api/entityMentions";
-import { createEntityAlias } from "../api/entityMentions";
+import { createEntityAlias, updateEntityAlias } from "../api/entityMentions";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { PhoneticVariantsSection } from "../components/corrections/PhoneticVariantsSection";
 import { ExclusionPatternsSection } from "../components/corrections/ExclusionPatternsSection";
@@ -533,11 +533,65 @@ function EntityVideoCard({
 // Alias row
 // ---------------------------------------------------------------------------
 
-function AliasRow({ alias }: { alias: EntityAliasSummary }) {
+interface AliasRowProps {
+  alias: EntityAliasSummary;
+  entityId: string;
+  /** Called after the flag is persisted, so the caller can rebuild mentions. */
+  onCaseSensitivityChanged: () => void;
+}
+
+function AliasRow({ alias, entityId, onCaseSensitivityChanged }: AliasRowProps) {
+  const [caseSensitive, setCaseSensitive] = useState(alias.case_sensitive);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const toggleId = `alias-case-${alias.id}`;
+
+  async function handleToggle(next: boolean) {
+    // Optimistic, because the switch is the feedback — a checkbox that lags
+    // behind the click reads as broken.
+    setCaseSensitive(next);
+    setIsSaving(true);
+    setError(null);
+    try {
+      await updateEntityAlias(entityId, alias.id, next);
+      onCaseSensitivityChanged();
+    } catch {
+      setCaseSensitive(!next);
+      setError("Could not save. Try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
   return (
     <div className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-slate-50 transition-colors">
       <span className="text-sm font-medium text-gray-800">{alias.alias_name}</span>
       <div className="flex items-center gap-3">
+        <label
+          htmlFor={toggleId}
+          className="flex items-center gap-1.5 text-xs text-slate-600 cursor-pointer"
+          title={
+            `Match "${alias.alias_name}" only with this exact capitalisation. ` +
+            "Use when the alias is also an ordinary word and casing tells them " +
+            "apart — check the mentions first, since automatic transcripts " +
+            "often drop capitals from names."
+          }
+        >
+          <input
+            id={toggleId}
+            type="checkbox"
+            checked={caseSensitive}
+            disabled={isSaving}
+            onChange={(e) => void handleToggle(e.target.checked)}
+            className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 disabled:opacity-50"
+          />
+          Match case
+        </label>
+        {error !== null && (
+          <span role="alert" className="text-xs text-red-600">
+            {error}
+          </span>
+        )}
         <span
           className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded border ${getAliasTypeBadgeClass(alias.alias_type)}`}
         >
@@ -1369,7 +1423,16 @@ export function EntityDetailPage() {
           {entity.aliases.length > 0 ? (
             <div className="divide-y divide-slate-100">
               {entity.aliases.map((alias) => (
-                <AliasRow key={alias.alias_name} alias={alias} />
+                <AliasRow
+                  key={alias.id}
+                  alias={alias}
+                  entityId={entityId ?? ""}
+                  // Changing the flag changes nothing until mentions are
+                  // rebuilt: an incremental scan only adds, so it would never
+                  // retract what the previous rule matched. Firing the rescan
+                  // here is what makes the toggle mean something.
+                  onCaseSensitivityChanged={handleScanClick}
+                />
               ))}
             </div>
           ) : (

--- a/frontend/src/pages/__tests__/EntityDetailPage.AddAliasForm.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.AddAliasForm.test.tsx
@@ -208,9 +208,11 @@ beforeEach(() => {
 
   // Default: createEntityAlias resolves successfully.
   vi.mocked(createEntityAlias).mockResolvedValue({
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
     alias_name: "Chomsky",
     alias_type: "name_variant",
     occurrence_count: 0,
+    case_sensitive: false,
   });
 });
 
@@ -610,7 +612,13 @@ describe("AddAliasForm (inside EntityDetailPage)", () => {
       expect(screen.getByRole("button", { name: /adding/i })).toBeInTheDocument();
 
       // Settle the promise to avoid unhandled rejections.
-      resolveFn({ alias_name: "pending-alias", alias_type: "name_variant", occurrence_count: 0 });
+      resolveFn({
+        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        alias_name: "pending-alias",
+        alias_type: "name_variant",
+        occurrence_count: 0,
+        case_sensitive: false,
+      });
     });
   });
 
@@ -636,7 +644,13 @@ describe("AddAliasForm (inside EntityDetailPage)", () => {
 
       expect(input).toBeDisabled();
 
-      resolveFn({ alias_name: "pending-alias", alias_type: "name_variant", occurrence_count: 0 });
+      resolveFn({
+        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        alias_name: "pending-alias",
+        alias_type: "name_variant",
+        occurrence_count: 0,
+        case_sensitive: false,
+      });
     });
 
     it("disables the alias type select while the request is pending", async () => {
@@ -657,7 +671,13 @@ describe("AddAliasForm (inside EntityDetailPage)", () => {
       const select = screen.getByRole("combobox", { name: /alias type/i });
       expect(select).toBeDisabled();
 
-      resolveFn({ alias_name: "pending-alias", alias_type: "name_variant", occurrence_count: 0 });
+      resolveFn({
+        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        alias_name: "pending-alias",
+        alias_type: "name_variant",
+        occurrence_count: 0,
+        case_sensitive: false,
+      });
     });
   });
 

--- a/frontend/src/pages/__tests__/EntityDetailPage.aliasCase.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.aliasCase.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * EntityDetailPage — per-alias case-sensitivity toggle (#177).
+ *
+ * An alias that is also an ordinary word matches every occurrence of that word.
+ * Case sometimes separates the two and sometimes does not — on real data one
+ * entity's lowercase hits were almost all the common noun, while another's were
+ * mostly the person with automatic transcription failing to capitalise. So the
+ * switch is a per-alias human decision, and these tests cover the two things
+ * that make it usable: it persists, and it rebuilds mentions afterwards.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { EntityDetailPage } from "../EntityDetailPage";
+
+const scanMutate = vi.fn();
+
+vi.mock("../../hooks/useEntityMentions", () => ({
+  useEntityVideos: vi.fn(() => ({
+    videos: [],
+    total: null,
+    pagination: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    loadMoreRef: { current: null },
+  })),
+  useVideoEntities: vi.fn(() => ({
+    entities: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+  useDeleteManualAssociation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    isSuccess: false,
+  })),
+  useScanEntity: vi.fn(() => ({
+    mutate: scanMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+    data: null,
+    reset: vi.fn(),
+  })),
+  useScanVideoEntities: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    data: null,
+    reset: vi.fn(),
+  })),
+  useUpdateEntity: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    isSuccess: false,
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock("../../components/corrections/PhoneticVariantsSection", () => ({
+  PhoneticVariantsSection: () => null,
+}));
+vi.mock("../../components/corrections/ExclusionPatternsSection", () => ({
+  ExclusionPatternsSection: () => null,
+}));
+// Stubbed for the same reason as the sections above: the global useQuery mock
+// hands every consumer the entity payload, which this panel cannot read.
+vi.mock("../../components/entity/CooccurringPanel", () => ({
+  CooccurringPanel: () => null,
+}));
+
+vi.mock("../../api/entityMentions", () => ({
+  createEntityAlias: vi.fn(),
+  updateEntityAlias: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return { ...actual, useQuery: vi.fn() };
+});
+
+import { useQuery } from "@tanstack/react-query";
+import { updateEntityAlias } from "../../api/entityMentions";
+
+const ALIAS_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+function mockEntity(caseSensitive = false) {
+  return {
+    entity_id: "entity-uuid-001",
+    canonical_name: "Kareem Dennis",
+    entity_type: "person",
+    description: null,
+    status: "active",
+    mention_count: 50,
+    video_count: 12,
+    aliases: [
+      {
+        id: ALIAS_ID,
+        alias_name: "Ordinaryword",
+        alias_type: "name_variant",
+        occurrence_count: 4,
+        case_sensitive: caseSensitive,
+      },
+    ],
+    exclusion_patterns: [] as string[],
+  };
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/entities/entity-uuid-001"]}>
+        <Routes>
+          <Route path="/entities/:entityId" element={<EntityDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("EntityDetailPage — alias case-sensitivity toggle (#177)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useQuery).mockReturnValue({
+      data: mockEntity(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as unknown as ReturnType<typeof useQuery>);
+    vi.mocked(updateEntityAlias).mockResolvedValue({
+      id: ALIAS_ID,
+      alias_name: "Ordinaryword",
+      alias_type: "name_variant",
+      occurrence_count: 4,
+      case_sensitive: true,
+    });
+  });
+
+  it("renders an unchecked toggle for an alias that matches any casing", () => {
+    renderPage();
+    const toggle = screen.getByRole("checkbox", { name: /match case/i });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("reflects an alias that already opted in", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: mockEntity(true),
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as unknown as ReturnType<typeof useQuery>);
+
+    renderPage();
+    expect(screen.getByRole("checkbox", { name: /match case/i })).toBeChecked();
+  });
+
+  it("persists the change against the alias, not the entity", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("checkbox", { name: /match case/i }));
+
+    await waitFor(() => {
+      expect(updateEntityAlias).toHaveBeenCalledWith(
+        "entity-uuid-001",
+        ALIAS_ID,
+        true
+      );
+    });
+  });
+
+  it("rebuilds mentions after the flag is saved", async () => {
+    // Without this the toggle is inert: matching rules are applied when a scan
+    // runs, so flipping the switch alone changes nothing the user can see, and
+    // they conclude the feature is broken.
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("checkbox", { name: /match case/i }));
+
+    await waitFor(() => {
+      expect(scanMutate).toHaveBeenCalledTimes(1);
+    });
+    const [variables] = scanMutate.mock.calls[0] as [
+      { options?: { full_rescan?: boolean } },
+    ];
+    expect(variables.options?.full_rescan).toBe(true);
+  });
+
+  it("does not rescan when saving the flag failed", async () => {
+    // Rebuilding against a flag that was never stored would silently produce
+    // the old result and read as the toggle not working.
+    vi.mocked(updateEntityAlias).mockRejectedValue(new Error("boom"));
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("checkbox", { name: /match case/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/could not save/i);
+    });
+    expect(scanMutate).not.toHaveBeenCalled();
+  });
+
+  it("reverts the switch when saving failed", async () => {
+    vi.mocked(updateEntityAlias).mockRejectedValue(new Error("boom"));
+    const user = userEvent.setup();
+    renderPage();
+
+    const toggle = screen.getByRole("checkbox", { name: /match case/i });
+    await user.click(toggle);
+
+    await waitFor(() => expect(toggle).not.toBeChecked());
+  });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
       - Correct transcripts: user-guide/corrections.md
       - Analyze topics: user-guide/topic-analytics.md
       - Find entity intersections: user-guide/entity-intersection.md
+      - Fix an over-matching entity: user-guide/entity-curation.md
       - CLI workflows: user-guide/cli-overview.md
       - Run the REST API: user-guide/rest-api.md
       - Deploy with Docker: guides/migrating-to-docker.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.62.0"
+version = "0.63.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.62.0"
+__version__ = "0.63.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -42,6 +42,7 @@ from chronovista.api.schemas.entity_mentions import (
     ScanJobResponse,
     ScanRequest,
     ScanResultData,
+    UpdateEntityAliasRequest,
     UpdateEntityRequest,
     VideoEntitiesResponse,
     VideoEntitySummary,
@@ -606,9 +607,11 @@ async def get_entity_detail(
     # name_variant, abbreviation, nickname, translated_name, former_name.
     genuine_aliases = [
         EntityAliasSummary(
+            id=a.id,
             alias_name=a.alias_name,
             alias_type=a.alias_type,
             occurrence_count=a.occurrence_count,
+            case_sensitive=a.case_sensitive,
         )
         for a in entity.aliases
         if a.alias_type != "asr_error"
@@ -927,9 +930,82 @@ async def create_entity_alias(
 
     return {
         "data": EntityAliasSummary(
+            id=db_alias.id,
             alias_name=db_alias.alias_name,
             alias_type=db_alias.alias_type,
             occurrence_count=db_alias.occurrence_count,
+            case_sensitive=db_alias.case_sensitive,
+        ).model_dump()
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PATCH /entities/{entity_id}/aliases/{alias_id}
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.patch(
+    "/entities/{entity_id}/aliases/{alias_id}",
+    status_code=200,
+    summary="Update an alias's matching behaviour",
+)
+async def update_entity_alias(
+    entity_id: uuid.UUID = Path(..., description="Named entity UUID"),
+    alias_id: uuid.UUID = Path(..., description="Alias UUID"),
+    body: UpdateEntityAliasRequest = Body(...),
+    session: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Set whether an alias matches case-sensitively.
+
+    Changing the flag does not retroactively alter existing mentions — matching
+    rules are applied when a scan runs. A caller that wants the change
+    reflected must follow this with a full rescan of the entity; an incremental
+    scan only adds, so it would never retract the mentions the previous rule
+    produced.
+
+    Parameters
+    ----------
+    entity_id : uuid.UUID
+        Named entity that owns the alias.
+    alias_id : uuid.UUID
+        Alias to update.
+    body : UpdateEntityAliasRequest
+        New matching behaviour.
+    session : AsyncSession
+        Database session (injected).
+
+    Returns
+    -------
+    dict
+        The updated alias wrapped in a ``data`` envelope.
+
+    Raises
+    ------
+    NotFoundError
+        If the entity does not exist, or the alias does not exist on it (404).
+    """
+    entity = await session.get(NamedEntityDB, entity_id)
+    if entity is None:
+        raise NotFoundError(resource_type="Entity", identifier=str(entity_id))
+
+    alias = await session.get(EntityAliasDB, alias_id)
+    # The entity_id check is what makes the path meaningful: without it, an
+    # alias could be updated through any entity's URL, and a 404 for a
+    # mismatched pair would instead silently succeed.
+    if alias is None or alias.entity_id != entity_id:
+        raise NotFoundError(resource_type="Alias", identifier=str(alias_id))
+
+    alias.case_sensitive = body.case_sensitive
+    await session.commit()
+    await session.refresh(alias)
+
+    return {
+        "data": EntityAliasSummary(
+            id=alias.id,
+            alias_name=alias.alias_name,
+            alias_type=alias.alias_type,
+            occurrence_count=alias.occurrence_count,
+            case_sensitive=alias.case_sensitive,
         ).model_dump()
     }
 

--- a/src/chronovista/api/schemas/entity_mentions.py
+++ b/src/chronovista/api/schemas/entity_mentions.py
@@ -173,6 +173,8 @@ class EntityAliasSummary(BaseModel):
 
     Attributes
     ----------
+    id : UUID
+        Alias identifier, needed to address a single alias for update.
     alias_name : str
         The alias text as stored.
     alias_type : str
@@ -180,10 +182,13 @@ class EntityAliasSummary(BaseModel):
         or former_name.
     occurrence_count : int
         Number of times this alias form has been observed.
+    case_sensitive : bool
+        Whether this alias matches only its exact casing.
     """
 
     model_config = ConfigDict(strict=True)
 
+    id: UUID = Field(..., description="Alias identifier")
     alias_name: str = Field(..., description="Alias text")
     alias_type: str = Field(
         ...,
@@ -194,6 +199,35 @@ class EntityAliasSummary(BaseModel):
     )
     occurrence_count: int = Field(
         ..., description="Number of observed occurrences of this alias form"
+    )
+    case_sensitive: bool = Field(
+        default=False,
+        description=(
+            "When true, this alias matches only the exact casing shown in "
+            "alias_name. False (the default) matches any casing."
+        ),
+    )
+
+
+class UpdateEntityAliasRequest(BaseModel):
+    """PATCH body for a single alias.
+
+    Only ``case_sensitive`` is settable. Renaming an alias would change what
+    it matches and orphan the mentions it produced, so it is deliberately not
+    offered here.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    case_sensitive: bool = Field(
+        ...,
+        description=(
+            "Match only the exact casing stored in alias_name. Intended for "
+            "an alias that is also an ordinary word, where casing separates "
+            "the name from the word — but only where that has been confirmed "
+            "against real occurrences, since automatic transcription drops "
+            "capitalisation often enough that the opposite can hold."
+        ),
     )
 
 

--- a/src/chronovista/db/migrations/versions/f1a3c9e2b7d4_add_entity_alias_case_sensitive.py
+++ b/src/chronovista/db/migrations/versions/f1a3c9e2b7d4_add_entity_alias_case_sensitive.py
@@ -1,0 +1,63 @@
+"""add case_sensitive flag to entity_aliases
+
+Revision ID: f1a3c9e2b7d4
+Revises: e6f1a2b3c4d5
+Create Date: 2026-08-05 00:00:00.000000
+
+Adds ``entity_aliases.case_sensitive`` so a single alias can opt out of
+case-insensitive matching.
+
+An alias that is also an ordinary English word matches every occurrence of that
+word, and exclusion patterns cannot close the set — the word appears in
+arbitrary constructions. Case is often the discriminator, but *only sometimes*:
+measured on real data, one entity's lowercase occurrences were almost entirely
+the common noun, while another's were mostly the person with automatic
+transcription simply failing to capitalise. The two want opposite settings and
+nothing in the schema predicts which, so this is a per-alias human decision
+rather than a rule or a heuristic.
+
+Defaults to ``false``, which is exactly today's behaviour, so no existing alias
+changes meaning on upgrade and no backfill is required. A rescan is only needed
+for entities whose flag someone actually sets.
+
+Related: #177
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a3c9e2b7d4"
+down_revision = "e6f1a2b3c4d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the case_sensitive column, defaulting to current behaviour."""
+    op.add_column(
+        "entity_aliases",
+        sa.Column(
+            "case_sensitive",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+            comment=(
+                "When true, this alias matches only the exact casing stored in "
+                "alias_name. Defaults to false (case-insensitive), which is the "
+                "historical behaviour for every alias."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the case_sensitive column.
+
+    Any opt-in settings are lost; on re-upgrade every alias returns to
+    case-insensitive matching. Mentions are unaffected until the next rescan,
+    which is when matching rules are actually applied.
+    """
+    op.drop_column("entity_aliases", "case_sensitive")

--- a/src/chronovista/db/models.py
+++ b/src/chronovista/db/models.py
@@ -896,6 +896,13 @@ class EntityAlias(Base):
         String(30), nullable=False, default="name_variant"
     )
 
+    # Matching behaviour. False (the default, and every alias historically)
+    # means case-insensitive. True restricts this one alias to the exact
+    # casing in alias_name — for aliases that collide with an ordinary word.
+    case_sensitive: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+
     # Usage statistics
     occurrence_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 

--- a/src/chronovista/models/entity_alias.py
+++ b/src/chronovista/models/entity_alias.py
@@ -31,6 +31,18 @@ class EntityAliasBase(BaseModel):
         default=EntityAliasType.NAME_VARIANT,
         description="Type of alias relationship",
     )
+    case_sensitive: bool = Field(
+        default=False,
+        description=(
+            "When true, this alias matches only the exact casing stored in "
+            "alias_name. Defaults to false, which is how every alias has "
+            "always matched. Intended for an alias that is also an ordinary "
+            "word, where casing distinguishes the name from the word — but "
+            "only where a human has confirmed it does, since automatic "
+            "transcription drops capitalisation often enough that the "
+            "opposite can be true."
+        ),
+    )
 
     model_config = ConfigDict(
         validate_assignment=True,
@@ -58,6 +70,7 @@ class EntityAliasUpdate(BaseModel):
     alias_type: EntityAliasType | None = None
     entity_id: uuid.UUID | None = None
     occurrence_count: int | None = Field(default=None, ge=0)
+    case_sensitive: bool | None = None
 
     model_config = ConfigDict(
         validate_assignment=True,

--- a/src/chronovista/services/entity_mention_scan_service.py
+++ b/src/chronovista/services/entity_mention_scan_service.py
@@ -134,6 +134,26 @@ class _EntityPattern:
     pg_pattern: str  # diacritic-folded, re.escaped alias alternation (no \b)
     alias_names: list[str]  # all raw names contributing to pattern
     exclusion_patterns: list[str] = field(default_factory=list)
+    # True when at least one alias opted into case-sensitive matching (#177).
+    # The pattern then carries per-alternative `(?i:...)` scopes and MUST be
+    # compiled without the global IGNORECASE flag, which would override them.
+    has_case_sensitive_alias: bool = False
+
+
+def _compile_entity_regex(pattern: _EntityPattern) -> re.Pattern[str]:
+    """Compile an entity's alias alternation with the right case behaviour.
+
+    Transcript and metadata scanning compile the same pattern independently.
+    Setting the flag in one and not the other would silently make an alias
+    case-sensitive in transcripts but not in titles — a divergence no test
+    asserting counts would notice — so both call this.
+
+    The global ``IGNORECASE`` is dropped only when an alias opted in, because
+    a global flag overrides the per-alternative ``(?i:...)`` scopes that carry
+    the distinction.
+    """
+    flags = re.NOFLAG if pattern.has_case_sensitive_alias else re.IGNORECASE
+    return re.compile(r"\b(" + pattern.pg_pattern + r")\b", flags)
 
 
 class EntityMentionScanService:
@@ -563,10 +583,7 @@ class EntityMentionScanService:
             compiled_patterns: list[tuple[_EntityPattern, re.Pattern[str]]] = []
             for pattern in patterns:
                 try:
-                    py_regex = re.compile(
-                        r"\b(" + pattern.pg_pattern + r")\b",
-                        re.IGNORECASE,
-                    )
+                    py_regex = _compile_entity_regex(pattern)
                     compiled_patterns.append((pattern, py_regex))
                 except re.error:
                     logger.warning(
@@ -1026,23 +1043,30 @@ class EntityMentionScanService:
         alias_result = await session.execute(alias_stmt)
         all_aliases = list(alias_result.scalars().all())
 
-        # Group aliases by entity_id
-        alias_map: dict[uuid.UUID, list[str]] = {}
+        # Group aliases by entity_id, carrying each alias's case-sensitivity.
+        alias_map: dict[uuid.UUID, list[tuple[str, bool]]] = {}
         for alias in all_aliases:
-            alias_map.setdefault(alias.entity_id, []).append(alias.alias_name)
+            alias_map.setdefault(alias.entity_id, []).append(
+                (alias.alias_name, bool(alias.case_sensitive))
+            )
 
         patterns: list[_EntityPattern] = []
         for entity in entities:
             names: list[str] = []
+            # Names matched only at their exact casing (#177). The canonical
+            # name is never here — it is not an alias and has no flag to set.
+            case_sensitive_names: set[str] = set()
 
             # Add canonical name
             names.append(entity.canonical_name)
 
             # Add aliases (may include canonical name again, dedup below)
             entity_aliases = alias_map.get(entity.id, [])
-            for alias_name in entity_aliases:
+            for alias_name, alias_cs in entity_aliases:
                 if alias_name not in names:
                     names.append(alias_name)
+                if alias_cs:
+                    case_sensitive_names.add(alias_name)
 
             # Warn about short aliases
             for name in names:
@@ -1061,11 +1085,32 @@ class EntityMentionScanService:
             # match "México".  Case is still handled by re.IGNORECASE at compile
             # time.  Names that fold to empty (pure combining marks) cannot match
             # anything meaningful and are dropped to avoid an empty alternative.
-            folded_names = [f for f in (_fold_diacritics(n)[0] for n in names) if f]
-            escaped_names = sorted(
-                [re.escape(n) for n in folded_names], key=len, reverse=True
-            )
-            pg_pattern = "|".join(escaped_names)
+            #
+            # Case sensitivity is per ALIAS, but the alternation is per ENTITY,
+            # and Python picks the first alternative that matches — which is why
+            # the list is sorted longest-first. Splitting into a case-sensitive
+            # group and a case-insensitive one would break that ordering, so
+            # each alternative carries its own scoped flag instead and the
+            # single length-sorted order survives intact.
+            #
+            # When nothing on this entity opted in — every entity, until
+            # someone sets the flag — the pattern and the global IGNORECASE
+            # are built exactly as before, so the default path is unchanged.
+            folded_pairs = [
+                (folded, n in case_sensitive_names)
+                for n, folded in ((n, _fold_diacritics(n)[0]) for n in names)
+                if folded
+            ]
+            folded_pairs.sort(key=lambda p: len(p[0]), reverse=True)
+
+            any_case_sensitive = any(cs for _, cs in folded_pairs)
+            if any_case_sensitive:
+                pg_pattern = "|".join(
+                    re.escape(f) if cs else f"(?i:{re.escape(f)})"
+                    for f, cs in folded_pairs
+                )
+            else:
+                pg_pattern = "|".join(re.escape(f) for f, _ in folded_pairs)
 
             patterns.append(
                 _EntityPattern(
@@ -1075,6 +1120,7 @@ class EntityMentionScanService:
                     pg_pattern=pg_pattern,
                     alias_names=names,
                     exclusion_patterns=list(entity.exclusion_patterns or []),
+                    has_case_sensitive_alias=any_case_sensitive,
                 )
             )
 
@@ -1194,10 +1240,7 @@ class EntityMentionScanService:
         compiled_patterns: list[tuple[_EntityPattern, re.Pattern[str]]] = []
         for pattern in patterns:
             try:
-                py_regex = re.compile(
-                    r"\b(" + pattern.pg_pattern + r")\b",
-                    re.IGNORECASE,
-                )
+                py_regex = _compile_entity_regex(pattern)
                 compiled_patterns.append((pattern, py_regex))
             except re.error:
                 logger.warning(

--- a/tests/integration/api/test_alias_case_sensitivity_endpoint.py
+++ b/tests/integration/api/test_alias_case_sensitivity_endpoint.py
@@ -1,0 +1,221 @@
+"""Integration tests for PATCH /api/v1/entities/{id}/aliases/{alias_id} (#177).
+
+An alias that is also an ordinary word matches every occurrence of that word.
+This endpoint lets a human mark one alias as exact-cased after reading the
+evidence — never a default, never inferred.
+
+Requires the integration database (chronovista_integration_test).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import EntityAlias as EntityAliasDB
+from chronovista.db.models import NamedEntity as NamedEntityDB
+from tests.factories.named_entity_orm_factory import create_named_entity_db
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+pytestmark = pytest.mark.asyncio
+
+_PREFIX = "acs177"
+_NORMS = [f"{_PREFIX} primary", f"{_PREFIX} other"]
+
+
+def _url(entity_id: uuid.UUID, alias_id: uuid.UUID) -> str:
+    return f"/api/v1/entities/{entity_id}/aliases/{alias_id}"
+
+
+async def _purge(factory: async_sessionmaker[AsyncSession]) -> None:
+    async with factory() as session:
+        ids = (
+            (
+                await session.execute(
+                    select(NamedEntityDB.id).where(
+                        NamedEntityDB.canonical_name_normalized.in_(_NORMS)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if ids:
+            await session.execute(
+                delete(EntityAliasDB).where(EntityAliasDB.entity_id.in_(list(ids)))
+            )
+            await session.execute(
+                delete(NamedEntityDB).where(NamedEntityDB.id.in_(list(ids)))
+            )
+        await session.commit()
+
+
+async def _seed(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    normalized: str,
+    alias_name: str,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    entity_id = uuid.uuid4()
+    alias_id = uuid.uuid4()
+    async with factory() as session:
+        session.add(
+            create_named_entity_db(
+                id=entity_id,
+                canonical_name=normalized.title(),
+                canonical_name_normalized=normalized,
+                entity_type="person",
+            )
+        )
+        await session.flush()
+        session.add(
+            EntityAliasDB(
+                id=alias_id,
+                entity_id=entity_id,
+                alias_name=alias_name,
+                alias_name_normalized=alias_name.lower(),
+                alias_type="name_variant",
+                occurrence_count=0,
+            )
+        )
+        await session.commit()
+    return entity_id, alias_id
+
+
+@pytest.fixture
+async def seeded(
+    integration_session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[tuple[uuid.UUID, uuid.UUID], None]:
+    await _purge(integration_session_factory)
+    pair = await _seed(
+        integration_session_factory,
+        normalized=f"{_PREFIX} primary",
+        alias_name="Ordinaryword",
+    )
+    yield pair
+    await _purge(integration_session_factory)
+
+
+def _auth():  # type: ignore[no-untyped-def]
+    return patch("chronovista.api.deps.youtube_oauth")
+
+
+class TestAliasCaseSensitivityEndpoint:
+    async def test_defaults_to_case_insensitive(
+        self,
+        async_client: AsyncClient,
+        seeded: tuple[uuid.UUID, uuid.UUID],
+    ) -> None:
+        # A newly created alias must behave exactly as aliases always have.
+        entity_id, _ = seeded
+        with _auth() as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            resp = await async_client.get(f"/api/v1/entities/{entity_id}")
+        assert resp.status_code == 200, resp.text
+        aliases = resp.json()["data"]["aliases"]
+        assert aliases, "seeded alias should be returned"
+        assert aliases[0]["case_sensitive"] is False
+
+    async def test_enabling_persists_and_is_returned(
+        self,
+        async_client: AsyncClient,
+        seeded: tuple[uuid.UUID, uuid.UUID],
+        integration_session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        entity_id, alias_id = seeded
+        with _auth() as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            resp = await async_client.patch(
+                _url(entity_id, alias_id), json={"case_sensitive": True}
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["case_sensitive"] is True
+
+        async with integration_session_factory() as session:
+            alias = (
+                await session.execute(
+                    select(EntityAliasDB).where(EntityAliasDB.id == alias_id)
+                )
+            ).scalar_one()
+            assert alias.case_sensitive is True
+
+    async def test_toggling_back_off_works(
+        self,
+        async_client: AsyncClient,
+        seeded: tuple[uuid.UUID, uuid.UUID],
+    ) -> None:
+        # Reversible: a wrong call is a mistake, not a trap.
+        entity_id, alias_id = seeded
+        with _auth() as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            await async_client.patch(
+                _url(entity_id, alias_id), json={"case_sensitive": True}
+            )
+            resp = await async_client.patch(
+                _url(entity_id, alias_id), json={"case_sensitive": False}
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["case_sensitive"] is False
+
+    async def test_alias_belonging_to_another_entity_is_404(
+        self,
+        async_client: AsyncClient,
+        seeded: tuple[uuid.UUID, uuid.UUID],
+        integration_session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # The ownership check is what makes the path meaningful. Without it an
+        # alias is reachable through any entity's URL, and a mismatched pair
+        # silently succeeds instead of 404ing.
+        _, alias_id = seeded
+        other_entity_id, _ = await _seed(
+            integration_session_factory,
+            normalized=f"{_PREFIX} other",
+            alias_name="Unrelated",
+        )
+
+        with _auth() as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            resp = await async_client.patch(
+                _url(other_entity_id, alias_id), json={"case_sensitive": True}
+            )
+        assert resp.status_code == 404, resp.text
+
+        # And the alias must be untouched by the rejected call.
+        async with integration_session_factory() as session:
+            alias = (
+                await session.execute(
+                    select(EntityAliasDB).where(EntityAliasDB.id == alias_id)
+                )
+            ).scalar_one()
+            assert alias.case_sensitive is False
+
+    async def test_unknown_entity_is_404(
+        self, async_client: AsyncClient, seeded: tuple[uuid.UUID, uuid.UUID]
+    ) -> None:
+        _, alias_id = seeded
+        with _auth() as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            resp = await async_client.patch(
+                _url(uuid.uuid4(), alias_id), json={"case_sensitive": True}
+            )
+        assert resp.status_code == 404, resp.text
+
+    async def test_unknown_alias_is_404(
+        self, async_client: AsyncClient, seeded: tuple[uuid.UUID, uuid.UUID]
+    ) -> None:
+        entity_id, _ = seeded
+        with _auth() as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            resp = await async_client.patch(
+                _url(entity_id, uuid.uuid4()), json={"case_sensitive": True}
+            )
+        assert resp.status_code == 404, resp.text

--- a/tests/unit/api/routers/test_entity_aliases.py
+++ b/tests/unit/api/routers/test_entity_aliases.py
@@ -86,6 +86,7 @@ def _make_alias_db_row(
     alias_name: str = "Musk",
     alias_type: str = "name_variant",
     occurrence_count: int = 0,
+    case_sensitive: bool = False,
 ) -> MagicMock:
     """Create a minimal mock EntityAliasDB row that the repo returns after create().
 
@@ -97,6 +98,10 @@ def _make_alias_db_row(
         The alias type string.
     occurrence_count : int
         Number of times this alias has been observed.
+    case_sensitive : bool
+        Whether the alias matches only its exact casing. Must be set
+        explicitly: an unset MagicMock attribute is truthy, and the response
+        model rejects a non-bool under strict validation.
 
     Returns
     -------
@@ -108,6 +113,7 @@ def _make_alias_db_row(
     row.alias_name = alias_name
     row.alias_type = alias_type
     row.occurrence_count = occurrence_count
+    row.case_sensitive = case_sensitive
     row.first_seen_at = datetime(2024, 1, 15, tzinfo=UTC)
     row.last_seen_at = datetime(2024, 1, 15, tzinfo=UTC)
     return row

--- a/tests/unit/services/test_entity_mention_scan_service.py
+++ b/tests/unit/services/test_entity_mention_scan_service.py
@@ -59,11 +59,19 @@ def _make_entity_row(
     return row
 
 
-def _make_alias_row(entity_id: uuid.UUID, alias_name: str) -> MagicMock:
-    """Create a mock ORM EntityAlias row."""
+def _make_alias_row(
+    entity_id: uuid.UUID, alias_name: str, case_sensitive: bool = False
+) -> MagicMock:
+    """Create a mock ORM EntityAlias row.
+
+    ``case_sensitive`` must be set explicitly: an unset MagicMock attribute is
+    truthy, which would quietly make every alias in every test case-sensitive
+    and change what the compiled pattern means.
+    """
     row = MagicMock()
     row.entity_id = entity_id
     row.alias_name = alias_name
+    row.case_sensitive = case_sensitive
     return row
 
 
@@ -3101,3 +3109,189 @@ class TestScanUsesCorrectedTranscriptText:
 
         sql = str(captured["stmt"])
         assert "corrected_text IS NULL" in sql or "corrected_text = ''" in sql
+
+
+class TestPerAliasCaseSensitivity:
+    """Per-alias case sensitivity (#177).
+
+    An alias that is also an ordinary word matches every occurrence of that
+    word. Case is sometimes the discriminator and sometimes not — measured on
+    real data, one entity's lowercase hits were almost all the common noun
+    while another's were mostly the person, with automatic transcription simply
+    failing to capitalise. So this is a per-alias opt-in, never a default and
+    never inferred.
+
+    The hard part is that case sensitivity is per ALIAS while the compiled
+    alternation is per ENTITY. These tests pin the mixed case, which is the one
+    that a naive two-group implementation gets wrong.
+    """
+
+    @staticmethod
+    def _pattern(names_and_flags: list[tuple[str, bool]]) -> Any:
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
+
+        folded = sorted(names_and_flags, key=lambda p: len(p[0]), reverse=True)
+        any_cs = any(cs for _, cs in folded)
+        if any_cs:
+            pg = "|".join(
+                re.escape(n) if cs else f"(?i:{re.escape(n)})" for n, cs in folded
+            )
+        else:
+            pg = "|".join(re.escape(n) for n, _ in folded)
+        return _EntityPattern(
+            entity_id=_make_uuid(),
+            canonical_name=folded[0][0],
+            entity_type="person",
+            pg_pattern=pg,
+            alias_names=[n for n, _ in folded],
+            has_case_sensitive_alias=any_cs,
+        )
+
+    def _matches(self, names_and_flags: list[tuple[str, bool]], text: str) -> list[str]:
+        from chronovista.services.entity_mention_scan_service import (
+            _compile_entity_regex,
+        )
+
+        rx = _compile_entity_regex(self._pattern(names_and_flags))
+        return [m.group(1) for m in rx.finditer(text)]
+
+    def test_default_stays_case_insensitive(self) -> None:
+        # Every alias today. This path must be byte-for-byte the old behaviour.
+        found = self._matches([("Tesla", False)], "TESLA and tesla and Tesla all count")
+        assert found == ["TESLA", "tesla", "Tesla"]
+
+    def test_case_sensitive_alias_matches_only_its_own_casing(self) -> None:
+        found = self._matches(
+            [("Destiny", True)],
+            "Destiny said so, but our destiny is shared, and DESTINY shouted",
+        )
+        assert found == ["Destiny"]
+
+    def test_mixed_aliases_each_keep_their_own_rule(self) -> None:
+        # The case a two-group implementation breaks: one entity, one
+        # alternation, two different rules inside it.
+        found = self._matches(
+            [("Steven Bonnell", False), ("Destiny", True)],
+            "steven bonnell aka Destiny; our destiny is elsewhere",
+        )
+        assert "steven bonnell" in found  # insensitive alias still folds case
+        assert "Destiny" in found  # sensitive alias matched exactly
+        assert "destiny" not in found  # and the common noun did not
+
+    def test_longest_first_ordering_survives_mixed_flags(self) -> None:
+        # Python alternation is first-match-wins, so the length ordering is
+        # load-bearing. Grouping by case would reorder it and let a short alias
+        # claim text belonging to a longer one.
+        found = self._matches(
+            [("Ada", True), ("Ada Lovelace", False)],
+            "Ada Lovelace wrote the notes",
+        )
+        assert found == ["Ada Lovelace"]
+
+    def test_a_global_flag_would_defeat_the_scoped_ones(self) -> None:
+        # Guards the specific mistake the helper exists to prevent: compiling
+        # the mixed pattern with re.IGNORECASE makes every alias insensitive
+        # again, silently.
+        pattern = self._pattern([("Steven Bonnell", False), ("Destiny", True)])
+        wrong = re.compile(r"\b(" + pattern.pg_pattern + r")\b", re.IGNORECASE)
+        assert wrong.search("our destiny is shared") is not None
+
+        from chronovista.services.entity_mention_scan_service import (
+            _compile_entity_regex,
+        )
+
+        assert _compile_entity_regex(pattern).search("our destiny is shared") is None
+
+    def test_case_sensitive_alias_still_matches_across_accents(self) -> None:
+        # Folding strips accents but preserves case, so the two features
+        # compose: an exact-cased alias still matches an accented occurrence.
+        from chronovista.services.entity_mention_scan_service import (
+            _fold_diacritics,
+        )
+
+        folded_text = _fold_diacritics("Hoy en México se discutio")[0]
+        found = self._matches([("Mexico", True)], folded_text)
+        assert found == ["Mexico"]
+
+        assert self._matches([("Mexico", True)], _fold_diacritics("méxico")[0]) == []
+
+
+class TestCaseSensitivityReachesTheCompiledPattern:
+    """The flag survives the trip from alias row to compiled regex (#177).
+
+    The tests above exercise `_compile_entity_regex` against a hand-built
+    pattern. That leaves the real assembly in `_load_entity_patterns`
+    unverified — the step that reads `alias.case_sensitive` off the row and
+    decides how to escape each alternative. A break there produces patterns
+    that compile and match, just under the wrong rule.
+    """
+
+    async def _load(self, entity_row: MagicMock, alias_rows: list[MagicMock]) -> Any:
+        session = AsyncMock()
+        session.execute = AsyncMock(
+            side_effect=[_scalars_execute([entity_row]), _scalars_execute(alias_rows)]
+        )
+        svc = _build_service(MagicMock())
+        patterns: list[Any] = await svc._load_entity_patterns(
+            session, entity_type=None, new_entities_only=False
+        )
+        return patterns[0]
+
+    async def test_all_insensitive_produces_the_original_pattern_shape(self) -> None:
+        # No opt-in anywhere means the pattern must not gain scoped flags, so
+        # the overwhelmingly common path is unchanged rather than merely
+        # equivalent.
+        entity_id = _make_uuid()
+        pattern = await self._load(
+            _make_entity_row(entity_id=entity_id, canonical_name="Tesla"),
+            [_make_alias_row(entity_id=entity_id, alias_name="Tesla Motors")],
+        )
+
+        assert pattern.has_case_sensitive_alias is False
+        assert "(?i:" not in pattern.pg_pattern
+
+    async def test_opted_in_alias_becomes_case_sensitive_end_to_end(self) -> None:
+        from chronovista.services.entity_mention_scan_service import (
+            _compile_entity_regex,
+        )
+
+        entity_id = _make_uuid()
+        pattern = await self._load(
+            _make_entity_row(entity_id=entity_id, canonical_name="Steven Bonnell"),
+            [
+                _make_alias_row(
+                    entity_id=entity_id, alias_name="Destiny", case_sensitive=True
+                )
+            ],
+        )
+
+        assert pattern.has_case_sensitive_alias is True
+        rx = _compile_entity_regex(pattern)
+        assert rx.search("Destiny said so") is not None
+        assert rx.search("our destiny is shared") is None
+        # The canonical name has no flag of its own and stays insensitive.
+        assert rx.search("steven bonnell was there") is not None
+
+    async def test_one_opted_in_alias_does_not_bind_the_others(self) -> None:
+        from chronovista.services.entity_mention_scan_service import (
+            _compile_entity_regex,
+        )
+
+        entity_id = _make_uuid()
+        pattern = await self._load(
+            _make_entity_row(entity_id=entity_id, canonical_name="Kareem Dennis"),
+            [
+                _make_alias_row(
+                    entity_id=entity_id, alias_name="Lowkey", case_sensitive=True
+                ),
+                _make_alias_row(
+                    entity_id=entity_id, alias_name="K Dennis", case_sensitive=False
+                ),
+            ],
+        )
+
+        rx = _compile_entity_regex(pattern)
+        assert rx.search("Lowkey performed") is not None
+        assert rx.search("I lowkey agree") is None
+        # The sibling alias keeps its own rule rather than inheriting.
+        assert rx.search("k dennis performed") is not None


### PR DESCRIPTION
Closes #177.

## Problem

An alias that is also an ordinary word matches every occurrence of that word, and exclusion patterns cannot close the set — the word appears in arbitrary constructions.

Case is *sometimes* the discriminator. Measured on real data:

| | Capitalised | lowercase | Verdict |
|---|---|---|---|
| Entity A | the person | almost entirely the common noun | case-sensitivity **helps a lot** |
| Entity B | the person | **mostly the person too** — ASR simply failed to capitalise | case-sensitivity **would lose more than it saves** |

The two want opposite settings and nothing in the schema predicts which. Both are single-word aliases colliding with English, both people, identical in the data model. Only the mention contexts distinguish them.

So this ships as a **per-alias opt-in**, defaulting to off. No global rule, and deliberately no heuristic like "case-sensitive when the alias is a dictionary word" — that would have got Entity B backwards.

## The design decision worth reviewing

Case sensitivity is per **alias**, but the compiled alternation is per **entity**, and Python takes the first alternative that matches — which is why the alias list is sorted longest-first.

The obvious implementation (a case-sensitive group beside a case-insensitive one) **breaks that ordering** and lets a short alias claim text belonging to a longer one. So each alternative carries its own scope instead:

```
(?i:Peter\ Naur)|River|(?i:another\ alias)
```

and the single length-sorted order survives intact. `test_longest_first_ordering_survives_mixed_flags` pins exactly this.

When no alias on an entity has opted in — every entity, until someone sets the flag — the pattern is built exactly as before with the global `IGNORECASE`, so the common path is **unchanged rather than merely equivalent**.

Both scan paths compile through one helper. Setting the flag in the transcript path but not the metadata path would make an alias case-sensitive in transcripts and not in titles, a divergence no test asserting counts would catch.

**Incidental finding:** the `~*` PostgreSQL regex in the service docstring is stale — no SQL regex is used, matching is pure Python. That made this a one-language problem rather than two.

## Layers

| Layer | Change |
|---|---|
| Migration `f1a3c9e2b7d4` | `entity_aliases.case_sensitive`, default `false`, no backfill |
| Models | DB + Pydantic |
| Scan | per-alias scoped flags; one compile helper |
| API | `case_sensitive` and `id` on alias responses; `PATCH /entities/{id}/aliases/{alias_id}` |
| Frontend | "Match case" switch per alias row, firing the entity rescan |

`EntityAliasSummary` gains `id` because it previously carried no identifier — there was no way to address a single alias, and keying on `alias_name` would round-trip user text through a URL.

The PATCH takes only `case_sensitive`. Renaming an alias would change what it matches and orphan the mentions it produced, so that is not offered here.

## Toggling rescans, by necessity

Flipping the flag changes nothing until mentions are rebuilt: an incremental scan only **adds**, so it would never retract what the previous rule matched. The switch fires the entity's full rescan, so the feature works rather than appearing to do nothing.

A failed save reverts the switch, shows an inline error, and deliberately does **not** rescan — rebuilding against a flag that was never stored would reproduce the old result and read as the toggle being broken.

## Verification

- **6,793 backend unit**, **832 API integration**, **177 files / 3,914 frontend** — all pass
- `ruff`, `black --check`, `mypy --strict`, `npm run typecheck` clean
- Migration applied, downgraded, and re-applied cleanly
- **Mutation-tested at three points**: removing the alias-ownership check fails the 404 test; compiling the mixed pattern with a global `IGNORECASE` fails the case test; severing the rescan wiring fails the rebuild test
- **Verified end to end in the browser** against a migrated database — clicking the switch issues `PATCH {"case_sensitive":true}` against the alias, then `POST /scan` with `{"sources":["transcript","title","description"],"full_rescan":true}`, and the flag persists

One test-harness bug fixed along the way: the alias mock factory never set `case_sensitive`, and an unset MagicMock attribute is truthy — every alias in every existing test would have silently become case-sensitive.

## Deploying

The production database is one migration behind and I have **not** applied it. Run `alembic upgrade head` before the container picks this up. The column defaults to `false`, so no existing alias changes meaning and no rescan is needed until someone sets a flag.
