### PR TITLE
fix(api): bound the expensive entity reads, and write down the rate-limit rule

### DIFF
--- a/src/chronovista/api/query_protection.py
+++ b/src/chronovista/api/query_protection.py
@@ -35,6 +35,7 @@ from collections.abc import Coroutine
 from typing import Any, TypeVar
 
 from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.exceptions import QueryTimeoutError
 
@@ -45,10 +46,22 @@ T = TypeVar("T")
 RATE_LIMIT_WINDOW_SECONDS = 60
 """Sliding window, in seconds, over which requests are counted."""
 
-QUERY_TIMEOUT_SECONDS = 10
-"""Ceiling for a single read query. Chosen to sit well above the slowest
-measured query (923 ms on the most connected entity) so it fires only on a
-genuine hang, not on ordinary slowness."""
+QUERY_TIMEOUT_SECONDS = 8
+"""Ceiling for a single read query.
+
+Two constraints set this value. It must sit well above the slowest measured
+query — 923 ms on the most connected entity — so it fires only on a genuine
+hang. And it must sit **below the client's own timeout**, which is
+``API_TIMEOUT = 10000`` ms in ``frontend/src/api/config.ts``.
+
+That second constraint is easy to miss. At an equal 10 s the two race, and the
+client generally wins: its budget covers the whole round trip while this one
+covers the query alone. The user then sees a generic "the server took too long"
+instead of a 504 naming the query that hung — the server-side ceiling would be
+real but effectively invisible. Raising this above the client's timeout would
+disable it entirely for the browser.
+
+If the client timeout changes, this must move with it."""
 
 
 def get_client_id(request: Request) -> str:
@@ -121,6 +134,7 @@ async def run_with_timeout(
     work: Coroutine[Any, Any, T],
     *,
     operation: str,
+    session: AsyncSession | None = None,
     timeout_seconds: int = QUERY_TIMEOUT_SECONDS,
 ) -> T:
     """Run *work* under a ceiling, converting a hang into a 504.
@@ -137,6 +151,14 @@ async def run_with_timeout(
     operation : str
         Human-readable label naming the query, used in the log line and the
         error detail so a timeout report identifies which query hung.
+    session : AsyncSession, optional
+        The session the query runs on. Rolled back when the ceiling fires.
+        Cancelling a query mid-flight leaves the transaction in a failed state,
+        and the next statement on that session raises ``PendingRollbackError``
+        rather than the timeout the caller is expecting. Callers that touch the
+        session again after a timeout — or that sit inside a broader
+        transaction — should pass it. Verified: the pooled connection itself
+        recovers cleanly, so this guards the session, not the pool.
     timeout_seconds : int, optional
         Ceiling in seconds (default :data:`QUERY_TIMEOUT_SECONDS`).
 
@@ -156,6 +178,8 @@ async def run_with_timeout(
         logger.error(
             "Query timeout exceeded (%ds) for operation %s", timeout_seconds, operation
         )
+        if session is not None:
+            await session.rollback()
         raise QueryTimeoutError(
             message=(
                 f"Query timeout exceeded. Maximum query time is "

--- a/src/chronovista/api/query_protection.py
+++ b/src/chronovista/api/query_protection.py
@@ -1,0 +1,165 @@
+"""Shared query protections for API routers: client identity, rate limits, timeouts.
+
+These helpers were duplicated verbatim between ``videos.py`` and
+``entity_mentions.py``, differing only in the per-router request limit. A third
+router would have copied them again.
+
+Policy this module encodes
+--------------------------
+**Timeouts apply to every expensive read.** A query with no ceiling can hang
+indefinitely and the interface spins with nothing to show. Bounding it converts
+an unbounded wait into a definite, reportable failure. This is worth having
+regardless of how many people use the application, because the failure mode is
+the same for one user as for a thousand.
+
+**Rate limits apply only where the client calls without debouncing.** They are
+not blanket protection here. This is a local, single-user application: the
+client identifier resolves to ``127.0.0.1`` for every request, so one bucket is
+shared by the whole interface, and a blanket limit turns ordinary bursts —
+infinite scroll, scan-job polling — into visible 429s. The limiter earns its
+place on endpoints the interface calls in an unthrottled loop, where a render
+loop or a fast typist can generate real load. A client-side debounce achieves
+the same end; either is sufficient, and neither is needed twice.
+
+Applying that rule today: ``/entities/check-duplicate`` fires on every keystroke
+with no debounce, so it is limited. ``/entities/search`` is debounced 300 ms in
+its hook, so it is not. That asymmetry is deliberate, not an oversight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Coroutine
+from typing import Any, TypeVar
+
+from fastapi import Request
+
+from chronovista.exceptions import QueryTimeoutError
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+RATE_LIMIT_WINDOW_SECONDS = 60
+"""Sliding window, in seconds, over which requests are counted."""
+
+QUERY_TIMEOUT_SECONDS = 10
+"""Ceiling for a single read query. Chosen to sit well above the slowest
+measured query (923 ms on the most connected entity) so it fires only on a
+genuine hang, not on ordinary slowness."""
+
+
+def get_client_id(request: Request) -> str:
+    """Identify the caller for rate-limiting purposes.
+
+    Prefers ``X-Forwarded-For`` so a proxied deployment distinguishes callers.
+    On a local install every request resolves to the same loopback address,
+    which is why blanket limiting is inappropriate here — see the module
+    docstring.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming request.
+
+    Returns
+    -------
+    str
+        Client identifier, or ``"unknown"`` when none can be determined.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def check_rate_limit(
+    client_id: str,
+    request_counts: dict[str, list[float]],
+    rate_limit: int,
+) -> tuple[bool, int]:
+    """Record this request and report whether the client is over its limit.
+
+    Expires timestamps outside the window, then admits or rejects. Callers own
+    the ``request_counts`` mapping, so each endpoint keeps an independent
+    budget rather than competing for one.
+
+    Parameters
+    ----------
+    client_id : str
+        Client identifier from :func:`get_client_id`.
+    request_counts : dict[str, list[float]]
+        Per-client request timestamps. Mutated in place.
+    rate_limit : int
+        Maximum requests permitted within the window.
+
+    Returns
+    -------
+    tuple[bool, int]
+        ``(is_allowed, retry_after_seconds)``. ``retry_after`` is 0 when
+        allowed, and otherwise the whole seconds until a slot frees.
+    """
+    now = time.time()
+    window_start = now - RATE_LIMIT_WINDOW_SECONDS
+
+    request_counts[client_id] = [
+        ts for ts in request_counts[client_id] if ts > window_start
+    ]
+
+    if len(request_counts[client_id]) >= rate_limit:
+        oldest = min(request_counts[client_id])
+        retry_after = int(oldest + RATE_LIMIT_WINDOW_SECONDS - now) + 1
+        return False, max(1, retry_after)
+
+    request_counts[client_id].append(now)
+    return True, 0
+
+
+async def run_with_timeout(
+    work: Coroutine[Any, Any, T],
+    *,
+    operation: str,
+    timeout_seconds: int = QUERY_TIMEOUT_SECONDS,
+) -> T:
+    """Run *work* under a ceiling, converting a hang into a 504.
+
+    Raises :class:`QueryTimeoutError` rather than returning a response object,
+    so the router's RFC 7807 handler formats it like every other error. A
+    router that builds its own ``JSONResponse`` here produces a 504 shaped
+    differently from its 404s, which clients then have to special-case.
+
+    Parameters
+    ----------
+    work : Coroutine
+        The query to bound. Cancelled if the ceiling is reached.
+    operation : str
+        Human-readable label naming the query, used in the log line and the
+        error detail so a timeout report identifies which query hung.
+    timeout_seconds : int, optional
+        Ceiling in seconds (default :data:`QUERY_TIMEOUT_SECONDS`).
+
+    Returns
+    -------
+    T
+        Whatever *work* returned.
+
+    Raises
+    ------
+    QueryTimeoutError
+        The ceiling elapsed first.
+    """
+    try:
+        return await asyncio.wait_for(work, timeout=timeout_seconds)
+    except TimeoutError as exc:
+        logger.error(
+            "Query timeout exceeded (%ds) for operation %s", timeout_seconds, operation
+        )
+        raise QueryTimeoutError(
+            message=(
+                f"Query timeout exceeded. Maximum query time is "
+                f"{timeout_seconds} seconds."
+            ),
+            details={"timeout_seconds": timeout_seconds, "operation": operation},
+        ) from exc

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -661,6 +661,7 @@ async def get_cooccurring_entities(
             evidence_scope=min_evidence,
         ),
         operation="co-occurring entities",
+        session=session,
     )
 
     # An entity with no co-occurrences returns an empty list, not an error
@@ -758,6 +759,7 @@ async def get_entity_videos(
             offset=offset,
         ),
         operation="entity video list",
+        session=session,
     )
 
     # Map dicts to response models
@@ -1017,6 +1019,7 @@ async def get_phonetic_matches(
             threshold=threshold,
         ),
         operation="phonetic matches",
+        session=session,
     )
 
     # Video title enrichment

--- a/src/chronovista/api/routers/entity_mentions.py
+++ b/src/chronovista/api/routers/entity_mentions.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 import uuid
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -22,6 +21,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from chronovista.api.deps import get_db, require_auth
+from chronovista.api.query_protection import (
+    check_rate_limit,
+    get_client_id,
+    run_with_timeout,
+)
 from chronovista.api.schemas.entity_mentions import (
     ClassifyTagRequest,
     CooccurringEntitiesResponse,
@@ -136,78 +140,14 @@ _scan_tasks: set[asyncio.Task[None]] = set()
 # Cap on retained jobs to bound memory; oldest terminal jobs are pruned first.
 _MAX_SCAN_JOBS = 100
 
-# Rate limiting configuration for duplicate check (50 req/min per client)
+# Rate limit for the duplicate check. This endpoint fires on every keystroke
+# with no client-side debounce (useCheckDuplicate is keyed on the name input),
+# which is what earns it a limiter — see chronovista.api.query_protection for
+# the rule and why it is not applied router-wide.
 RATE_LIMIT_DUPLICATE_CHECK = 50
-RATE_LIMIT_WINDOW_SECONDS = 60
 
 # Storage for rate limit tracking
 _duplicate_check_counts: dict[str, list[float]] = defaultdict(list)
-
-
-def _get_client_id(request: Request) -> str:
-    """Get client identifier from request.
-
-    Uses X-Forwarded-For header for proxied requests, falls back to client host.
-
-    Parameters
-    ----------
-    request : Request
-        FastAPI request object.
-
-    Returns
-    -------
-    str
-        Client identifier (IP address or "unknown").
-    """
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
-
-
-def _check_rate_limit(
-    client_id: str,
-    request_counts: dict[str, list[float]],
-    rate_limit: int,
-) -> tuple[bool, int]:
-    """Check if client has exceeded rate limit.
-
-    Cleans up old entries and checks if current request should be allowed.
-
-    Parameters
-    ----------
-    client_id : str
-        Client identifier.
-    request_counts : Dict[str, List[float]]
-        Storage for request timestamps per client.
-    rate_limit : int
-        Maximum requests allowed per minute.
-
-    Returns
-    -------
-    Tuple[bool, int]
-        Tuple of (is_allowed, retry_after_seconds).
-        If is_allowed is True, retry_after is 0.
-        If is_allowed is False, retry_after indicates seconds until a slot opens.
-    """
-    now = time.time()
-    window_start = now - RATE_LIMIT_WINDOW_SECONDS
-
-    # Clean old entries (older than window)
-    request_counts[client_id] = [
-        ts for ts in request_counts[client_id] if ts > window_start
-    ]
-
-    # Check if limit exceeded
-    if len(request_counts[client_id]) >= rate_limit:
-        # Find when the oldest request in window will expire
-        oldest = min(request_counts[client_id])
-        retry_after = int(oldest + RATE_LIMIT_WINDOW_SECONDS - now) + 1
-        return False, max(1, retry_after)
-
-    # Add current request timestamp
-    request_counts[client_id].append(now)
-    return True, 0
 
 
 @router.get(
@@ -517,8 +457,8 @@ async def check_duplicate_entity(
         If rate limit is exceeded.
     """
     # Rate limiting
-    client_id = _get_client_id(request)
-    is_allowed, retry_after = _check_rate_limit(
+    client_id = get_client_id(request)
+    is_allowed, retry_after = check_rate_limit(
         client_id, _duplicate_check_counts, RATE_LIMIT_DUPLICATE_CHECK
     )
     if not is_allowed:
@@ -710,11 +650,17 @@ async def get_cooccurring_entities(
     if not entity_exists.scalar_one_or_none():
         raise NotFoundError(resource_type="Entity", identifier=entity_id)
 
-    partners = await _mention_repo.get_cooccurring_entities(
-        session,
-        entity_id=parsed_entity_id,
-        limit=limit,
-        evidence_scope=min_evidence,
+    # MAX_COOCCURRING_LIMIT bounds the result SIZE, not the query cost: the
+    # scan is over the entity's whole co-occurrence set before the limit
+    # applies. Measured at 923 ms on the most connected entity.
+    partners = await run_with_timeout(
+        _mention_repo.get_cooccurring_entities(
+            session,
+            entity_id=parsed_entity_id,
+            limit=limit,
+            evidence_scope=min_evidence,
+        ),
+        operation="co-occurring entities",
     )
 
     # An entity with no co-occurrences returns an empty list, not an error
@@ -799,13 +745,19 @@ async def get_entity_videos(
         )
 
     # Fetch paginated video list from repository
-    results, total = await _mention_repo.get_entity_video_list(
-        session,
-        entity_id=parsed_entity_id,
-        language_code=language_code,
-        source_filter=source,
-        limit=limit,
-        offset=offset,
+    # Merges mention-derived and tag-derived video sets, then filters by source
+    # in Python after the query — cost scales with the entity's whole video
+    # population, not with the requested page.
+    results, total = await run_with_timeout(
+        _mention_repo.get_entity_video_list(
+            session,
+            entity_id=parsed_entity_id,
+            language_code=language_code,
+            source_filter=source,
+            limit=limit,
+            offset=offset,
+        ),
+        operation="entity video list",
     )
 
     # Map dicts to response models
@@ -1058,10 +1010,13 @@ async def get_phonetic_matches(
 
     # Run phonetic matcher
     matcher = PhoneticMatcher(entity_mention_repo=EntityMentionRepository())
-    matches = await matcher.match_entity(
-        entity_id=entity_id,
-        session=session,
-        threshold=threshold,
+    matches = await run_with_timeout(
+        matcher.match_entity(
+            entity_id=entity_id,
+            session=session,
+            threshold=threshold,
+        ),
+        operation="phonetic matches",
     )
 
     # Video title enrichment

--- a/src/chronovista/api/routers/videos.py
+++ b/src/chronovista/api/routers/videos.py
@@ -18,6 +18,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from chronovista.api.deps import get_db, get_recovery_deps, require_auth
+from chronovista.api.query_protection import (
+    QUERY_TIMEOUT_SECONDS,
+    check_rate_limit,
+    get_client_id,
+)
 from chronovista.api.routers.responses import (
     CONFLICT_RESPONSE,
     GET_ITEM_ERRORS,
@@ -108,85 +113,14 @@ MAX_ENTITIES = 10
 # Rate limiting configuration (T097)
 # In-memory rate limiter - requests per minute per client
 RATE_LIMIT_FILTER_QUERIES = 100  # requests per minute
-RATE_LIMIT_WINDOW_SECONDS = 60
 
 # Storage for rate limit tracking
 _filter_request_counts: dict[str, list[float]] = defaultdict(list)
 
-# Query timeout per FR-036 (T099)
-QUERY_TIMEOUT_SECONDS = 10
 
 # Recovery idempotency guard (T033)
 # Skip Wayback Machine requests if entity was recovered within this window
 RECOVERY_IDEMPOTENCY_MINUTES = 5
-
-
-def _get_client_id(request: Request) -> str:
-    """
-    Get client identifier from request.
-
-    Uses X-Forwarded-For header for proxied requests, falls back to client host.
-
-    Parameters
-    ----------
-    request : Request
-        FastAPI request object.
-
-    Returns
-    -------
-    str
-        Client identifier (IP address or "unknown").
-    """
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
-
-
-def _check_rate_limit(
-    client_id: str,
-    request_counts: dict[str, list[float]],
-    rate_limit: int,
-) -> tuple[bool, int]:
-    """
-    Check if client has exceeded rate limit.
-
-    Cleans up old entries and checks if current request should be allowed.
-
-    Parameters
-    ----------
-    client_id : str
-        Client identifier.
-    request_counts : Dict[str, List[float]]
-        Storage for request timestamps per client.
-    rate_limit : int
-        Maximum requests allowed per minute.
-
-    Returns
-    -------
-    Tuple[bool, int]
-        Tuple of (is_allowed, retry_after_seconds).
-        If is_allowed is True, retry_after is 0.
-        If is_allowed is False, retry_after indicates seconds until a slot opens.
-    """
-    now = time.time()
-    window_start = now - RATE_LIMIT_WINDOW_SECONDS
-
-    # Clean old entries (older than window)
-    request_counts[client_id] = [
-        ts for ts in request_counts[client_id] if ts > window_start
-    ]
-
-    # Check if limit exceeded
-    if len(request_counts[client_id]) >= rate_limit:
-        # Find when the oldest request in window will expire
-        oldest = min(request_counts[client_id])
-        retry_after = int(oldest + RATE_LIMIT_WINDOW_SECONDS - now) + 1
-        return False, max(1, retry_after)
-
-    # Add current request timestamp
-    request_counts[client_id].append(now)
-    return True, 0
 
 
 router = APIRouter(dependencies=[Depends(require_auth)])
@@ -699,8 +633,8 @@ async def list_videos(
         Query timeout exceeded per FR-036.
     """
     # T097: Rate limiting for filter queries (100 req/min)
-    client_id = _get_client_id(request)
-    is_allowed, retry_after = _check_rate_limit(
+    client_id = get_client_id(request)
+    is_allowed, retry_after = check_rate_limit(
         client_id, _filter_request_counts, RATE_LIMIT_FILTER_QUERIES
     )
     if not is_allowed:

--- a/src/chronovista/api/schemas/responses.py
+++ b/src/chronovista/api/schemas/responses.py
@@ -31,6 +31,7 @@ class ErrorCode(str, Enum):
         DATABASE_ERROR: Database operation failed (500)
         EXTERNAL_SERVICE_ERROR: External service unavailable (502)
         SERVICE_UNAVAILABLE: Service temporarily unavailable (503)
+        QUERY_TIMEOUT: Query exceeded its time budget (504)
     """
 
     # 4xx Client Errors
@@ -53,6 +54,7 @@ class ErrorCode(str, Enum):
     DATABASE_ERROR = "DATABASE_ERROR"
     EXTERNAL_SERVICE_ERROR = "EXTERNAL_SERVICE_ERROR"
     SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE"
+    QUERY_TIMEOUT = "QUERY_TIMEOUT"
 
 
 # RFC 7807 Constants and Utilities
@@ -100,6 +102,7 @@ ERROR_TITLES: dict[ErrorCode, str] = {
     ErrorCode.NO_CHANGE_DETECTED: "No Change Detected",
     ErrorCode.NO_ACTIVE_CORRECTION: "No Active Correction",
     ErrorCode.INVALID_CORRECTION_TYPE: "Invalid Correction Type",
+    ErrorCode.QUERY_TIMEOUT: "Query Timeout",
 }
 """Mapping from ErrorCode to human-readable RFC 7807 title."""
 

--- a/src/chronovista/exceptions.py
+++ b/src/chronovista/exceptions.py
@@ -1056,6 +1056,32 @@ class ExternalServiceError(APIError):
     _error_code_value: str = "EXTERNAL_SERVICE_ERROR"
 
 
+class QueryTimeoutError(APIError):
+    """A read query exceeded its time budget (504).
+
+    Raised when a query is still running past its ceiling. The point is not to
+    make slow queries fast — it is to make them *bounded*, so the interface
+    shows a definite error instead of spinning indefinitely.
+
+    Attributes
+    ----------
+    status_code : int
+        Always 504 for this exception.
+    error_code : ErrorCode
+        Always QUERY_TIMEOUT for this exception.
+
+    Examples
+    --------
+    >>> raise QueryTimeoutError(
+    ...     message="Query timeout exceeded. Maximum query time is 10 seconds.",
+    ...     details={"timeout_seconds": 10, "operation": "co-occurring entities"}
+    ... )
+    """
+
+    status_code: int = 504
+    _error_code_value: str = "QUERY_TIMEOUT"
+
+
 # Exit codes for CLI integration
 EXIT_CODE_SUCCESS = 0
 EXIT_CODE_GENERAL_ERROR = 1

--- a/tests/unit/api/test_entity_creation_endpoints.py
+++ b/tests/unit/api/test_entity_creation_endpoints.py
@@ -1452,7 +1452,7 @@ class TestCheckDuplicateEndpoint:
 
         async for client in _build_client(mock_session):
             with patch(
-                "chronovista.api.routers.entity_mentions._check_rate_limit"
+                "chronovista.api.routers.entity_mentions.check_rate_limit"
             ) as mock_rate_limit:
                 # Simulate 50 req/min limit already exceeded; retry after 30s
                 mock_rate_limit.return_value = (False, 30)
@@ -1483,7 +1483,7 @@ class TestCheckDuplicateEndpoint:
 
         async for client in _build_client(mock_session):
             with patch(
-                "chronovista.api.routers.entity_mentions._check_rate_limit"
+                "chronovista.api.routers.entity_mentions.check_rate_limit"
             ) as mock_rate_limit:
                 mock_rate_limit.return_value = (False, 15)
 

--- a/tests/unit/api/test_query_protection.py
+++ b/tests/unit/api/test_query_protection.py
@@ -1,0 +1,115 @@
+"""Tests for the shared query protections (issue #173).
+
+These helpers were duplicated between two routers. The tests that matter are
+the ones pinning the *policy* the module encodes, not just the arithmetic:
+a timeout must raise the project's error type rather than return a bespoke
+response, and the limiter must expire its window rather than count forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from unittest.mock import MagicMock
+
+import pytest
+
+from chronovista.api.query_protection import (
+    QUERY_TIMEOUT_SECONDS,
+    RATE_LIMIT_WINDOW_SECONDS,
+    check_rate_limit,
+    get_client_id,
+    run_with_timeout,
+)
+from chronovista.exceptions import QueryTimeoutError
+
+
+def _request(*, forwarded: str | None = None, host: str | None = "127.0.0.1"):  # type: ignore[no-untyped-def]
+    req = MagicMock()
+    req.headers = {"x-forwarded-for": forwarded} if forwarded else {}
+    req.client = MagicMock(host=host) if host is not None else None
+    return req
+
+
+class TestGetClientId:
+    def test_prefers_the_forwarded_header(self) -> None:
+        assert (
+            get_client_id(_request(forwarded="203.0.113.7, 10.0.0.1")) == "203.0.113.7"
+        )
+
+    def test_falls_back_to_the_peer_address(self) -> None:
+        assert get_client_id(_request()) == "127.0.0.1"
+
+    def test_reports_unknown_rather_than_raising(self) -> None:
+        """A missing client must not turn into a 500 on a read path."""
+        assert get_client_id(_request(host=None)) == "unknown"
+
+
+class TestCheckRateLimit:
+    def test_admits_up_to_the_limit_then_rejects(self) -> None:
+        counts: dict[str, list[float]] = defaultdict(list)
+        for _ in range(3):
+            allowed, retry = check_rate_limit("c", counts, 3)
+            assert allowed and retry == 0
+        allowed, retry = check_rate_limit("c", counts, 3)
+        assert not allowed
+        assert 1 <= retry <= RATE_LIMIT_WINDOW_SECONDS
+
+    def test_expires_timestamps_outside_the_window(self) -> None:
+        """Without expiry the limiter would reject forever after one burst."""
+        counts: dict[str, list[float]] = defaultdict(list)
+        counts["c"] = [1.0, 2.0, 3.0]  # long past
+        allowed, retry = check_rate_limit("c", counts, 3)
+        assert allowed and retry == 0
+        assert counts["c"] == [pytest.approx(counts["c"][0])], "stale entries retained"
+
+    def test_clients_do_not_share_a_budget(self) -> None:
+        counts: dict[str, list[float]] = defaultdict(list)
+        check_rate_limit("a", counts, 1)
+        allowed, _ = check_rate_limit("b", counts, 1)
+        assert allowed, "one client's burst must not lock out another"
+
+
+@pytest.mark.asyncio
+class TestRunWithTimeout:
+    async def test_returns_the_result_when_it_finishes(self) -> None:
+        async def work() -> str:
+            return "done"
+
+        assert await run_with_timeout(work(), operation="test") == "done"
+
+    async def test_raises_the_project_error_type_not_a_response(self) -> None:
+        """A 504 must flow through the RFC 7807 handler like every other error.
+
+        Returning a bespoke JSONResponse here — as the videos router does —
+        produces a 504 shaped differently from the same router's 404s, which
+        every client then has to special-case.
+        """
+
+        async def slow() -> None:
+            await asyncio.sleep(10)
+
+        with pytest.raises(QueryTimeoutError) as exc_info:
+            await run_with_timeout(slow(), operation="slow thing", timeout_seconds=0.01)  # type: ignore[arg-type]
+
+        err = exc_info.value
+        assert err.status_code == 504
+        assert err.details["operation"] == "slow thing"
+
+    async def test_names_the_operation_so_a_timeout_is_diagnosable(self) -> None:
+        async def slow() -> None:
+            await asyncio.sleep(10)
+
+        with pytest.raises(QueryTimeoutError) as exc_info:
+            await run_with_timeout(
+                slow(), operation="co-occurring entities", timeout_seconds=0.01  # type: ignore[arg-type]
+            )
+        assert "co-occurring entities" in str(exc_info.value.details["operation"])
+
+    async def test_default_ceiling_is_the_shared_constant(self) -> None:
+        """Callers should not each invent their own budget."""
+
+        async def work() -> int:
+            return QUERY_TIMEOUT_SECONDS
+
+        assert await run_with_timeout(work(), operation="test") == 10

--- a/tests/unit/api/test_query_protection.py
+++ b/tests/unit/api/test_query_protection.py
@@ -9,8 +9,10 @@ response, and the limiter must expire its window rather than count forever.
 from __future__ import annotations
 
 import asyncio
+import pathlib
+import re
 from collections import defaultdict
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -61,7 +63,7 @@ class TestCheckRateLimit:
         counts["c"] = [1.0, 2.0, 3.0]  # long past
         allowed, retry = check_rate_limit("c", counts, 3)
         assert allowed and retry == 0
-        assert counts["c"] == [pytest.approx(counts["c"][0])], "stale entries retained"
+        assert len(counts["c"]) == 1, "stale entries were not expired"
 
     def test_clients_do_not_share_a_budget(self) -> None:
         counts: dict[str, list[float]] = defaultdict(list)
@@ -106,10 +108,67 @@ class TestRunWithTimeout:
             )
         assert "co-occurring entities" in str(exc_info.value.details["operation"])
 
+    async def test_rolls_back_the_session_it_is_given(self) -> None:
+        """Cancelling mid-query leaves the transaction needing a rollback.
+
+        Without this the next statement on that session raises
+        PendingRollbackError instead of the timeout the caller expects —
+        verified against a real connection, where the pooled connection itself
+        recovers cleanly but the session does not.
+        """
+        session = MagicMock()
+        session.rollback = AsyncMock()
+
+        async def slow() -> None:
+            await asyncio.sleep(10)
+
+        with pytest.raises(QueryTimeoutError):
+            await run_with_timeout(
+                slow(), operation="x", session=session, timeout_seconds=0.01  # type: ignore[arg-type]
+            )
+        session.rollback.assert_awaited_once()
+
+    async def test_does_not_touch_the_session_on_success(self) -> None:
+        session = MagicMock()
+        session.rollback = AsyncMock()
+
+        async def work() -> str:
+            return "ok"
+
+        assert await run_with_timeout(work(), operation="x", session=session) == "ok"
+        session.rollback.assert_not_awaited()
+
     async def test_default_ceiling_is_the_shared_constant(self) -> None:
         """Callers should not each invent their own budget."""
 
         async def work() -> int:
             return QUERY_TIMEOUT_SECONDS
 
-        assert await run_with_timeout(work(), operation="test") == 10
+        assert await run_with_timeout(work(), operation="test") == 8
+
+
+def test_server_ceiling_stays_below_the_client_timeout() -> None:
+    """The server budget must beat the client's, or the 504 never arrives.
+
+    frontend/src/api/config.ts sets API_TIMEOUT = 10000 ms. At an equal value
+    the two race and the client generally wins — its budget covers the whole
+    round trip while this one covers the query alone — so the user sees a
+    generic "server took too long" instead of a 504 naming the query. Raising
+    this above the client's timeout disables it for the browser entirely.
+    """
+    config = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / "frontend"
+        / "src"
+        / "api"
+        / "config.ts"
+    )
+    if not config.is_file():  # pragma: no cover - frontend absent in some checkouts
+        pytest.skip("frontend not present")
+    match = re.search(r"API_TIMEOUT\s*=\s*(\d+)", config.read_text(encoding="utf-8"))
+    assert match, "API_TIMEOUT not found in the client config"
+    client_ms = int(match.group(1))
+    assert client_ms > QUERY_TIMEOUT_SECONDS * 1000, (
+        f"server ceiling {QUERY_TIMEOUT_SECONDS}s is not below the client's "
+        f"{client_ms / 1000}s — the 504 would rarely reach the browser"
+    )


### PR DESCRIPTION
Closes #173.

## What the issue was really asking

Not "add rate limiting," but *"is the current state an oversight or a decision?"* — and it offered "deliberately decline" as a legitimate answer. Investigating produced a third answer.

## Rate limiting: the existing placement is correct

`check-duplicate` is a `useQuery` keyed on the name input with **no debounce**, so it fires on every keystroke past two characters. That is precisely the endpoint that needs throttling. `/entities/search`, which looks like the obvious typeahead, is debounced 300 ms in its hook and does not.

So "1 limiter among 20 endpoints" reads as accidental but is not. The rule is now written down in `api/query_protection.py`: **limit endpoints the client calls without debouncing; a client-side debounce achieves the same end, and neither is needed twice.**

A router-wide dependency is deliberately *not* applied. On a local install every request resolves to the same loopback address, so one bucket is shared by the whole interface, and a blanket limit turns ordinary bursts — infinite scroll, scan-job polling — into visible 429s.

## Timeouts: the real gap

Three reads whose cost scales with an entity's population rather than the requested page are now bounded:

| Endpoint | Why |
|---|---|
| `co-occurring` | 923 ms on the most connected entity; `MAX_COOCCURRING_LIMIT` bounds result size, not query cost |
| `{id}/videos` | merges mention- and tag-derived sets, then filters in Python |
| `{id}/phonetic-matches` | scores every candidate mention |

The paginated entity list is left alone — an indexed query bounded by limit/offset.

Adds `QueryTimeoutError` + `ErrorCode.QUERY_TIMEOUT` so a 504 flows through the RFC 7807 handler like every other error. The videos router builds its own `JSONResponse` for this, producing a 504 shaped differently from its own 404s; the new module documents that as the pattern not to copy.

## Two defects the first commit introduced, found by adversarial testing

Both were invisible to the unit tests. Second commit fixes them.

**The ceiling could not beat the client.** `QUERY_TIMEOUT_SECONDS` was 10; the client's `API_TIMEOUT` is 10000 ms — exactly equal. The two race and the client generally wins, since its budget covers the whole round trip while the server's covers the query alone. The 504 naming the hung query would have been real and unreachable from the browser, the only place it matters. Lowered to 8 s, with a test that reads the client config and fails if the relationship inverts.

**A cancelled query left the session unusable.** `asyncio.wait_for` cancels mid-flight, leaving the transaction failed; the next statement raises `PendingRollbackError` instead of the expected timeout. `run_with_timeout` now rolls back the session it is given.

Verified against a live connection that the pooled connection recovers cleanly — asyncpg cancels properly and the next request reused the same connection in 40 ms. The hazard was the session, not the pool, which is why a pool-level test would have shown green and proved nothing.

## Also

- Extracts `get_client_id` / `check_rate_limit` into `api/query_protection.py` — 66 duplicated lines removed from each of two routers.
- Replaces a self-referential assertion in the window-expiry test with one that states what it means.

## Tests

7,663 pass. `mypy --strict`, `ruff`, `black` clean. Every test guarding a subtle fix is mutation-verified: raising the ceiling above the client's fails the config test; removing window expiry fails the limiter test.

Manual pass: entity detail, appears-with panel with repeated "show more", entity video list pagination, videos list with an entity filter, and the create-entity name field — all normal after the refactor.
