### PR TITLE
chore: add a pre-push gate that reproduces CI locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,11 +191,22 @@ test-cov-dev:
 		--cov-report=term-missing \
 		--cov-report=html
 
+# Both select by directory rather than by marker. Selecting by marker meant
+# `test-unit` filtered on "unit", which no test carries and pytest.ini does not
+# declare: it deselected all 8,167 tests, collected none, and exited 0. And
+# `test-integration` filtered on "integration", a marker only 153 of the 1,308
+# tests under tests/integration/ actually carry — it ran 12% of the suite while
+# printing a pass.
+#
+# No marker exclusions here, unlike `pre-push`. That target mirrors CI, which
+# skips the docker and auth tests because a runner has neither Docker
+# credentials nor YouTube authentication. Locally you have both, so these run
+# everything; tests needing a database skip themselves when it is absent.
 test-unit:
-	$(POETRY_RUN) pytest $(TEST_DIR) -v -m "unit"
+	$(POETRY_RUN) pytest $(TEST_DIR)/unit/ -v
 
 test-integration:
-	$(POETRY_RUN) pytest $(TEST_DIR) -v -m "integration"
+	$(POETRY_RUN) pytest $(TEST_DIR)/integration/ -v
 
 test-integration-reset:
 	@echo "🔄 Resetting integration test database..."

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile for chronovista development (Poetry-based)
-.PHONY: help install install-dev clean test test-cov test-unit test-integration test-integration-reset lint format type-check quality pre-commit run build docs docs-serve docs-build docs-deploy dev dev-backend dev-frontend generate-api docker-build docker-up docker-down docker-logs docker-shell docker-db-shell docker-status docker-setup docker-clean docker-restart
+.PHONY: help install install-dev clean test test-cov test-unit test-integration test-integration-reset lint format type-check quality pre-commit pre-push run build docs docs-serve docs-build docs-deploy dev dev-backend dev-frontend generate-api docker-build docker-up docker-down docker-logs docker-shell docker-db-shell docker-status docker-setup docker-clean docker-restart
 
 # Default target
 help:
@@ -34,6 +34,7 @@ help:
 	@echo "  type-check        - Run type checking (mypy)"
 	@echo "  quality           - Run all checks (format-check + lint + type-check)"
 	@echo "  pre-commit        - Run pre-commit hooks on all files"
+	@echo "  pre-push          - Reproduce all four CI jobs locally before pushing"
 	@echo "  quick-check       - Quick format + lint check (src only)"
 	@echo ""
 	@echo "Development:"
@@ -235,6 +236,36 @@ quality: format-check lint type-check
 
 pre-commit:
 	$(POETRY_RUN) pre-commit run --all-files
+
+# Reproduces .github/workflows/test.yml step for step, so that a green run here
+# predicts a green CI run. Drift between the two defeats the whole purpose —
+# when you change one, change the other.
+#
+# Deliberately does NOT reuse `quality` or `test-unit`, despite the overlap:
+#   - `quality` also runs isort, which CI does not, so it can fail on something
+#     CI would pass.
+#   - `test-unit` selects `-m "unit"`, a marker no test in this repo carries. It
+#     collects zero tests and exits 0 — the exact false green this target exists
+#     to prevent.
+pre-push:
+	@echo "==> [1/6] ruff"
+	$(POETRY_RUN) ruff check $(SRC_DIR)/$(PACKAGE_NAME)/ $(TEST_DIR)/
+	@echo "==> [2/6] black --check"
+	$(POETRY_RUN) black --check $(SRC_DIR)/$(PACKAGE_NAME)/ $(TEST_DIR)/
+	@echo "==> [3/6] mypy --strict"
+	$(POETRY_RUN) mypy $(SRC_DIR)/$(PACKAGE_NAME)/ --strict --no-error-summary
+	@echo "==> [4/6] backend unit tests"
+	NO_COLOR=1 $(POETRY_RUN) pytest $(TEST_DIR)/unit/ -x -q -o "addopts=-v --strict-markers --strict-config" -m "not db"
+	@echo "==> [5/6] frontend type check + tests"
+	cd frontend && npm run typecheck && npx vitest run
+	@echo "==> [6/6] backend integration tests"
+	@docker exec chronovista-postgres-dev pg_isready -U dev_user -q 2>/dev/null || \
+		(echo "❌ Integration database unreachable. Start it with 'make dev-db-up'." && \
+		 echo "   Not skipping: CI runs this job, so passing without it would be a false green." && \
+		 exit 1)
+	NO_COLOR=1 $(POETRY_RUN) pytest $(TEST_DIR)/integration/ -q -o "addopts=-v --strict-markers --strict-config" -m "not docker and not slow and not auth and not db"
+	@echo ""
+	@echo "✅ pre-push passed — all four CI jobs reproduced locally"
 
 # Development targets
 run:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,9 +16,8 @@ poetry run pre-commit install
 # Create feature branch
 git checkout -b feature/your-feature
 
-# Make changes and test
-make quality
-make test
+# Make changes, then reproduce CI locally before pushing
+make pre-push
 
 # Submit pull request
 ```
@@ -44,11 +43,28 @@ See [Development Setup](development/setup.md) for detailed instructions.
 ### 4. Test Your Changes
 
 ```bash
-# Run all quality checks
-make quality
+# Reproduce every CI job locally, in CI's order, stopping at the first failure
+make pre-push
+```
 
-# Run tests with coverage
-make test-cov
+This mirrors `.github/workflows/test.yml` step for step: ruff, black, mypy
+`--strict`, backend unit tests, frontend type check and tests, and backend
+integration tests. A green run here is the closest thing to a guarantee that CI
+will agree. It needs the development database running (`make dev-db-up`) and
+fails rather than skipping if it is not — a skipped job cannot tell you anything.
+
+Prefer it over running the individual targets by hand. `make quality` also runs
+isort, which CI does not, so it can fail on something CI would pass; and a
+mistyped flag in a hand-run `pytest` can report success having collected no
+tests at all.
+
+While iterating, the narrower targets are still useful:
+
+```bash
+make format       # Apply black + isort
+make lint         # ruff only
+make type-check   # mypy only
+make test-cov     # Full suite with the 90% coverage threshold
 ```
 
 ### 5. Submit Pull Request

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -53,7 +53,8 @@ chronovista follows these principles:
 
 ```bash
 # Quality checks
-make quality          # All checks
+make pre-push         # Reproduce every CI job locally (run this before pushing)
+make quality          # format-check + lint + type-check
 make format           # Format code
 make lint             # Linting
 make type-check       # mypy

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -13,6 +13,16 @@ chronovista maintains **90%+ test coverage** with:
 
 ## Running Tests
 
+### Before pushing
+
+```bash
+make pre-push
+```
+
+Runs every CI job locally in CI's order — lint, format, types, backend unit,
+frontend, backend integration — and stops at the first failure. This is the one
+to run before opening a pull request; the commands below are for iterating.
+
 ### Quick Commands
 
 ```bash


### PR DESCRIPTION
Adds `make pre-push`, which runs all four CI jobs locally in CI's order and stops on the first failure.

## Why

Running the four jobs by hand is six commands, and getting one subtly wrong is easy. A bad pytest flag piped to `tail` returns *tail's* exit code — the run reports success having executed nothing. That happened during this week's outage and cost a round trip to find.

## It mirrors the workflow rather than composing existing targets

That looks like duplication and isn't. Neither existing target is safe to build on:

| Target | Problem |
|---|---|
| `quality` | also runs isort, which CI does not — it can fail on something CI would pass |
| `test-unit` | selects `-m "unit"`, **a marker no test in this repo carries** |

`make test-unit` deselects all 8,167 tests, collects zero, and exits 0. It has been reporting success while running nothing. Reusing it would have baked that false green into the new gate — so the target inlines CI's exact invocations instead, with a comment saying why, and the two must be changed together.

Fixing `test-unit` itself is left to a separate change; it's a different concern from adding the gate.

## Two design choices

**A missing database fails, it does not skip.** CI runs the integration job, so passing without it would be a false green — the precise thing this target exists to prevent. The error names the fix.

**It adopts CI's marker filter** (`not docker and not slow and not auth and not db`), which excludes the Docker build test. That test needs a working local credential helper and is something CI never evaluates, so failing on it locally would be stricter than the gate it is meant to predict.

## Verified in both directions

Asserting a gate passes proves nothing unless it can also fail:

- Malformed file in `src/chronovista/` → halts at the black step, **exit code 2**, steps 3-6 never run
- Clean tree → all six steps, ending `1217 passed, 23 skipped, 66 deselected` on integration and the success banner

The 66 deselected are the marker filter working as intended.

## Docs (second commit)

`contributing.md` told contributors to run `make quality` and `make test-cov` before submitting. Neither predicts CI — `quality` adds isort, which CI does not run, and `test-cov` applies a 90% coverage threshold CI never checks. The documented ritual could redden a branch on arrival, or block one CI would have accepted.

Replaced with `make pre-push` in the Quick Start and in step 4, with the narrower targets kept for iterating. Also added to `development/index.md`, and to the top of `development/testing.md` above the per-suite commands.

Deliberately untouched: the `make test-unit` / `make test-integration` references in those files. Repairing those targets is a separate change.

## Scope

Four files. `Makefile` gains the target, a `.PHONY` entry and a help line; three docs files point at it. No behaviour change to any existing target.


## Third commit: repairing the two targets that lied

Folded in rather than split off — same defect, same investigation, and the docs above already reference both targets.

Both selected tests by marker, and both markers were wrong:

| Target | Tests in its directory | What it actually ran |
|---|---|---|
| `test-unit` | 6,843 | **0** — `unit` is undeclared in `pytest.ini` and carried by no test |
| `test-integration` | 1,308 | **153** — only 12% carry the `integration` marker |

`test-unit` is the honest failure: collects nothing, and you would eventually notice. `test-integration` is the dangerous one — it ran, printed a credible pass, and silently skipped 88% of the suite.

Both now select by directory, which is what the documentation always claimed. No doc rewording needed as a result: "Unit tests only" and "Integration tests only" simply become true.

**No marker exclusions here, deliberately** — unlike `pre-push`, which mirrors CI. CI skips the `docker` and `auth` tests because a runner has neither Docker credentials nor YouTube authentication; a developer has both, and the integration testing docs already tell you to authenticate first.

Verified: `test-unit` now runs 6,828 passed / 15 skipped; `test-integration` 1,283 passed / 23 skipped.
