### PR TITLE
fix(ci): give pg_isready a database, silencing a recurring FATAL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,19 @@ jobs:
           POSTGRES_DB: chronovista_integration_test
         ports:
           - 5434:5432
+        # `-d` matters only for the logs, and that is reason enough. Without it
+        # pg_isready connects to a database named after the user, which does not
+        # exist, so the server logs `FATAL: database "dev_user" does not exist`
+        # every interval for the life of the job.
+        #
+        # It is not a stronger check: pg_isready exits 0 whenever the *server*
+        # responds, and a missing database is still a response — verified,
+        # `pg_isready -d no_such_db` also exits 0. So this changes nothing about
+        # what is detected. What it removes is a recurring FATAL that reads
+        # exactly like a real connection failure, which is the kind of noise
+        # that gets a genuine startup problem dismissed.
         options: >-
-          --health-cmd="pg_isready -U dev_user"
+          --health-cmd="pg_isready -U dev_user -d chronovista_integration_test"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ pre-push:
 	@echo "==> [5/6] frontend type check + tests"
 	cd frontend && npm run typecheck && npx vitest run
 	@echo "==> [6/6] backend integration tests"
-	@docker exec chronovista-postgres-dev pg_isready -U dev_user -q 2>/dev/null || \
+	@docker exec chronovista-postgres-dev pg_isready -U dev_user -d chronovista_integration_test -q 2>/dev/null || \
 		(echo "❌ Integration database unreachable. Start it with 'make dev-db-up'." && \
 		 echo "   Not skipping: CI runs this job, so passing without it would be a false green." && \
 		 exit 1)


### PR DESCRIPTION
The integration job's Postgres healthcheck ran `pg_isready -U dev_user` with no
`-d`. pg_isready defaults the database name to the **username**, so it connected
to a database called `dev_user` — which does not exist — and the server logged

```
FATAL:  database "dev_user" does not exist
```

every 10 seconds for the life of the job. Spotted in the tail of a passing
integration run.

## Nothing was broken by it

`pg_isready` exits 0 whenever the *server* responds, and a missing database is
still a response. The container reported healthy and CI worked correctly.

Nor does naming the database make the check stronger — I assumed it would and
tested it: `pg_isready -d no_such_db` **also exits 0**. Nothing about what is
detected changes here.

## What it does fix

A recurring FATAL that reads exactly like a real connection failure. That is
what a one-word fix is worth paying: a genuine startup problem in that log would
be indistinguishable from the usual noise, and would therefore be dismissed.

## Measured

| | exit code | new FATAL lines |
|---|---|---|
| old form, 3 checks | 0 (healthy) | **+3** |
| new form, 3 checks | 0 (healthy) | **0** |

## Second occurrence

The same omission was in `Makefile`'s pre-push integration guard. Every other
`pg_isready` in the repo — both compose files, `entrypoint.sh`, two other
Makefile targets — already passes `-d`. These two were the outliers.

Workflow-only change; no source, tests, or schema touched.
