### PR TITLE
fix(entities): scope --new-entities-only across every scan source (0.65.1)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.65.1] - 2026-08-07
+
+### Fixed
+- **`entities scan --new-entities-only` now scopes every source, not just transcripts.** Two defects compounded. (1) `scan_metadata()` took no `new_entities_only` parameter and passed a hardcoded `False` to `_load_entity_patterns`, while `scan()` honoured it — so `--sources transcript,title,description` scoped the transcript half to zero-mention entities and silently ran the metadata half across every active entity. Measured: a dry run reported **139,845 mentions across 369 entities** where 27 were expected, and 277s instead of 31s. (2) With that fixed, the zero-mention set was still re-evaluated *per phase*: the transcript scan runs first and writes, so by the time the metadata scan loaded its patterns those entities no longer had zero mentions and were filtered out — **23 of 32 newly created entities ended up with transcript mentions only**, missing titles and descriptions entirely, which is the surface with 100% coverage rather than 2.4% and the one ASR does not mangle. The CLI now resolves the set once, before any phase runs, and passes it to both calls as explicit `entity_ids`. Backend-only; no schema change, no migration.
+- The two scan entry points maintain parallel filter parameters by hand and had drifted by exactly this one. A signature test now pins them together so the next drift fails in CI rather than in production.
+
+
 ## [0.65.0] - 2026-08-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chronovista"
-version = "0.65.0"
+version = "0.65.1"
 description = "Personal YouTube data analytics tool for comprehensive access to your YouTube engagement history"
 authors = ["chronovista <noreply@chronovista.dev>"]
 maintainers = ["chronovista <noreply@chronovista.dev>"]

--- a/scripts/utilities/gen_private_terms.py
+++ b/scripts/utilities/gen_private_terms.py
@@ -80,6 +80,10 @@ COMMON_WORD_ALIASES = {
     "Mate",
     "Peek",
     "Sham",
+    # An ASR mis-transcription registered as an alias, and also a Python
+    # keyword: it fires on every `# type: ignore` pragma, which `mypy --strict`
+    # requires throughout the codebase.
+    "Type",
     "Web",
 }
 

--- a/src/chronovista/__init__.py
+++ b/src/chronovista/__init__.py
@@ -7,7 +7,7 @@ their personal YouTube account data using the YouTube Data API.
 
 from __future__ import annotations
 
-__version__ = "0.65.0"
+__version__ = "0.65.1"
 __author__ = "chronovista"
 __email__ = "noreply@chronovista.dev"
 __license__ = "AGPL-3.0-or-later"

--- a/src/chronovista/cli/entity_commands.py
+++ b/src/chronovista/cli/entity_commands.py
@@ -1072,6 +1072,31 @@ def scan_entities(
             effective_new_entities_only = False
             effective_entity_ids = [parsed_entity_uuid]
 
+        elif new_entities_only:
+            # Resolve the zero-mention set ONCE and express it as explicit ids.
+            #
+            # `--sources transcript,title,description` dispatches two service
+            # calls, and each would otherwise re-evaluate "has zero mentions"
+            # against the database. The transcript scan runs first and writes,
+            # so by the time the metadata scan loads its patterns those entities
+            # are no longer new and get filtered out — 23 of 32 entities ended up
+            # with transcript mentions only, missing titles and descriptions
+            # entirely, which is the surface with 100% coverage rather than 2.4%.
+            #
+            # Pinning the set up front makes the scope identical for every phase
+            # regardless of what earlier phases wrote.
+            async for session in db_manager.get_session(echo=False):
+                mention_repo = EntityMentionRepository()
+                effective_entity_ids = (
+                    await mention_repo.get_entities_with_zero_mentions(
+                        session, entity_type=entity_type
+                    )
+                )
+            effective_new_entities_only = False
+            if not effective_entity_ids:
+                console.print("[yellow]No entities with zero mentions.[/yellow]")
+                return
+
         # Determine which service calls to make based on parsed_sources
         transcript_sources = ["transcript"] if "transcript" in parsed_sources else []
         metadata_sources = [s for s in parsed_sources if s != "transcript"]
@@ -1111,6 +1136,7 @@ def scan_entities(
                         batch_size=batch_size,
                         dry_run=True,
                         full_rescan=full,
+                        new_entities_only=effective_new_entities_only,
                         entity_ids=effective_entity_ids,
                     )
 
@@ -1242,6 +1268,7 @@ def scan_entities(
                         batch_size=batch_size,
                         dry_run=False,
                         full_rescan=full,
+                        new_entities_only=effective_new_entities_only,
                         entity_ids=effective_entity_ids,
                         progress_callback=_progress_callback,
                     )

--- a/src/chronovista/services/entity_mention_scan_service.py
+++ b/src/chronovista/services/entity_mention_scan_service.py
@@ -494,6 +494,7 @@ class EntityMentionScanService:
         batch_size: int = 500,
         dry_run: bool = False,
         full_rescan: bool = False,
+        new_entities_only: bool = False,
         entity_ids: list[uuid.UUID] | None = None,
         progress_callback: Callable[[int, int], None] | None = None,
     ) -> ScanResult:
@@ -550,7 +551,7 @@ class EntityMentionScanService:
             patterns = await self._load_entity_patterns(
                 session,
                 entity_type=entity_type,
-                new_entities_only=False,
+                new_entities_only=new_entities_only,
                 entity_ids=entity_ids,
             )
 

--- a/tests/unit/cli/test_entity_commands_scan_new_entities_only.py
+++ b/tests/unit/cli/test_entity_commands_scan_new_entities_only.py
@@ -1,0 +1,228 @@
+"""
+Unit tests for ``entities scan --new-entities-only`` scope stability.
+
+Regression coverage for a defect where the zero-mention set was re-evaluated
+*per scan phase*. ``--sources transcript,title,description`` dispatches two
+service calls; the transcript call runs first and writes mentions, so by the time
+the metadata call loaded its patterns those entities no longer had zero mentions
+and were filtered out.
+
+Observed: of 32 newly created entities, **23 ended up with transcript mentions
+only** and none from titles or descriptions — the surface with 100% coverage
+rather than 2.4%, and the one that is not mangled by ASR.
+
+The fix resolves the set once, before any phase runs, and passes it to both calls
+as explicit ``entity_ids``. These tests assert on *what the service receives*,
+because both the fixed and broken versions produce a successful-looking run.
+
+All external dependencies are mocked; only CLI option handling is exercised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from chronovista.cli.entity_commands import entity_app
+
+
+def _make_scan_result(**kwargs: Any) -> MagicMock:
+    """Mock ScanResult with the fields the CLI summary reads."""
+    result = MagicMock()
+    result.segments_scanned = kwargs.get("segments_scanned", 0)
+    result.videos_scanned = kwargs.get("videos_scanned", 0)
+    result.mentions_found = kwargs.get("mentions_found", 0)
+    result.mentions_skipped = 0
+    result.skipped_exclusion_pattern = 0
+    result.skipped_longest_match = 0
+    result.unique_entities = 0
+    result.unique_videos = 0
+    result.duration_seconds = 0.1
+    result.dry_run = kwargs.get("dry_run", False)
+    result.dry_run_matches = kwargs.get("dry_run_matches", [])
+    result.failed_batches = 0
+    return result
+
+
+def _session_generator() -> AsyncGenerator[Any, None]:
+    async def _gen() -> AsyncGenerator[Any, None]:
+        yield AsyncMock()
+
+    return _gen()
+
+
+def _run_coro(coro: object) -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(coro)  # type: ignore[arg-type]
+    finally:
+        loop.close()
+
+
+class TestNewEntitiesOnlyScopeIsStable:
+    """The zero-mention set must be pinned before any scan phase runs."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    def _invoke(
+        self, runner: CliRunner, zero_mention_ids: list[uuid.UUID], sources: str
+    ) -> tuple[Any, Any]:
+        """Run the command; return the kwargs each service call received."""
+        service = MagicMock()
+        service.scan = AsyncMock(return_value=_make_scan_result())
+        service.scan_metadata = AsyncMock(return_value=_make_scan_result())
+
+        repo = MagicMock()
+        repo.get_entities_with_zero_mentions = AsyncMock(return_value=zero_mention_ids)
+
+        with (
+            patch(
+                "chronovista.cli.entity_commands.db_manager.get_session",
+                return_value=_session_generator(),
+            ),
+            patch(
+                "chronovista.cli.entity_commands.EntityMentionScanService",
+                return_value=service,
+            ),
+            patch(
+                "chronovista.cli.entity_commands.EntityMentionRepository",
+                return_value=repo,
+            ),
+            patch(
+                "chronovista.cli.entity_commands.asyncio.run",
+                side_effect=_run_coro,
+            ),
+        ):
+            runner.invoke(
+                entity_app,
+                ["scan", "--new-entities-only", "--sources", sources, "--dry-run"],
+            )
+
+        scan_kwargs = service.scan.call_args.kwargs if service.scan.call_args else None
+        meta_kwargs = (
+            service.scan_metadata.call_args.kwargs
+            if service.scan_metadata.call_args
+            else None
+        )
+        return scan_kwargs, meta_kwargs
+
+    def test_both_phases_receive_the_same_entity_ids(self, runner: CliRunner) -> None:
+        """The regression: the metadata phase must not re-derive its own scope.
+
+        Re-deriving it after the transcript phase has written means the second
+        phase sees a smaller set — which is how 23 of 32 entities were left
+        without title or description mentions.
+        """
+        ids = [uuid.uuid4(), uuid.uuid4(), uuid.uuid4()]
+        scan_kwargs, meta_kwargs = self._invoke(
+            runner, ids, "transcript,title,description"
+        )
+
+        assert scan_kwargs is not None, "transcript phase was not dispatched"
+        assert meta_kwargs is not None, "metadata phase was not dispatched"
+        assert scan_kwargs["entity_ids"] == ids
+        assert meta_kwargs["entity_ids"] == ids
+
+    def test_scope_is_resolved_once_not_per_phase(self, runner: CliRunner) -> None:
+        """The zero-mention query must run a single time for the whole command."""
+        service = MagicMock()
+        service.scan = AsyncMock(return_value=_make_scan_result())
+        service.scan_metadata = AsyncMock(return_value=_make_scan_result())
+        repo = MagicMock()
+        repo.get_entities_with_zero_mentions = AsyncMock(return_value=[uuid.uuid4()])
+
+        with (
+            patch(
+                "chronovista.cli.entity_commands.db_manager.get_session",
+                return_value=_session_generator(),
+            ),
+            patch(
+                "chronovista.cli.entity_commands.EntityMentionScanService",
+                return_value=service,
+            ),
+            patch(
+                "chronovista.cli.entity_commands.EntityMentionRepository",
+                return_value=repo,
+            ),
+            patch("chronovista.cli.entity_commands.asyncio.run", side_effect=_run_coro),
+        ):
+            runner.invoke(
+                entity_app,
+                [
+                    "scan",
+                    "--new-entities-only",
+                    "--sources",
+                    "transcript,title,description",
+                    "--dry-run",
+                ],
+            )
+
+        assert repo.get_entities_with_zero_mentions.await_count == 1
+
+    def test_flag_is_converted_to_explicit_ids(self, runner: CliRunner) -> None:
+        """Once the set is pinned, the flag itself must not be forwarded.
+
+        Passing both would let the service re-filter and reintroduce the drift.
+        """
+        ids = [uuid.uuid4()]
+        scan_kwargs, meta_kwargs = self._invoke(runner, ids, "transcript,title")
+
+        assert scan_kwargs["new_entities_only"] is False
+        assert meta_kwargs["new_entities_only"] is False
+        assert scan_kwargs["entity_ids"] == ids
+        assert meta_kwargs["entity_ids"] == ids
+
+    def test_metadata_only_sources_still_scoped(self, runner: CliRunner) -> None:
+        """Without a transcript phase the scope must still be applied."""
+        ids = [uuid.uuid4(), uuid.uuid4()]
+        scan_kwargs, meta_kwargs = self._invoke(runner, ids, "title,description")
+
+        assert scan_kwargs is None, "no transcript phase should be dispatched"
+        assert meta_kwargs is not None
+        assert meta_kwargs["entity_ids"] == ids
+
+    def test_no_zero_mention_entities_exits_without_scanning(
+        self, runner: CliRunner
+    ) -> None:
+        """An empty set must stop, not fall through to scanning everything.
+
+        Treating "nothing is new" as "no filter" is how the original bug
+        expressed itself.
+        """
+        service = MagicMock()
+        service.scan = AsyncMock(return_value=_make_scan_result())
+        service.scan_metadata = AsyncMock(return_value=_make_scan_result())
+        repo = MagicMock()
+        repo.get_entities_with_zero_mentions = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "chronovista.cli.entity_commands.db_manager.get_session",
+                return_value=_session_generator(),
+            ),
+            patch(
+                "chronovista.cli.entity_commands.EntityMentionScanService",
+                return_value=service,
+            ),
+            patch(
+                "chronovista.cli.entity_commands.EntityMentionRepository",
+                return_value=repo,
+            ),
+            patch("chronovista.cli.entity_commands.asyncio.run", side_effect=_run_coro),
+        ):
+            result = runner.invoke(
+                entity_app,
+                ["scan", "--new-entities-only", "--sources", "title", "--dry-run"],
+            )
+
+        service.scan.assert_not_awaited()
+        service.scan_metadata.assert_not_awaited()
+        assert "No entities with zero mentions" in result.output

--- a/tests/unit/services/test_scan_metadata_new_entities_only.py
+++ b/tests/unit/services/test_scan_metadata_new_entities_only.py
@@ -1,0 +1,188 @@
+"""
+Tests for ``scan_metadata(new_entities_only=...)``.
+
+Regression coverage for a defect where ``scan_metadata()`` accepted no
+``new_entities_only`` parameter and passed a hardcoded ``False`` to
+``_load_entity_patterns``. ``scan()`` honoured the flag, so
+``entities scan --new-entities-only --sources transcript,title,description``
+scoped the transcript half to zero-mention entities while the metadata half
+silently ran across every active entity.
+
+Observed before the fix: a dry run reported 139,845 mentions across 369 entities
+where 27 were expected.
+
+The parameter is the whole subject here, so every test asserts on what
+``_load_entity_patterns`` received rather than on scan output — output would look
+identical whether the flag was honoured or ignored, which is precisely why the
+bug survived.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chronovista.services.entity_mention_scan_service import (
+    EntityMentionScanService,
+)
+
+# CRITICAL: Module-level asyncio marker ensures async tests run properly
+# with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
+pytestmark = pytest.mark.asyncio
+
+
+def _make_session_factory() -> MagicMock:
+    """Session factory whose session yields no rows — enough to reach pattern
+    loading, which is all these tests inspect."""
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+
+    empty = MagicMock()
+    empty.all.return_value = []
+    empty.scalars.return_value.all.return_value = []
+    session.execute.return_value = empty
+
+    factory = MagicMock()
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    factory.return_value = ctx
+    return factory
+
+
+def _spy_on_pattern_loading(service: Any) -> dict[str, Any]:
+    """Replace ``_load_entity_patterns`` with a recorder returning no patterns."""
+    captured: dict[str, Any] = {}
+
+    async def _fake(
+        session: Any,
+        entity_type: Any = None,
+        new_entities_only: Any = False,
+        entity_ids: Any = None,
+    ) -> list[Any]:
+        captured["entity_type"] = entity_type
+        captured["new_entities_only"] = new_entities_only
+        captured["entity_ids"] = entity_ids
+        return []
+
+    service._load_entity_patterns = _fake  # type: ignore[method-assign]
+    return captured
+
+
+class TestScanMetadataHonoursNewEntitiesOnly:
+    """``scan_metadata`` must forward the flag, not hardcode it."""
+
+    async def test_flag_true_is_forwarded(self) -> None:
+        """new_entities_only=True must reach _load_entity_patterns.
+
+        This is the regression: the call site previously passed a literal False.
+        """
+        service = EntityMentionScanService(_make_session_factory())
+        captured = _spy_on_pattern_loading(service)
+
+        await service.scan_metadata(sources=["title"], new_entities_only=True)
+
+        assert captured["new_entities_only"] is True
+
+    async def test_flag_defaults_to_false(self) -> None:
+        """Omitting the flag must scan every active entity, as before."""
+        service = EntityMentionScanService(_make_session_factory())
+        captured = _spy_on_pattern_loading(service)
+
+        await service.scan_metadata(sources=["description"])
+
+        assert captured["new_entities_only"] is False
+
+    async def test_flag_false_is_forwarded(self) -> None:
+        """Explicit False behaves the same as omitting it."""
+        service = EntityMentionScanService(_make_session_factory())
+        captured = _spy_on_pattern_loading(service)
+
+        await service.scan_metadata(sources=["title"], new_entities_only=False)
+
+        assert captured["new_entities_only"] is False
+
+    async def test_flag_composes_with_entity_type(self) -> None:
+        """Both filters must arrive together, not one replacing the other."""
+        service = EntityMentionScanService(_make_session_factory())
+        captured = _spy_on_pattern_loading(service)
+
+        await service.scan_metadata(
+            sources=["title", "description"],
+            entity_type="person",
+            new_entities_only=True,
+        )
+
+        assert captured["new_entities_only"] is True
+        assert captured["entity_type"] == "person"
+
+    async def test_flag_composes_with_entity_ids(self) -> None:
+        """Explicit ids and the flag are an AND filter, per _load_entity_patterns."""
+        service = EntityMentionScanService(_make_session_factory())
+        captured = _spy_on_pattern_loading(service)
+        ids = [uuid.uuid4(), uuid.uuid4()]
+
+        await service.scan_metadata(
+            sources=["title"], new_entities_only=True, entity_ids=ids
+        )
+
+        assert captured["new_entities_only"] is True
+        assert captured["entity_ids"] == ids
+
+
+class TestScanAndScanMetadataAgree:
+    """The two entry points maintain parallel parameter lists by hand.
+
+    They had already drifted by exactly this parameter. These tests pin the
+    signatures together so the next drift fails here rather than in production.
+    """
+
+    async def test_both_forward_the_flag_identically(self) -> None:
+        """scan() and scan_metadata() must pass the same value through."""
+        results: dict[str, Any] = {}
+
+        for name, kwargs in (
+            ("scan", {}),
+            ("scan_metadata", {"sources": ["title"]}),
+        ):
+            service = EntityMentionScanService(_make_session_factory())
+            captured = _spy_on_pattern_loading(service)
+            await getattr(service, name)(new_entities_only=True, **kwargs)
+            results[name] = captured["new_entities_only"]
+
+        assert results["scan"] is True
+        assert results["scan_metadata"] is True
+        assert results["scan"] == results["scan_metadata"]
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestWarning")
+    async def test_scan_metadata_accepts_every_filter_scan_does(self) -> None:
+        """Filter parameters must not drift apart again.
+
+        ``progress_callback`` and the source/segment-specific parameters are
+        excluded: they are genuinely per-method. Everything that narrows *which
+        entities* are scanned must exist on both.
+        """
+        import inspect
+
+        shared = {
+            "entity_type",
+            "video_ids",
+            "language_code",
+            "batch_size",
+            "dry_run",
+            "full_rescan",
+            "new_entities_only",
+            "entity_ids",
+        }
+        scan_params = set(inspect.signature(EntityMentionScanService.scan).parameters)
+        meta_params = set(
+            inspect.signature(EntityMentionScanService.scan_metadata).parameters
+        )
+
+        assert shared <= scan_params, shared - scan_params
+        assert shared <= meta_params, shared - meta_params


### PR DESCRIPTION
## Summary

`entities scan --new-entities-only --sources transcript,title,description` scoped only the
transcript half. Two defects compounded, and **both produced a successful-looking run** —
which is why neither showed up in output and why the tests here assert on what the service
*receives* rather than on the scan summary.

## The two bugs

**1. `scan_metadata()` ignored the flag.** It took no `new_entities_only` parameter and passed
a hardcoded `False` to `_load_entity_patterns`, while `scan()` forwarded it correctly.

```python
# scan()                                  # scan_metadata()
new_entities_only=new_entities_only,      new_entities_only=False,   # <-- hardcoded
```

Measured before the fix:

| | entities | mentions | time |
|---|---|---|---|
| expected | 27 | ~6,500 | ~31 s |
| **actual** | **369** | **139,845** | **277 s** |

**2. With that fixed, the scope was still re-evaluated per phase.** `--sources
transcript,title,description` dispatches two service calls. The transcript call runs first
and *writes*; by the time the metadata call loaded its patterns, those entities no longer had
zero mentions and were filtered out.

Effect on 32 newly created entities:

| | before | after |
|---|---|---|
| both sources | 2 | 25 |
| **transcript only** | **23** | **0** |
| metadata only | 7 | 7 |

Twenty-three entities were left with transcript mentions only — the surface covering **2.4%**
of the library, where ASR mangles names — while missing titles and descriptions, which cover
**100%** and are human-written. One entity ended with 3 transcript mentions and zero
metadata, despite appearing in 339 titles and 295 descriptions.

## The fix

- `scan_metadata()` accepts and forwards `new_entities_only`.
- The CLI resolves the zero-mention set **once**, before any phase runs, and passes it to both
  calls as explicit `entity_ids`. The flag is not forwarded alongside the ids, so the service
  cannot re-filter and reintroduce the drift.
- An empty set stops the command rather than falling through to scanning everything —
  treating "nothing is new" as "no filter" is how the first bug expressed itself.

## Root cause worth naming

`scan()` and `scan_metadata()` maintain **parallel filter parameter lists by hand** and had
drifted by exactly this one. The same drift was duplicated in the CLI, which passed the flag to
one call and not the other.

A signature test now pins the shared filter parameters together, so the next drift fails in CI.
The structural fix — a shared filter object making drift unrepresentable — is deliberately out
of scope here.

That parallel structure is not hypothetical: while mutation-testing, my first attempt
string-matched a block that appears in *both* methods and silently mutated the wrong one. Only
one test failed and I nearly accepted that as the result.

## Tests

12 new tests, both fixes mutation-verified:

| mutation | tests killed |
|---|---|
| restore the hardcoded `new_entities_only=False` | 4 of 7 |
| revert the CLI resolve-once block | 5 of 5 |

## Also included

`scripts/utilities/gen_private_terms.py` — added `Type` to `COMMON_WORD_ALIASES`. It entered the
term list as an **ASR mis-transcription registered as an alias**, and being a Python keyword it
fired on every `# type: ignore` pragma, which `mypy --strict` requires. Without this the commit
could not be made at all. `Crystal` was already in that set, so this class has bitten before —
**567 `asr_error` aliases feed the term list** and the sample is full of ordinary
words and name fragments. Worth a follow-up on whether `asr_error` aliases belong in the
generator's query at all, given they are transcription noise rather than names anyone chose.

## Verification

- Backend unit **6,830 passed**, 15 skipped
- Integration **1,340 passed**, 23 skipped, 2 xpassed
- `ruff` · `black` · `mypy --strict` clean
- Version **0.65.0 → 0.65.1**; frontend untouched at 0.32.0

Backend-only. No schema change, no migration, no frontend change.

