### PR TITLE
feat(entities): edit an entity's type from the detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.0] - 2026-08-06
+
+### Added
+- **An entity's type can be corrected from the detail page.** Choosing the wrong type when creating an entity is easy, and there was no way to fix it: `PATCH /api/v1/entities/{id}` and `EntityCurationService.update_entity` handled name and description only, so the only remedy was a direct database `UPDATE` — which skips both the audit log and the collision pre-check. The edit form gains a Type select, driven from the shared `ENTITY_TYPE_LABELS` map so its options cannot drift from the types the database accepts. Type changes are recorded in `entity_operation_logs` with before/after, so a mis-click is undoable like any other entity edit.
+
+### Fixed
+- **The uniqueness pre-check now evaluates the pair it actually constrains.** `uq_named_entity_canonical` is on `(canonical_name_normalized, entity_type)`, but the check ran against the entity's *existing* type. For a retype that always passed — the entity is excluded from its own query — and the duplicate then failed at flush time as an `IntegrityError` (HTTP 500) instead of a clean 409. Both values are now resolved before one check. The undo path carried the same latent defect, restoring a name while checking it against the current type, and is fixed the same way.
+- **The edit request accepts a JSON string for `entity_type`.** The request model is strict, and Pydantic strict mode will not coerce `"place"` into the enum — it requires an enum instance, which no HTTP client can send. Every retype returned 422, surfaced in the UI as a generic "Failed to save changes." Service-level tests passed throughout because they call the service directly with a plain string and never exercise the schema; endpoint tests that PATCH real JSON now cover the gap.
+- The 409 message no longer blames the name alone: a collision can now originate from a type change.
+
 ## [0.60.0] - 2026-08-02
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chronovista-frontend",
   "private": true,
-  "version": "0.30.0",
+  "version": "0.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/entityMentions.ts
+++ b/frontend/src/api/entityMentions.ts
@@ -369,20 +369,22 @@ export async function fetchEntityDetail(
 export interface UpdateEntityRequest {
   canonical_name?: string;
   description?: string;
+  /** Corrects an entity filed under the wrong type (e.g. a place saved as a person). */
+  entity_type?: string;
 }
 
 /**
- * Updates a named entity's display name and/or description (Feature 057).
+ * Updates a named entity's display name, description, and/or type.
  *
  * Never modifies the tag(s) the entity is linked to. On a name change, the
  * backend recomputes the normalized identity and re-checks
  * `(canonical_name_normalized, entity_type)` uniqueness.
  *
  * @param entityId - UUID of the named entity
- * @param data - Fields to update (at least one of canonical_name/description)
+ * @param data - Fields to update (at least one of canonical_name/description/entity_type)
  * @returns The updated EntityDetail
  * @throws ApiError with status 400 (invalid/empty name), 404 (not found), or
- *   409 (the new name collides with an existing same-type entity)
+ *   409 (the resulting name+type pair collides with an existing entity)
  */
 export async function updateEntity(
   entityId: string,

--- a/frontend/src/pages/EntityDetailPage.tsx
+++ b/frontend/src/pages/EntityDetailPage.tsx
@@ -19,6 +19,7 @@ import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import { CooccurringPanel } from "../components/entity/CooccurringPanel";
 import { EntityTypeBadge } from "../components/EntityTypeBadge";
+import { ENTITY_TYPE_LABELS } from "../constants/entityTypes";
 import {
   useEntityVideos,
   useDeleteManualAssociation,
@@ -756,6 +757,7 @@ interface EntityNameEditorProps {
   entityId: string;
   canonicalName: string;
   description: string | null;
+  entityType: string;
   /** Rendered next to the name in read mode (the existing entity-type badge). */
   typeBadge: React.ReactNode;
 }
@@ -785,11 +787,13 @@ function EntityNameEditor({
   entityId,
   canonicalName,
   description,
+  entityType,
   typeBadge,
 }: EntityNameEditorProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [nameInput, setNameInput] = useState(canonicalName);
   const [descriptionInput, setDescriptionInput] = useState(description ?? "");
+  const [typeInput, setTypeInput] = useState(entityType);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
@@ -815,6 +819,7 @@ function EntityNameEditor({
   function enterEditMode() {
     setNameInput(canonicalName);
     setDescriptionInput(description ?? "");
+    setTypeInput(entityType);
     setErrorMsg(null);
     setSuccessMsg(null);
     setIsEditing(true);
@@ -859,6 +864,9 @@ function EntityNameEditor({
     if (descriptionInput !== (description ?? "")) {
       payload.description = descriptionInput;
     }
+    if (typeInput !== entityType) {
+      payload.entity_type = typeInput;
+    }
 
     if (Object.keys(payload).length === 0) {
       // Edge case: no-op save — nothing changed, just return to read view.
@@ -881,7 +889,7 @@ function EntityNameEditor({
           const status = (err as { status?: number } | null)?.status;
           if (status === 409) {
             setErrorMsg(
-              "Another entity of this type already has that name. Choose a different name."
+              "Another entity of that type already has this name. Choose a different name or type."
             );
           } else if (status === 400) {
             setErrorMsg(err.message || "Invalid name or description.");
@@ -979,6 +987,39 @@ function EntityNameEditor({
             disabled:bg-slate-100 disabled:text-slate-500
           "
         />
+      </div>
+
+      <div>
+        <label
+          htmlFor="entity-type-select"
+          className="block text-sm font-medium text-gray-700 mb-1"
+        >
+          Type
+        </label>
+        <select
+          id="entity-type-select"
+          value={typeInput}
+          onChange={(e) => {
+            setTypeInput(e.target.value);
+            if (errorMsg) setErrorMsg(null);
+          }}
+          disabled={updateMutation.isPending}
+          className="
+            w-full px-3 py-2
+            text-sm text-gray-900
+            border border-slate-300 rounded-md
+            focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
+            disabled:bg-slate-100 disabled:text-slate-500
+          "
+        >
+          {/* Driven from the shared label map so the options can never drift
+              from the types the database actually accepts. */}
+          {Object.entries(ENTITY_TYPE_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
       </div>
 
       <div>
@@ -1309,6 +1350,7 @@ export function EntityDetailPage() {
           entityId={entityId ?? ""}
           canonicalName={entity.canonical_name}
           description={entity.description}
+          entityType={entity.entity_type}
           typeBadge={
             <EntityTypeBadge entityType={entity.entity_type} size="md" />
           }

--- a/frontend/src/pages/__tests__/EntityDetailPage.edit.test.tsx
+++ b/frontend/src/pages/__tests__/EntityDetailPage.edit.test.tsx
@@ -11,7 +11,7 @@
  * 2. Edit mode: labeled Name input + Description textarea, pre-filled
  * 3. Cancel restores read view without calling the mutation
  * 4. Escape key cancels the edit
- * 5. Save sends only the changed field(s) to useUpdateEntity
+ * 5. Save sends only the changed field(s) to useUpdateEntity, including entity_type
  * 6. Successful save returns to read view and announces "Saved." via role="status"
  * 7. Pending state disables Save/inputs and announces "Saving…" via role="status"
  * 8. Client-side validation blocks an empty name without calling the mutation
@@ -338,6 +338,69 @@ describe("EntityNameEditor (inside EntityDetailPage)", () => {
       );
     });
 
+    it("sends only entity_type when only the type changed", async () => {
+      // The reason this control exists: picking the wrong type at creation is
+      // easy, and the only previous remedy was a direct database UPDATE, which
+      // skipped both the audit log and the collision pre-check.
+      const mockMutate = vi.fn();
+      vi.mocked(useUpdateEntity).mockReturnValue(makeUpdateEntityMock(mockMutate));
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(
+        screen.getByRole("button", { name: /edit name and description/i })
+      );
+      await user.selectOptions(
+        screen.getByRole("combobox", { name: /^type$/i }),
+        "place"
+      );
+
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        { entityId: ENTITY_ID, data: { entity_type: "place" } },
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+          onError: expect.any(Function),
+        })
+      );
+    });
+
+    it("does not send entity_type when the type was left alone", async () => {
+      const mockMutate = vi.fn();
+      vi.mocked(useUpdateEntity).mockReturnValue(makeUpdateEntityMock(mockMutate));
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(
+        screen.getByRole("button", { name: /edit name and description/i })
+      );
+      const nameInput = screen.getByRole("textbox", { name: /^name$/i });
+      await user.clear(nameInput);
+      await user.type(nameInput, "Anthropic");
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      const payload = mockMutate.mock.calls[0]?.[0] as { data: object };
+      expect(payload.data).not.toHaveProperty("entity_type");
+    });
+
+    it("pre-fills the type select with the entity's current type", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(
+        screen.getByRole("button", { name: /edit name and description/i })
+      );
+
+      const select = screen.getByRole("combobox", { name: /^type$/i });
+      expect(select).toHaveValue("organization");
+      // Options come from the shared label map, so they cannot drift from the
+      // types the database accepts.
+      expect(
+        screen.getByRole("option", { name: "Place" })
+      ).toBeInTheDocument();
+    });
+
     it("sends only description when only the description changed", async () => {
       const mockMutate = vi.fn();
       vi.mocked(useUpdateEntity).mockReturnValue(makeUpdateEntityMock(mockMutate));
@@ -481,8 +544,10 @@ describe("EntityNameEditor (inside EntityDetailPage)", () => {
         expect(screen.getByRole("alert")).toBeInTheDocument();
       });
 
+      // Wording covers a type change too: the collision is on the
+      // (name, type) pair, not the name alone.
       expect(screen.getByRole("alert")).toHaveTextContent(
-        /already has that name/i
+        /already has this name/i
       );
       // Editor remains open with the user's input preserved (FR-022).
       expect(screen.getByRole("textbox", { name: /^name$/i })).toHaveValue(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.63.0"
+version = "0.64.0"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.63.0"
+__version__ = "0.64.0"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -1643,14 +1643,14 @@ async def create_entity(
 @router.patch(
     "/entities/{entity_id}",
     status_code=200,
-    summary="Edit an entity's display name and/or description",
+    summary="Edit an entity's display name, description, and/or type",
 )
 async def update_entity(
     entity_id: str = Path(..., description="Named entity UUID"),
     body: UpdateEntityRequest = Body(...),
     session: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
-    """Edit a named entity's display name and/or description.
+    """Edit a named entity's display name, description, and/or type.
 
     Delegates to ``EntityCurationService.update_entity`` which validates,
     recomputes the normalized identity together with the name (INV-1),
@@ -1663,7 +1663,8 @@ async def update_entity(
     entity_id : str
         Named entity UUID (string representation).
     body : UpdateEntityRequest
-        Optional ``canonical_name`` / ``description`` (at least one required).
+        Optional ``canonical_name`` / ``description`` / ``entity_type``
+        (at least one required).
     session : AsyncSession
         Database session (injected).
 
@@ -1679,7 +1680,8 @@ async def update_entity(
     NotFoundError
         The entity does not exist — 404.
     ConflictError
-        The new normalized name collides with an existing same-type entity — 409.
+        The resulting ``(normalized name, entity type)`` pair collides with an
+        existing entity — 409.
     """
     try:
         parsed_entity_id = uuid.UUID(entity_id)
@@ -1692,6 +1694,9 @@ async def update_entity(
             parsed_entity_id,
             canonical_name=body.canonical_name,
             description=body.description,
+            entity_type=(
+                body.entity_type.value if body.entity_type is not None else None
+            ),
             actor=ACTOR_USER_LOCAL,
         )
     except EntityNotFoundError as exc:

--- a/src/chronovista/api/schemas/entity_mentions.py
+++ b/src/chronovista/api/schemas/entity_mentions.py
@@ -13,6 +13,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from chronovista.api.schemas.responses import PaginationMeta
+from chronovista.models.enums import EntityType
 
 
 class VideoEntitySummary(BaseModel):
@@ -578,6 +579,8 @@ class UpdateEntityRequest(BaseModel):
         New verbatim display name (1-500 chars). Omit to leave unchanged.
     description : str | None
         New description (empty string clears it). Omit to leave unchanged.
+    entity_type : EntityType | None
+        New entity type. Omit to leave unchanged.
     """
 
     model_config = ConfigDict(strict=True)
@@ -593,13 +596,22 @@ class UpdateEntityRequest(BaseModel):
         max_length=5000,
         description="New entity description (empty string clears it)",
     )
+    entity_type: EntityType | None = Field(
+        default=None,
+        description="New entity type (e.g. correcting a place filed as a person)",
+    )
 
     @model_validator(mode="after")
     def at_least_one_field(self) -> UpdateEntityRequest:
         """Require at least one editable field to be present."""
-        if self.canonical_name is None and self.description is None:
+        if (
+            self.canonical_name is None
+            and self.description is None
+            and self.entity_type is None
+        ):
             raise ValueError(
-                "At least one of 'canonical_name' or 'description' is required"
+                "At least one of 'canonical_name', 'description' or "
+                "'entity_type' is required"
             )
         return self
 

--- a/src/chronovista/api/schemas/entity_mentions.py
+++ b/src/chronovista/api/schemas/entity_mentions.py
@@ -598,6 +598,10 @@ class UpdateEntityRequest(BaseModel):
     )
     entity_type: EntityType | None = Field(
         default=None,
+        # This model is strict, and strict mode will not coerce the JSON string
+        # "place" into the enum — it demands an EntityType instance, which no
+        # HTTP client can send. Same opt-out as CorrectionType uses.
+        strict=False,
         description="New entity type (e.g. correcting a place filed as a person)",
     )
 

--- a/src/chronovista/models/entity_operation_log.py
+++ b/src/chronovista/models/entity_operation_log.py
@@ -32,6 +32,9 @@ class EntityEditSnapshot(BaseModel):
     description: str | None = Field(
         default=None, description="Entity description at this point"
     )
+    entity_type: str | None = Field(
+        default=None, description="Entity type at this point"
+    )
 
     model_config = ConfigDict(validate_assignment=True)
 

--- a/src/chronovista/services/entity_curation_service.py
+++ b/src/chronovista/services/entity_curation_service.py
@@ -26,6 +26,7 @@ from chronovista.models.entity_operation_log import (
     EntityEditSnapshot,
     EntityOperationLogCreate,
 )
+from chronovista.models.enums import EntityType
 from chronovista.models.named_entity import NamedEntityUpdate
 from chronovista.repositories.entity_operation_log_repository import (
     EntityOperationLogRepository,
@@ -104,18 +105,25 @@ class EntityCurationService:
         *,
         canonical_name: str | None = None,
         description: str | None = None,
+        entity_type: str | None = None,
         actor: str,
     ) -> NamedEntityDB:
         """
-        Edit an entity's display name and/or description.
+        Edit an entity's display name, description, and/or type.
 
         PATCH semantics: an omitted argument (``None``) leaves that field
         unchanged. Passing ``description=""`` clears the description (a valid,
         distinct value — FR-013). ``canonical_name`` is stored verbatim (only
         leading/trailing whitespace trimmed — FR-013); its normalized form is
-        recomputed together with it (INV-1). A name change that would duplicate
-        an existing same-type entity is rejected (FR-005). Aliases and mentions
-        are never touched (FR-015, FR-020).
+        recomputed together with it (INV-1). Aliases and mentions are never
+        touched (FR-015, FR-020).
+
+        Uniqueness is a property of the **pair** ``(canonical_name_normalized,
+        entity_type)``, so the collision pre-check runs against the values as
+        they will be *after* the edit. Checking a renamed entity against its old
+        type — or a retyped entity against its old name — would let a duplicate
+        through the pre-check and fail at flush time with an IntegrityError
+        (→ 500) instead of a clean 409.
 
         Parameters
         ----------
@@ -127,6 +135,9 @@ class EntityCurationService:
             New display name (verbatim). Omit to leave unchanged.
         description : str, optional
             New description (empty string clears it). Omit to leave unchanged.
+        entity_type : str, optional
+            New entity type. Must be a valid ``EntityType``. Omit to leave
+            unchanged.
         actor : str
             Actor string recorded in the audit log (e.g. ``"user:local"``).
 
@@ -138,16 +149,18 @@ class EntityCurationService:
         Raises
         ------
         InvalidEntityEditError
-            No fields provided, or the name is empty / too long / normalizes
-            to empty.
+            No fields provided, the name is empty / too long / normalizes to
+            empty, or the entity type is not a valid ``EntityType``.
         EntityNotFoundError
             The entity does not exist.
         EntityNameCollisionError
-            The new normalized name collides with an existing same-type entity.
+            The resulting ``(normalized name, entity type)`` pair collides with
+            an existing entity.
         """
-        if canonical_name is None and description is None:
+        if canonical_name is None and description is None and entity_type is None:
             raise InvalidEntityEditError(
-                "At least one of 'canonical_name' or 'description' is required."
+                "At least one of 'canonical_name', 'description' or "
+                "'entity_type' is required."
             )
 
         entity = await self._entity_repo.get(session, entity_id)
@@ -160,6 +173,14 @@ class EntityCurationService:
         after = EntityEditSnapshot()
         changed_fields: list[str] = []
         update_fields: dict[str, Any] = {}
+
+        # The values the entity will hold after this edit. Both feed one
+        # collision check below, because uniqueness is on the pair.
+        effective_normalized = entity.canonical_name_normalized
+        effective_type = entity.entity_type
+        name_changed = False
+        type_changed = False
+        trimmed = ""
 
         if canonical_name is not None:
             trimmed = canonical_name.strip()
@@ -176,25 +197,49 @@ class EntityCurationService:
                 raise InvalidEntityEditError(
                     "Entity name normalizes to an empty value."
                 )
-
-            if (
+            name_changed = (
                 trimmed != entity.canonical_name
                 or normalized != entity.canonical_name_normalized
-            ):
-                await self._assert_no_collision(
-                    session,
-                    normalized=normalized,
-                    entity_type=entity.entity_type,
-                    exclude_id=entity.id,
+            )
+            if name_changed:
+                effective_normalized = normalized
+
+        if entity_type is not None:
+            valid_types = {t.value for t in EntityType}
+            if entity_type not in valid_types:
+                raise InvalidEntityEditError(
+                    f"Entity type must be one of {sorted(valid_types)}, "
+                    f"got {entity_type!r}."
                 )
-                before.canonical_name = entity.canonical_name
-                before.canonical_name_normalized = entity.canonical_name_normalized
-                after.canonical_name = trimmed
-                after.canonical_name_normalized = normalized
-                changed_fields.append("canonical_name")
-                # INV-1: both columns always move together.
-                update_fields["canonical_name"] = trimmed
-                update_fields["canonical_name_normalized"] = normalized
+            type_changed = entity_type != entity.entity_type
+            if type_changed:
+                effective_type = entity_type
+
+        # One check, on the pair as it will be. A rename validated against the
+        # old type, or a retype validated against the old name, both miss.
+        if name_changed or type_changed:
+            await self._assert_no_collision(
+                session,
+                normalized=effective_normalized,
+                entity_type=effective_type,
+                exclude_id=entity.id,
+            )
+
+        if name_changed:
+            before.canonical_name = entity.canonical_name
+            before.canonical_name_normalized = entity.canonical_name_normalized
+            after.canonical_name = trimmed
+            after.canonical_name_normalized = effective_normalized
+            changed_fields.append("canonical_name")
+            # INV-1: both columns always move together.
+            update_fields["canonical_name"] = trimmed
+            update_fields["canonical_name_normalized"] = effective_normalized
+
+        if type_changed:
+            before.entity_type = entity.entity_type
+            after.entity_type = effective_type
+            changed_fields.append("entity_type")
+            update_fields["entity_type"] = effective_type
 
         if description is not None and description != entity.description:
             before.description = entity.description
@@ -291,22 +336,46 @@ class EntityCurationService:
         before = rollback.before
         update_fields: dict[str, Any] = {}
 
+        # Resolve both restored values before checking, for the same reason the
+        # forward edit does: the constraint is on the pair. An undo that
+        # restores name and type together must be checked against both.
+        restored_normalized = entity.canonical_name_normalized
+        restored_type = entity.entity_type
+
         if "canonical_name" in rollback.changed_fields:
-            restored_name = before.canonical_name
-            restored_normalized = before.canonical_name_normalized
-            if restored_name is None or restored_normalized is None:
+            if (
+                before.canonical_name is None
+                or before.canonical_name_normalized is None
+            ):
                 raise InvalidEntityEditError(
                     "Rollback data is missing the previous name."
                 )
-            if restored_normalized != entity.canonical_name_normalized:
-                await self._assert_no_collision(
-                    session,
-                    normalized=restored_normalized,
-                    entity_type=entity.entity_type,
-                    exclude_id=entity.id,
+            restored_normalized = before.canonical_name_normalized
+
+        if "entity_type" in rollback.changed_fields:
+            if before.entity_type is None:
+                raise InvalidEntityEditError(
+                    "Rollback data is missing the previous entity type."
                 )
-            update_fields["canonical_name"] = restored_name
+            restored_type = before.entity_type
+
+        if (
+            restored_normalized != entity.canonical_name_normalized
+            or restored_type != entity.entity_type
+        ):
+            await self._assert_no_collision(
+                session,
+                normalized=restored_normalized,
+                entity_type=restored_type,
+                exclude_id=entity.id,
+            )
+
+        if "canonical_name" in rollback.changed_fields:
+            update_fields["canonical_name"] = before.canonical_name
             update_fields["canonical_name_normalized"] = restored_normalized
+
+        if "entity_type" in rollback.changed_fields:
+            update_fields["entity_type"] = restored_type
 
         if "description" in rollback.changed_fields:
             update_fields["description"] = before.description

--- a/tests/integration/api/test_entity_update_endpoint.py
+++ b/tests/integration/api/test_entity_update_endpoint.py
@@ -295,3 +295,88 @@ class TestUpdateEntityEndpoint:
                 assert entity.entity_type == "organization"
         finally:
             await _purge(integration_session_factory)
+
+    async def test_entity_type_change_200(
+        self,
+        async_client: AsyncClient,
+        seed_entity: uuid.UUID,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """A JSON string must be accepted for entity_type.
+
+        The request model is strict, and Pydantic strict mode will not coerce
+        "place" into the EntityType enum — it demands an enum instance, which
+        no HTTP client can send. Service-level tests pass a plain string and so
+        never exercise the schema; this is the layer where that fails, with a
+        422 the UI surfaces as a generic "Failed to save changes."
+        """
+        with _auth() as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            resp = await async_client.patch(
+                _url(str(seed_entity)), json={"entity_type": "place"}
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["entity_type"] == "place"
+
+        async with integration_session_factory() as session:
+            entity = (
+                await session.execute(
+                    select(NamedEntityDB).where(NamedEntityDB.id == seed_entity)
+                )
+            ).scalar_one()
+            assert entity.entity_type == "place"
+            # A retype is not a rename.
+            assert entity.canonical_name == "Ect057upd Openai"
+
+    async def test_unknown_entity_type_422(
+        self,
+        async_client: AsyncClient,
+        seed_entity: uuid.UUID,
+    ) -> None:
+        with _auth() as mock_oauth:
+            mock_oauth.is_authenticated.return_value = True
+            resp = await async_client.patch(
+                _url(str(seed_entity)), json={"entity_type": "country"}
+            )
+        assert resp.status_code == 422, resp.text
+
+    async def test_retype_into_an_occupied_pair_409(
+        self,
+        async_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Uniqueness is the pair, so a retype can collide without a rename.
+
+        Checking the retype against the entity's OLD type always passes — the
+        entity is excluded from its own query — and the duplicate then fails at
+        flush time as a 500 instead of a clean 409.
+        """
+        await _purge(integration_session_factory)
+        await _seed_entity(
+            integration_session_factory,
+            canonical_name="Ect057upd Luxembourg",
+            normalized=f"{_PREFIX} luxembourg",
+            entity_type="place",
+        )
+        person_id = await _seed_entity(
+            integration_session_factory,
+            canonical_name="Ect057upd Luxembourg",
+            normalized=f"{_PREFIX} luxembourg",
+            entity_type="person",
+        )
+        try:
+            with _auth() as mock_oauth:
+                mock_oauth.is_authenticated.return_value = True
+                resp = await async_client.patch(
+                    _url(str(person_id)), json={"entity_type": "place"}
+                )
+            assert resp.status_code == 409, resp.text
+            async with integration_session_factory() as session:
+                entity = (
+                    await session.execute(
+                        select(NamedEntityDB).where(NamedEntityDB.id == person_id)
+                    )
+                ).scalar_one()
+                assert entity.entity_type == "person", "must not have mutated"
+        finally:
+            await _purge(integration_session_factory)

--- a/tests/unit/services/test_entity_curation_service.py
+++ b/tests/unit/services/test_entity_curation_service.py
@@ -239,6 +239,156 @@ class TestUpdateEntity:
         log_repo.create.assert_not_awaited()
 
 
+class TestUpdateEntityType:
+    """Correcting an entity filed under the wrong type.
+
+    Picking the wrong type at creation is easy and, before this, the only
+    remedy was a direct database UPDATE — which skipped the audit log and the
+    collision pre-check entirely.
+    """
+
+    async def test_changes_the_type(self) -> None:
+        entity = _entity(
+            canonical_name="Luxembourg", normalized="luxembourg", entity_type="person"
+        )
+        service, _repo, _log = _make_service(entity)
+        session = _no_collision_session()
+
+        updated = await service.update_entity(
+            session, entity.id, entity_type="place", actor=_ACTOR
+        )
+
+        assert updated.entity_type == "place"
+        # The name is untouched: a retype is not a rename.
+        assert updated.canonical_name == "Luxembourg"
+        assert updated.canonical_name_normalized == "luxembourg"
+
+    async def test_rejects_an_invalid_type(self) -> None:
+        entity = _entity(canonical_name="Luxembourg", normalized="luxembourg")
+        service, _repo, _log = _make_service(entity)
+
+        with pytest.raises(InvalidEntityEditError, match="Entity type must be one of"):
+            await service.update_entity(
+                _no_collision_session(), entity.id, entity_type="country", actor=_ACTOR
+            )
+
+    async def test_collision_is_checked_against_the_NEW_type(self) -> None:
+        """The unique key is the pair, so the check must query the new type.
+
+        Asserting that a collision raises is NOT enough: a blanket
+        collision-returning mock raises whichever type was queried, so such a
+        test passes even when the code checks the old type. This inspects the
+        emitted query's bound parameters instead.
+
+        Checking a retype against the entity's *old* type always passes — the
+        entity itself is excluded — and the duplicate then fails at flush time
+        with an IntegrityError (500) rather than a clean 409.
+        """
+        entity = _entity(
+            canonical_name="Luxembourg", normalized="luxembourg", entity_type="person"
+        )
+        service, _repo, _log = _make_service(entity)
+        session = _no_collision_session()
+
+        await service.update_entity(
+            session, entity.id, entity_type="place", actor=_ACTOR
+        )
+
+        stmt = session.execute.await_args.args[0]
+        params = stmt.compile().params
+        queried_types = {v for v in params.values() if v in {"person", "place"}}
+        assert queried_types == {
+            "place"
+        }, f"collision check queried {queried_types}, must query the NEW type"
+
+    async def test_no_op_retype_writes_nothing(self) -> None:
+        entity = _entity(
+            canonical_name="Luxembourg", normalized="luxembourg", entity_type="place"
+        )
+        service, repo, log_repo = _make_service(entity)
+
+        await service.update_entity(
+            _no_collision_session(), entity.id, entity_type="place", actor=_ACTOR
+        )
+
+        repo.update.assert_not_awaited()
+        log_repo.create.assert_not_awaited()
+
+    async def test_type_change_is_logged_for_undo(self) -> None:
+        entity = _entity(
+            canonical_name="Luxembourg", normalized="luxembourg", entity_type="person"
+        )
+        service, _repo, log_repo = _make_service(entity)
+
+        await service.update_entity(
+            _no_collision_session(), entity.id, entity_type="place", actor=_ACTOR
+        )
+
+        rollback = log_repo.create.await_args.kwargs["obj_in"].rollback_data
+        assert "entity_type" in rollback.changed_fields
+        assert rollback.before.entity_type == "person"
+        assert rollback.after.entity_type == "place"
+
+    async def test_name_and_type_change_together(self) -> None:
+        entity = _entity(
+            canonical_name="Luxemburg", normalized="luxemburg", entity_type="person"
+        )
+        service, _repo, log_repo = _make_service(entity)
+
+        updated = await service.update_entity(
+            _no_collision_session(),
+            entity.id,
+            canonical_name="Luxembourg",
+            entity_type="place",
+            actor=_ACTOR,
+        )
+
+        assert updated.canonical_name == "Luxembourg"
+        assert updated.entity_type == "place"
+        changed = log_repo.create.await_args.kwargs[
+            "obj_in"
+        ].rollback_data.changed_fields
+        assert set(changed) == {"canonical_name", "entity_type"}
+
+    async def test_undo_restores_the_previous_type(self) -> None:
+        entity = _entity(
+            canonical_name="Luxembourg", normalized="luxembourg", entity_type="place"
+        )
+        service, _repo, log_repo = _make_service(entity)
+        log = create_entity_operation_log(
+            entity_id=entity.id,
+            rollback_data={
+                "before": {"entity_type": "person"},
+                "after": {"entity_type": "place"},
+                "changed_fields": ["entity_type"],
+            },
+        )
+        log_repo.get = AsyncMock(return_value=log)
+
+        restored = await service.undo_operation(
+            _no_collision_session(), log.id, actor=_ACTOR
+        )
+
+        assert restored.entity_type == "person"
+
+    async def test_undo_without_a_recorded_type_is_rejected(self) -> None:
+        """Refuse rather than guess when the rollback record is incomplete."""
+        entity = _entity(entity_type="place")
+        service, _repo, log_repo = _make_service(entity)
+        log = create_entity_operation_log(
+            entity_id=entity.id,
+            rollback_data={
+                "before": {},
+                "after": {"entity_type": "place"},
+                "changed_fields": ["entity_type"],
+            },
+        )
+        log_repo.get = AsyncMock(return_value=log)
+
+        with pytest.raises(InvalidEntityEditError, match="previous entity type"):
+            await service.undo_operation(_no_collision_session(), log.id, actor=_ACTOR)
+
+
 class TestUndoOperation:
     async def test_undo_restores_name(self) -> None:
         entity = _entity(canonical_name="OpenAI", normalized="openai")


### PR DESCRIPTION
## Why

Choosing the wrong type when creating an entity is easy, and nothing could fix it. `PATCH /api/v1/entities/{id}` and `EntityCurationService.update_entity` handled name and description only, so the only remedy was a direct `UPDATE` against the database — which skips the audit log and the collision pre-check entirely.

## What

A **Type** select in the entity edit form, alongside Name and Description. Options come from the shared `ENTITY_TYPE_LABELS` map, so they cannot drift from the types the database accepts. Changes are recorded in `entity_operation_logs` with before/after, so a mis-click is undoable like any other entity edit.

## The substantive fix

`uq_named_entity_canonical` is on the **pair** `(canonical_name_normalized, entity_type)`, but the pre-check ran against the entity's *existing* type. For a retype that always passes — the entity is excluded from its own query — and the duplicate then fails at flush time as an `IntegrityError` (500) rather than a clean 409.

Both values are now resolved before a single check. The undo path carried the same latent defect (restoring a name while checking it against the current type) and is fixed the same way.

## A bug my own tests could not see

The first version shipped broken: the request model is strict, and Pydantic strict mode refuses to coerce `"place"` into the enum — it wants an enum instance, which no HTTP client can send. Every retype returned 422, which the UI flattens into "Failed to save changes."

Eight service-level tests passed throughout, because they call the service directly with a plain string and never touch the schema. The gap was the layer between them. Endpoint tests that PATCH real JSON now cover it.

## Tests

- 3 service tests for the pair-collision rule, including one that inspects the emitted query's bound parameters — asserting that a collision *raises* is not enough, because a blanket collision-returning mock raises whichever type was queried, so such a test passes even when the code checks the old type.
- 3 endpoint tests: a successful retype, an unknown type (422), and a retype into an occupied pair (409, nothing mutated).
- 3 frontend tests: the select sends `entity_type` only when changed, and pre-fills from the current value.

All mutation-verified — each fails when its fix is reverted.

**7,650 backend + 3,919 frontend tests pass.** mypy `--strict`, ruff, black, tsc clean.

## Notes

- The 409 message is reworded: a collision can now originate from a type change, so "another entity of this type already has that name" was misleading.
- No migration. `NamedEntityUpdate` already carried `entity_type`, so the repository layer is unchanged.
