### PR TITLE
perf(entities): page the entity scan by key instead of OFFSET

### DIFF
--- a/src/chronovista/services/entity_mention_scan_service.py
+++ b/src/chronovista/services/entity_mention_scan_service.py
@@ -38,6 +38,11 @@ logger = logging.getLogger(__name__)
 # Minimum alias length before a warning is emitted.
 _MIN_ALIAS_LENGTH = 3
 
+# Consecutive failed fetches at the same cursor before a scan gives up. Keyset
+# pagination cannot skip a batch it never received, so the choice is retry or
+# stop; this bounds the retry.
+_MAX_FETCH_RETRIES = 3
+
 
 def _fold_diacritics(raw: str) -> tuple[str, list[int]]:
     """Fold accents off a string and map folded positions back to raw ones.
@@ -278,7 +283,8 @@ class EntityMentionScanService:
             matched_entity_ids: set[uuid.UUID] = set()
             matched_video_ids: set[str] = set()
 
-            offset = 0
+            last_id = 0
+            fetch_failures_at_cursor = 0
             while True:
                 try:
                     batch_rows = await self._fetch_segment_batch(
@@ -286,17 +292,32 @@ class EntityMentionScanService:
                         video_ids=video_ids,
                         language_code=language_code,
                         batch_size=batch_size,
-                        offset=offset,
+                        after_id=last_id,
                     )
                 except Exception:
+                    # Under OFFSET pagination a failed fetch could be skipped by
+                    # advancing the offset. A cursor has no such fixed stride:
+                    # the ids to skip are exactly the ones the failed query did
+                    # not return. Retrying is the only way forward, so bound it
+                    # rather than spin.
                     logger.warning(
-                        "Failed to fetch segment batch at offset=%d",
-                        offset,
+                        "Failed to fetch segment batch after id=%d",
+                        last_id,
                         exc_info=True,
                     )
                     result.failed_batches += 1
-                    offset += batch_size
+                    fetch_failures_at_cursor += 1
+                    if fetch_failures_at_cursor >= _MAX_FETCH_RETRIES:
+                        logger.error(
+                            "Aborting scan: %d consecutive fetch failures after "
+                            "id=%d. Scanned %d segments before stopping.",
+                            fetch_failures_at_cursor,
+                            last_id,
+                            result.segments_scanned,
+                        )
+                        break
                     continue
+                fetch_failures_at_cursor = 0
 
                 if not batch_rows:
                     break
@@ -325,12 +346,14 @@ class EntityMentionScanService:
                     )
                 except Exception:
                     logger.warning(
-                        "Failed to process segment batch at offset=%d",
-                        offset,
+                        "Failed to process segment batch after id=%d",
+                        last_id,
                         exc_info=True,
                     )
                     result.failed_batches += 1
-                    offset += batch_size
+                    # The rows are in hand, so the batch can still be skipped
+                    # exactly as before: advance past the ones just fetched.
+                    last_id = batch_rows[-1].id
                     if progress_callback:
                         progress_callback(
                             result.segments_scanned, result.mentions_found
@@ -361,7 +384,7 @@ class EntityMentionScanService:
                 if progress_callback:
                     progress_callback(result.segments_scanned, result.mentions_found)
 
-                offset += batch_size
+                last_id = batch_rows[-1].id
 
                 # If dry-run and we have reached the limit, stop early
                 if (
@@ -605,24 +628,36 @@ class EntityMentionScanService:
             matched_entity_ids: set[uuid.UUID] = set()
             matched_video_ids: set[str] = set()
 
-            offset = 0
+            last_video_id = ""
+            fetch_failures_at_cursor = 0
             while True:
                 try:
                     batch_rows = await self._fetch_video_batch(
                         session,
                         video_ids=video_ids,
                         batch_size=batch_size,
-                        offset=offset,
+                        after_video_id=last_video_id,
                     )
                 except Exception:
                     logger.warning(
-                        "Failed to fetch video batch at offset=%d",
-                        offset,
+                        "Failed to fetch video batch after video_id=%r",
+                        last_video_id,
                         exc_info=True,
                     )
                     result.failed_batches += 1
-                    offset += batch_size
+                    fetch_failures_at_cursor += 1
+                    if fetch_failures_at_cursor >= _MAX_FETCH_RETRIES:
+                        logger.error(
+                            "Aborting metadata scan: %d consecutive fetch "
+                            "failures after video_id=%r. Scanned %d videos "
+                            "before stopping.",
+                            fetch_failures_at_cursor,
+                            last_video_id,
+                            result.segments_scanned,
+                        )
+                        break
                     continue
+                fetch_failures_at_cursor = 0
 
                 if not batch_rows:
                     break
@@ -639,12 +674,12 @@ class EntityMentionScanService:
                     )
                 except Exception:
                     logger.warning(
-                        "Failed to process video batch at offset=%d",
-                        offset,
+                        "Failed to process video batch after video_id=%r",
+                        last_video_id,
                         exc_info=True,
                     )
                     result.failed_batches += 1
-                    offset += batch_size
+                    last_video_id = batch_rows[-1].video_id
                     if progress_callback:
                         progress_callback(
                             result.segments_scanned, result.mentions_found
@@ -670,7 +705,7 @@ class EntityMentionScanService:
                 if progress_callback:
                     progress_callback(result.segments_scanned, result.mentions_found)
 
-                offset += batch_size
+                last_video_id = batch_rows[-1].video_id
 
             result.unique_entities = len(matched_entity_ids)
             result.unique_videos = len(matched_video_ids)
@@ -721,9 +756,15 @@ class EntityMentionScanService:
         session: AsyncSession,
         video_ids: list[str] | None,
         batch_size: int,
-        offset: int,
+        after_video_id: str,
     ) -> list[Any]:
         """Fetch a batch of video rows for metadata scanning.
+
+        Keyset-paginated on ``video_id`` for the same reason as
+        :meth:`_fetch_segment_batch` — see that method for the measurements.
+        The videos table is far smaller than transcript_segments, so the win
+        here is small today; it is fixed alongside because it is the identical
+        defect and grows the same way.
 
         Parameters
         ----------
@@ -733,8 +774,10 @@ class EntityMentionScanService:
             Optional video ID filter.
         batch_size : int
             Maximum videos per batch.
-        offset : int
-            Pagination offset.
+        after_video_id : str
+            Exclusive lower bound on video_id; pass ``""`` to start. Ordering
+            and seeking use the same collation, so the comparison agrees with
+            the ORDER BY and no row is visited twice or skipped.
 
         Returns
         -------
@@ -751,8 +794,9 @@ class EntityMentionScanService:
         if video_ids is not None:
             stmt = stmt.where(VideoDB.video_id.in_(video_ids))
 
+        stmt = stmt.where(VideoDB.video_id > after_video_id)
         stmt = stmt.order_by(VideoDB.video_id.asc())
-        stmt = stmt.limit(batch_size).offset(offset)
+        stmt = stmt.limit(batch_size)
 
         result = await session.execute(stmt)
         return list(result.all())
@@ -1138,9 +1182,16 @@ class EntityMentionScanService:
         video_ids: list[str] | None,
         language_code: str | None,
         batch_size: int,
-        offset: int,
+        after_id: int,
     ) -> list[Any]:
         """Fetch a batch of transcript segments with effective text.
+
+        Paginates by primary key (``id > after_id``) rather than by ``OFFSET``.
+        ``OFFSET n`` makes PostgreSQL walk and discard n rows to reach each
+        window, so per-batch cost grows with depth and total scan cost grows
+        with the *square* of the corpus.  Measured on a 1.9M-segment corpus,
+        the same 500 rows took 11 ms at offset 0 and 531 ms at offset 1.8M.
+        Seeking on the indexed key holds every batch at the offset-0 price.
 
         Parameters
         ----------
@@ -1152,8 +1203,10 @@ class EntityMentionScanService:
             Optional language filter.
         batch_size : int
             Maximum segments per batch.
-        offset : int
-            Pagination offset.
+        after_id : int
+            Exclusive lower bound on segment id; pass 0 to start. Ids are a
+            monotonic sequence, so ordering by id and seeking past the last id
+            of the previous batch visits every row exactly once.
 
         Returns
         -------
@@ -1185,8 +1238,9 @@ class EntityMentionScanService:
         if language_code is not None:
             stmt = stmt.where(TranscriptSegmentDB.language_code == language_code)
 
+        stmt = stmt.where(TranscriptSegmentDB.id > after_id)
         stmt = stmt.order_by(TranscriptSegmentDB.id.asc())
-        stmt = stmt.limit(batch_size).offset(offset)
+        stmt = stmt.limit(batch_size)
 
         result = await session.execute(stmt)
         return list(result.all())

--- a/tests/unit/services/test_entity_mention_scan_service.py
+++ b/tests/unit/services/test_entity_mention_scan_service.py
@@ -686,7 +686,7 @@ class TestFilterParameters:
             video_ids: list[str] | None,
             language_code: str | None,
             batch_size: int,
-            offset: int,
+            after_id: int,
         ) -> list[Any]:
             captured.append({"video_ids": video_ids, "language_code": language_code})
             return []  # End loop
@@ -720,7 +720,7 @@ class TestFilterParameters:
             video_ids: list[str] | None,
             language_code: str | None,
             batch_size: int,
-            offset: int,
+            after_id: int,
         ) -> list[Any]:
             captured.append({"language_code": language_code})
             return []
@@ -801,7 +801,7 @@ class TestBatchProcessing:
             video_ids: Any,
             language_code: Any,
             batch_size: int,
-            offset: int,
+            after_id: int,
         ) -> list[Any]:
             nonlocal batch_idx
             result = batches[batch_idx] if batch_idx < len(batches) else []
@@ -1739,7 +1739,7 @@ class TestFailedBatchHandling:
             video_ids: Any,
             language_code: Any,
             batch_size: int,
-            offset: int,
+            after_id: int,
         ) -> list[Any]:
             nonlocal fetch_calls
             fetch_calls += 1
@@ -3042,6 +3042,137 @@ class TestTranscriptMentionContext:
         assert "discutió" in context
 
 
+class TestKeysetPagination:
+    """The scan pages by primary key, never by OFFSET.
+
+    OFFSET pagination made a full scan cost grow with the square of the
+    corpus: PostgreSQL walks and discards n rows to reach each window, so the
+    same 500 rows cost 11 ms at offset 0 and 531 ms at offset 1.8M on a
+    1.9M-segment corpus.  A single-entity scan reads every segment (the entity
+    filter narrows the patterns, not the rows), so this hit every scan.
+
+    These tests pin the two properties that make the seek correct, because a
+    test double that merely accepts ``after_id`` and returns canned batches
+    would keep passing if the cursor never advanced at all.
+    """
+
+    async def test_cursor_advances_to_last_id_of_previous_batch(self) -> None:
+        """Each fetch must resume strictly after the last id already seen.
+
+        This is the property that makes the seek both complete and duplicate
+        free.  If the cursor stalled, the same batch would be re-fetched
+        forever; if it overshot, rows would be skipped silently.
+        """
+        from chronovista.services.entity_mention_scan_service import _EntityPattern
+
+        fake_pattern = _EntityPattern(
+            entity_id=_make_uuid(),
+            canonical_name="Bar",
+            entity_type="person",
+            pg_pattern="Bar",
+            alias_names=["Bar"],
+            exclusion_patterns=[],
+        )
+
+        session = AsyncMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        svc = _build_service(_make_session_factory(session))
+
+        batches = [
+            [_make_segment_row(seg_id=i) for i in (3, 7, 11)],
+            [_make_segment_row(seg_id=i) for i in (12, 40)],
+            [],
+        ]
+        seen_after_ids: list[int] = []
+        batch_idx = 0
+
+        async def fetch_batches(
+            _session: Any,
+            video_ids: Any,
+            language_code: Any,
+            batch_size: int,
+            after_id: int,
+        ) -> list[Any]:
+            nonlocal batch_idx
+            seen_after_ids.append(after_id)
+            result = batches[batch_idx] if batch_idx < len(batches) else []
+            batch_idx += 1
+            return result
+
+        svc._mention_repo.update_entity_counters = AsyncMock()
+        svc._mention_repo.update_alias_counters = AsyncMock()
+        with (
+            patch.object(svc, "_load_entity_patterns", return_value=[fake_pattern]),
+            patch.object(svc, "_fetch_segment_batch", side_effect=fetch_batches),
+            patch.object(svc, "_scan_batch", return_value=([], 0, [], 0, 0)),
+        ):
+            await svc.scan()
+
+        # Starts at 0, then resumes from the highest id of each prior batch.
+        assert seen_after_ids == [0, 11, 40]
+
+    async def test_fetch_query_seeks_by_id_and_uses_no_offset(self) -> None:
+        """The emitted SQL must carry the keyset predicate and no OFFSET.
+
+        Asserting on the statement rather than the result is what catches a
+        regression to ``.offset(...)``: both forms return the same rows for
+        the first page, so a row-level assertion cannot tell them apart.
+        """
+        captured: dict[str, Any] = {}
+
+        async def capture_execute(stmt: Any) -> Any:
+            captured["stmt"] = stmt
+            mock_result = MagicMock()
+            mock_result.all.return_value = []
+            return mock_result
+
+        session = AsyncMock()
+        session.execute = capture_execute
+        svc = _build_service(_make_session_factory(session))
+
+        await svc._fetch_segment_batch(
+            session,
+            video_ids=None,
+            language_code=None,
+            batch_size=10,
+            after_id=4242,
+        )
+
+        sql = str(captured["stmt"]).upper()
+        assert "OFFSET" not in sql
+        assert "TRANSCRIPT_SEGMENTS.ID >" in sql
+        assert "ORDER BY TRANSCRIPT_SEGMENTS.ID ASC" in sql
+
+    async def test_metadata_fetch_query_seeks_by_video_id_and_uses_no_offset(
+        self,
+    ) -> None:
+        """The title/description scan pages the same way, on video_id."""
+        captured: dict[str, Any] = {}
+
+        async def capture_execute(stmt: Any) -> Any:
+            captured["stmt"] = stmt
+            mock_result = MagicMock()
+            mock_result.all.return_value = []
+            return mock_result
+
+        session = AsyncMock()
+        session.execute = capture_execute
+        svc = _build_service(_make_session_factory(session))
+
+        await svc._fetch_video_batch(
+            session,
+            video_ids=None,
+            batch_size=10,
+            after_video_id="abc123",
+        )
+
+        sql = str(captured["stmt"]).upper()
+        assert "OFFSET" not in sql
+        assert "VIDEOS.VIDEO_ID >" in sql
+        assert "ORDER BY VIDEOS.VIDEO_ID ASC" in sql
+
+
 class TestScanUsesCorrectedTranscriptText:
     """The scan reads corrected transcript text where a correction exists.
 
@@ -3073,7 +3204,7 @@ class TestScanUsesCorrectedTranscriptText:
             video_ids=None,
             language_code=None,
             batch_size=10,
-            offset=0,
+            after_id=0,
         )
 
         sql = str(captured["stmt"])
@@ -3104,7 +3235,7 @@ class TestScanUsesCorrectedTranscriptText:
             video_ids=None,
             language_code=None,
             batch_size=10,
-            offset=0,
+            after_id=0,
         )
 
         sql = str(captured["stmt"])


### PR DESCRIPTION
A full-corpus entity scan took about **ten minutes**. It now takes about
**eight seconds**, measured end to end over 1,919,518 segments.

## The defect

The scan paged with `LIMIT 500 OFFSET n`, advancing the offset each round.
PostgreSQL walks and discards all n rows to reach each window, so per-batch
cost grows with depth and total cost grows with the **square** of the corpus.

Measured with the scan's own query, on the real corpus:

| offset | time for the same 500 rows |
|---|---|
| 0 | 11 ms |
| 500,000 | 410 ms |
| 1,000,000 | 394 ms |
| 1,800,000 | 531 ms |

Scanning a single entity did not avoid it: `--entity-id` narrows which
*patterns* are matched, not which *rows* are read, so every scan is a full
pass over every segment.

## Why it felt sudden

The corpus grew **20.8% in a week** — 1,583,046 → 1,913,035 segments. Under a
quadratic cost that is ~46% more work, not 21%. Growth was the trigger; the
exponent was the defect. It would have kept compounding.

## The change

Both paginated loops now seek on their indexed key instead of counting past
rows: `transcript_segments.id` and `videos.video_id`. The videos table is
small enough that the win there is negligible today, but it is the identical
defect and it grows the same way, so it is fixed alongside rather than left
as a second landmine.

This covers **every** scan entry point, because there is one implementation
behind all of them — the CLI global rescan, the entity-detail rescan, and the
per-video rescan in the video detail view all funnel into `scan()` /
`scan_metadata()`. `grep '\.offset('` now returns nothing in this module.

### One deliberate behaviour change

Under OFFSET, a failed fetch could be skipped by advancing the offset. A
cursor has no fixed stride — the ids to skip are exactly the ones the failed
query did not return — so a fetch failure now retries at the same cursor and
aborts after 3 consecutive failures rather than spinning forever. The
*processing*-failure path is unchanged in effect: those rows are already in
hand, so the batch is still skipped exactly as before.

## Verification

Read-only, against the real 1.9M-row corpus — the property that matters is
not just speed but that the seek visits every row exactly once:

```
expected rows      : 1919518
rows returned      : 1919518
distinct ids seen  : 1919518
duplicates         : 0
missing            : 0
batches            : 3840
full pass wall time: 7.5s
```

Per-video path exercised separately as a dry run, since it is a different
call shape: 1,503 segments scanned (correctly scoped to one video), 0 failed
batches, 0.54s; metadata path 1 video, 1 title match, 0.03s.

## What the tests needed

Four existing test doubles declared `offset: int` and raised `TypeError` on
the new keyword. Updating only those would have been a **weak green**: a
double that accepts a cursor and then ignores it passes whether or not the
cursor ever advances.

So three tests were added that pin the real behaviour:

- the cursor must resume at the last id of the previous batch, asserted as
  the exact sequence `[0, 11, 40]` — a stalled cursor produces `[0, 0, 0]`
  and cannot pass
- both fetch queries must emit the seek predicate and **no** `OFFSET`,
  asserted on the statement rather than the rows, because both forms return
  identical rows for the first page and a row-level assertion cannot tell
  them apart

## Not in scope

Four sibling loops share this defect elsewhere — three in
`takeout_recovery_service.py` and one in `image_cache.py`. They walk tables
~35x smaller than `transcript_segments`, so the quadratic term is worth about
a second each today. Filed separately rather than widening this diff.

## Checks

- 6,847 unit and 1,276 integration tests pass
- mypy `--strict`, black, ruff clean
