### PR TITLE
perf(corrections): make diff-analysis counts index-eligible (#203)

### DIFF
--- a/src/chronovista/api/routers/batch_corrections.py
+++ b/src/chronovista/api/routers/batch_corrections.py
@@ -9,7 +9,7 @@ reverting entire batches.
 import uuid
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import case, func, select
+from sqlalchemy import case, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid_utils import uuid7
 
@@ -563,14 +563,35 @@ async def get_diff_analysis(
     # Build response items with entity enrichment.
     results: list[DiffErrorPatternResponse] = []
     for (error_token, canonical_form), freq in aggregated.items():
-        # Token-level remaining_matches query
-        remaining_stmt = (
-            select(func.count())
-            .select_from(TranscriptSegmentDB)
-            .where(effective_text.contains(error_token))
-        )
-        remaining_result = await session.execute(remaining_stmt)
-        remaining = remaining_result.scalar_one()
+        # An empty error_token reaches here whenever the canonical form is
+        # non-empty (the skip above requires *both* to be empty), and
+        # `contains("")` compiles to LIKE '%%', which matches every row in the
+        # corpus. That is both a meaningless count and the single most
+        # expensive query this loop can issue.
+        if not error_token:
+            remaining = 0
+        else:
+            remaining_stmt = (
+                select(func.count())
+                .select_from(TranscriptSegmentDB)
+                .where(
+                    # Index-eligible super-set on the RAW columns so PostgreSQL
+                    # can use the pg_trgm GIN indexes (idx_segments_text_trgm /
+                    # idx_segments_corrected_text_trgm). A CASE expression is
+                    # opaque to them and forces a parallel seq scan of ~2M rows
+                    # — once per token. Same fix as #150.
+                    or_(
+                        TranscriptSegmentDB.text.contains(error_token),
+                        TranscriptSegmentDB.corrected_text.contains(error_token),
+                    ),
+                    # Exact predicate, re-checked against the super-set. A
+                    # segment whose raw text matches but whose correction
+                    # removed the token must not be counted, so this stays.
+                    effective_text.contains(error_token),
+                )
+            )
+            remaining_result = await session.execute(remaining_stmt)
+            remaining = remaining_result.scalar_one()
 
         # Apply show_completed filter at the token level
         if not show_completed and remaining == 0:

--- a/src/chronovista/repositories/transcript_correction_repository.py
+++ b/src/chronovista/repositories/transcript_correction_repository.py
@@ -15,7 +15,7 @@ import datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, case, distinct, func, select
+from sqlalchemy import and_, case, distinct, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.db.models import TranscriptCorrection as TranscriptCorrectionDB
@@ -571,10 +571,26 @@ class TranscriptCorrectionRepository(
 
         patterns: list[CorrectionPattern] = []
         for row in pairs:
+            # One count per pair, and `limit` is applied after this loop, so
+            # every pair is scanned however few are returned. Filtering the RAW
+            # text/corrected_text columns first gives PostgreSQL an
+            # index-eligible predicate (idx_segments_text_trgm /
+            # idx_segments_corrected_text_trgm); the CASE expression alone is
+            # opaque to those indexes and turns each iteration into a parallel
+            # seq scan of the whole segment corpus.
             remaining_stmt = (
                 select(func.count())
                 .select_from(TranscriptSegmentDB)
-                .where(effective_text.contains(row.original_text))
+                .where(
+                    or_(
+                        TranscriptSegmentDB.text.contains(row.original_text),
+                        TranscriptSegmentDB.corrected_text.contains(row.original_text),
+                    ),
+                    # The super-set is a candidate filter only. This keeps the
+                    # exact semantics: a segment whose raw text matches but
+                    # whose correction removed the phrase is not remaining.
+                    effective_text.contains(row.original_text),
+                )
             )
             remaining_result = await session.execute(remaining_stmt)
             remaining = remaining_result.scalar_one()

--- a/tests/unit/repositories/test_correction_pattern_index_eligibility.py
+++ b/tests/unit/repositories/test_correction_pattern_index_eligibility.py
@@ -1,0 +1,137 @@
+"""The remaining-matches counts must stay index-eligible (#203).
+
+`get_correction_patterns` issues one COUNT per correction pair, and applies
+`limit` only *after* that loop, so every pair is scanned however few are
+returned. Each count originally filtered on
+
+    CASE WHEN has_correction THEN corrected_text ELSE text END LIKE '%phrase%'
+
+A GIN trigram index cannot be used when LIKE targets a CASE expression, so each
+iteration became a parallel sequential scan of the whole segment corpus:
+measured at 100 pairs x ~105 ms = ~10.5 s, 83% of the endpoint's runtime.
+
+The fix adds an index-eligible super-set over the RAW `text` / `corrected_text`
+columns, keeping the CASE predicate as an exact re-check.
+
+Both halves are load-bearing and neither is protected by a functional test:
+
+* drop the **super-set** and every result stays correct while the query silently
+  returns to a full scan — no assertion anywhere would fail;
+* drop the **re-check** and it gets faster and quietly wrong, counting segments
+  whose correction already removed the phrase.
+
+So this asserts the shape of the emitted SQL, in the spirit of the
+constitution's rule that unit tests for queries verify the columns rather than
+just the return value.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.repositories.transcript_correction_repository import (
+    TranscriptCorrectionRepository,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _pair_row(original: str = "acme corp", corrected: str = "Acme Corp") -> MagicMock:
+    row = MagicMock()
+    row.original_text = original
+    row.corrected_text = corrected
+    row.occurrences = 3
+    return row
+
+
+def _session_returning_one_pair() -> tuple[MagicMock, list[Any]]:
+    """Session whose first execute yields one pair, and every later one a count.
+
+    The captured statement list is what the assertions inspect.
+    """
+    captured: list[Any] = []
+    session = MagicMock(spec=AsyncSession)
+
+    pairs_result = MagicMock()
+    pairs_result.all.return_value = [_pair_row()]
+
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = 7
+
+    async def _execute(stmt: Any, *args: Any, **kwargs: Any) -> Any:
+        captured.append(stmt)
+        return pairs_result if len(captured) == 1 else count_result
+
+    session.execute = AsyncMock(side_effect=_execute)
+    return session, captured
+
+
+def _remaining_sql(captured: list[Any]) -> str:
+    """Compile the per-pair COUNT statement (the second execute)."""
+    assert len(captured) >= 2, "expected a per-pair count query"
+    return str(captured[1].compile(compile_kwargs={"literal_binds": False}))
+
+
+class TestRemainingMatchesStaysIndexEligible:
+    async def test_filters_the_raw_columns_so_the_trigram_index_can_be_used(
+        self,
+    ) -> None:
+        """The super-set must name `text` AND `corrected_text` directly.
+
+        Naming them only inside the CASE would satisfy a substring check while
+        leaving the predicate opaque to the index, so the assertion below looks
+        for the raw comparisons rather than for the column names alone.
+        """
+        session, captured = _session_returning_one_pair()
+        await TranscriptCorrectionRepository().get_correction_patterns(
+            session, min_occurrences=2, limit=25, show_completed=True
+        )
+
+        sql = _remaining_sql(captured)
+        normalised = " ".join(sql.split()).lower()
+
+        assert "transcript_segments.text like" in normalised, (
+            "the raw `text` column is no longer filtered directly, so the "
+            "pg_trgm index cannot be used and this count is a full seq scan"
+        )
+        assert (
+            "transcript_segments.corrected_text like" in normalised
+        ), "the raw `corrected_text` column is no longer filtered directly"
+
+    async def test_keeps_the_case_expression_as_an_exact_recheck(self) -> None:
+        """The super-set alone over-counts; the CASE re-check is what fixes that."""
+        session, captured = _session_returning_one_pair()
+        await TranscriptCorrectionRepository().get_correction_patterns(
+            session, min_occurrences=2, limit=25, show_completed=True
+        )
+
+        normalised = " ".join(_remaining_sql(captured).split()).lower()
+
+        assert "case when" in normalised, (
+            "the CASE re-check is gone — the count now includes segments whose "
+            "correction already removed the phrase"
+        )
+        assert "has_correction" in normalised
+
+    async def test_the_raw_filter_is_a_union_not_an_intersection(self) -> None:
+        """`text OR corrected_text`, never AND.
+
+        AND would drop every uncorrected segment, because `corrected_text` is
+        NULL for 99.77% of the corpus — a silent under-count rather than a
+        slow query.
+        """
+        session, captured = _session_returning_one_pair()
+        await TranscriptCorrectionRepository().get_correction_patterns(
+            session, min_occurrences=2, limit=25, show_completed=True
+        )
+
+        normalised = " ".join(_remaining_sql(captured).split()).lower()
+        start = normalised.index("transcript_segments.text like")
+        end = normalised.index("transcript_segments.corrected_text like")
+        between = normalised[start:end]
+
+        assert " or " in between, "the raw-column candidate filter must be an OR"


### PR DESCRIPTION
Fixes #203.

`GET /api/v1/corrections/batch/diff-analysis` took ~15s and the ASR Error Patterns page could appear to hang.

**Measured on the live corpus (1,964,881 segments): 15.9s → 2.7–3.8s, with a byte-identical response** (43 patterns, same 4,837 total `remaining_matches`).

## Root cause

Two loops counted remaining matches with

```sql
CASE WHEN has_correction THEN corrected_text ELSE text END LIKE '%phrase%'
```

A GIN trigram index cannot be used when `LIKE` targets a CASE expression, so every iteration was a parallel sequential scan of the whole segment corpus. Confirmed with `EXPLAIN (ANALYZE, BUFFERS)`:

| predicate | plan | time |
|---|---|---|
| `CASE WHEN ... END LIKE '%tok%'` | Parallel Seq Scan | 356 ms |
| raw columns + CASE re-check | BitmapOr over both trigram indexes | 68 ms |

Both loops now filter the **raw** `text` / `corrected_text` columns first — an index-eligible candidate super-set — and keep the CASE predicate as an exact re-check, so results are unchanged. Same fix as #150.

## The issue named the mechanism but not the location

The loop #203 pointed at was real, and was the **smaller of the two**. 83% of the runtime was the same defect in `TranscriptCorrectionRepository.get_correction_patterns`, which the issue never measured — and which applies `limit` *after* its loop, so all 100 pairs are scanned however few are returned.

| phase | before | after |
|---|---|---|
| `get_patterns()` | **10.60 s** | **3.57 s** |
| count queries | ~14 s of seq scans | **0.52 s** |
| `word_level_diff` (CPU) | 0.002 s | 0.001 s |
| `_find_entity_by_name` ×43 | 0.09 s | 0.12 s |

Because the second fix is in the repository, every other `get_patterns()` caller benefits too, including the CLI.

## Suggestions from the issue that measurement ruled out

- **Collapsing the per-token counts into one grouped query is ~3× SLOWER** — 555 ms versus 186 ms for the same five tokens. The OR'd union fetches every matching row (23,960 against 1,770) and then evaluates each CASE against all of them.
- **The `_find_entity_by_name` N+1** is real but costs 0.09 s.
- **A short-token guard** would never fire: no token is shorter than three characters. One 3-char token does cost ~1.3 s — the index is used but has no selectivity — which is a separate problem worth its own issue.

## Also fixed

An empty `error_token` reaches the loop whenever the canonical form is non-empty, because the skip above it requires **both** to be empty. `contains("")` compiles to `LIKE '%%'` and matches every row in the corpus — simultaneously a meaningless count and the most expensive query the loop can issue.

## Testing

The new tests assert the **shape of the emitted SQL** rather than the return value, because neither half of the fix is observable through behaviour:

- drop the **super-set** and every result stays correct while the query silently returns to a full scan — no functional assertion would fail;
- drop the **re-check** and it gets faster and quietly wrong, counting segments whose correction already removed the phrase.

Both mutations were applied and verified to fail the new tests (2 and 1 respectively), with the tree green again after restoring.

This follows the constitution's rule that unit tests for queries verify the columns rather than just the return value.

## Checks

`ruff` · `black --check` · `mypy --strict` · full backend unit suite · full backend integration suite — all green. Frontend is untouched.
