### PR TITLE
fix(tags): repair aliases stranded on merged canonical tags

### DIFF
--- a/src/chronovista/cli/tag_commands.py
+++ b/src/chronovista/cli/tag_commands.py
@@ -1623,3 +1623,85 @@ def review_collisions(
                 console.print()  # blank line between groups
 
     asyncio.run(_run())
+
+
+@tag_app.command("repair-orphans")
+def repair_orphaned_aliases(
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview the repair without writing to the database.",
+    ),
+) -> None:
+    """Re-point aliases stranded on merged canonical tags at their target.
+
+    A merge moves the source's aliases to the target. Aliases that were never
+    moved sit on a deprecated tag where the canonical relationship cannot reach
+    them, while name-based matching still can — so entity association counts
+    disagree, and the rows are invisible in the UI because canonical-tag search
+    only returns active tags.
+
+    Each merged tag records its ``merged_into_id``, so the destination is read
+    rather than guessed. Idempotent and safe to re-run.
+    """
+
+    async def _run() -> None:
+        from chronovista.services.tag_management import OrphanRepairReport
+
+        service = _create_tag_management_service()
+
+        async for session in db_manager.get_session(echo=False):
+            # The service owns the transaction here: a dry run has to roll back
+            # inside, so the CLI must not commit on its behalf.
+            report: OrphanRepairReport = await service.repair_orphaned_aliases(
+                session, dry_run=dry_run
+            )
+
+            title = (
+                "Orphaned aliases (dry-run) — no changes written"
+                if report.dry_run
+                else "Orphaned aliases repaired"
+            )
+
+            if report.repaired_count == 0 and report.skipped_count == 0:
+                console.print(
+                    Panel(
+                        "No aliases are stranded on merged canonical tags.",
+                        title="Nothing to repair",
+                        border_style="green",
+                    )
+                )
+                return
+
+            if report.repaired:
+                table = Table(show_header=True, header_style="bold")
+                table.add_column("Alias")
+                table.add_column("Now belongs to")
+                for r in report.repaired:
+                    table.add_row(r.raw_form, r.to_normalized_form)
+                console.print(table)
+
+            for skip in report.skipped:
+                console.print(
+                    f"[yellow]Skipped[/yellow] '{skip.raw_form}': {skip.reason}"
+                )
+
+            lines = [
+                f"[bold]Repaired:[/bold] {report.repaired_count}",
+                f"[bold]Skipped:[/bold] {report.skipped_count}",
+            ]
+            if report.operation_id is not None:
+                lines.append(f"[bold]Operation ID:[/bold] {report.operation_id}")
+                lines.append(
+                    f"[dim]Reverse with: chronovista tags undo "
+                    f"{report.operation_id}[/dim]"
+                )
+            console.print(
+                Panel(
+                    "\n".join(lines),
+                    title=title,
+                    border_style="yellow" if report.dry_run else "green",
+                )
+            )
+
+    asyncio.run(_run())

--- a/src/chronovista/db/migrations/versions/a7c2e5d9f4b8_allow_repair_tag_operation_type.py
+++ b/src/chronovista/db/migrations/versions/a7c2e5d9f4b8_allow_repair_tag_operation_type.py
@@ -1,0 +1,57 @@
+"""allow 'repair' in the tag_operation_logs type constraint
+
+Revision ID: a7c2e5d9f4b8
+Revises: f1a3c9e2b7d4
+Create Date: 2026-08-05 00:00:00.000000
+
+``tags repair-orphans`` records its work as a ``repair`` operation so the audit
+trail distinguishes correcting earlier damage from expressing a decision. The
+CHECK constraint written in 028a enumerates the five original types, so that
+INSERT is rejected at the database even though the enum and the Pydantic
+validator both accept it.
+
+The same list lived in three places — the enum-derived validator, the ORM
+``CheckConstraint``, and this DDL. Both Python copies now derive from
+``TagOperationType``; the DDL cannot, so it is spelled out here and this
+migration is what keeps it in step.
+
+Recreating the constraint validates existing rows. Every stored value is one of
+the five already permitted, so the check passes and no data is rewritten.
+
+Related: #184
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a7c2e5d9f4b8"
+down_revision = "f1a3c9e2b7d4"
+branch_labels = None
+depends_on = None
+
+CONSTRAINT_NAME = "chk_tag_operation_type_valid"
+TABLE_NAME = "tag_operation_logs"
+
+_WITHOUT_REPAIR = "operation_type IN ('merge', 'split', 'rename', 'delete', 'create')"
+_WITH_REPAIR = (
+    "operation_type IN ('merge', 'split', 'rename', 'delete', 'create', 'repair')"
+)
+
+
+def upgrade() -> None:
+    """Widen the constraint to admit 'repair'."""
+    op.drop_constraint(CONSTRAINT_NAME, TABLE_NAME, type_="check")
+    op.create_check_constraint(CONSTRAINT_NAME, TABLE_NAME, _WITH_REPAIR)
+
+
+def downgrade() -> None:
+    """Restore the original five types.
+
+    Fails if any 'repair' row exists rather than deleting audit history: those
+    rows carry the rollback data for repairs already applied, and dropping them
+    would make those repairs unreversible. Remove or reclassify them first.
+    """
+    op.drop_constraint(CONSTRAINT_NAME, TABLE_NAME, type_="check")
+    op.create_check_constraint(CONSTRAINT_NAME, TABLE_NAME, _WITHOUT_REPAIR)

--- a/src/chronovista/db/models.py
+++ b/src/chronovista/db/models.py
@@ -31,6 +31,8 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.sql import func, text
 from uuid_utils import uuid7
 
+from chronovista.models.enums import TagOperationType
+
 
 class Base(DeclarativeBase):
     """Base class for all database models."""
@@ -1110,7 +1112,13 @@ class TagOperationLog(Base):
     # Table constraints
     __table_args__ = (
         CheckConstraint(
-            "operation_type IN ('merge', 'split', 'rename', 'delete', 'create')",
+            # Built from TagOperationType rather than restated. The same list
+            # lived here, in the Pydantic validator, and in the migration DDL;
+            # adding a member updated one and left writes failing at the two
+            # others, each from a layer far from the change.
+            "operation_type IN ("
+            + ", ".join(f"'{t.value}'" for t in TagOperationType)
+            + ")",
             name="chk_tag_operation_type_valid",
         ),
     )

--- a/src/chronovista/models/enums.py
+++ b/src/chronovista/models/enums.py
@@ -353,6 +353,10 @@ class TagOperationType(str, Enum):
     RENAME = "rename"
     DELETE = "delete"
     CREATE = "create"
+    # Completes a merge that left aliases behind on the deprecated source.
+    # Distinct from MERGE so the audit trail says what actually happened —
+    # these repairs correct earlier damage rather than expressing a decision.
+    REPAIR = "repair"
 
 
 class CorrectionType(str, Enum):

--- a/src/chronovista/models/tag_operation_log.py
+++ b/src/chronovista/models/tag_operation_log.py
@@ -13,7 +13,12 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-ALLOWED_OPERATION_TYPES = {"merge", "split", "rename", "delete", "create"}
+from chronovista.models.enums import TagOperationType
+
+# Derived from the enum rather than restated. These were two independent lists,
+# so adding a member to TagOperationType left this validator rejecting it — a
+# failure that surfaces only at write time, from a model far from the change.
+ALLOWED_OPERATION_TYPES = {t.value for t in TagOperationType}
 
 
 class TagOperationLogBase(BaseModel):

--- a/src/chronovista/services/tag_management.py
+++ b/src/chronovista/services/tag_management.py
@@ -64,6 +64,45 @@ class MergeResult:
 
 
 @dataclass
+class OrphanRepair:
+    """One alias moved off a merged canonical tag onto its merge target."""
+
+    alias_id: uuid.UUID
+    raw_form: str
+    from_canonical_tag_id: uuid.UUID
+    to_canonical_tag_id: uuid.UUID
+    from_normalized_form: str
+    to_normalized_form: str
+
+
+@dataclass
+class OrphanSkip:
+    """An orphan left alone, with the reason it could not be repaired."""
+
+    alias_id: uuid.UUID
+    raw_form: str
+    reason: str
+
+
+@dataclass
+class OrphanRepairReport:
+    """Result of an orphaned-alias repair (dry-run or applied)."""
+
+    dry_run: bool
+    repaired: list[OrphanRepair]
+    skipped: list[OrphanSkip]
+    operation_id: uuid.UUID | None = None
+
+    @property
+    def repaired_count(self) -> int:
+        return len(self.repaired)
+
+    @property
+    def skipped_count(self) -> int:
+        return len(self.skipped)
+
+
+@dataclass
 class SplitResult:
     """Result of a split operation."""
 
@@ -761,6 +800,152 @@ class TagManagementService:
             operation_id=operation_id,
         )
 
+    async def repair_orphaned_aliases(
+        self,
+        session: AsyncSession,
+        *,
+        dry_run: bool,
+        actor: str = "cli",
+    ) -> OrphanRepairReport:
+        """Re-point aliases stranded on merged canonical tags at their target.
+
+        A merge reassigns the source's aliases to the target and rewrites their
+        ``normalized_form``. Aliases that were never moved sit on a deprecated
+        tag: the canonical relationship cannot reach them, because a merged tag
+        holds no ``entity_id``, while anything matching on
+        ``tag_aliases.normalized_form`` still finds them. The two entity
+        association paths therefore disagree by exactly the videos those rows
+        reach — and the rows are invisible in the UI, since canonical-tag search
+        filters to ``status = 'active'``.
+
+        Completing the move is what a merge would have done. Each tag records
+        ``merged_into_id``, so the destination is read rather than inferred; an
+        orphan whose target is missing or itself merged is reported and left
+        alone rather than guessed at.
+
+        Idempotent: a second run finds nothing. One transaction, rolled back
+        entirely on ``dry_run``.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        dry_run : bool
+            Compute the report without writing.
+        actor : str
+            Recorded as ``performed_by`` on the operation log.
+
+        Returns
+        -------
+        OrphanRepairReport
+            What was (or would be) moved, plus what was skipped and why.
+        """
+        orphan_rows = (
+            await session.execute(
+                select(TagAliasDB, CanonicalTagDB)
+                .join(CanonicalTagDB, CanonicalTagDB.id == TagAliasDB.canonical_tag_id)
+                .where(CanonicalTagDB.status == "merged")
+                .order_by(TagAliasDB.id)
+            )
+        ).all()
+
+        repairs: list[OrphanRepair] = []
+        skipped: list[OrphanSkip] = []
+
+        for alias, source_tag in orphan_rows:
+            target_id = source_tag.merged_into_id
+            if target_id is None:
+                skipped.append(
+                    OrphanSkip(
+                        alias_id=alias.id,
+                        raw_form=alias.raw_form,
+                        reason="source tag is merged but records no merged_into_id",
+                    )
+                )
+                continue
+
+            target = await session.get(CanonicalTagDB, target_id)
+            if target is None:
+                skipped.append(
+                    OrphanSkip(
+                        alias_id=alias.id,
+                        raw_form=alias.raw_form,
+                        reason=f"merge target {target_id} no longer exists",
+                    )
+                )
+                continue
+            if target.status == "merged":
+                # Chasing a chain of merges would need cycle detection and a
+                # decision about which link is authoritative. Surface it.
+                skipped.append(
+                    OrphanSkip(
+                        alias_id=alias.id,
+                        raw_form=alias.raw_form,
+                        reason="merge target is itself merged (chained merge)",
+                    )
+                )
+                continue
+
+            repairs.append(
+                OrphanRepair(
+                    alias_id=alias.id,
+                    raw_form=alias.raw_form,
+                    from_canonical_tag_id=source_tag.id,
+                    to_canonical_tag_id=target.id,
+                    from_normalized_form=alias.normalized_form,
+                    to_normalized_form=target.normalized_form,
+                )
+            )
+
+        operation_id: uuid.UUID | None = None
+
+        if repairs and not dry_run:
+            for r in repairs:
+                await session.execute(
+                    update(TagAliasDB)
+                    .where(TagAliasDB.id == r.alias_id)
+                    .values(
+                        canonical_tag_id=r.to_canonical_tag_id,
+                        normalized_form=r.to_normalized_form,
+                    )
+                )
+
+            # The orphans exist because something skipped the operation log.
+            # Repairing them without one would repeat that mistake, and there
+            # would be no way to reverse this.
+            operation_id = await self._log_operation(
+                session,
+                operation_type=TagOperationType.REPAIR.value,
+                source_ids=sorted({r.from_canonical_tag_id for r in repairs}),
+                target_id=None,
+                alias_ids=[r.alias_id for r in repairs],
+                reason="Re-point aliases stranded on merged canonical tags",
+                rollback_data={
+                    "aliases": [
+                        {
+                            "alias_id": str(r.alias_id),
+                            "previous_canonical_tag_id": str(r.from_canonical_tag_id),
+                            "previous_normalized_form": r.from_normalized_form,
+                        }
+                        for r in repairs
+                    ]
+                },
+                actor=actor,
+            )
+            await session.commit()
+        elif not dry_run:
+            # Idempotent no-op: nothing to move, nothing to log.
+            await session.commit()
+        else:
+            await session.rollback()
+
+        return OrphanRepairReport(
+            dry_run=dry_run,
+            repaired=repairs,
+            skipped=skipped,
+            operation_id=operation_id,
+        )
+
     async def undo(
         self,
         session: AsyncSession,
@@ -812,6 +997,8 @@ class TagManagementService:
             details = await self._undo_classify(session, log_entry)
         elif op_type == TagOperationType.DELETE.value:
             details = await self._undo_deprecate(session, log_entry)
+        elif op_type == TagOperationType.REPAIR.value:
+            details = await self._undo_repair(session, log_entry)
         else:
             raise ValueError(f"Unknown operation type: {op_type}")
 
@@ -1754,6 +1941,43 @@ class TagManagementService:
             f"Unclassified '{tag.normalized_form}' "
             f"(removed type '{new_entity_type}')"
         )
+
+    async def _undo_repair(
+        self, session: AsyncSession, log_entry: TagOperationLogDB
+    ) -> str:
+        """Reverse an orphaned-alias repair.
+
+        Puts each alias back on the merged canonical tag it was stranded on,
+        restoring its previous ``normalized_form``. That reinstates the broken
+        state, which is the point of an undo — the repair may have been run
+        against data someone was mid-way through fixing by hand.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        log_entry : TagOperationLogDB
+            The operation log entry with rollback_data.
+
+        Returns
+        -------
+        str
+            Human-readable description of what was reversed.
+        """
+        entries = (log_entry.rollback_data or {}).get("aliases", [])
+        restored = 0
+        for entry in entries:
+            await session.execute(
+                update(TagAliasDB)
+                .where(TagAliasDB.id == uuid.UUID(entry["alias_id"]))
+                .values(
+                    canonical_tag_id=uuid.UUID(entry["previous_canonical_tag_id"]),
+                    normalized_form=entry["previous_normalized_form"],
+                )
+            )
+            restored += 1
+
+        return f"Restored {restored} alias(es) to their previous canonical tag"
 
     async def _undo_deprecate(
         self, session: AsyncSession, log_entry: TagOperationLogDB

--- a/tests/integration/db/test_tag_normalization_schema.py
+++ b/tests/integration/db/test_tag_normalization_schema.py
@@ -37,6 +37,7 @@ from chronovista.db.models import (
     TagAlias,
     TagOperationLog,
 )
+from chronovista.models.enums import TagOperationType
 
 # CRITICAL: This line ensures async tests work with coverage
 # Note: This applies to ALL tests in the module, including sync tests
@@ -250,6 +251,28 @@ class TestCheckConstraints:
             await db_session.flush()
 
         assert "chk_tag_operation_type_valid" in str(exc_info.value).lower()
+        await db_session.rollback()
+
+    async def test_tag_operation_log_accepts_every_declared_type(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Every TagOperationType member must satisfy the CHECK constraint.
+
+        The permitted list was written out by hand in the constraint, so adding
+        an enum member left writes failing at the database with the enum and the
+        Pydantic validator both accepting the value — a mismatch that surfaced
+        only on a real run, after the work had already been done. Driving this
+        from the enum means a new member fails here instead.
+        """
+        for operation_type in TagOperationType:
+            operation = TagOperationLog(
+                id=uuid7(),
+                operation_type=operation_type.value,
+                performed_by="system",
+            )
+            db_session.add(operation)
+            await db_session.flush()
+
         await db_session.rollback()
 
     async def test_entity_alias_invalid_alias_type(

--- a/tests/unit/services/test_tag_orphan_repair.py
+++ b/tests/unit/services/test_tag_orphan_repair.py
@@ -1,0 +1,236 @@
+"""Repair of aliases stranded on merged canonical tags (#184).
+
+A merge reassigns the source's aliases to the target and rewrites their
+``normalized_form``. Aliases that were never moved sit on a deprecated tag: the
+canonical relationship cannot reach them, because a merged tag holds no
+``entity_id``, while anything matching on ``tag_aliases.normalized_form`` still
+finds them. That is why the two entity-association paths disagreed, and why the
+rows are invisible in the UI — canonical-tag search filters to active tags.
+
+These tests pin the properties that make the repair safe to run against real
+data: it reads the destination rather than guessing, it refuses the cases it
+cannot resolve, a dry run writes nothing, and it is idempotent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from uuid_utils import uuid7
+
+from chronovista.services.tag_management import TagManagementService
+
+pytestmark = pytest.mark.asyncio
+
+
+def _uuid() -> uuid.UUID:
+    return uuid.UUID(bytes=uuid7().bytes)
+
+
+def _alias(raw_form: str, canonical_tag_id: uuid.UUID, normalized: str) -> MagicMock:
+    a = MagicMock()
+    a.id = _uuid()
+    a.raw_form = raw_form
+    a.canonical_tag_id = canonical_tag_id
+    a.normalized_form = normalized
+    return a
+
+
+def _tag(
+    normalized: str, status: str, merged_into_id: uuid.UUID | None = None
+) -> MagicMock:
+    t = MagicMock()
+    t.id = _uuid()
+    t.normalized_form = normalized
+    t.status = status
+    t.merged_into_id = merged_into_id
+    return t
+
+
+def _service(
+    orphan_rows: list[tuple[MagicMock, MagicMock]],
+    targets: dict[uuid.UUID, MagicMock | None],
+) -> tuple[TagManagementService, MagicMock]:
+    """Service wired so the orphan query returns *orphan_rows*."""
+    log_repo = MagicMock()
+    created = MagicMock()
+    created.id = _uuid()
+    log_repo.create = AsyncMock(return_value=created)
+
+    service = TagManagementService(
+        canonical_tag_repo=MagicMock(),
+        tag_alias_repo=MagicMock(),
+        named_entity_repo=MagicMock(),
+        entity_alias_repo=MagicMock(),
+        operation_log_repo=log_repo,
+    )
+
+    session = MagicMock(spec=AsyncSession)
+    result = MagicMock()
+    result.all.return_value = orphan_rows
+    session.execute = AsyncMock(return_value=result)
+    session.get = AsyncMock(side_effect=lambda _model, tid: targets.get(tid))
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    return service, session
+
+
+class TestOrphanRepair:
+    async def test_moves_the_alias_to_the_recorded_merge_target(self) -> None:
+        target = _tag("benjamin netanyahu", "active")
+        source = _tag("bibi", "merged", merged_into_id=target.id)
+        alias = _alias("Bibi", source.id, "bibi")
+
+        service, session = _service([(alias, source)], {target.id: target})
+        report = await service.repair_orphaned_aliases(session, dry_run=False)
+
+        assert report.repaired_count == 1
+        assert report.skipped_count == 0
+        moved = report.repaired[0]
+        # The destination is READ from merged_into_id, never inferred from the
+        # alias text — inferring is what produced the mess in the first place.
+        assert moved.to_canonical_tag_id == target.id
+        assert moved.to_normalized_form == "benjamin netanyahu"
+        assert moved.from_normalized_form == "bibi"
+
+    async def test_the_update_sets_both_columns(self) -> None:
+        # Asserting the report is not enough: the report can be correct while
+        # the UPDATE omits normalized_form, leaving the alias discoverable under
+        # its old form and the two association paths still in disagreement.
+        # Per the Constitution's Cross-Feature Data Contract Verification, an
+        # UPDATE test inspects the SET clause rather than the return value.
+        target = _tag("benjamin netanyahu", "active")
+        source = _tag("bibi", "merged", merged_into_id=target.id)
+        alias = _alias("Bibi", source.id, "bibi")
+
+        service, session = _service([(alias, source)], {target.id: target})
+        await service.repair_orphaned_aliases(session, dry_run=False)
+
+        # Match on the statement STARTING with UPDATE. A substring test picks up
+        # the SELECT as well, because its column list contains `updated_at` —
+        # and that select mentions `normalized_form`, so the assertion below
+        # would pass against the wrong statement and catch nothing.
+        updates = [
+            str(call.args[0]).strip()
+            for call in session.execute.await_args_list
+            if call.args and str(call.args[0]).strip().upper().startswith("UPDATE")
+        ]
+        assert updates, "expected an UPDATE against tag_aliases"
+        set_clause = updates[0].split("WHERE")[0]
+        assert "canonical_tag_id" in set_clause
+        assert "normalized_form" in set_clause
+
+    async def test_dry_run_writes_nothing_and_logs_nothing(self) -> None:
+        target = _tag("target", "active")
+        source = _tag("source", "merged", merged_into_id=target.id)
+        alias = _alias("Source", source.id, "source")
+
+        service, session = _service([(alias, source)], {target.id: target})
+        report = await service.repair_orphaned_aliases(session, dry_run=True)
+
+        assert report.dry_run is True
+        assert report.repaired_count == 1  # still reports what it would do
+        assert report.operation_id is None
+        session.commit.assert_not_awaited()
+        session.rollback.assert_awaited()
+
+    async def test_applied_run_logs_the_operation(self) -> None:
+        # The orphans exist because something skipped the operation log.
+        # Repairing them without one would repeat that mistake and leave the
+        # change unreversible.
+        target = _tag("target", "active")
+        source = _tag("source", "merged", merged_into_id=target.id)
+        alias = _alias("Source", source.id, "source")
+
+        service, session = _service([(alias, source)], {target.id: target})
+        report = await service.repair_orphaned_aliases(session, dry_run=False)
+
+        assert report.operation_id is not None
+        session.commit.assert_awaited()
+
+    async def test_rollback_data_can_restore_the_previous_state(self) -> None:
+        target = _tag("target", "active")
+        source = _tag("source", "merged", merged_into_id=target.id)
+        alias = _alias("Source", source.id, "source")
+
+        service, session = _service([(alias, source)], {target.id: target})
+        await service.repair_orphaned_aliases(session, dry_run=False)
+
+        log_call = service._operation_log_repo.create.await_args  # type: ignore[attr-defined]
+        rollback: dict[str, Any] = log_call.kwargs["obj_in"].rollback_data
+        entry = rollback["aliases"][0]
+        assert entry["alias_id"] == str(alias.id)
+        assert entry["previous_canonical_tag_id"] == str(source.id)
+        assert entry["previous_normalized_form"] == "source"
+
+    async def test_is_idempotent_when_there_is_nothing_to_repair(self) -> None:
+        service, session = _service([], {})
+        report = await service.repair_orphaned_aliases(session, dry_run=False)
+
+        assert report.repaired_count == 0
+        assert report.skipped_count == 0
+        assert report.operation_id is None  # nothing happened, nothing logged
+
+
+class TestOrphanRepairRefusals:
+    """Cases the repair reports rather than guessing at."""
+
+    async def test_skips_a_merged_tag_with_no_merged_into_id(self) -> None:
+        source = _tag("source", "merged", merged_into_id=None)
+        alias = _alias("Source", source.id, "source")
+
+        service, session = _service([(alias, source)], {})
+        report = await service.repair_orphaned_aliases(session, dry_run=False)
+
+        assert report.repaired_count == 0
+        assert report.skipped_count == 1
+        assert "merged_into_id" in report.skipped[0].reason
+
+    async def test_skips_when_the_merge_target_no_longer_exists(self) -> None:
+        missing_id = _uuid()
+        source = _tag("source", "merged", merged_into_id=missing_id)
+        alias = _alias("Source", source.id, "source")
+
+        service, session = _service([(alias, source)], {missing_id: None})
+        report = await service.repair_orphaned_aliases(session, dry_run=False)
+
+        assert report.repaired_count == 0
+        assert report.skipped_count == 1
+        assert "no longer exists" in report.skipped[0].reason
+
+    async def test_skips_a_chained_merge_rather_than_following_it(self) -> None:
+        # Following a chain needs cycle detection and a decision about which
+        # link is authoritative. Surfacing it is honest; guessing is not.
+        final = _tag("final", "active")
+        middle = _tag("middle", "merged", merged_into_id=final.id)
+        source = _tag("source", "merged", merged_into_id=middle.id)
+        alias = _alias("Source", source.id, "source")
+
+        service, session = _service([(alias, source)], {middle.id: middle})
+        report = await service.repair_orphaned_aliases(session, dry_run=False)
+
+        assert report.repaired_count == 0
+        assert report.skipped_count == 1
+        assert "chained" in report.skipped[0].reason
+
+    async def test_one_bad_orphan_does_not_block_the_good_ones(self) -> None:
+        good_target = _tag("good target", "active")
+        good_source = _tag("good source", "merged", merged_into_id=good_target.id)
+        good_alias = _alias("Good", good_source.id, "good source")
+
+        bad_source = _tag("bad source", "merged", merged_into_id=None)
+        bad_alias = _alias("Bad", bad_source.id, "bad source")
+
+        service, session = _service(
+            [(good_alias, good_source), (bad_alias, bad_source)],
+            {good_target.id: good_target},
+        )
+        report = await service.repair_orphaned_aliases(session, dry_run=False)
+
+        assert report.repaired_count == 1
+        assert report.skipped_count == 1
+        assert report.repaired[0].raw_form == "Good"


### PR DESCRIPTION
Fixes #184.

## Problem

A merge reassigns the source's aliases to the target and rewrites their `normalized_form`. Aliases that were never moved sit on a deprecated tag where:

- the **canonical path** (`canonical_tags.entity_id` → `tag_aliases` → `video_tags`) cannot reach them, because a merged tag holds no `entity_id`
- anything matching on **`tag_aliases.normalized_form`** still finds them

So the two entity-association paths disagree by exactly the videos those rows reach — and the rows are invisible in the UI, since canonical-tag search filters to `status = 'active'`.

## Approach

`chronovista tags repair-orphans --dry-run`, following the shape of `identity repair` (Feature 060), which is this repo's precedent for a data-integrity repair: one transaction, rolled back entirely on a dry run, idempotent, safe to re-run.

A migration was the wrong tool — there is no schema change, and it would run on fresh installs that never had orphans. A one-off script was wrong too: the root cause is an unidentified write path, so this can recur.

**The destination is read from each tag's `merged_into_id`, never inferred from the alias text.** Inferring is what produced the damage.

## Refusals

Three cases are reported rather than guessed at:

| Case | Why not guess |
|---|---|
| No `merged_into_id` recorded | Nothing says where it should go |
| Target no longer exists | Same |
| Target is itself merged (chained) | Following a chain needs cycle detection and a decision about which link is authoritative |

One unresolvable orphan does not block the others.

## Auditability

The repair writes to `tag_operation_logs` and is undoable via `tags undo`. **The orphans exist precisely because something skipped that log** — repairing them without one would repeat the mistake and leave the change unreversible.

`_undo_repair` restores each alias to its previous canonical tag and `normalized_form` from rollback data. That reinstates the broken state, which is the point: the repair may have run against data someone was mid-way through fixing by hand.

## Incidental fix

`ALLOWED_OPERATION_TYPES` in `models/tag_operation_log.py` restated the `TagOperationType` enum as a literal set. Adding a member to the enum left the validator rejecting it — a failure that surfaces only at write time, from a model far from the change. It now derives from the enum. Caught by these tests.

## Verification

- **10 new unit tests**; **6,803 backend unit tests** pass overall
- `ruff`, `black --check`, `mypy --strict` clean
- **Mutation-tested at two points**: refusing chained merges, and setting *both* columns in the UPDATE

The second mutation initially **passed**, which was a real gap in the test rather than in the code. The assertion filtered statements with `"UPDATE" in str(stmt).upper()` — which also matches the SELECT, because its column list contains `updated_at`, and that select mentions `normalized_form`. It was asserting against the wrong statement. Now it matches statements *starting* with `UPDATE` and inspects only the SET clause, per the Constitution's rule that an UPDATE test verifies columns in the SET clause rather than return values.

**Verified against production data** — 13 orphans found, 0 skipped, every target resolved:

```
Repaired: 13   Skipped: 0
```

Dry run confirmed genuinely read-only: row count unchanged, no `repair` entry in `tag_operation_logs`.

## Sequencing

This should land **before** the entity-count consolidation (#169). If the two association paths are collapsed onto the canonical FK path while these rows exist, the video associations they reach disappear silently — the alias path is currently the only thing that can see them.

## Not addressed here

Finding the write path that marked 13 tags merged with **no operation-log entry**. All 13 share one timestamp and no logged operation; every merge through `TagManagementService` leaves a complete trail. Tracked in #184.
