### PR TITLE
perf(corrections): stop counting remaining matches nobody reads (#213)

### DIFF
--- a/src/chronovista/api/routers/batch_corrections.py
+++ b/src/chronovista/api/routers/batch_corrections.py
@@ -6,6 +6,7 @@ full transcript text from corrected segments, listing batches, and
 reverting entire batches.
 """
 
+import logging
 import uuid
 
 from fastapi import APIRouter, Depends, Query
@@ -66,6 +67,22 @@ _correction_service = TranscriptCorrectionService(
     segment_repo=_segment_repo,
     transcript_repo=_transcript_repo,
 )
+logger = logging.getLogger(__name__)
+
+# How many correction pairs diff-analysis will tokenise.
+#
+# `limit` used to truncate the pattern list *before* word-level extraction,
+# which can only lose tokens: 106 pairs against the default limit of 100
+# dropped six, and with them one token that no longer appeared in the response
+# at all. Since the endpoint returns tokens rather than patterns, and the
+# pattern fetch is cheap once the remaining-match counts are skipped (~0.12s
+# for 106 pairs), it now tokenises everything and applies `limit` to the
+# result — which is what that parameter has always claimed to do.
+#
+# The cap exists so the work stays bounded if the correction corpus grows. It
+# is logged when it bites rather than silently truncating.
+_PATTERN_TOKENISE_CAP = 1000
+
 _batch_service = BatchCorrectionService(
     correction_service=_correction_service,
     segment_repo=_segment_repo,
@@ -507,7 +524,9 @@ async def get_diff_analysis(
     min_occurrences : int
         Minimum number of occurrences for a pattern to be included (1-50).
     limit : int
-        Maximum number of patterns to return (1-500).
+        Maximum number of error patterns to return (1-500). Applied to the
+        response, after every correction pair has been tokenised — truncating
+        beforehand dropped tokens that were never derived at all.
     show_completed : bool
         Whether to include patterns with no remaining un-corrected matches.
     entity_name : str | None
@@ -523,12 +542,25 @@ async def get_diff_analysis(
     """
     # Always fetch all patterns (including completed) so we can extract
     # word-level tokens and recompute remaining_matches at the token level.
+    #
+    # with_remaining=False because this endpoint reads only original_text,
+    # corrected_text and occurrences — it recomputes remaining matches per
+    # token below, since the segment-level figure does not survive word-level
+    # extraction. Computing it here was the single largest cost in the
+    # request, and the result was discarded.
     patterns = await _batch_service.get_patterns(
         session,
         min_occurrences=min_occurrences,
-        limit=limit,
+        limit=_PATTERN_TOKENISE_CAP,
         show_completed=True,
+        with_remaining=False,
     )
+    if len(patterns) == _PATTERN_TOKENISE_CAP:
+        logger.warning(
+            "diff-analysis hit the pattern cap (%d); tokens from further "
+            "correction pairs are not represented in this response.",
+            _PATTERN_TOKENISE_CAP,
+        )
 
     # Aggregate word-level token pairs across all patterns.
     # Key: (error_token, canonical_form) -> frequency
@@ -623,7 +655,10 @@ async def get_diff_analysis(
     # Sort by remaining_matches DESC so actionable patterns come first
     results.sort(key=lambda r: r.remaining_matches, reverse=True)
 
-    return ApiResponse[list[DiffErrorPatternResponse]](data=results)
+    # `limit` now bounds what is returned rather than what is tokenised.
+    # Applied after the sort, so it keeps the most actionable patterns instead
+    # of dropping tokens before they were ever derived.
+    return ApiResponse[list[DiffErrorPatternResponse]](data=results[:limit])
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/src/chronovista/cli/correction_commands.py
+++ b/src/chronovista/cli/correction_commands.py
@@ -902,7 +902,11 @@ def patterns(
                     _truncate_end(p.original_text, 80),
                     _truncate_end(p.corrected_text, 80),
                     f"{p.occurrences:,}",
-                    f"{p.remaining_matches:,}",
+                    # This command asks for the counts, so they are present.
+                    # An em dash rather than 0 if that ever changes: unknown
+                    # and none-remaining are different facts, and printing 0
+                    # for the first would read as "fully corrected".
+                    "—" if p.remaining_matches is None else f"{p.remaining_matches:,}",
                     suggested,
                 )
 

--- a/src/chronovista/models/batch_correction_models.py
+++ b/src/chronovista/models/batch_correction_models.py
@@ -242,9 +242,14 @@ class CorrectionPattern(BaseModel):
         The corrected text that replaced the original.
     occurrences : int
         Number of times this correction has been applied (must be >= 0).
-    remaining_matches : int
+    remaining_matches : int | None
         Number of remaining segments that still contain the original text
-        (must be >= 0).
+        (must be >= 0), or ``None`` when the caller asked not to compute it.
+
+        ``None`` means *unknown*, never *zero*. Counting this is by far the
+        most expensive part of pattern discovery, and callers that never read
+        it can skip it; representing "not computed" as 0 would make a skipped
+        count indistinguishable from a correction that has been fully applied.
     """
 
     original_text: str = Field(
@@ -260,10 +265,13 @@ class CorrectionPattern(BaseModel):
         ge=0,
         description="Number of times this correction has been applied",
     )
-    remaining_matches: int = Field(
+    remaining_matches: int | None = Field(
         ...,
         ge=0,
-        description="Number of remaining segments still containing the original text",
+        description=(
+            "Number of remaining segments still containing the original text, "
+            "or null when not computed. Null means unknown, not zero."
+        ),
     )
 
     model_config = ConfigDict(frozen=True)

--- a/src/chronovista/repositories/transcript_correction_repository.py
+++ b/src/chronovista/repositories/transcript_correction_repository.py
@@ -504,6 +504,7 @@ class TranscriptCorrectionRepository(
         min_occurrences: int = 2,
         limit: int = 25,
         show_completed: bool = False,
+        with_remaining: bool = True,
     ) -> list[CorrectionPattern]:
         """
         Discover recurring correction patterns across all transcripts.
@@ -514,6 +515,13 @@ class TranscriptCorrectionRepository(
         by scanning transcript segments whose *effective text* (respecting
         ``has_correction``) still contains the original text — i.e. segments
         that have not yet been corrected.
+
+        That count is the expensive part: one query per pair, and ``limit`` is
+        applied afterwards, so every pair is counted however few are returned.
+        Measured over 106 pairs on a ~2M-segment corpus it was 4.68s against
+        0.13s for the grouping query — and 101 of those 106 counts came back
+        zero. Callers that never read ``remaining_matches`` should pass
+        ``with_remaining=False``.
 
         Parameters
         ----------
@@ -527,13 +535,32 @@ class TranscriptCorrectionRepository(
         show_completed : bool, optional
             If ``False`` (default), exclude patterns where
             ``remaining_matches == 0`` (all instances already corrected).
+        with_remaining : bool, optional
+            If ``True`` (default), count remaining matches per pair and order
+            by that count. If ``False``, skip the counts entirely, leave
+            ``remaining_matches`` as ``None`` and order by ``occurrences``.
 
         Returns
         -------
         list[CorrectionPattern]
-            Patterns sorted by ``remaining_matches`` DESC (highest-impact
-            first), limited to *limit* rows.
+            Patterns limited to *limit* rows, sorted by ``remaining_matches``
+            DESC when it was computed and by ``occurrences`` DESC otherwise.
+
+        Raises
+        ------
+        ValueError
+            If ``show_completed=False`` is combined with
+            ``with_remaining=False``. Excluding fully-applied patterns is a
+            filter on a count that would not be computed, so the combination
+            has no coherent meaning and silently returning everything would
+            be worse than refusing.
         """
+        if not with_remaining and not show_completed:
+            raise ValueError(
+                "show_completed=False requires with_remaining=True: patterns "
+                "cannot be filtered by a remaining-match count that is not "
+                "computed."
+            )
         revert_value = CorrectionType.REVERT.value
 
         # ---- Step 1: grouped pairs with occurrence counts ----
@@ -561,6 +588,24 @@ class TranscriptCorrectionRepository(
 
         if not pairs:
             return []
+
+        if not with_remaining:
+            # The whole cost of this method is the loop below. Skipping it is
+            # not an optimisation of the counting — it is not counting.
+            # Ordering falls back to `occurrences`, which the grouping query
+            # already produced, and which does not tie 95% of rows the way a
+            # remaining-match count does once most corrections are applied.
+            uncounted: list[CorrectionPattern] = [
+                CorrectionPattern(
+                    original_text=row.original_text,
+                    corrected_text=row.corrected_text,
+                    occurrences=row.occurrences,
+                    remaining_matches=None,
+                )
+                for row in pairs
+            ]
+            uncounted.sort(key=lambda p: p.occurrences, reverse=True)
+            return uncounted[:limit]
 
         # ---- Step 2: remaining_matches for each pair ----
         # Build the effective text expression for transcript segments
@@ -607,8 +652,10 @@ class TranscriptCorrectionRepository(
                 )
             )
 
-        # Sort by remaining_matches DESC, then limit
-        patterns.sort(key=lambda p: p.remaining_matches, reverse=True)
+        # Sort by remaining_matches DESC, then limit. Every pattern on this
+        # path has a computed count; the `or 0` satisfies the optional type
+        # without inventing an ordering for a value that cannot occur here.
+        patterns.sort(key=lambda p: p.remaining_matches or 0, reverse=True)
         return patterns[:limit]
 
     async def get_by_batch_id(

--- a/src/chronovista/services/batch_correction_service.py
+++ b/src/chronovista/services/batch_correction_service.py
@@ -1438,6 +1438,7 @@ class BatchCorrectionService:
         min_occurrences: int = 2,
         limit: int = 25,
         show_completed: bool = False,
+        with_remaining: bool = True,
     ) -> list[CorrectionPattern]:
         """
         Discover recurring correction patterns.
@@ -1452,11 +1453,17 @@ class BatchCorrectionService:
             Maximum patterns to return (default 25).
         show_completed : bool, optional
             Include patterns with zero remaining matches (default False).
+        with_remaining : bool, optional
+            If ``False``, skip the per-pair remaining-match counts — the
+            dominant cost of this call — leaving ``remaining_matches`` as
+            ``None`` and ordering by ``occurrences``. Callers that do not read
+            the count should pass ``False``.
 
         Returns
         -------
         list[CorrectionPattern]
-            Patterns sorted by remaining_matches DESC.
+            Patterns sorted by remaining_matches DESC, or by occurrences DESC
+            when ``with_remaining=False``.
         """
         _start_time = time.monotonic()
         logger.info(
@@ -1471,6 +1478,7 @@ class BatchCorrectionService:
             min_occurrences=min_occurrences,
             limit=limit,
             show_completed=show_completed,
+            with_remaining=with_remaining,
         )
 
         _elapsed = time.monotonic() - _start_time

--- a/src/chronovista/services/cross_segment_discovery.py
+++ b/src/chronovista/services/cross_segment_discovery.py
@@ -863,11 +863,14 @@ class CrossSegmentDiscovery:
         list[CrossSegmentCandidate]
             Candidates with ``discovery_source='correction_pattern'``.
         """
+        # with_remaining=False: only `original_text` is read below, so the
+        # per-pair remaining-match counts would be computed and discarded.
         patterns = await self._batch_service.get_patterns(
             session,
             min_occurrences=min_corrections,
             limit=200,
             show_completed=True,
+            with_remaining=False,
         )
 
         if not patterns:

--- a/tests/unit/api/test_diff_analysis_endpoint.py
+++ b/tests/unit/api/test_diff_analysis_endpoint.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.api.deps import get_db, require_auth
 from chronovista.api.main import app
+from chronovista.api.routers.batch_corrections import _PATTERN_TOKENISE_CAP
 from chronovista.models.batch_correction_models import CorrectionPattern
 
 # CRITICAL: This line ensures async tests work with coverage
@@ -162,6 +163,72 @@ class TestGetDiffAnalysis:
         assert data[0]["remaining_matches"] == 3
         assert data[0]["entity_id"] == str(entity_id)
         assert data[0]["entity_name"] == "Johnson"
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_limit_truncates_the_response(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+        client: AsyncClient,
+    ) -> None:
+        """`limit` bounds what is returned, now that it no longer bounds
+        what is tokenised.
+
+        Moving it off the pattern fetch would otherwise make it a silent
+        no-op: the endpoint would accept the parameter and ignore it.
+        """
+        patterns = [
+            _make_pattern(original_text=f"err{i}", corrected_text=f"Fix{i}")
+            for i in range(5)
+        ]
+        mock_service.get_patterns = AsyncMock(return_value=patterns)
+        mock_find_entity.return_value = (None, None)
+
+        response = await client.get(self.BASE_URL, params={"limit": 2})
+
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 2
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_every_pattern_is_tokenised_regardless_of_limit(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+        client: AsyncClient,
+    ) -> None:
+        """A small limit must not stop tokens being derived.
+
+        This is the defect the cap replaced: truncating the pattern list
+        before word-level extraction removed tokens from the response that
+        were never computed in the first place, so no amount of paging could
+        reach them.
+        """
+        patterns = [
+            _make_pattern(original_text=f"err{i}", corrected_text=f"Fix{i}")
+            for i in range(5)
+        ]
+        mock_service.get_patterns = AsyncMock(return_value=patterns)
+        mock_find_entity.return_value = (None, None)
+
+        await client.get(self.BASE_URL, params={"limit": 1})
+
+        assert (
+            mock_service.get_patterns.call_args.kwargs["limit"] == _PATTERN_TOKENISE_CAP
+        )
 
     @patch(
         "chronovista.api.routers.batch_corrections._find_entity_by_name",
@@ -315,9 +382,20 @@ class TestGetDiffAnalysis:
         mock_service.get_patterns.assert_awaited_once()
         call_kwargs = mock_service.get_patterns.call_args.kwargs
         assert call_kwargs["min_occurrences"] == 5
-        assert call_kwargs["limit"] == 50
+        # NOT the caller's limit. Truncating patterns before word-level
+        # extraction drops tokens that are never derived at all — measured as
+        # one token missing from the response entirely, because 106 correction
+        # pairs exceeded the default limit of 100. Every pair is tokenised and
+        # `limit` is applied to the response instead.
+        assert call_kwargs["limit"] == _PATTERN_TOKENISE_CAP
         # Always True — token-level filtering happens after word_level_diff
         assert call_kwargs["show_completed"] is True
+        # Always False — this endpoint recomputes remaining matches per token
+        # and never reads the segment-level figure. Asking for it cost ~3.5s
+        # per request and the result was discarded, so this is pinned: the
+        # saving is invisible in the response and nothing else would catch
+        # its loss.
+        assert call_kwargs["with_remaining"] is False
 
     @patch(
         "chronovista.api.routers.batch_corrections._find_entity_by_name",

--- a/tests/unit/repositories/test_correction_patterns_skip_counts.py
+++ b/tests/unit/repositories/test_correction_patterns_skip_counts.py
@@ -1,0 +1,141 @@
+"""`with_remaining=False` must actually skip the counting (#213).
+
+Counting remaining matches is the whole cost of `get_correction_patterns`:
+measured over 106 pairs on a ~2M-segment corpus at 4.68s, against 0.13s for the
+grouping query that precedes it. Two of the three callers never read the
+result — the diff-analysis endpoint recomputes it per token, and cross-segment
+discovery reads only `original_text`.
+
+The saving is entirely in *queries not issued*, so a test that only checked the
+returned values would pass against an implementation that still ran all 106
+counts and then discarded them. These assert the query count instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.repositories.transcript_correction_repository import (
+    TranscriptCorrectionRepository,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _pair(original: str, corrected: str, occurrences: int) -> MagicMock:
+    row = MagicMock()
+    row.original_text = original
+    row.corrected_text = corrected
+    row.occurrences = occurrences
+    return row
+
+
+def _session(pairs: list[MagicMock], remaining: int = 4) -> tuple[MagicMock, list[Any]]:
+    """First execute returns the grouped pairs; any later one returns a count."""
+    captured: list[Any] = []
+    session = MagicMock(spec=AsyncSession)
+
+    pairs_result = MagicMock()
+    pairs_result.all.return_value = pairs
+
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = remaining
+
+    async def _execute(stmt: Any, *a: Any, **kw: Any) -> Any:
+        captured.append(stmt)
+        return pairs_result if len(captured) == 1 else count_result
+
+    session.execute = AsyncMock(side_effect=_execute)
+    return session, captured
+
+
+THREE_PAIRS = [
+    _pair("aaa", "AAA", 5),
+    _pair("bbb", "BBB", 50),
+    _pair("ccc", "CCC", 12),
+]
+
+
+class TestSkipsTheCountQueries:
+    async def test_issues_only_the_grouping_query(self) -> None:
+        """One query total, not one per pair — this is the entire point."""
+        session, captured = _session(list(THREE_PAIRS))
+        await TranscriptCorrectionRepository().get_correction_patterns(
+            session, show_completed=True, with_remaining=False
+        )
+
+        assert len(captured) == 1, (
+            f"expected 1 query (the grouping query) but {len(captured)} were "
+            "issued — the per-pair counts are still running"
+        )
+
+    async def test_counting_is_still_the_default(self) -> None:
+        """Callers that do not opt out keep the previous behaviour exactly."""
+        session, captured = _session(list(THREE_PAIRS))
+        await TranscriptCorrectionRepository().get_correction_patterns(
+            session, show_completed=True
+        )
+
+        assert len(captured) == 1 + len(THREE_PAIRS)
+
+    async def test_remaining_is_none_not_zero(self) -> None:
+        """Unknown and none-remaining are different facts.
+
+        Reporting 0 for a count that was never taken would read as "this
+        correction has been fully applied", which is the opposite conclusion.
+        """
+        session, _ = _session(list(THREE_PAIRS))
+        patterns = await TranscriptCorrectionRepository().get_correction_patterns(
+            session, show_completed=True, with_remaining=False
+        )
+
+        assert patterns, "expected patterns back"
+        assert all(p.remaining_matches is None for p in patterns)
+
+
+class TestOrdering:
+    async def test_orders_by_occurrences_when_counts_are_skipped(self) -> None:
+        """The old sort key is unavailable, so fall back to a meaningful one."""
+        session, _ = _session(list(THREE_PAIRS))
+        patterns = await TranscriptCorrectionRepository().get_correction_patterns(
+            session, show_completed=True, with_remaining=False
+        )
+
+        assert [p.occurrences for p in patterns] == [50, 12, 5]
+
+    async def test_limit_applies_after_ordering(self) -> None:
+        """Otherwise the limit would drop the highest-occurrence patterns."""
+        session, _ = _session(list(THREE_PAIRS))
+        patterns = await TranscriptCorrectionRepository().get_correction_patterns(
+            session, limit=2, show_completed=True, with_remaining=False
+        )
+
+        assert [p.occurrences for p in patterns] == [50, 12]
+
+
+class TestIncoherentCombinationIsRefused:
+    async def test_show_completed_false_requires_the_counts(self) -> None:
+        """`show_completed=False` filters on a count that would not exist.
+
+        Silently returning everything would look like a working filter, which
+        is worse than refusing.
+        """
+        session, captured = _session(list(THREE_PAIRS))
+
+        with pytest.raises(ValueError, match="show_completed=False requires"):
+            await TranscriptCorrectionRepository().get_correction_patterns(
+                session, show_completed=False, with_remaining=False
+            )
+
+        assert captured == [], "refused before touching the database"
+
+    async def test_the_default_combination_is_allowed(self) -> None:
+        """show_completed=False with counting is the pre-existing default."""
+        session, _ = _session(list(THREE_PAIRS))
+        await TranscriptCorrectionRepository().get_correction_patterns(
+            session, show_completed=False
+        )

--- a/tests/unit/services/test_batch_correction_service.py
+++ b/tests/unit/services/test_batch_correction_service.py
@@ -1771,6 +1771,10 @@ class TestGetPatterns:
             min_occurrences=2,
             limit=25,
             show_completed=False,
+            # Defaults to counting: opting out is the caller's decision, and
+            # a service that silently skipped it would change every existing
+            # caller's results.
+            with_remaining=True,
         )
         assert len(result) == 1
         assert result[0].original_text == "teh"
@@ -1809,6 +1813,7 @@ class TestGetPatterns:
             min_occurrences=5,
             limit=10,
             show_completed=True,
+            with_remaining=True,
         )
 
     async def test_empty_patterns(
@@ -1880,7 +1885,7 @@ class TestGetPatterns:
         mock_session: AsyncMock,
         mock_correction_repo: AsyncMock,
     ) -> None:
-        """Default parameters are min_occurrences=2, limit=25, show_completed=False."""
+        """Defaults: min_occurrences=2, limit=25, show_completed=False, counting on."""
         mock_correction_repo.get_correction_patterns.return_value = []
 
         await service.get_patterns(mock_session)
@@ -1890,6 +1895,7 @@ class TestGetPatterns:
             min_occurrences=2,
             limit=25,
             show_completed=False,
+            with_remaining=True,
         )
 
     async def test_show_completed_true(

--- a/tests/unit/services/test_cross_segment_discovery.py
+++ b/tests/unit/services/test_cross_segment_discovery.py
@@ -359,6 +359,10 @@ class TestCrossSegmentDiscoveryDiscover:
             min_occurrences=3,
             limit=200,
             show_completed=True,
+            # Only `original_text` is read from these patterns, so the
+            # per-pair remaining-match counts would be computed and thrown
+            # away. Pinned here because the saving is invisible in the result.
+            with_remaining=False,
         )
 
     # (b) min_corrections forwarded to get_patterns


### PR DESCRIPTION
Fixes #213.

`get_correction_patterns` issues one `COUNT` per correction pair. Measured on the live corpus (1,964,881 segments):

```
STEP 1  grouped pairs query        0.130s  (106 pairs)
STEP 2  106 per-pair counts        4.680s
```

**101 of those 106 counts came back zero**, and two of the three callers never read the result.

## It is not round trips

Worth stating first, because it is the intuitive guess and it is wrong. Across 106 sequential awaits the overhead was **1 millisecond** of a 4.68s loop — batching or pipelining would buy nothing.

The queries are doing real work. A long `LIKE '%phrase%'` extracts many trigrams and the index scan must intersect that many posting lists, which is why the slowest are 39–43 characters long and match nothing:

| phrase length | matches | time |
|---|---|---|
| 41 | 0 | 212 ms |
| 43 | 0 | 163 ms |
| 39 | 0 | 134 ms |

The mirror image of #212, where a 3-character token is too *short* for the index to narrow anything.

## Who reads the value

| caller | reads `remaining_matches`? |
|---|---|
| diff-analysis endpoint | **no** — recomputes per token, since the segment-level figure does not survive word-level extraction |
| `cross_segment_discovery` | **no** — reads only `original_text` |
| CLI `corrections patterns` | yes, displays it |

The first two now pass `with_remaining=False`. The CLI is unchanged.

## Results

| phase | at #203 | now |
|---|---|---|
| `get_patterns()` | 3.58 s | **0.12 s** |
| endpoint end-to-end | 2.7–3.8 s | **0.58–0.67 s** |

Cumulative with #203: **15.9s → ~0.6s**.

## A pre-existing defect this surfaced

Skipping the counts removes the sort key, so ordering falls back to `occurrences`. That is not merely a substitute — 101 of 106 pairs tie at zero on the old key, so it ranked almost nothing.

Changing the order exposed something older: **`limit` truncated the pattern list *before* word-level extraction.** Patterns dropped there were never tokenised, so their tokens could not appear in the response and no amount of paging could reach them. With 106 pairs against the default limit of 100, one token was missing from the response entirely — and had been all along.

The endpoint now tokenises every pair and applies `limit` to the result, which is what that parameter has always claimed to do ("Maximum patterns to return"), applied after the sort so it keeps the most actionable.

Verified by set containment rather than by counting:

```
OLD (counted, limit=100):  100 patterns -> 45 tokens
NEW (all pairs, cap=1000): 106 patterns -> 46 tokens

old tokens are a SUBSET of new: True
  lost: 0    gained: 1
```

A cap bounds the tokenised set if the correction corpus grows, and **logs a warning when it bites** rather than truncating silently.

The frontend never sends `limit` — only `entityName` and `showCompleted` — so no current caller is affected by the response-truncation change.

## Contract details

`remaining_matches` becomes `int | None`, where **`None` means not computed, never zero**. Reporting `0` for a count that was never taken would read as "this correction has been fully applied" — the opposite conclusion.

`show_completed=False` combined with `with_remaining=False` raises `ValueError`: it filters on a count that would not exist, and silently returning everything would look like a working filter.

`CorrectionPattern.remaining_matches` is internal — the API's `remaining_matches` field belongs to `DiffErrorPatternResponse`, which the endpoint builds from its own token-level count — so no response schema changes.

## Testing

The new tests assert **the number of queries issued**, because the saving is entirely in queries not made: a test on returned values would pass against an implementation that still ran all 106 counts and discarded them. Forcing the flag off fails four of them.

Two endpoint tests cover the `limit` change — that it still truncates the response (otherwise moving it off the fetch makes it a parameter the endpoint accepts and ignores), and that every pattern is tokenised regardless of it.

## Checks

`ruff` · `black --check` · `mypy --strict` · backend unit (6,873 passed) · backend integration (1,281 passed) · `alembic check` — all green. Frontend untouched.
