### PR TITLE
fix(entities): make the video scan rebuild instead of adding

### DIFF
--- a/frontend/src/components/EntityMentionsPanel.tsx
+++ b/frontend/src/components/EntityMentionsPanel.tsx
@@ -672,7 +672,24 @@ export function EntityMentionsPanel({
                 setScanMessage(null);
                 scanMutation.reset();
                 scanMutation.mutate(
-                  { videoId, options: { sources: ["transcript", "title", "description"] } },
+                  {
+                    videoId,
+                    options: {
+                      sources: ["transcript", "title", "description"],
+                      // Always a rebuild, never incremental. An incremental
+                      // scan only ADDS, so the action a user takes right after
+                      // curating an entity — adding an exclusion pattern,
+                      // registering a longer competing entity — cannot remove
+                      // the mentions that motivated the curation. The scan then
+                      // reports success while the wrong rows survive.
+                      //
+                      // Scoped to this video: the delete filters on
+                      // video_id IN (…) AND detection_method='rule_match', so
+                      // other videos are untouched and hand-curated mentions
+                      // survive everywhere.
+                      full_rescan: true,
+                    },
+                  },
                   {
                     onSuccess: (result) => {
                       const { unique_entities, mentions_found } = result.data;
@@ -680,7 +697,7 @@ export function EntityMentionsPanel({
                         setScanMessage({ text: "No entity mentions found", kind: "success" });
                       } else {
                         setScanMessage({
-                          text: `Found ${unique_entities} ${unique_entities === 1 ? "entity" : "entities"} with ${mentions_found} ${mentions_found === 1 ? "mention" : "mentions"}`,
+                          text: `Rebuilt ${mentions_found} ${mentions_found === 1 ? "mention" : "mentions"} across ${unique_entities} ${unique_entities === 1 ? "entity" : "entities"}`,
                           kind: "success",
                         });
                       }
@@ -705,14 +722,22 @@ export function EntityMentionsPanel({
               {scanMutation.isPending ? (
                 <>
                   <SpinnerIcon className="w-4 h-4 mr-2 animate-spin" />
-                  Scanning...
-                  <span className="sr-only">Scanning for mentions...</span>
+                  Rescanning...
+                  <span className="sr-only">Rebuilding mentions for this video...</span>
                 </>
               ) : (
-                "Scan for Entity Mentions"
+                "Rescan Entity Mentions"
               )}
             </button>
           </span>
+
+          {!scanMutation.isPending && (
+            <p className="text-sm text-slate-500">
+              Rebuilds this video's detected mentions from every entity's
+              current aliases and exclusion patterns. Mentions you added or
+              corrected by hand are kept.
+            </p>
+          )}
 
           {/* In-progress announcement — separate from the button so screen
               readers not focused on the button still hear it via aria-live. */}

--- a/frontend/src/components/__tests__/EntityMentionsPanel.test.tsx
+++ b/frontend/src/components/__tests__/EntityMentionsPanel.test.tsx
@@ -300,38 +300,38 @@ describe("EntityMentionsPanel", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Scan for Entity Mentions button (T012, Feature 052)
+  // Rescan Entity Mentions button (T012, Feature 052)
   // ---------------------------------------------------------------------------
 
-  describe("Scan for Entity Mentions button (T012)", () => {
+  describe("Rescan Entity Mentions button (T012)", () => {
     it("renders the scan button when hasTranscript is true", () => {
       renderPanel({ entities: [], hasTranscript: true });
       expect(
-        screen.getByRole("button", { name: /scan for entity mentions/i })
+        screen.getByRole("button", { name: /rescan entity mentions/i })
       ).toBeInTheDocument();
     });
 
     it("does not render the scan button when hasTranscript is false", () => {
       renderPanel({ entities: [], hasTranscript: false });
       expect(
-        screen.queryByRole("button", { name: /scan for entity mentions/i })
+        screen.queryByRole("button", { name: /rescan entity mentions/i })
       ).not.toBeInTheDocument();
     });
 
     it("does not render the scan button when hasTranscript is omitted (default)", () => {
       renderPanel({ entities: [] });
       expect(
-        screen.queryByRole("button", { name: /scan for entity mentions/i })
+        screen.queryByRole("button", { name: /rescan entity mentions/i })
       ).not.toBeInTheDocument();
     });
 
     it("scan button is enabled in idle state", () => {
       renderPanel({ entities: [], hasTranscript: true });
-      const button = screen.getByRole("button", { name: /scan for entity mentions/i });
+      const button = screen.getByRole("button", { name: /rescan entity mentions/i });
       expect(button).not.toBeDisabled();
     });
 
-    it("shows 'Scanning...' and disables the button when isPending is true", () => {
+    it("shows 'Rescanning...' and disables the button when isPending is true", () => {
       (useScanVideoEntities as Mock).mockReturnValue({
         mutate: vi.fn(),
         isPending: true,
@@ -377,7 +377,7 @@ describe("EntityMentionsPanel", () => {
 
       renderPanel({ entities: [], videoId: VIDEO_ID, hasTranscript: true });
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
 
       expect(mockMutate).toHaveBeenCalledOnce();
       expect(mockMutate).toHaveBeenCalledWith(
@@ -386,7 +386,51 @@ describe("EntityMentionsPanel", () => {
       );
     });
 
-    it("shows success message 'Found N entities with M mentions' after scan finds results", () => {
+    it("always requests a rebuild, never an incremental scan", () => {
+      // The behaviour, as distinct from the label. An incremental scan only
+      // ADDS, so the action a user takes immediately after curating an entity
+      // — adding an exclusion pattern, registering a longer competing entity —
+      // cannot retract the mentions that motivated the curation. The scan then
+      // reports success while the wrong rows survive, which is worse than an
+      // error. Renaming the button passes every other test in this file.
+      const mockMutate = vi.fn();
+      (useScanVideoEntities as Mock).mockReturnValue({
+        mutate: mockMutate,
+        isPending: false,
+        isError: false,
+        error: null,
+        data: null,
+        reset: vi.fn(),
+      });
+
+      renderPanel({ entities: [], videoId: VIDEO_ID, hasTranscript: true });
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
+
+      const [variables] = mockMutate.mock.calls[0] as [
+        { options?: { full_rescan?: boolean; sources?: string[] } },
+      ];
+      expect(variables.options?.full_rescan).toBe(true);
+      // All three sources, or a "rebuild" silently skips two of them.
+      expect(variables.options?.sources).toEqual([
+        "transcript",
+        "title",
+        "description",
+      ]);
+    });
+
+    it("tells the user hand-curated mentions survive the rebuild", () => {
+      // The delete is scoped to detection_method='rule_match', so manual and
+      // correction-derived mentions are preserved — but nobody can infer that
+      // from a button labelled "Rescan", and the cost of guessing wrong is
+      // that they never press it.
+      renderPanel({ entities: [], hasTranscript: true });
+
+      expect(
+        screen.getByText(/added or corrected by hand are kept/i)
+      ).toBeInTheDocument();
+    });
+
+    it("shows success message 'Rebuilt M mentions across N entities' after scan finds results", () => {
       const mockMutate = vi.fn().mockImplementation((_vars, callbacks) => {
         callbacks?.onSuccess?.({
           data: {
@@ -412,9 +456,9 @@ describe("EntityMentionsPanel", () => {
 
       renderPanel({ entities: [], hasTranscript: true });
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
 
-      expect(screen.getByText(/found 4 entities with 12 mentions/i)).toBeInTheDocument();
+      expect(screen.getByText(/rebuilt 12 mentions across 4 entities/i)).toBeInTheDocument();
     });
 
     it("shows 'No entity mentions found' when scan returns zero results", () => {
@@ -443,7 +487,7 @@ describe("EntityMentionsPanel", () => {
 
       renderPanel({ entities: [], hasTranscript: true });
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
 
       expect(screen.getByText(/no entity mentions found/i)).toBeInTheDocument();
     });
@@ -474,7 +518,7 @@ describe("EntityMentionsPanel", () => {
 
       renderPanel({ entities: [], hasTranscript: true });
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
 
       expect(screen.getByRole("status")).toBeInTheDocument();
     });
@@ -495,7 +539,7 @@ describe("EntityMentionsPanel", () => {
 
       renderPanel({ entities: [], hasTranscript: true });
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
 
       const alert = screen.getByRole("alert");
       expect(alert).toBeInTheDocument();
@@ -528,9 +572,9 @@ describe("EntityMentionsPanel", () => {
 
       renderPanel({ entities: [], hasTranscript: true });
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
 
-      expect(screen.getByText(/found 1 entity with 1 mention/i)).toBeInTheDocument();
+      expect(screen.getByText(/rebuilt 1 mention across 1 entity/i)).toBeInTheDocument();
     });
 
     it("error message persists (does not auto-dismiss) after failed scan", () => {
@@ -550,7 +594,7 @@ describe("EntityMentionsPanel", () => {
 
       renderPanel({ entities: [], hasTranscript: true });
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
 
       // Advance timers past the 3-second auto-dismiss window
       vi.advanceTimersByTime(5000);
@@ -577,7 +621,7 @@ describe("EntityMentionsPanel", () => {
 
       renderPanel({ entities: [], hasTranscript: true });
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
 
       expect(screen.getByRole("alert")).toHaveTextContent(/already running/i);
     });
@@ -598,7 +642,7 @@ describe("EntityMentionsPanel", () => {
 
       renderPanel({ entities: [], hasTranscript: true });
 
-      fireEvent.click(screen.getByRole("button", { name: /scan for entity mentions/i }));
+      fireEvent.click(screen.getByRole("button", { name: /rescan entity mentions/i }));
 
       expect(screen.getByRole("alert")).toHaveTextContent("Transcript fetch timed out");
     });


### PR DESCRIPTION
**Phase 0** of the entity-counting roadmap — the only piece that needs no design decision.

Refs #167.

## Problem

The video-detail scan ran **incrementally**, which only ever *adds*. So the action a user takes immediately after curating an entity — adding an exclusion pattern, registering a longer competing entity — could not retract the mentions that motivated the curation. The scan then reported success while the wrong rows survived.

That is the defect #167 names directly:

> The UI offers a scan action that structurally cannot fix what the user just tried to fix.

#179 fixed the identical problem on the **entity** detail page. This is the same one-boolean change on the **video** page, and completes item 3 of that issue.

## Why it is safe

`delete_by_scope` filters on `video_id IN (…)` **AND** `detection_method = 'rule_match'`:

```python
if video_ids is not None:
    stmt = stmt.where(EntityMentionDB.video_id.in_(video_ids))
```

So the rebuild touches this video only, and hand-curated mentions — `manual` and `user_correction`, 1,653 rows on the current corpus — survive everywhere. Verified by reading the where-clause rather than assuming it.

The delete and rebuild also run in one transaction, so an interrupted scan rolls back completely.

## Changes

- `full_rescan: true` alongside all three sources
- Relabelled **"Rescan Entity Mentions"** (pending: "Rescanning...")
- Success copy: *"Found N entities with M mentions"* → *"Rebuilt M mentions across N entities"*
- A line under the button stating hand-curated mentions are kept

## Tests

Renaming a button would pass every existing test in the file, so the new tests assert the **payload**:

- `always requests a rebuild, never an incremental scan` — inspects the mutation variables for `full_rescan: true` and all three sources
- `tells the user hand-curated mentions survive the rebuild`

Mutation-checked: removing `full_rescan: true` fails the first.

Existing assertions updated for the new wording.

## Verification

- **177 files / 3,916 frontend tests** pass, 19 skipped; `npm run typecheck` clean
- Verified in the browser against a real video — the intercepted POST body is exactly:

```json
{"sources":["transcript","title","description"],"full_rescan":true}
```

(Request stubbed at the fetch layer so no real rebuild ran.)

## Scope

Frontend only. No API change — `full_rescan` already existed on `ScanRequest` and was already plumbed to the dispatcher; the UI simply never sent it.

This deliberately does **not** touch the counting problem. Phases 1–3 (#169, #170, #172, then #167's staleness detection, then #181/#106) need design decisions first — see `005-FEEDBACK-entity-association-counting.md`.
