### PR TITLE
perf: seek by key instead of counting past rows in four table walks (#204)

### DIFF
--- a/src/chronovista/repositories/base.py
+++ b/src/chronovista/repositories/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic
 
-from sqlalchemy import select
+from sqlalchemy import inspect, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
 from typing_extensions import TypeVar
@@ -125,6 +125,62 @@ class BaseSQLAlchemyRepository(
     ) -> list[ModelType]:
         """Get multiple entities with pagination."""
         result = await session.execute(select(self.model).offset(skip).limit(limit))
+        return list(result.scalars().all())
+
+    async def get_multi_after(
+        self,
+        session: AsyncSession,
+        *,
+        after: Any = None,
+        limit: int = 100,
+    ) -> list[ModelType]:
+        """Get a batch of entities after *after*, ordered by primary key.
+
+        Keyset pagination, for walking a whole table. Prefer this over
+        ``get_multi(skip=...)`` in a loop: ``OFFSET n`` makes PostgreSQL walk
+        and discard n rows to reach each window, so the per-batch cost grows
+        with depth and a full walk costs O(rows²). Seeking on the indexed key
+        keeps every batch the same price.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        after : Any, optional
+            Exclusive lower bound — the primary key of the last row of the
+            previous batch. ``None`` starts from the beginning.
+        limit : int, optional
+            Maximum rows to return (default 100).
+
+        Returns
+        -------
+        list[ModelType]
+            Up to *limit* entities in ascending primary-key order. An empty
+            list means the walk is finished.
+
+        Raises
+        ------
+        NotImplementedError
+            If the model has a composite primary key. Seeking on one would
+            need tuple comparison against the full key, and returning rows
+            ordered by only its first column would silently skip or repeat
+            rows sharing that value — a wrong answer rather than a slow one.
+        """
+        primary_key = inspect(self.model).primary_key
+        if len(primary_key) != 1:
+            columns = ", ".join(c.name for c in primary_key)
+            raise NotImplementedError(
+                f"{type(self).__name__}.get_multi_after() needs a single-column "
+                f"primary key; {self.model.__name__} has ({columns}). Walk it "
+                "with an explicit keyset statement over the full key instead."
+            )
+
+        pk_column = primary_key[0]
+        stmt = select(self.model).order_by(pk_column.asc()).limit(limit)
+        if after is not None:
+            stmt = stmt.where(pk_column > after)
+
+        result = await session.execute(stmt)
         return list(result.scalars().all())
 
     async def update(

--- a/src/chronovista/services/image_cache.py
+++ b/src/chronovista/services/image_cache.py
@@ -966,17 +966,17 @@ class ImageCacheService:
         count_result = await session.execute(select(func.count()).select_from(VideoDB))
         total = count_result.scalar_one()
 
-        # Stream video IDs in 1,000-row batches
+        # Stream video IDs in 1,000-row batches, seeking on the primary key
+        # rather than counting past rows: OFFSET n discards n rows to reach
+        # each window, so a full walk costs O(rows²) (#202, #204).
         batch_size = 1000
-        offset = 0
+        after: str | None = None
 
         while True:
-            result = await session.execute(
-                select(VideoDB.video_id)
-                .order_by(VideoDB.video_id)
-                .offset(offset)
-                .limit(batch_size)
-            )
+            stmt = select(VideoDB.video_id).order_by(VideoDB.video_id).limit(batch_size)
+            if after is not None:
+                stmt = stmt.where(VideoDB.video_id > after)
+            result = await session.execute(stmt)
             batch = result.scalars().all()
             if not batch:
                 break
@@ -1035,7 +1035,8 @@ class ImageCacheService:
                 if delay > 0:
                     await asyncio.sleep(delay)
 
-            offset += batch_size
+            # Advance from the last row returned, not by a fixed stride.
+            after = batch[-1]
 
         return WarmResult(
             downloaded=downloaded,

--- a/src/chronovista/services/takeout_recovery_service.py
+++ b/src/chronovista/services/takeout_recovery_service.py
@@ -181,16 +181,18 @@ class TakeoutRecoveryService:
         """
         logger.info("Scanning database for recoverable videos...")
 
-        # Get all videos from database
-        # Process in batches to handle large datasets
-        skip = 0
+        # Get all videos from database, walking by key rather than by offset:
+        # OFFSET n discards n rows to reach each window, so a full walk costs
+        # O(rows²). See #202, where the same shape made an entity scan
+        # quadratic in corpus size.
+        after: str | None = None
         videos_checked = 0
         placeholder_count = 0
         null_channel_count = 0
 
         while True:
-            videos = await self.video_repository.get_multi(
-                session, skip=skip, limit=options.batch_size
+            videos = await self.video_repository.get_multi_after(
+                session, after=after, limit=options.batch_size
             )
 
             if not videos:
@@ -293,7 +295,9 @@ class TakeoutRecoveryService:
 
                 result.videos_recovered += 1
 
-            skip += options.batch_size
+            # Advance from the last row actually returned. There is no fixed
+            # stride to add: the cursor is data, not a count.
+            after = videos[-1].video_id
 
             if options.verbose:
                 logger.info(
@@ -449,12 +453,12 @@ class TakeoutRecoveryService:
             Number of placeholder videos
         """
         count = 0
-        skip = 0
+        after: str | None = None
         batch_size = 100
 
         while True:
-            videos = await self.video_repository.get_multi(
-                session, skip=skip, limit=batch_size
+            videos = await self.video_repository.get_multi_after(
+                session, after=after, limit=batch_size
             )
 
             if not videos:
@@ -464,7 +468,7 @@ class TakeoutRecoveryService:
                 if is_placeholder_video_title(video.title):
                     count += 1
 
-            skip += batch_size
+            after = videos[-1].video_id
 
         return count
 
@@ -483,12 +487,12 @@ class TakeoutRecoveryService:
             Number of placeholder channels
         """
         count = 0
-        skip = 0
+        after: str | None = None
         batch_size = 100
 
         while True:
-            channels = await self.channel_repository.get_multi(
-                session, skip=skip, limit=batch_size
+            channels = await self.channel_repository.get_multi_after(
+                session, after=after, limit=batch_size
             )
 
             if not channels:
@@ -498,6 +502,6 @@ class TakeoutRecoveryService:
                 if is_placeholder_channel_name(channel.title):
                     count += 1
 
-            skip += batch_size
+            after = channels[-1].channel_id
 
         return count

--- a/tests/unit/repositories/test_keyset_pagination.py
+++ b/tests/unit/repositories/test_keyset_pagination.py
@@ -1,0 +1,290 @@
+"""Keyset pagination must actually seek, and callers must actually advance (#204).
+
+``OFFSET n`` makes PostgreSQL walk and discard n rows to reach each window, so
+per-batch cost grows with depth and a full table walk costs O(rows²). #202 hit
+this in the entity mention scan; #204 is the same defect in four other loops.
+
+Two things make this hard to test, both learned in #202:
+
+* **OFFSET and keyset return identical rows for the first page.** A test that
+  only checks returned values passes against either implementation, so the
+  emitted SQL has to be asserted directly.
+* **A mock that accepts a cursor and ignores it passes whether or not the
+  cursor advances.** Every stub here honours the cursor, and the fakes below
+  fail loudly rather than hanging if a caller stops advancing it — an
+  unbounded loop in a test suite reads as a hung machine, not a bug.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import Video as VideoDB
+from chronovista.models.video import VideoCreate, VideoUpdate
+from chronovista.repositories.base import BaseSQLAlchemyRepository
+
+pytestmark = pytest.mark.asyncio
+
+
+class _VideoRepo(BaseSQLAlchemyRepository[VideoDB, VideoCreate, VideoUpdate]):
+    def __init__(self) -> None:
+        super().__init__(VideoDB)
+
+
+def _capturing_session() -> tuple[MagicMock, list[Any]]:
+    """Session that records every statement and returns no rows."""
+    captured: list[Any] = []
+    session = MagicMock(spec=AsyncSession)
+
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = []
+    result.scalars.return_value = scalars
+
+    async def _execute(stmt: Any, *a: Any, **kw: Any) -> Any:
+        captured.append(stmt)
+        return result
+
+    session.execute = AsyncMock(side_effect=_execute)
+    return session, captured
+
+
+def _sql(stmt: Any) -> str:
+    return " ".join(str(stmt.compile()).split()).lower()
+
+
+class TestEmittedSql:
+    """The plan, not the rows — the two are indistinguishable on page one."""
+
+    async def test_no_offset_is_emitted(self) -> None:
+        session, captured = _capturing_session()
+        await _VideoRepo().get_multi_after(session, after="abc", limit=10)
+
+        assert "offset" not in _sql(
+            captured[0]
+        ), "OFFSET is back: the walk is quadratic in table size again"
+
+    async def test_seeks_on_the_primary_key(self) -> None:
+        session, captured = _capturing_session()
+        await _VideoRepo().get_multi_after(session, after="abc", limit=10)
+
+        sql = _sql(captured[0])
+        assert "videos.video_id >" in sql, f"no keyset predicate in: {sql}"
+
+    async def test_orders_by_the_primary_key(self) -> None:
+        """Without a total order the cursor cannot be resumed from."""
+        session, captured = _capturing_session()
+        await _VideoRepo().get_multi_after(session, after="abc", limit=10)
+
+        assert "order by videos.video_id asc" in _sql(captured[0])
+
+    async def test_first_page_has_no_predicate(self) -> None:
+        """`after=None` starts at the beginning rather than excluding rows."""
+        session, captured = _capturing_session()
+        await _VideoRepo().get_multi_after(session, after=None, limit=10)
+
+        sql = _sql(captured[0])
+        assert "videos.video_id >" not in sql
+        assert "order by videos.video_id asc" in sql
+        assert "limit" in sql
+
+
+class TestCompositeKeyIsRefused:
+    async def test_composite_primary_key_raises(self) -> None:
+        """Ordering by only the first column of a composite key would silently
+        skip or repeat rows sharing that value — wrong, not merely slow."""
+        from chronovista.db.models import UserVideo
+
+        class _UserVideoRepo(BaseSQLAlchemyRepository[UserVideo, Any, Any]):
+            def __init__(self) -> None:
+                super().__init__(UserVideo)
+
+        session, _ = _capturing_session()
+        with pytest.raises(NotImplementedError, match="single-column primary key"):
+            await _UserVideoRepo().get_multi_after(session, after=None, limit=10)
+
+
+class _FakeKeysetRepo:
+    """Repository double that genuinely honours the cursor.
+
+    Returning a fixed sequence regardless of `after` — which is what the
+    existing service stubs do — cannot distinguish a caller that advances the
+    cursor from one that does not. This one can, and refuses to loop forever.
+    """
+
+    MAX_CALLS = 50
+
+    def __init__(self, ids: list[str]) -> None:
+        self.ids = sorted(ids)
+        self.cursors: list[str | None] = []
+
+    async def get_multi_after(
+        self, session: Any, *, after: str | None = None, limit: int = 100
+    ) -> list[Any]:
+        self.cursors.append(after)
+        if len(self.cursors) > self.MAX_CALLS:
+            raise AssertionError(
+                f"cursor did not advance: {self.MAX_CALLS} calls, "
+                f"last cursors {self.cursors[-3:]}. A caller that fails to "
+                "advance would otherwise hang rather than fail."
+            )
+        remaining = [i for i in self.ids if after is None or i > after]
+        rows = []
+        for vid in remaining[:limit]:
+            row = MagicMock()
+            row.video_id = vid
+            row.channel_id = "UCtest"
+            rows.append(row)
+        return rows
+
+
+class TestTheFakeItself:
+    """A test double this load-bearing needs its own proof."""
+
+    async def test_walks_every_row_exactly_once(self) -> None:
+        repo = _FakeKeysetRepo([f"vid{i:03d}" for i in range(25)])
+        seen: list[str] = []
+        after: str | None = None
+        while True:
+            batch = await repo.get_multi_after(None, after=after, limit=10)
+            if not batch:
+                break
+            seen.extend(r.video_id for r in batch)
+            after = batch[-1].video_id
+
+        assert seen == sorted(seen)
+        assert len(seen) == len(set(seen)) == 25
+        assert repo.cursors == [None, "vid009", "vid019", "vid024"]
+
+    async def test_a_non_advancing_caller_fails_instead_of_hanging(self) -> None:
+        repo = _FakeKeysetRepo([f"vid{i:03d}" for i in range(25)])
+        with pytest.raises(AssertionError, match="cursor did not advance"):
+            while True:
+                batch = await repo.get_multi_after(None, after=None, limit=10)
+                if not batch:
+                    break
+
+
+class TestRealCallSitesAdvanceTheCursor:
+    """The call sites, against a double that can tell the difference.
+
+    The service's own suite stubs the repository with a fixed `side_effect`
+    sequence, which returns the same batches no matter what cursor it is
+    handed — so it passes whether or not the caller advances. These drive the
+    real methods through a cursor-honouring fake instead, where failing to
+    advance means revisiting the first batch forever.
+    """
+
+    async def test_count_placeholder_videos_walks_the_whole_table(self) -> None:
+        from chronovista.services.takeout_recovery_service import (
+            TakeoutRecoveryService,
+        )
+
+        # Batch size inside the method is 100; 250 rows forces three windows
+        # plus the terminating empty read.
+        ids = [f"vid{i:04d}" for i in range(250)]
+        repo = _FakeKeysetRepo(ids)
+        service = TakeoutRecoveryService(
+            video_repository=repo,  # type: ignore[arg-type]
+            channel_repository=MagicMock(),
+        )
+
+        count = await service.count_placeholder_videos(MagicMock())
+
+        # The fake's titles are MagicMocks, not placeholder strings, so the
+        # count is not the assertion — the walk is.
+        assert isinstance(count, int)
+        assert repo.cursors == [None, "vid0099", "vid0199", "vid0249"], (
+            "the cursor sequence should be the last id of each batch; "
+            f"got {repo.cursors}"
+        )
+
+    async def test_count_placeholder_channels_walks_the_whole_table(self) -> None:
+        from chronovista.services.takeout_recovery_service import (
+            TakeoutRecoveryService,
+        )
+
+        class _FakeChannelRepo(_FakeKeysetRepo):
+            async def get_multi_after(
+                self, session: Any, *, after: str | None = None, limit: int = 100
+            ) -> list[Any]:
+                rows = await super().get_multi_after(session, after=after, limit=limit)
+                for row in rows:
+                    row.channel_id = row.video_id
+                return rows
+
+        ids = [f"UC{i:04d}" for i in range(250)]
+        repo = _FakeChannelRepo(ids)
+        service = TakeoutRecoveryService(
+            video_repository=MagicMock(),
+            channel_repository=repo,  # type: ignore[arg-type]
+        )
+
+        await service.count_placeholder_channels(MagicMock())
+
+        assert repo.cursors == [None, "UC0099", "UC0199", "UC0249"]
+
+    async def test_image_cache_warm_videos_walks_the_whole_table(
+        self, tmp_path: Any
+    ) -> None:
+        """The fourth site, which builds its own statement rather than using
+        the repository.
+
+        `warm_videos` is mocked out wholesale everywhere else in the suite, so
+        its loop body had no coverage at all — the conversion would otherwise
+        be unverified. Driven in dry-run so nothing is fetched over the
+        network.
+        """
+        from chronovista.services.image_cache import (
+            ImageCacheConfig,
+            ImageCacheService,
+        )
+
+        ids = [f"vid{i:05d}" for i in range(2500)]  # three 1,000-row windows
+        cursors: list[str | None] = []
+
+        def _after_from(stmt: Any) -> str | None:
+            """Recover the bound cursor from the compiled statement."""
+            params = stmt.compile().params
+            for key, value in params.items():
+                if "video_id" in key and isinstance(value, str):
+                    return value
+            return None
+
+        session = MagicMock(spec=AsyncSession)
+        calls = {"n": 0}
+
+        async def _execute(stmt: Any, *a: Any, **kw: Any) -> Any:
+            calls["n"] += 1
+            result = MagicMock()
+            sql = " ".join(str(stmt).split()).lower()
+            if "count" in sql:
+                result.scalar_one.return_value = len(ids)
+                return result
+            after = _after_from(stmt)
+            cursors.append(after)
+            if len(cursors) > 20:
+                raise AssertionError(f"cursor did not advance: {cursors[-3:]}")
+            remaining = [i for i in ids if after is None or i > after]
+            scalars = MagicMock()
+            scalars.all.return_value = remaining[:1000]
+            result.scalars.return_value = scalars
+            return result
+
+        session.execute = AsyncMock(side_effect=_execute)
+
+        config = ImageCacheConfig(
+            cache_dir=tmp_path,
+            channels_dir=tmp_path / "channels",
+            videos_dir=tmp_path / "videos",
+        )
+        result = await ImageCacheService(config).warm_videos(
+            session, dry_run=True, delay=0
+        )
+
+        assert result.downloaded == 2500, "every row should have been visited"
+        assert cursors == [None, "vid00999", "vid01999", "vid02499"]

--- a/tests/unit/services/test_takeout_recovery_service.py
+++ b/tests/unit/services/test_takeout_recovery_service.py
@@ -61,12 +61,12 @@ class TestRecoverFromHistoricalTakeouts:
     def mock_repositories(self) -> tuple[MagicMock, MagicMock]:
         """Create mock video and channel repositories."""
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(return_value=[])
+        video_repo.get_multi_after = AsyncMock(return_value=[])
         video_repo.update = AsyncMock()
 
         channel_repo = MagicMock()
         channel_repo.get = AsyncMock(return_value=None)
-        channel_repo.get_multi = AsyncMock(return_value=[])
+        channel_repo.get_multi_after = AsyncMock(return_value=[])
         channel_repo.create = AsyncMock()
         channel_repo.update = AsyncMock()
 
@@ -239,7 +239,7 @@ class TestRecoverVideos:
         mock_video.channel_id = "UCplaceholder"
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
         video_repo.update = AsyncMock()
 
         channel_repo = MagicMock()
@@ -281,7 +281,7 @@ class TestRecoverVideos:
         mock_video.channel_id = "UCreal"  # Has channel_id already
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
 
         service = TakeoutRecoveryService(
             video_repository=video_repo,
@@ -319,7 +319,7 @@ class TestRecoverVideos:
         mock_channel.channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
         video_repo.update = AsyncMock()
 
         channel_repo = MagicMock()
@@ -367,7 +367,7 @@ class TestRecoverVideos:
         mock_channel.channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
         video_repo.update = AsyncMock()
 
         channel_repo = MagicMock()
@@ -412,7 +412,7 @@ class TestRecoverVideos:
         mock_video.channel_id = None  # NULL channel_id
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
         video_repo.update = AsyncMock()
 
         channel_repo = MagicMock()
@@ -453,7 +453,7 @@ class TestRecoverVideos:
         mock_video.title = "[Placeholder] Video missing123"
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
 
         service = TakeoutRecoveryService(
             video_repository=video_repo,
@@ -478,7 +478,7 @@ class TestRecoverVideos:
         mock_video.channel_id = None
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
         video_repo.update = AsyncMock()
 
         service = TakeoutRecoveryService(
@@ -690,7 +690,7 @@ class TestCountPlaceholders:
         ]
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[mock_videos, []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[mock_videos, []])
 
         service = TakeoutRecoveryService(
             video_repository=video_repo,
@@ -710,7 +710,7 @@ class TestCountPlaceholders:
         ]
 
         channel_repo = MagicMock()
-        channel_repo.get_multi = AsyncMock(side_effect=[mock_channels, []])
+        channel_repo.get_multi_after = AsyncMock(side_effect=[mock_channels, []])
 
         service = TakeoutRecoveryService(
             video_repository=MagicMock(),
@@ -724,10 +724,10 @@ class TestCountPlaceholders:
     async def test_count_empty_database(self, mock_session: AsyncMock) -> None:
         """Test counting placeholders in empty database."""
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(return_value=[])
+        video_repo.get_multi_after = AsyncMock(return_value=[])
 
         channel_repo = MagicMock()
-        channel_repo.get_multi = AsyncMock(return_value=[])
+        channel_repo.get_multi_after = AsyncMock(return_value=[])
 
         service = TakeoutRecoveryService(
             video_repository=video_repo,
@@ -770,7 +770,7 @@ class TestRecoveryNeverSetsDeletedFlag:
         )  # Video is not deleted initially
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
         video_repo.update = AsyncMock()
 
         channel_repo = MagicMock()
@@ -827,7 +827,7 @@ class TestRecoveryNeverSetsDeletedFlag:
         )  # Previously marked as deleted
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
         video_repo.update = AsyncMock()
 
         channel_repo = MagicMock()
@@ -877,7 +877,7 @@ class TestRecoveryNeverSetsDeletedFlag:
         """Test that new videos created from recovery have availability_status=False."""
         # No videos in database initially
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(return_value=[])
+        video_repo.get_multi_after = AsyncMock(return_value=[])
 
         channel_repo = MagicMock()
         channel_repo.get = AsyncMock(return_value=None)
@@ -929,7 +929,7 @@ class TestRecoveryNeverSetsDeletedFlag:
         mock_video.availability_status = AvailabilityStatus.AVAILABLE
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
         video_repo.update = AsyncMock()
 
         service = TakeoutRecoveryService(
@@ -970,7 +970,7 @@ class TestRecoveryNeverSetsDeletedFlag:
         mock_video.availability_status = AvailabilityStatus.AVAILABLE  # Not deleted
 
         video_repo = MagicMock()
-        video_repo.get_multi = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
         video_repo.update = AsyncMock()
 
         service = TakeoutRecoveryService(


### PR DESCRIPTION
Fixes #204.

`OFFSET n` makes PostgreSQL walk and discard n rows to reach each window, so the per-batch cost grows with depth and a full table walk costs **O(rows²)**. #202 fixed this in the entity mention scan; these four loops had the identical defect and were left out of that diff to keep it scoped.

| site | walks |
|---|---|
| `takeout_recovery_service.py` — recovery loop | videos |
| `takeout_recovery_service.py` — count placeholder videos | videos |
| `takeout_recovery_service.py` — count placeholder channels | channels |
| `image_cache.py` — warm | videos |

## The design question the issue left open

Three of the four go through `BaseSQLAlchemyRepository.get_multi(skip=...)`, so the issue asked for a choice: a keyset-capable variant on the base repository, or direct statements at each call site.

**Base repository**, because there are three real call sites — the Rule of Three is met rather than anticipated. It is a **concrete** method, so none of the 23 subclasses is affected.

```python
async def get_multi_after(self, session, *, after=None, limit=100) -> list[ModelType]
```

The key column comes from `inspect(model).primary_key`, and a **composite key is refused** rather than approximated: ordering by only the first column of `(user_id, video_id)` would silently skip or repeat rows sharing that value — a wrong answer rather than a slow one. The fourth site builds its own statement and was converted in place.

## The error path from #202 does not arise

#202 had to redesign failure handling, because under `OFFSET` a failed fetch can be skipped by advancing the offset, while a cursor has no fixed stride. None of these four loops wraps the fetch in `try/except`, so there is no skip-on-failure behaviour a cursor would break. Checked rather than assumed.

## Deliberately not done

Two of these walk the entire table only to **count** rows matching `title.startswith(prefix)` — expressible as `LIKE 'prefix%'`, which would remove the walk rather than merely linearise it.

Not done here because **#207 is open about that predicate being wrong** (it misses the URL-as-title form), and it already exists in two Python copies. Encoding it in SQL now would make #207 a three-place fix. Worth revisiting once #207 consolidates it.

## Testing — the existing tests could not have caught a broken conversion

The service suite stubs the repository with a fixed `side_effect` sequence, which returns the same batches whatever cursor it is handed. Those tests pass whether or not the caller advances — exactly the trap the issue warned about. Renaming the stubs made 87 tests pass again and proved nothing.

The new tests assert what the returned values cannot show:

- **the emitted SQL**, because `OFFSET` and keyset return identical rows for the first page;
- **the cursor sequence**, through doubles that honour the cursor and **fail loudly rather than looping forever** — an unbounded loop in a test suite reads as a hung machine, not a bug.

All three mutable points were mutation-verified:

| mutation | caught by |
|---|---|
| a call site stops advancing the cursor | cursor-honouring fake's call guard (fails in ~3.5s) |
| base repository reverts to `OFFSET` | emitted-SQL assertions |
| `image_cache` stops advancing | walk-completeness assertion |

`warm_videos` had **no loop coverage at all** — it is mocked out wholesale everywhere else — so that conversion would otherwise have shipped unverified.

## Checks

`ruff` · `black --check` · `mypy --strict` (249 files) · backend unit (**6,883 passed**) · backend integration (**1,284 passed**) · `alembic check` (no drift) — all green.

No migration, no schema change, no frontend change.
