### PR TITLE
fix(db): add a session context manager and roll back on cancellation (#189)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,19 @@ jobs:
           POSTGRES_DB: chronovista_integration_test
         ports:
           - 5434:5432
+        # `-d` matters only for the logs, and that is reason enough. Without it
+        # pg_isready connects to a database named after the user, which does not
+        # exist, so the server logs `FATAL: database "dev_user" does not exist`
+        # every interval for the life of the job.
+        #
+        # It is not a stronger check: pg_isready exits 0 whenever the *server*
+        # responds, and a missing database is still a response — verified,
+        # `pg_isready -d no_such_db` also exits 0. So this changes nothing about
+        # what is detected. What it removes is a recurring FATAL that reads
+        # exactly like a real connection failure, which is the kind of noise
+        # that gets a genuine startup problem dismissed.
         options: >-
-          --health-cmd="pg_isready -U dev_user"
+          --health-cmd="pg_isready -U dev_user -d chronovista_integration_test"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ pre-push:
 	@echo "==> [5/6] frontend type check + tests"
 	cd frontend && npm run typecheck && npx vitest run
 	@echo "==> [6/6] backend integration tests"
-	@docker exec chronovista-postgres-dev pg_isready -U dev_user -q 2>/dev/null || \
+	@docker exec chronovista-postgres-dev pg_isready -U dev_user -d chronovista_integration_test -q 2>/dev/null || \
 		(echo "❌ Integration database unreachable. Start it with 'make dev-db-up'." && \
 		 echo "   Not skipping: CI runs this job, so passing without it would be a false green." && \
 		 exit 1)

--- a/src/chronovista/config/database.py
+++ b/src/chronovista/config/database.py
@@ -4,7 +4,8 @@ Database configuration and connection management.
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
 
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.ext.asyncio import (
@@ -69,15 +70,33 @@ class DatabaseManager:
             )
         return self._session_factory
 
-    async def get_session(
-        self, echo: bool | None = None
-    ) -> AsyncGenerator[AsyncSession, None]:
-        """Get async database session."""
+    @asynccontextmanager
+    async def session(self, echo: bool | None = None) -> AsyncIterator[AsyncSession]:
+        """Session scope that commits on success and rolls back on failure.
+
+        Prefer this over :meth:`get_session`. Because it is a context manager,
+        leaving the block early — ``return``, ``break``, an exception — is
+        ordinary control flow, and the commit still runs::
+
+            async with db_manager.session() as session:
+                await repo.create(session, obj_in=thing)
+                return thing          # committed
+
+        The generator form cannot offer that. Exiting an ``async for`` loop
+        early throws ``GeneratorExit`` at the suspended ``yield``, so the
+        ``await session.commit()`` after it never runs and the write is lost
+        with no error at the call site.
+
+        ``except BaseException`` rather than ``except Exception``: both
+        ``GeneratorExit`` and ``asyncio.CancelledError`` derive from
+        ``BaseException``, so the narrower form left a cancelled request — a
+        client disconnecting mid-write — with no rollback at all.
+        """
+        temp_engine: AsyncEngine | None = None
+
         if echo is not None:
-            # Create a temporary session factory with custom echo setting
+            # A distinct engine, because `echo` is fixed at engine construction.
             self.get_engine()
-            # Create a new engine with custom echo setting
-            database_url = settings.effective_database_url
             engine_kwargs = {
                 "echo": echo,
                 "future": True,
@@ -85,35 +104,43 @@ class DatabaseManager:
                 "pool_recycle": 3600,
                 **self._pool_kwargs(),
             }
-
-            temp_engine = create_async_engine(database_url, **engine_kwargs)
-            temp_session_factory = async_sessionmaker(
+            temp_engine = create_async_engine(
+                settings.effective_database_url, **engine_kwargs
+            )
+            session_factory = async_sessionmaker(
                 bind=temp_engine,
                 class_=AsyncSession,
                 expire_on_commit=False,
             )
-
-            async with temp_session_factory() as session:
-                try:
-                    yield session
-                    await session.commit()
-                except Exception:
-                    await session.rollback()
-                    raise
-                finally:
-                    await session.close()
-                    await temp_engine.dispose()
         else:
             session_factory = self.get_session_factory()
-            async with session_factory() as session:
-                try:
-                    yield session
-                    await session.commit()
-                except Exception:
-                    await session.rollback()
-                    raise
-                finally:
-                    await session.close()
+
+        # One commit/rollback path for both branches. They were duplicated, so
+        # the `except Exception` defect existed — and had to be fixed — twice.
+        async with session_factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except BaseException:
+                await session.rollback()
+                raise
+            finally:
+                await session.close()
+                if temp_engine is not None:
+                    await temp_engine.dispose()
+
+    async def get_session(
+        self, echo: bool | None = None
+    ) -> AsyncGenerator[AsyncSession, None]:
+        """Generator form of :meth:`session`, for FastAPI's ``Depends``.
+
+        FastAPI dependencies must be generators, so this form has to exist. It
+        carries the early-exit hazard described in :meth:`session`: consumers
+        writing ``async for s in db_manager.get_session(): ... break`` skip the
+        commit. New code should use ``async with db_manager.session()``.
+        """
+        async with self.session(echo=echo) as session:
+            yield session
 
     async def close(self) -> None:
         """Close database connections."""

--- a/tests/unit/config/test_session_scope.py
+++ b/tests/unit/config/test_session_scope.py
@@ -1,0 +1,194 @@
+"""
+Tests for ``DatabaseManager.session()`` — commit, rollback and early exit.
+
+Regression coverage for issue #189. ``get_session()`` is an async generator that
+commits *after* the yield, so a consumer writing::
+
+    async for session in db_manager.get_session():
+        await repo.create(session, obj_in=thing)
+        break
+
+throws ``GeneratorExit`` at the suspended yield. ``GeneratorExit`` derives from
+``BaseException``, so the ``except Exception`` arm did not catch it, the
+``finally`` closed the session, and ``await session.commit()`` never ran. The
+write was lost with no error at the call site.
+
+Two things are asserted here, and they are different:
+
+1. ``session()`` is a context manager, so ``return``/``break`` inside the block
+   is ordinary control flow and **the commit still happens**. This is the fix —
+   it makes the mistake unrepresentable rather than documenting it.
+2. ``CancelledError`` now rolls back. That half was a live defect, not a latent
+   one: it fires whenever a client disconnects mid-request, and under
+   ``except Exception`` nothing rolled back at all.
+
+The session is a mock throughout — the subject is the commit/rollback control
+flow of the scope itself, not any database behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chronovista.config.database import DatabaseManager
+
+# CRITICAL: Module-level asyncio marker ensures async tests run properly
+# with coverage tools, avoiding silent test-skipping (see CLAUDE.md).
+pytestmark = pytest.mark.asyncio
+
+
+def _manager_with_mock_session() -> tuple[DatabaseManager, MagicMock]:
+    """A manager whose session factory yields a mock session."""
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.close = AsyncMock()
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+
+    factory = MagicMock(return_value=ctx)
+    manager = DatabaseManager()
+    manager.get_session_factory = MagicMock(return_value=factory)  # type: ignore[method-assign]
+    return manager, session
+
+
+class TestSessionScopeCommits:
+    """The happy path, and the early exit that used to lose writes."""
+
+    async def test_commits_on_normal_exit(self) -> None:
+        manager, session = _manager_with_mock_session()
+
+        async with manager.session():
+            pass
+
+        session.commit.assert_awaited_once()
+        session.rollback.assert_not_awaited()
+        session.close.assert_awaited_once()
+
+    async def test_commits_when_the_block_returns_early(self) -> None:
+        """The #189 regression, in the form the fix is meant to make safe.
+
+        The equivalent `async for ... break` skips the commit entirely. Inside a
+        context manager an early ``return`` is just control flow, so ``__aexit__``
+        runs with no exception and the commit happens.
+        """
+        manager, session = _manager_with_mock_session()
+
+        async def write_and_return() -> str:
+            async with manager.session():
+                return "done"
+
+        assert await write_and_return() == "done"
+        session.commit.assert_awaited_once()
+        session.rollback.assert_not_awaited()
+
+    async def test_commits_when_the_block_breaks_out_of_a_loop(self) -> None:
+        """`break` inside the block is likewise ordinary control flow."""
+        manager, session = _manager_with_mock_session()
+
+        async with manager.session():
+            for _ in range(3):
+                break
+
+        session.commit.assert_awaited_once()
+        session.rollback.assert_not_awaited()
+
+
+class TestSessionScopeRollsBack:
+    """Failure paths, including the two that ``except Exception`` missed."""
+
+    async def test_rolls_back_on_exception(self) -> None:
+        manager, session = _manager_with_mock_session()
+
+        with pytest.raises(ValueError, match="boom"):
+            async with manager.session():
+                raise ValueError("boom")
+
+        session.rollback.assert_awaited_once()
+        session.commit.assert_not_awaited()
+        session.close.assert_awaited_once()
+
+    async def test_rolls_back_on_cancellation(self) -> None:
+        """The live half of #189: a cancelled request rolled nothing back.
+
+        ``CancelledError`` derives from ``BaseException``, so the previous
+        ``except Exception`` arm never ran — the session was closed with the
+        transaction neither committed nor rolled back.
+        """
+        manager, session = _manager_with_mock_session()
+
+        with pytest.raises(asyncio.CancelledError):
+            async with manager.session():
+                raise asyncio.CancelledError()
+
+        session.rollback.assert_awaited_once()
+        session.commit.assert_not_awaited()
+        session.close.assert_awaited_once()
+
+    async def test_rolls_back_on_base_exception(self) -> None:
+        """Any ``BaseException`` leaves the transaction resolved, not dangling."""
+        manager, session = _manager_with_mock_session()
+
+        with pytest.raises(KeyboardInterrupt):
+            async with manager.session():
+                raise KeyboardInterrupt()
+
+        session.rollback.assert_awaited_once()
+        session.commit.assert_not_awaited()
+
+    async def test_a_failed_commit_still_closes_the_session(self) -> None:
+        """A connection lost at commit time must not leak the session."""
+        manager, session = _manager_with_mock_session()
+        session.commit.side_effect = RuntimeError("connection lost")
+
+        with pytest.raises(RuntimeError, match="connection lost"):
+            async with manager.session():
+                pass
+
+        session.rollback.assert_awaited_once()
+        session.close.assert_awaited_once()
+
+
+class TestGetSessionDelegates:
+    """``get_session()`` stays for FastAPI, and shares the same scope."""
+
+    async def test_generator_form_commits_when_fully_consumed(self) -> None:
+        manager, session = _manager_with_mock_session()
+
+        async for _ in manager.get_session():
+            pass
+
+        session.commit.assert_awaited_once()
+
+    async def test_generator_form_does_not_commit_on_early_exit(self) -> None:
+        """Documents the hazard `session()` exists to remove.
+
+        Note what `break` alone does: **nothing, yet**. The generator is left
+        suspended at its yield, and ``GeneratorExit`` is only thrown when it is
+        finalized — by garbage collection, or at interpreter shutdown, which is
+        where issue #189 reports the stray traceback appearing. So the commit is
+        not merely skipped; the cleanup happens at an unpredictable later time.
+
+        ``aclose()`` here forces that finalization deterministically, which is
+        the only way to assert on it. The write is discarded either way.
+        """
+        manager, session = _manager_with_mock_session()
+
+        agen = manager.get_session()
+        async for _ in agen:
+            break
+
+        # Nothing has run yet — the generator is still suspended at its yield.
+        session.commit.assert_not_awaited()
+        session.rollback.assert_not_awaited()
+
+        await agen.aclose()  # what GC or shutdown would eventually do
+
+        session.commit.assert_not_awaited()
+        session.rollback.assert_awaited_once()
+        session.close.assert_awaited_once()


### PR DESCRIPTION
`get_session()` is an async generator that commits *after* the yield, so it
yields exactly once and every call site uses `async for session in
db_manager.get_session():` — an idiom that naturally invites `break`. Exiting
early throws `GeneratorExit` at the suspended yield; `GeneratorExit` derives
from `BaseException`, so the `except Exception` arm never caught it and the
commit never ran. The write was lost with no error at the call site.

Closes #189.

## The fix: make the mistake unrepresentable

`session()` is a new `@asynccontextmanager` where leaving the block early is
ordinary control flow and the commit still runs:

```python
async with db_manager.session() as session:
    await repo.create(session, obj_in=thing)
    return thing          # committed
```

Verified against a real database, not just mocks: an early `return` inside the
block leaves the row committed (1, not 0).

`get_session()` remains and delegates to the same scope — FastAPI's `Depends`
requires a generator form.

## A live defect, not only a latent one

`except Exception` → `except BaseException`.

`CancelledError` also derives from `BaseException`, so **a client disconnecting
mid-write rolled nothing back** — the session closed with the transaction
neither committed nor rolled back. Unlike the `break` hazard, this one fires in
production today.

The `echo` and non-`echo` branches each carried their own copy of the
try/commit/rollback block, so this defect existed twice and had to be fixed
twice. They now share one path.

## A correction to the issue's description

`break` alone does **nothing immediately**. The generator is left suspended at
its yield, and `GeneratorExit` is thrown only when it is finalized — by garbage
collection, or at interpreter shutdown, which is exactly where #189 reports the
stray traceback appearing.

So the cleanup is not merely skipped; it happens at an unpredictable later time.
My first test failed for precisely this reason, with
`Task was destroyed but it is pending`. The test now forces finalization with
`aclose()` and asserts both stages: nothing has run after `break`, and the
rollback happens only once the generator is closed.

## Existing call sites deliberately not migrated

All 118 were audited:

| | Count |
|---|---|
| `async for … get_session()` call sites | 118 |
| …that exit early via `break`/`return` | 57 |
| …that both write **and** rely on the implicit commit | **0** |

The single candidate — `enrich.py`, which looked like a write — takes a
PostgreSQL **advisory** lock (`pg_advisory_lock()`), which is connection-scoped
and needs no commit. So there is no data loss in shipped code, matching the
issue's own assessment.

Migrating the call sites is #66's CLI consolidation ("`asyncio.run()` + session
boilerplate, 25+ occurrences"). Doing #189 first gives that work a utility to
adopt; bundling them would invert the dependency and turn a contained fix into a
refactor across most CLI files.

## Verification

- 9 new unit tests, **mutation-verified**: restoring `except Exception` fails
  three of them; restoring the commit-after-yield generator shape fails one
- Real-database check: early `return` inside `async with` commits
- **6,853** unit tests pass (6,844 baseline + the 9 new)
- **1,342** integration tests pass — unchanged from baseline, which is what
  shows a semantic change to a primitive with 118 call sites disturbed none of
  them
- mypy `--strict`, black and ruff clean


---

## Also included: CI Postgres healthcheck

Unrelated to #189, folded in rather than carried as a second PR.

The integration job's healthcheck ran `pg_isready -U dev_user` with no `-d`.
pg_isready defaults the database name to the **username**, so it connected to a
database called `dev_user` — which does not exist — and the server logged
`FATAL: database "dev_user" does not exist` every 10 seconds for the life of the
job. Spotted in the tail of a passing integration run.

**Nothing was broken by it.** pg_isready exits 0 whenever the *server* responds,
and a missing database is still a response. Nor does naming the database make
the check stronger — tested: `pg_isready -d no_such_db` also exits 0.

What it fixes is a recurring FATAL that reads exactly like a real connection
failure, which is the kind of noise that gets a genuine startup problem
dismissed. Measured: three checks in the old form add three FATAL lines, three
in the new form add none, and both exit 0.

The same omission was in `Makefile`'s pre-push integration guard. Every other
`pg_isready` in the repo — both compose files, `entrypoint.sh`, two other
Makefile targets — already passes `-d`; these two were the outliers.
