### PR TITLE
refactor(cli): rename playlist SortOrder to PlaylistListSortField

### DIFF
--- a/src/chronovista/cli/commands/playlist.py
+++ b/src/chronovista/cli/commands/playlist.py
@@ -50,8 +50,19 @@ class OutputFormat(str, Enum):
     CSV = "csv"
 
 
-class SortOrder(str, Enum):
-    """Sort order options for playlist list command."""
+class PlaylistListSortField(str, Enum):
+    """Sort key for `playlist list`.
+
+    Named a *field*, not an *order*, to match the convention the API layer
+    already uses: ``SortOrder`` means direction (``ASC``/``DESC``) and lives in
+    ``api/schemas/sorting.py``, while the key to sort by is a
+    ``<Thing>SortField`` (``PlaylistSortField``, ``VideoSortField``,
+    ``ChannelVideoSortField``). This enum holds keys, so it was the odd one out.
+
+    Not merged into the API's ``PlaylistSortField``: that one offers
+    ``CREATED_AT``/``VIDEO_COUNT`` where this offers ``VIDEOS``/``STATUS``, and
+    reconciling them would change values a shipped endpoint accepts.
+    """
 
     TITLE = "title"
     VIDEOS = "videos"
@@ -90,8 +101,8 @@ def list(
         "--format",
         help="Output format",
     ),
-    sort: SortOrder = typer.Option(
-        SortOrder.TITLE,
+    sort: PlaylistListSortField = typer.Option(
+        PlaylistListSortField.TITLE,
         "--sort",
         help="Sort order: title (alphabetical), videos (by count), status (linked first)",
     ),
@@ -146,15 +157,15 @@ def list(
                 stats = await repository.get_link_statistics(session)
 
                 # Apply sorting based on --sort flag
-                if sort == SortOrder.TITLE:
+                if sort == PlaylistListSortField.TITLE:
                     # Alphabetical by title (A-Z)
                     playlists = sorted(playlists, key=lambda p: p.title.lower())
-                elif sort == SortOrder.VIDEOS:
+                elif sort == PlaylistListSortField.VIDEOS:
                     # By video count (descending)
                     playlists = sorted(
                         playlists, key=lambda p: p.video_count, reverse=True
                     )
-                elif sort == SortOrder.STATUS:
+                elif sort == PlaylistListSortField.STATUS:
                     # Linked first, then unlinked, then alphabetical within each group
                     # A playlist is "linked" if playlist_id starts with "PL" or is a system ID
                     playlists = sorted(


### PR DESCRIPTION
`SortOrder` named two unrelated things, so the name resolved to a different
field set depending on which module you were reading:

| definition | members | actual meaning |
|---|---|---|
| `api/schemas/sorting.py:12` | `ASC`, `DESC` | sort **direction** |
| `cli/commands/playlist.py:53` | `TITLE`, `VIDEOS`, `STATUS` | sort **key** |

The API layer already draws this line consistently — direction is `SortOrder`,
and the key to sort by is a `<Thing>SortField`: `PlaylistSortField`,
`PlaylistVideoSortField`, `VideoSortField`, `ChannelSortField`,
`ChannelVideoSortField`. The endpoints pair them, `sort_by: PlaylistSortField`
alongside `sort_order: SortOrder`.

The CLI enum holds keys, so it was the one out of step. Renamed to
**`PlaylistListSortField`**.

## Why not the API's `PlaylistSortField`

That is the semantically exact name, and it is already taken by
`api/routers/playlists.py:46`. Reusing it would mean reconciling two different
vocabularies — the API offers `CREATED_AT`/`VIDEO_COUNT` where the CLI offers
`VIDEOS`/`STATUS` — which changes the values a shipped endpoint accepts. That is
an API contract decision, and it does not belong inside a rename. The reasoning
is recorded in the class docstring so the next reader does not have to
re-derive it.

Worth noting separately: the CLI and API use different words for the same sort
key (`VIDEOS` vs `VIDEO_COUNT`). Unifying that changes a user-facing flag value,
so it is left alone here.

## No user-visible change

Internal identifier only. Verified against the real command output, not assumed:

```
--sort   [title|videos|status]   Sort order: title (alphabetical), videos (by
                                 count), status (linked first)
```

## Scope

One file, +18/-7, of which 10 insertions are the docstring. Five call sites.

Scope was established by enumerating every usage rather than grepping: the two
`SortOrder` definitions have 24 usages across 5 files between them, and a
`grep SortOrder` conflates them. Resolving per-definition showed the CLI enum is
confined to its own file with **no test importing it**, which is why no test
changed.

`SortOrder` is now defined exactly once in the codebase. Duplicate class names
drop from 27 to 26.

## Verification

- 6,847 unit and 1,270 integration tests pass
- mypy `--strict`, black, ruff clean
- `chronovista playlist list --help` renders identically

## How this was found

A duplicate-class-name audit across the codebase. It also surfaced
`TranscriptSearchFilters` (genuinely dead), `LockAcquisitionError` (filed as
#205 — the live copy bypasses `ChronovistaError`), `OutputFormat` (three
copies with three different member sets) and `RecoveryResult` (two live
models). Those are separate conversations; this PR changes only the one case
that was a clear-cut misnomer.
