### PR TITLE
fix(cache): walk the image cache with os.walk instead of rglob (#101)

### DIFF
--- a/src/chronovista/api/routers/settings.py
+++ b/src/chronovista/api/routers/settings.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 from datetime import datetime
 
@@ -125,59 +124,21 @@ async def get_cache_status() -> ApiResponse[CacheStatusResponse]:
     ApiResponse[CacheStatusResponse]
         Cache statistics including counts, size, and file timestamps.
     """
-    # ImageCacheService.get_stats() uses pathlib.rglob which fails on Docker
-    # overlayfs with many prefix directories.  Use os.walk instead.
-    channel_count = 0
-    video_count = 0
-    total_size_bytes = 0
-    oldest_mtime: float | None = None
-    newest_mtime: float | None = None
-
-    def _update_mtime(mtime: float) -> None:
-        nonlocal oldest_mtime, newest_mtime
-        if oldest_mtime is None or mtime < oldest_mtime:
-            oldest_mtime = mtime
-        if newest_mtime is None or mtime > newest_mtime:
-            newest_mtime = mtime
-
-    channels_dir = _image_cache_config.channels_dir
-    if channels_dir.is_dir():
-        for entry in os.scandir(channels_dir):
-            if entry.name.endswith(".jpg") and entry.is_file():
-                channel_count += 1
-                stat = entry.stat()
-                total_size_bytes += stat.st_size
-                _update_mtime(stat.st_mtime)
-
-    videos_dir = _image_cache_config.videos_dir
-    if videos_dir.is_dir():
-        for root, _dirs, files in os.walk(videos_dir):
-            for fname in files:
-                if fname.endswith(".jpg"):
-                    video_count += 1
-                    fpath = os.path.join(root, fname)
-                    try:
-                        stat = os.stat(fpath)
-                        total_size_bytes += stat.st_size
-                        _update_mtime(stat.st_mtime)
-                    except OSError:
-                        pass
-
-    oldest_file = (
-        datetime.fromtimestamp(oldest_mtime) if oldest_mtime is not None else None
-    )
-    newest_file = (
-        datetime.fromtimestamp(newest_mtime) if newest_mtime is not None else None
-    )
+    # This endpoint used to walk the cache itself, because
+    # ImageCacheService.get_stats() reached for pathlib's rglob, which raises
+    # FileNotFoundError on Docker overlay2 when an entry disappears mid-scan.
+    # The service now walks with os.walk and tolerates that, so there is one
+    # implementation again rather than two that could drift apart.
+    stats = await _image_cache_service.get_stats()
 
     response = CacheStatusResponse(
-        channel_count=channel_count,
-        video_count=video_count,
-        total_count=channel_count + video_count,
-        total_size_bytes=total_size_bytes,
-        total_size_display=_format_size_display(total_size_bytes),
-        oldest_file=oldest_file,
-        newest_file=newest_file,
+        channel_count=stats.channel_count,
+        video_count=stats.video_count,
+        total_count=stats.channel_count + stats.video_count,
+        total_size_bytes=stats.total_size_bytes,
+        total_size_display=_format_size_display(stats.total_size_bytes),
+        oldest_file=stats.oldest_file,
+        newest_file=stats.newest_file,
     )
     return ApiResponse[CacheStatusResponse](data=response)
 

--- a/src/chronovista/services/image_cache.py
+++ b/src/chronovista/services/image_cache.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from collections.abc import Callable
+import os
+from collections.abc import Callable, Iterator
 from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
@@ -26,6 +27,78 @@ from chronovista.db.models import Channel as ChannelDB
 from chronovista.db.models import Video as VideoDB
 
 logger = logging.getLogger(__name__)
+
+
+def iter_cached_files(
+    directory: Path, suffix: str, *, recursive: bool
+) -> Iterator[tuple[Path, os.stat_result]]:
+    """Yield ``(path, stat)`` for every file under *directory* ending in *suffix*.
+
+    Uses ``os.walk`` / ``os.scandir`` rather than ``pathlib``'s ``glob`` and
+    ``rglob``, and tolerates entries that vanish mid-iteration.
+
+    WHY NOT rglob
+    -------------
+    Before Python 3.13, ``pathlib``'s recursive glob raises ``FileNotFoundError``
+    when a directory entry disappears between enumeration and the follow-up
+    ``stat`` (CPython bpo-33428, fixed by GH-116380). On Docker's overlay2
+    filesystem that race fires readily: the video cache holds roughly 16,000
+    thumbnails across ~1,439 sharded prefix directories, and the failure landed
+    on a different random directory each run — the signature of a race rather
+    than a corrupt tree. The container runs Python 3.11.
+
+    ``os.walk`` swallows errors from its own ``scandir`` iteration and keeps
+    going, but a ``stat`` on a file that has since been removed still raises, so
+    that call is guarded here too. A vanished file is skipped rather than
+    counted at zero bytes: cache entries are evicted concurrently, and a stats
+    call that crashes is worse than one that omits a file being deleted as it
+    reads.
+
+    Parameters
+    ----------
+    directory : Path
+        Root to scan. A non-directory yields nothing.
+    suffix : str
+        Filename suffix to match, e.g. ``".jpg"``.
+    recursive : bool
+        Descend into subdirectories. The video cache is sharded by prefix and
+        needs this; the channel cache is flat and does not.
+
+    Yields
+    ------
+    tuple[Path, os.stat_result]
+        Each matching file and its stat, already resolved so callers need no
+        second syscall that could fail on its own.
+    """
+    if not directory.is_dir():
+        return
+
+    if recursive:
+        for root, _dirs, files in os.walk(directory):
+            for name in files:
+                if not name.endswith(suffix):
+                    continue
+                path = Path(root) / name
+                try:
+                    yield path, os.stat(path)
+                except OSError:
+                    continue
+        return
+
+    try:
+        entries = list(os.scandir(directory))
+    except OSError:
+        return
+    for entry in entries:
+        if not entry.name.endswith(suffix):
+            continue
+        try:
+            if not entry.is_file():
+                continue
+            yield Path(entry.path), entry.stat()
+        except OSError:
+            continue
+
 
 # ---------------------------------------------------------------------------
 # Maximum image size: 5 MB (FR-029)
@@ -1078,31 +1151,25 @@ class ImageCacheService:
             if newest_mtime is None or mtime > newest_mtime:
                 newest_mtime = mtime
 
-        # Scan channels directory
+        # Scan channels directory (flat)
         channels_dir = self._config.channels_dir
-        if channels_dir.is_dir():
-            for path in channels_dir.glob("*.jpg"):
-                if path.is_file():
-                    channel_count += 1
-                    stat = path.stat()
-                    total_size_bytes += stat.st_size
-                    _update_mtime(stat.st_mtime)
-            for path in channels_dir.glob("*.missing"):
-                if path.is_file():
-                    channel_missing_count += 1
+        for _path, stat in iter_cached_files(channels_dir, ".jpg", recursive=False):
+            channel_count += 1
+            total_size_bytes += stat.st_size
+            _update_mtime(stat.st_mtime)
+        for _path, _stat in iter_cached_files(
+            channels_dir, ".missing", recursive=False
+        ):
+            channel_missing_count += 1
 
-        # Scan videos directory (recursive due to sharding)
+        # Scan videos directory (recursive due to prefix sharding)
         videos_dir = self._config.videos_dir
-        if videos_dir.is_dir():
-            for path in videos_dir.rglob("*.jpg"):
-                if path.is_file():
-                    video_count += 1
-                    stat = path.stat()
-                    total_size_bytes += stat.st_size
-                    _update_mtime(stat.st_mtime)
-            for path in videos_dir.rglob("*.missing"):
-                if path.is_file():
-                    video_missing_count += 1
+        for _path, stat in iter_cached_files(videos_dir, ".jpg", recursive=True):
+            video_count += 1
+            total_size_bytes += stat.st_size
+            _update_mtime(stat.st_mtime)
+        for _path, _stat in iter_cached_files(videos_dir, ".missing", recursive=True):
+            video_missing_count += 1
 
         oldest_file = (
             datetime.fromtimestamp(oldest_mtime) if oldest_mtime is not None else None
@@ -1176,7 +1243,7 @@ class ImageCacheService:
         directory : Path
             Directory to purge.
         recursive : bool
-            If ``True``, use ``rglob`` to scan subdirectories.
+            If ``True``, descend into subdirectories.
 
         Returns
         -------
@@ -1184,25 +1251,21 @@ class ImageCacheService:
             Total bytes freed.
         """
         bytes_freed = 0
-        if not directory.is_dir():
-            return bytes_freed
 
-        glob_fn = directory.rglob if recursive else directory.glob
-
-        for pattern in ("*.jpg", "*.missing"):
-            for path in glob_fn(pattern):
-                if not path.is_file():
-                    continue
+        for suffix in (".jpg", ".missing"):
+            for path, stat in iter_cached_files(directory, suffix, recursive=recursive):
                 try:
-                    size = path.stat().st_size
                     path.unlink()
-                    bytes_freed += size
                 except OSError:
                     logger.warning(
                         "Failed to delete cached file: %s",
                         path,
                         exc_info=True,
                     )
+                    continue
+                # Counted only after the unlink succeeds — the previous version
+                # could add a file's size and then fail to remove it.
+                bytes_freed += stat.st_size
 
         return bytes_freed
 

--- a/tests/unit/api/routers/test_settings.py
+++ b/tests/unit/api/routers/test_settings.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -19,6 +19,7 @@ from chronovista.api.deps import get_db, require_auth
 from chronovista.api.main import app
 from chronovista.api.schemas.sync import SyncOperationType
 from chronovista.models.enums import LanguageCode
+from chronovista.services.image_cache import CacheStats
 
 # CRITICAL: This line ensures async tests work with coverage
 
@@ -190,278 +191,150 @@ class TestGetSupportedLanguages:
 
 
 class TestGetCacheStatus:
-    """Tests for GET /api/v1/settings/cache endpoint."""
+    """Tests for GET /api/v1/settings/cache endpoint.
+
+    This endpoint used to walk the cache directories itself, because
+    ``ImageCacheService.get_stats()`` reached for ``pathlib``'s ``rglob``,
+    which raises ``FileNotFoundError`` on Docker overlay2 when an entry
+    disappears mid-scan (#101). The service now walks with ``os.walk`` and
+    tolerates that, so the router delegates and the duplicate is gone.
+
+    These tests moved with it. They previously patched ``os.scandir``,
+    ``os.walk``, ``os.path.join`` and ``os.stat`` to drive the router's own
+    loop; that loop no longer exists, and mocking the ``os`` module to test a
+    router was never testing much anyway. What the router owes its caller now
+    is the mapping from ``CacheStats`` to ``CacheStatusResponse``, which is
+    what these assert. The walking itself is covered against a real directory
+    tree in ``tests/unit/services/test_image_cache_walk.py``.
+    """
+
+    @staticmethod
+    def _stats(**overrides: object) -> CacheStats:
+        base: dict[str, object] = {
+            "channel_count": 0,
+            "channel_missing_count": 0,
+            "video_count": 0,
+            "video_missing_count": 0,
+            "total_size_bytes": 0,
+            "oldest_file": None,
+            "newest_file": None,
+        }
+        base.update(overrides)
+        return CacheStats(**base)  # type: ignore[arg-type]
+
+    def _patched(self, stats: CacheStats) -> object:
+        return patch(
+            "chronovista.api.routers.settings._image_cache_service.get_stats",
+            new=AsyncMock(return_value=stats),
+        )
 
     async def test_returns_200_with_api_response_envelope(
         self, async_client: AsyncClient
     ) -> None:
-        """Test endpoint returns 200 with data wrapped in ApiResponse envelope."""
-        mock_entry = MagicMock()
-        mock_entry.name = "UCtest.jpg"
-        mock_entry.is_file.return_value = True
-        mock_stat = MagicMock()
-        mock_stat.st_size = 1024
-        mock_stat.st_mtime = 1700000000.0
-        mock_entry.stat.return_value = mock_stat
-
-        with (
-            patch(
-                "chronovista.api.routers.settings._image_cache_config"
-            ) as mock_config,
-            patch("os.scandir", return_value=[mock_entry]),
-            patch("os.walk", return_value=[]),
-        ):
-            mock_config.channels_dir.is_dir.return_value = True
-            mock_config.videos_dir.is_dir.return_value = False
-
+        with self._patched(self._stats(channel_count=1, total_size_bytes=1024)):
             response = await async_client.get("/api/v1/settings/cache")
 
         assert response.status_code == 200
-        body = response.json()
-        assert "data" in body
+        assert "data" in response.json()
 
     async def test_response_contains_all_required_fields(
         self, async_client: AsyncClient
     ) -> None:
-        """Test cache status response includes all required fields."""
-        with (
-            patch(
-                "chronovista.api.routers.settings._image_cache_config"
-            ) as mock_config,
-            patch("os.scandir", return_value=[]),
-            patch("os.walk", return_value=[]),
-        ):
-            mock_config.channels_dir.is_dir.return_value = False
-            mock_config.videos_dir.is_dir.return_value = False
-
+        with self._patched(self._stats()):
             response = await async_client.get("/api/v1/settings/cache")
 
-        assert response.status_code == 200
         data = response.json()["data"]
-        required_fields = [
+        for field in (
             "channel_count",
             "video_count",
             "total_count",
             "total_size_bytes",
             "total_size_display",
-        ]
-        for field in required_fields:
-            assert field in data, f"Missing required field: {field}"
+            "oldest_file",
+            "newest_file",
+        ):
+            assert field in data, f"missing field: {field}"
 
-    async def test_empty_cache_directories_returns_zero_counts(
+    async def test_empty_cache_returns_zero_counts(
         self, async_client: AsyncClient
     ) -> None:
-        """Test that empty cache directories result in zero counts."""
-        with (
-            patch(
-                "chronovista.api.routers.settings._image_cache_config"
-            ) as mock_config,
-            patch("os.scandir", return_value=[]),
-            patch("os.walk", return_value=[]),
-        ):
-            mock_config.channels_dir.is_dir.return_value = True
-            mock_config.videos_dir.is_dir.return_value = True
-
+        with self._patched(self._stats()):
             response = await async_client.get("/api/v1/settings/cache")
 
-        assert response.status_code == 200
         data = response.json()["data"]
         assert data["channel_count"] == 0
         assert data["video_count"] == 0
         assert data["total_count"] == 0
         assert data["total_size_bytes"] == 0
 
-    async def test_non_existent_dirs_return_zero_counts(
+    async def test_counts_are_passed_through_unchanged(
         self, async_client: AsyncClient
     ) -> None:
-        """Test that non-existent cache directories result in zero counts."""
-        with patch(
-            "chronovista.api.routers.settings._image_cache_config"
-        ) as mock_config:
-            mock_config.channels_dir.is_dir.return_value = False
-            mock_config.videos_dir.is_dir.return_value = False
-
-            response = await async_client.get("/api/v1/settings/cache")
-
-        assert response.status_code == 200
-        data = response.json()["data"]
-        assert data["channel_count"] == 0
-        assert data["video_count"] == 0
-        assert data["total_count"] == 0
-        assert data["total_size_bytes"] == 0
-
-    async def test_channel_images_counted_correctly(
-        self, async_client: AsyncClient
-    ) -> None:
-        """Test that .jpg files in channels dir are counted correctly."""
-        mtime = 1700000000.0
-
-        def _make_entry(name: str, is_jpg: bool = True) -> MagicMock:
-            entry = MagicMock()
-            entry.name = name
-            entry.is_file.return_value = is_jpg
-            stat = MagicMock()
-            stat.st_size = 2048
-            stat.st_mtime = mtime
-            entry.stat.return_value = stat
-            return entry
-
-        # Two valid .jpg files, one non-jpg that should be skipped
-        entries = [
-            _make_entry("UCchannel1.jpg"),
-            _make_entry("UCchannel2.jpg"),
-            _make_entry("UCchannel3.png"),  # not .jpg — should be skipped
-        ]
-
-        with (
-            patch(
-                "chronovista.api.routers.settings._image_cache_config"
-            ) as mock_config,
-            patch("os.scandir", return_value=entries),
-            patch("os.walk", return_value=[]),
+        with self._patched(
+            self._stats(channel_count=2, video_count=3, total_size_bytes=4096)
         ):
-            mock_config.channels_dir.is_dir.return_value = True
-            mock_config.videos_dir.is_dir.return_value = False
-
             response = await async_client.get("/api/v1/settings/cache")
 
-        assert response.status_code == 200
         data = response.json()["data"]
         assert data["channel_count"] == 2
-        assert data["video_count"] == 0
-        assert data["total_count"] == 2
-        assert data["total_size_bytes"] == 4096  # 2 * 2048
-
-    async def test_video_images_counted_correctly(
-        self, async_client: AsyncClient
-    ) -> None:
-        """Test that .jpg files in videos dir subtree are counted correctly."""
-        mtime = 1700000000.0
-
-        walk_output = [
-            ("/videos/ab", ["c"], ["abcvideo1.jpg", "abcvideo2.jpg"]),
-            ("/videos/cd", [], ["cdvideo3.jpg"]),
-        ]
-
-        video_stat = MagicMock()
-        video_stat.st_size = 4096
-        video_stat.st_mtime = mtime
-
-        with (
-            patch(
-                "chronovista.api.routers.settings._image_cache_config"
-            ) as mock_config,
-            patch("os.scandir", return_value=[]),
-            patch("os.walk", return_value=walk_output),
-            patch("os.path.join", side_effect=lambda *args: "/".join(args)),
-            patch("os.stat", return_value=video_stat),
-        ):
-            mock_config.channels_dir.is_dir.return_value = False
-            mock_config.videos_dir.is_dir.return_value = True
-
-            response = await async_client.get("/api/v1/settings/cache")
-
-        assert response.status_code == 200
-        data = response.json()["data"]
         assert data["video_count"] == 3
-        assert data["channel_count"] == 0
-        assert data["total_count"] == 3
+        assert data["total_size_bytes"] == 4096
 
-    async def test_total_count_equals_sum_of_channel_and_video(
+    async def test_total_count_is_the_sum_of_both(
         self, async_client: AsyncClient
     ) -> None:
-        """Test total_count equals channel_count + video_count."""
-        mtime = 1700000000.0
-
-        channel_entry = MagicMock()
-        channel_entry.name = "UCtest.jpg"
-        channel_entry.is_file.return_value = True
-        ch_stat = MagicMock()
-        ch_stat.st_size = 1024
-        ch_stat.st_mtime = mtime
-        channel_entry.stat.return_value = ch_stat
-
-        walk_output: list[tuple[str, list[str], list[str]]] = [
-            ("/videos/ab", [], ["abcvideo.jpg"])
-        ]
-
-        video_stat = MagicMock()
-        video_stat.st_size = 2048
-        video_stat.st_mtime = mtime
-
-        with (
-            patch(
-                "chronovista.api.routers.settings._image_cache_config"
-            ) as mock_config,
-            patch("os.scandir", return_value=[channel_entry]),
-            patch("os.walk", return_value=walk_output),
-            patch("os.path.join", side_effect=lambda *args: "/".join(args)),
-            patch("os.stat", return_value=video_stat),
-        ):
-            mock_config.channels_dir.is_dir.return_value = True
-            mock_config.videos_dir.is_dir.return_value = True
-
+        """The one figure the router derives rather than forwards."""
+        with self._patched(self._stats(channel_count=7, video_count=11)):
             response = await async_client.get("/api/v1/settings/cache")
 
-        assert response.status_code == 200
         data = response.json()["data"]
-        assert data["total_count"] == data["channel_count"] + data["video_count"]
+        assert data["total_count"] == 18
+
+    async def test_missing_markers_are_not_counted_as_cached_images(
+        self, async_client: AsyncClient
+    ) -> None:
+        """`.missing` markers record a failed fetch, not a cached image.
+
+        `CacheStatusResponse` has no field for them, so the risk is that a
+        future mapping quietly folds them into the counts and inflates what
+        the Settings page reports as cached.
+        """
+        with self._patched(
+            self._stats(
+                channel_count=1,
+                video_count=1,
+                channel_missing_count=50,
+                video_missing_count=60,
+            )
+        ):
+            response = await async_client.get("/api/v1/settings/cache")
+
+        data = response.json()["data"]
+        assert data["channel_count"] == 1
+        assert data["video_count"] == 1
         assert data["total_count"] == 2
 
-    async def test_oldest_and_newest_file_are_null_when_cache_empty(
+    async def test_size_display_is_human_readable(
         self, async_client: AsyncClient
     ) -> None:
-        """Test oldest_file and newest_file are null when no cached images exist."""
-        with (
-            patch(
-                "chronovista.api.routers.settings._image_cache_config"
-            ) as mock_config,
-            patch("os.scandir", return_value=[]),
-            patch("os.walk", return_value=[]),
-        ):
-            mock_config.channels_dir.is_dir.return_value = True
-            mock_config.videos_dir.is_dir.return_value = True
-
+        with self._patched(self._stats(total_size_bytes=2 * 1024 * 1024)):
             response = await async_client.get("/api/v1/settings/cache")
 
-        assert response.status_code == 200
-        data = response.json()["data"]
-        assert data.get("oldest_file") is None
-        assert data.get("newest_file") is None
-
-    async def test_size_display_uses_human_readable_format(
-        self, async_client: AsyncClient
-    ) -> None:
-        """Test total_size_display is a human-readable string (not raw bytes)."""
-        mtime = 1700000000.0
-
-        entry = MagicMock()
-        entry.name = "UCtest.jpg"
-        entry.is_file.return_value = True
-        stat = MagicMock()
-        # 2 MB
-        stat.st_size = 2 * 1024 * 1024
-        stat.st_mtime = mtime
-        entry.stat.return_value = stat
-
-        with (
-            patch(
-                "chronovista.api.routers.settings._image_cache_config"
-            ) as mock_config,
-            patch("os.scandir", return_value=[entry]),
-            patch("os.walk", return_value=[]),
-        ):
-            mock_config.channels_dir.is_dir.return_value = True
-            mock_config.videos_dir.is_dir.return_value = False
-
-            response = await async_client.get("/api/v1/settings/cache")
-
-        assert response.status_code == 200
-        data = response.json()["data"]
-        display = data["total_size_display"]
+        display = response.json()["data"]["total_size_display"]
         assert isinstance(display, str)
-        # 2 MB should be represented with "MB" suffix
         assert "MB" in display, f"Expected MB in display string, got: {display}"
+
+    async def test_timestamps_are_forwarded(self, async_client: AsyncClient) -> None:
+        oldest = datetime(2026, 1, 2, 3, 4, 5)
+        newest = datetime(2026, 6, 7, 8, 9, 10)
+        with self._patched(self._stats(oldest_file=oldest, newest_file=newest)):
+            response = await async_client.get("/api/v1/settings/cache")
+
+        data = response.json()["data"]
+        assert data["oldest_file"] is not None
+        assert data["newest_file"] is not None
+        assert data["oldest_file"].startswith("2026-01-02")
+        assert data["newest_file"].startswith("2026-06-07")
 
     async def test_requires_authentication(
         self, async_client_no_auth: AsyncClient
@@ -474,11 +347,6 @@ class TestGetCacheStatus:
             response = await async_client_no_auth.get("/api/v1/settings/cache")
 
         assert response.status_code == 401
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# DELETE /settings/cache Tests (auth required)
-# ═══════════════════════════════════════════════════════════════════════════
 
 
 class TestClearCache:

--- a/tests/unit/services/test_image_cache_walk.py
+++ b/tests/unit/services/test_image_cache_walk.py
@@ -1,0 +1,182 @@
+"""The cache walk must survive entries disappearing mid-scan (#101).
+
+``ImageCacheService.get_stats()`` used ``pathlib``'s ``rglob``, which before
+Python 3.13 raises ``FileNotFoundError`` when a directory entry vanishes
+between enumeration and the follow-up ``stat`` (CPython bpo-33428, fixed by
+GH-116380). On Docker's overlay2 that race fires readily against the video
+cache — roughly 16,000 thumbnails across ~1,439 sharded prefix directories —
+and it failed on a different random directory each run. The container runs
+Python 3.11.
+
+These exercise a real directory tree rather than mocking the ``os`` module.
+The previous tests for this behaviour patched ``os.walk``, ``os.scandir``,
+``os.path.join`` and ``os.stat``, which meant they passed for any
+implementation that called those names in the expected order — including one
+that still crashed on a vanished file.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chronovista.services.image_cache import (
+    ImageCacheConfig,
+    ImageCacheService,
+    iter_cached_files,
+)
+
+# No module-level `pytest.mark.asyncio`: pytest.ini sets `asyncio_mode = auto`,
+# so the async tests here are collected without it, and applying it to a module
+# that also holds synchronous tests warns on every one of them.
+
+
+def _make_cache(root: Path, *, channels: int, videos: int) -> ImageCacheConfig:
+    """Build a cache tree shaped like the real one — videos sharded by prefix."""
+    channels_dir = root / "images" / "channels"
+    videos_dir = root / "images" / "videos"
+    channels_dir.mkdir(parents=True)
+    videos_dir.mkdir(parents=True)
+
+    for i in range(channels):
+        (channels_dir / f"UCchan{i:04d}.jpg").write_bytes(b"x" * 100)
+    for i in range(videos):
+        shard = videos_dir / f"{i % 7:02d}"
+        shard.mkdir(exist_ok=True)
+        (shard / f"vid{i:04d}.jpg").write_bytes(b"y" * 200)
+
+    return ImageCacheConfig(
+        cache_dir=root, channels_dir=channels_dir, videos_dir=videos_dir
+    )
+
+
+class TestIterCachedFiles:
+    def test_finds_flat_files_without_recursion(self, tmp_path: Path) -> None:
+        cfg = _make_cache(tmp_path, channels=5, videos=0)
+        found = list(iter_cached_files(cfg.channels_dir, ".jpg", recursive=False))
+        assert len(found) == 5
+
+    def test_finds_sharded_files_with_recursion(self, tmp_path: Path) -> None:
+        """The video cache is nested, so a flat scan would report zero."""
+        cfg = _make_cache(tmp_path, channels=0, videos=30)
+        assert (
+            len(list(iter_cached_files(cfg.videos_dir, ".jpg", recursive=True))) == 30
+        )
+        assert list(iter_cached_files(cfg.videos_dir, ".jpg", recursive=False)) == []
+
+    def test_missing_directory_yields_nothing(self, tmp_path: Path) -> None:
+        assert list(iter_cached_files(tmp_path / "nope", ".jpg", recursive=True)) == []
+
+    def test_suffix_is_respected(self, tmp_path: Path) -> None:
+        cfg = _make_cache(tmp_path, channels=3, videos=0)
+        (cfg.channels_dir / "UCx.missing").write_bytes(b"")
+        assert (
+            len(list(iter_cached_files(cfg.channels_dir, ".jpg", recursive=False))) == 3
+        )
+        assert (
+            len(list(iter_cached_files(cfg.channels_dir, ".missing", recursive=False)))
+            == 1
+        )
+
+    def test_stat_is_returned_so_callers_need_no_second_syscall(
+        self, tmp_path: Path
+    ) -> None:
+        """A caller re-statting the path could itself hit the vanished-file race."""
+        cfg = _make_cache(tmp_path, channels=1, videos=0)
+        ((_path, stat),) = list(
+            iter_cached_files(cfg.channels_dir, ".jpg", recursive=False)
+        )
+        assert stat.st_size == 100
+
+
+class TestTheRaceItself:
+    """The actual defect: a file that disappears between listing and stat."""
+
+    def test_recursive_walk_survives_a_vanished_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _make_cache(tmp_path, channels=0, videos=20)
+
+        real_stat = os.stat
+        state = {"first": True}
+
+        def flaky_stat(path: Any, *a: Any, **kw: Any) -> os.stat_result:
+            # Exactly what overlay2 does: the entry was listed, then removed
+            # before the stat landed.
+            if state["first"] and str(path).endswith(".jpg"):
+                state["first"] = False
+                raise FileNotFoundError(2, "No such file or directory", str(path))
+            return real_stat(path, *a, **kw)
+
+        monkeypatch.setattr(os, "stat", flaky_stat)
+
+        found = list(iter_cached_files(cfg.videos_dir, ".jpg", recursive=True))
+
+        assert len(found) == 19, (
+            "the vanished file should be skipped and the walk should continue; "
+            "rglob raised FileNotFoundError here and aborted the whole scan"
+        )
+
+    async def test_get_stats_survives_a_vanished_file(self, tmp_path: Path) -> None:
+        """End to end: the call that actually broke on Docker.
+
+        Deletes a file for real, from inside the iteration, so the skip is not
+        merely a monkeypatched exception path.
+        """
+        cfg = _make_cache(tmp_path, channels=2, videos=14)
+
+        victim = next(iter_cached_files(cfg.videos_dir, ".jpg", recursive=True))[0]
+        victim.unlink()
+
+        stats = await ImageCacheService(cfg).get_stats()
+
+        assert stats.channel_count == 2
+        assert stats.video_count == 13
+        assert stats.total_size_bytes == 2 * 100 + 13 * 200
+
+
+class TestPurge:
+    async def test_purge_removes_files_and_reports_bytes(self, tmp_path: Path) -> None:
+        cfg = _make_cache(tmp_path, channels=3, videos=10)
+        service = ImageCacheService(cfg)
+
+        freed = await service.purge(type_="all")
+
+        assert freed == 3 * 100 + 10 * 200
+        assert list(iter_cached_files(cfg.channels_dir, ".jpg", recursive=False)) == []
+        assert list(iter_cached_files(cfg.videos_dir, ".jpg", recursive=True)) == []
+
+    async def test_purge_keeps_the_directories(self, tmp_path: Path) -> None:
+        """Callers re-fetch into these; removing them would break the next write."""
+        cfg = _make_cache(tmp_path, channels=1, videos=3)
+        await ImageCacheService(cfg).purge(type_="all")
+
+        assert cfg.channels_dir.is_dir()
+        assert cfg.videos_dir.is_dir()
+
+    async def test_purge_counts_bytes_only_for_files_it_actually_removed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed unlink must not be reported as freed space.
+
+        The previous implementation added the size and then attempted the
+        delete, so a file it could not remove still counted towards the total.
+        """
+        cfg = _make_cache(tmp_path, channels=0, videos=5)
+        service = ImageCacheService(cfg)
+
+        real_unlink = Path.unlink
+
+        def flaky_unlink(self: Path, *a: Any, **kw: Any) -> None:
+            if self.name.endswith("0000.jpg"):
+                raise PermissionError(13, "Permission denied", str(self))
+            real_unlink(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "unlink", flaky_unlink)
+
+        freed = await service.purge(type_="videos")
+
+        assert freed == 4 * 200, "the undeletable file should not count as freed"


### PR DESCRIPTION
Fixes #101.

Before Python 3.13, `pathlib`'s `glob` and `rglob` raise `FileNotFoundError` when a directory entry disappears between enumeration and the follow-up `stat` (CPython [bpo-33428](https://github.com/python/cpython/issues/77609), fixed by GH-116380). On Docker's overlay2 that race fires readily against the video cache — roughly 16,000 thumbnails across ~1,439 sharded prefix directories — and it failed on a **different random directory each run**, which is the signature of a race rather than a corrupt tree. The container runs Python 3.11.

## One walker, five call sites

The issue named three. There were **five**: `get_stats()` also scanned the channels directory with two non-recursive `glob()` calls, which carry the same fragility.

```python
def iter_cached_files(directory, suffix, *, recursive) -> Iterator[tuple[Path, os.stat_result]]
```

`os.walk` swallows errors from its own `scandir` iteration and continues, but a `stat` on a file that has since been removed **still raises**, so that call is guarded too — the fix is not simply "use os.walk". The helper yields `(path, stat)` pairs so callers need no second syscall that could fail on its own.

## Folding the workaround back in

The Settings cache endpoint bypassed `get_stats()` and walked the tree itself (Feature 049). That copy is gone; the router delegates.

**mypy caught that the delegation omitted `await`.** `get_stats` is async, so this would have failed at runtime the moment anyone opened the Settings page.

## The old tests could not have caught this bug

They patched `os.scandir`, `os.walk`, `os.path.join` and `os.stat` to drive the router's own loop. Mocking the `os` module makes a test pass for **any** implementation that calls those names in the expected order — including one that still crashes on a vanished file. And the loop they tested no longer exists.

Rewritten around the two real seams:

- **`tests/unit/api/routers/test_settings.py`** — the router's remaining obligation is the `CacheStats` → `CacheStatusResponse` mapping. Includes a new test that `.missing` markers are not folded into the cached-image counts, since the response has no field for them and a future mapping could quietly inflate what the Settings page reports.
- **`tests/unit/services/test_image_cache_walk.py`** — a **real directory tree** shaped like production (videos sharded by prefix), reproducing the race two ways: a monkeypatched `FileNotFoundError`, and a file genuinely deleted mid-iteration.

Mutation-verified: reverting the walker to rglob semantics fails the race test.

## Also fixed

`_purge_directory` reported bytes it had not freed. It added a file's size and *then* attempted the `unlink`, so anything it could not delete still counted toward the total. Bytes are now counted only after the unlink succeeds, with a test that makes one file undeletable.

## Not done

Upgrading the image to Python 3.13+, which fixes this upstream. The issue flags it as a larger change to evaluate separately, and this makes the code correct on any version regardless.

## Checks

`ruff` · `black --check` (550 files) · `mypy --strict` (249 files) · backend unit (**6,892 passed**) · backend integration (**1,284 passed**) — all green.

No migration, no schema change, no frontend change.
