### PR TITLE
fix(tooling): make the local toolchain tell the truth (#159, #160, #163, #158)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,9 +292,15 @@ backups/
 specs/
 src/chronovista/docs/
 
-# Frontend generated files (Orval)
-frontend/src/api/*.ts
-!frontend/src/api/config.ts
+# Frontend generated files (Orval). Orval writes only into this directory —
+# see `target` in frontend/orval.config.ts. Everything directly under
+# frontend/src/api is hand-written and belongs in git.
+#
+# This replaces `frontend/src/api/*.ts` with a single `!config.ts` exception,
+# which silently ignored the other five hand-written modules; they survive only
+# because they were tracked before the rule was added. A new module was ignored
+# with no error, which is how one was nearly lost during Feature 061.
+frontend/src/api/generated/
 
 # Frontend dependencies and build
 frontend/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -545,10 +545,29 @@ export-requirements:
 # Frontend API Generation
 # NOTE: Requires backend to be running on port 8765 before execution
 # Start with: make dev-backend (in separate terminal) OR make dev
+# The spec is fetched to a temp file and validated before it replaces
+# contracts/openapi.json, and orval only runs if that succeeded. The old form,
+#
+#     curl -s http://localhost:8765/openapi.json > contracts/openapi.json
+#
+# had two failure modes that both ended with orval running against rubbish:
+# the shell truncates the target file before curl runs, so a connection failure
+# leaves an empty spec; and `curl -s` exits 0 on any HTTP response, so a proxy
+# error page or an HTML 404 is written out as if it were the spec.
+#
+# That matters because orval writes into frontend/src/api, where the API client
+# is hand-written, not generated. See `clean` in frontend/orval.config.ts.
+API_SPEC_URL ?= http://localhost:8765/openapi.json
+
 generate-api:
-	@echo "Exporting OpenAPI spec..."
-	@echo "NOTE: Backend must be running on port 8765"
-	curl -s http://localhost:8765/openapi.json > contracts/openapi.json
+	@echo "Exporting OpenAPI spec from $(API_SPEC_URL)..."
+	@set -e; \
+	tmp=contracts/openapi.json.tmp; \
+	trap 'rm -f $$tmp' EXIT; \
+	curl --fail --silent --show-error $(API_SPEC_URL) -o $$tmp; \
+	python3 -c "import json,sys; d=json.load(open('$$tmp')); sys.exit(0 if isinstance(d, dict) and d.get('openapi') and d.get('paths') else 1)" 2>/dev/null \
+		|| { echo "❌ $(API_SPEC_URL) did not return an OpenAPI document — refusing to generate."; exit 1; }; \
+	mv $$tmp contracts/openapi.json
 	@echo "Generating TypeScript client..."
 	cd frontend && npm run generate-api
 	@echo "API client generated successfully!"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ help:
 	@echo ""
 	@echo "Code Quality:"
 	@echo "  lint              - Run linting (ruff)"
-	@echo "  format            - Format code (black + isort)"
+	@echo "  format            - Format code (black + ruff import sort)"
 	@echo "  format-check      - Check formatting without modifying files"
 	@echo "  type-check        - Run type checking (mypy)"
 	@echo "  quality           - Run all checks (format-check + lint + type-check)"
@@ -228,19 +228,26 @@ test-fast:
 	$(POETRY_RUN) pytest $(TEST_DIR) -v --tb=short -x -q --disable-warnings --no-header --no-cov
 
 # Code quality targets
+#
+# These mirror the static checks in .github/workflows/test.yml. Import ordering is
+# owned by ruff's `I` rule (enabled in pyproject) — standalone isort is deliberately
+# NOT run here. The two tools are configured separately and disagree, so satisfying
+# isort pushes files into a state ruff rejects, breaking the gate CI actually runs.
 lint:
-	$(POETRY_RUN) ruff check $(SRC_DIR) $(TEST_DIR)
+	$(POETRY_RUN) ruff check $(SRC_DIR)/$(PACKAGE_NAME)/ $(TEST_DIR)/
 
 format:
-	$(POETRY_RUN) black $(SRC_DIR) $(TEST_DIR)
-	$(POETRY_RUN) isort $(SRC_DIR) $(TEST_DIR)
+	$(POETRY_RUN) black $(SRC_DIR)/$(PACKAGE_NAME)/ $(TEST_DIR)/
+	$(POETRY_RUN) ruff check --select I --fix $(SRC_DIR)/$(PACKAGE_NAME)/ $(TEST_DIR)/
 
 format-check:
-	$(POETRY_RUN) black --check $(SRC_DIR) $(TEST_DIR)
-	$(POETRY_RUN) isort --check-only $(SRC_DIR) $(TEST_DIR)
+	$(POETRY_RUN) black --check $(SRC_DIR)/$(PACKAGE_NAME)/ $(TEST_DIR)/
 
+# --strict, and src only. CI does not type-check tests/; running them here reports
+# 69 errors that no gate enforces, which makes the target unpassable and trains
+# people to ignore it.
 type-check:
-	$(POETRY_RUN) mypy $(SRC_DIR)/ $(TEST_DIR)/
+	$(POETRY_RUN) mypy $(SRC_DIR)/$(PACKAGE_NAME)/ --strict --no-error-summary
 
 quality: format-check lint type-check
 	@echo "✅ All quality checks passed!"
@@ -252,12 +259,13 @@ pre-commit:
 # predicts a green CI run. Drift between the two defeats the whole purpose —
 # when you change one, change the other.
 #
-# Deliberately does NOT reuse `quality` or `test-unit`, despite the overlap:
-#   - `quality` also runs isort, which CI does not, so it can fail on something
-#     CI would pass.
-#   - `test-unit` selects `-m "unit"`, a marker no test in this repo carries. It
-#     collects zero tests and exits 0 — the exact false green this target exists
-#     to prevent.
+# Deliberately does NOT reuse `test-unit`, despite the overlap: it selects
+# `-m "unit"`, a marker no test in this repo carries. It collects zero tests and
+# exits 0 — the exact false green this target exists to prevent.
+#
+# `quality` now runs the same three static checks as CI, so the steps below
+# duplicate it on purpose: this target must stay readable as a literal
+# transcription of the workflow, not a call into something that could drift.
 pre-push:
 	@echo "==> [1/6] ruff"
 	$(POETRY_RUN) ruff check $(SRC_DIR)/$(PACKAGE_NAME)/ $(TEST_DIR)/
@@ -460,10 +468,9 @@ ci-test:
 		--tb=short
 
 ci-quality:
-	$(POETRY_RUN) ruff check $(SRC_DIR) $(TEST_DIR) --output-format=github
-	$(POETRY_RUN) black --check $(SRC_DIR) $(TEST_DIR)
-	$(POETRY_RUN) isort --check-only $(SRC_DIR) $(TEST_DIR)
-	$(POETRY_RUN) mypy $(SRC_DIR)
+	$(POETRY_RUN) ruff check $(SRC_DIR)/$(PACKAGE_NAME)/ $(TEST_DIR)/ --output-format=github
+	$(POETRY_RUN) black --check $(SRC_DIR)/$(PACKAGE_NAME)/ $(TEST_DIR)/
+	$(POETRY_RUN) mypy $(SRC_DIR)/$(PACKAGE_NAME)/ --strict --no-error-summary
 
 ci: ci-quality ci-test
 	@echo "✅ CI checks complete!"

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -414,7 +414,7 @@ Audit log for tag normalization and management operations.
 
 **Constraints:**
 
-- CHECK `chk_tag_operation_type_valid`: `operation_type IN ('merge', 'split', 'rename', 'delete', 'create')`
+- CHECK `chk_tag_operation_type_valid`: `operation_type IN ('merge', 'split', 'rename', 'delete', 'create', 'repair')`
 
 ## Named Entities
 
@@ -463,6 +463,7 @@ Alternative names and variations for named entities.
 | `alias_name` | VARCHAR(500) | no |  |  |
 | `alias_name_normalized` | VARCHAR(500) | no |  |  |
 | `alias_type` | VARCHAR(30) | no | `'name_variant'` |  |
+| `case_sensitive` | BOOLEAN | no | `false` |  |
 | `occurrence_count` | INTEGER | no | `0` |  |
 | `first_seen_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
 | `last_seen_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -5,14 +5,15 @@ node_modules/
 dist/
 build/
 
-# Generated API client (regenerated from OpenAPI)
-src/api/*.ts
-!src/api/config.ts
-!src/api/batchCorrections.ts
-!src/api/entityMentions.ts
-!src/api/onboarding.ts
-!src/api/settings.ts
-!src/api/overview.ts
+# Generated API client (regenerated from OpenAPI by `make generate-api`).
+#
+# Orval writes only into this directory — see `target` in orval.config.ts. The
+# modules directly under src/api are hand-written and tracked.
+#
+# This replaces an ignore-all-then-whitelist rule over `src/api/*.ts`, which
+# required every new hand-written module to be added by hand or it was silently
+# untracked. Separating generated output by directory removes that step.
+src/api/generated/
 
 # Environment
 .env

--- a/frontend/orval.config.ts
+++ b/frontend/orval.config.ts
@@ -7,10 +7,18 @@ export default defineConfig({
     },
     output: {
       mode: "tags-split",
-      target: "./src/api",
-      schemas: "./src/api/models",
+      // Generated output is kept in its own directory. The modules directly
+      // under src/api (config, settings, onboarding, batchCorrections,
+      // entityMentions, overview) are HAND-WRITTEN and tracked in git —
+      // generating into that directory would put orval's file management in
+      // charge of files it did not create.
+      target: "./src/api/generated",
+      schemas: "./src/api/generated/models",
       client: "react-query",
       httpClient: "fetch",
+      // `clean` deletes everything in `target` that this run did not produce.
+      // Scoped to the generated directory that is correct; pointed at src/api
+      // it would delete the entire hand-written client.
       clean: true,
       prettier: true,
     },

--- a/frontend/tests/test-utils.tsx
+++ b/frontend/tests/test-utils.tsx
@@ -25,11 +25,6 @@ export function createTestQueryClient(): QueryClient {
         retry: false,
       },
     },
-    logger: {
-      log: () => {},
-      warn: () => {},
-      error: () => {},
-    },
   });
 }
 
@@ -41,8 +36,12 @@ import { useLocation } from 'react-router-dom';
 interface AllProvidersProps {
   children: ReactNode;
   queryClient?: QueryClient;
-  initialEntries?: string[];
-  path?: string;
+  // Explicitly `| undefined`: under `exactOptionalPropertyTypes`, `?:` alone means
+  // "may be absent", not "may be undefined". `renderWithProviders` destructures
+  // these out of its options object and forwards them positionally, so they arrive
+  // as an explicit `undefined` whenever the caller omits them.
+  initialEntries?: string[] | undefined;
+  path?: string | undefined;
 }
 
 // Global variable to track current location in tests

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,6 +28,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "tests/test-utils.tsx"],
   "exclude": ["node_modules", "dist"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,15 +127,13 @@ extend-exclude = '''
 )/
 '''
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 88
-known_first_party = ["chronovista"]
-known_third_party = ["typer", "sqlalchemy", "pydantic", "google", "alembic"]
-sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
-default_section = "THIRDPARTY"
-skip_glob = ["*/migrations/*"]
+# Import ordering is owned by ruff's `I` rule — see [tool.ruff.lint.isort] below.
+#
+# The standalone [tool.isort] config that lived here has been removed rather than
+# kept in sync. No gate ran it (CI, pre-commit and the Makefile all use ruff), but
+# its presence implied it was the project standard: running `isort` reordered 64
+# files into a state ruff's `I` rule rejects, so "fixing" the imports broke the
+# check that is actually enforced. Two formatters over one concern is the bug.
 
 [tool.mypy]
 python_version = "3.11"

--- a/scripts/gen_schema_ref.py
+++ b/scripts/gen_schema_ref.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import mkdocs_gen_files
 from sqlalchemy import Table
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.schema import CheckConstraint, UniqueConstraint
@@ -225,6 +224,12 @@ def render_schema() -> str:
 
 
 def main() -> None:
+    # Imported here, not at module scope: `mkdocs_gen_files` lives in the docs
+    # dependency group, which the backend CI job does not install. Rendering
+    # needs only SQLAlchemy metadata, so importing this module — from a test,
+    # say — must not require the docs toolchain.
+    import mkdocs_gen_files
+
     with mkdocs_gen_files.open("reference/schema.md", "w") as fd:
         fd.write(render_schema())
     mkdocs_gen_files.set_edit_path(
@@ -232,4 +237,9 @@ def main() -> None:
     )
 
 
-main()
+# Runs on execution, not on import. mkdocs-gen-files executes this file with
+# `runpy.run_path`, which sets `__name__` to "<run_path>" rather than
+# "__main__" — so a bare `if __name__ == "__main__"` guard would silently stop
+# generating the page. Importing the module writes nothing.
+if __name__ in {"__main__", "<run_path>"}:
+    main()

--- a/scripts/gen_schema_ref.py
+++ b/scripts/gen_schema_ref.py
@@ -142,12 +142,21 @@ def _render_table(table: Table, doc: str | None) -> list[str]:
         joined = ", ".join(f"`{c.name}`" for c in pk_cols)
         lines += [f"**Composite primary key:** {joined}", ""]
 
+    # `Table.constraints` is a set, so iteration follows object hashes and varies
+    # between processes. Sort by name or the same models render a different file
+    # on every run — a diff that looks like schema drift and is only reordering.
+    #
+    # Filter into a list first, then sort in place: `sorted()` over a generator
+    # drops the `isinstance` narrowing a comprehension keeps. `str(...)` because
+    # SQLAlchemy types `name` as `str | _NoneName | None`, which is not orderable.
     multi_unique = [
         c
         for c in table.constraints
         if isinstance(c, UniqueConstraint) and len(c.columns) > 1
     ]
+    multi_unique.sort(key=lambda c: str(c.name or ""))
     checks = [c for c in table.constraints if isinstance(c, CheckConstraint)]
+    checks.sort(key=lambda c: str(c.name or ""))
     if multi_unique or checks:
         lines.append("**Constraints:**")
         lines.append("")

--- a/tests/unit/scripts/test_gen_schema_ref.py
+++ b/tests/unit/scripts/test_gen_schema_ref.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for scripts/gen_schema_ref.py.
+
+Regression coverage for non-deterministic output: ``Table.constraints`` is a
+``set``, so iteration follows object hashes and varies between processes. Two
+comprehensions consumed it unsorted, so unchanged models rendered a different
+file on every run — a diff that reads as schema drift and is only reordering.
+
+**Why this asserts ordering rather than rendering twice.** The obvious test —
+call ``render_schema()`` twice and compare — passes even with the bug present.
+Set iteration is stable *within* a process: the same set object, holding the
+same objects, iterates the same way every time. The variation is between
+processes, so a same-process comparison is vacuous. Verified: with the fix
+reverted, two in-process renders are byte-identical.
+
+**Why a synthetic table as well as the real schema.** The live schema has tables
+with several CHECK constraints, so that half is exercised for real. It has no
+table with two or more *multi-column* UNIQUE constraints, so an assertion
+against the real schema could never fail for that branch. The synthetic table
+supplies the input the schema does not.
+
+No database is touched — rendering reads metadata only.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    UniqueConstraint,
+)
+
+from scripts.gen_schema_ref import _render_table, render_schema
+
+# One "**Constraints:**" block, capturing its bullet list.
+CONSTRAINT_BLOCK = re.compile(r"\*\*Constraints:\*\*\n\n((?:- .*\n)+)")
+
+# The two bullet shapes put the constraint name in different places, so they
+# need different patterns:
+#     - CHECK `ck_name`: `expr`             -> name is the first backtick
+#     - UNIQUE on `col_a`, `col_b` (`uq_name`)  -> name is the LAST, parenthesised
+# A single "first backticked token" pattern silently reads column names for
+# UNIQUE, yielding a list that is trivially sorted and can never fail.
+NAME_PATTERNS = {
+    "CHECK": re.compile(r"^- CHECK `([^`]+)`:", re.M),
+    "UNIQUE": re.compile(r"^- UNIQUE on .*\(`([^`]+)`\)\s*$", re.M),
+}
+
+
+def _named_constraints(text: str, kind: str) -> list[str]:
+    """Constraint names of one kind, in the order they were rendered."""
+    return NAME_PATTERNS[kind].findall(text)
+
+
+class TestRealSchemaOrdering:
+    """The rendered reference must be stable across runs."""
+
+    def test_check_constraints_are_sorted_within_each_table(self) -> None:
+        """The regression: CHECK constraints came out in set-iteration order."""
+        blocks = CONSTRAINT_BLOCK.findall(render_schema())
+        assert blocks, "no constraint blocks rendered — the parser is wrong"
+
+        unsorted_blocks = [
+            names
+            for block in blocks
+            if (names := _named_constraints(block, "CHECK")) != sorted(names)
+        ]
+        assert not unsorted_blocks, f"CHECK constraints not sorted: {unsorted_blocks}"
+
+    def test_a_table_actually_has_multiple_checks(self) -> None:
+        """Guards the test above from passing vacuously.
+
+        A table with 0 or 1 CHECK constraint is sorted whatever the code does.
+        If the schema ever lost every multi-constraint table, the ordering
+        assertion would still pass while testing nothing.
+        """
+        blocks = CONSTRAINT_BLOCK.findall(render_schema())
+        widest = max((len(_named_constraints(b, "CHECK")) for b in blocks), default=0)
+        assert widest >= 2, (
+            "no table renders 2+ CHECK constraints, so the ordering test "
+            f"cannot fail (widest block: {widest})"
+        )
+
+
+class TestSyntheticTableOrdering:
+    """Both branches of the sort, on input the live schema does not provide."""
+
+    @staticmethod
+    def _table() -> Table:
+        """A table whose constraint names are deliberately not in insertion order.
+
+        Six of each: with the sort removed, the chance that set iteration
+        happens to emit them alphabetically is 1/720 per kind, so the test
+        reliably catches a regression rather than catching it half the time.
+        """
+        columns = [Column(name, String) for name in "abcdef"]
+        constraints: list[UniqueConstraint | CheckConstraint] = []
+        for suffix in ("zulu", "yankee", "xray", "delta", "charlie", "alpha"):
+            constraints.append(UniqueConstraint("a", "b", name=f"uq_{suffix}"))
+            constraints.append(CheckConstraint("a IS NOT NULL", name=f"ck_{suffix}"))
+        return Table(
+            "synthetic",
+            MetaData(),
+            Column("id", Integer, primary_key=True),
+            *columns,
+            *constraints,
+        )
+
+    def test_multi_column_unique_constraints_are_sorted(self) -> None:
+        rendered = "\n".join(_render_table(self._table(), None))
+        names = _named_constraints(rendered, "UNIQUE")
+        assert len(names) == 6, f"expected 6 UNIQUE constraints, got {names}"
+        assert names == sorted(names), f"UNIQUE constraints not sorted: {names}"
+
+    def test_check_constraints_are_sorted(self) -> None:
+        rendered = "\n".join(_render_table(self._table(), None))
+        names = _named_constraints(rendered, "CHECK")
+        assert len(names) == 6, f"expected 6 CHECK constraints, got {names}"
+        assert names == sorted(names), f"CHECK constraints not sorted: {names}"


### PR DESCRIPTION
Four small fixes to local developer tooling. They share a theme: in each case
the toolchain reported something untrue, and the failure was silent rather than
loud.

No product code is touched — no migrations, no API contracts, no runtime paths.

Closes #159 
Closes #160 
Closes #163 
Closes #158

## What each one was lying about

| Issue | The lie |
|---|---|
| #159 | `typecheck` was green **by accident** — one `src/` import turned it red |
| #160 | `make quality`, the documented local gate, **could never pass** |
| #163 | Regenerating with **zero input change** produced a diff |
| #158 | A make target could **delete six tracked, hand-written modules** |

## #159 — `test-utils.tsx` type-checked unconditionally

`tsconfig.json` included only `src`, so `tests/test-utils.tsx` was type-checked
solely when a `src/` file imported it. Nothing did, leaving two errors latent in
a file 160+ test files depend on.

- `logger` was removed in TanStack Query v5. It was still passed, so it was
  silently ignored and test log noise was never actually suppressed.
- `initialEntries` / `path` are declared `?:`, which under
  `exactOptionalPropertyTypes` means "may be absent", not "may be undefined" —
  and they are forwarded as an explicit `undefined`. Widened accordingly.

Adding the whole `tests` tree to the include was measured and rejected: it
surfaces **388 pre-existing errors**, which is separate work. Including just
`tests/test-utils.tsx` makes the one shared file checked on every run.

Verified by mutation: re-introducing either defect turns `tsc --noEmit` red.

## #160 — `make quality` matches CI

- `isort --check-only` reported 64 errors while ruff's `I` rule passed cleanly.
  Worse than noise: `make format` **applied** isort, so running the repo's own
  formatter pushed files into a state ruff rejects — obeying the tooling broke
  the gate CI runs.
- `mypy src/ tests/` without `--strict` reported 69 errors in 23 files. CI runs
  `mypy src/chronovista/ --strict`, which is clean.

`ci-quality` carried the same divergence while its name claimed CI parity, and
is fixed identically. The orphaned `[tool.isort]` config is removed — nothing
ran it, but its presence implied isort was the standard. Its `skip_glob` for
migrations is not needed: ruff's `I` rule already covers all 39 migration files
and they pass.

The `isort` dev dependency is deliberately left in place; removing it
regenerates the lock file and belongs in its own change.

## #163 — deterministic schema reference

`Table.constraints` is a set, so iteration follows object hashes and varies
between processes. Unchanged models rendered a different file every run — a
diff that reads as schema drift and is only reordering.

The tests assert **sorted order** rather than rendering twice and comparing.
The double-render test is vacuous: set iteration is stable *within* a process,
so two in-process renders are byte-identical even with the bug present
(confirmed by reverting the fix). A synthetic table covers the UNIQUE branch,
which no table in the live schema can exercise, plus a guard asserting some
table really has 2+ CHECK constraints so the assertions cannot pass vacuously.

All three ordering tests fail when the sort is removed. The script's
`mypy --strict` error profile is unchanged.

## #158 — `generate-api` cannot destroy the client

`frontend/src/api` holds six hand-written, tracked modules. orval was configured
to generate into that same directory with `clean: true`, which deletes anything
a run did not produce.

- The spec is fetched to a temp file with `--fail`, validated as a JSON object
  carrying `openapi` and `paths`, and only then moved into place. Verified
  against an unreachable host, an HTTP 200 with an HTML body, and valid JSON
  that is not a spec — all three halt with nothing written and no temp file
  left behind. The live spec still passes.
- orval now targets `src/api/generated/`, so `clean` governs only files it
  created.
- Both `.gitignore` files carried an ignore-all-then-whitelist rule over
  `frontend/src/api/*.ts`. **The root copy whitelisted only `config.ts`** — the
  other five survive purely because they predate the rule. A newly added module
  was ignored with no error, which is how one was nearly lost during Feature
  061. Both now ignore the generated directory instead, which needs no
  maintenance as modules are added.

## Verification

| Suite | Result |
|---|---|
| Backend unit | 6,844 passed, 15 skipped |
| Backend integration | 1,340 passed, 23 skipped, 2 xpassed |
| Frontend | 3,940 passed, 19 skipped |
| **Total** | **12,124 passed** |

Plus `make quality`, `make ci-quality`, `npm run typecheck`, and `make format`
verified as a no-op on a clean tree.

## Note for review

Each commit is independently revertable and maps to one issue. The #158 commit
is the widest: it touches the orval config and both ignore files, beyond the
issue's "add a precondition" framing. Every change there traces to the same
hazard — a make target that can delete tracked source.
