### PR TITLE
perf(corrections): bound the per-token remaining-match count (#212)

### DIFF
--- a/src/chronovista/api/routers/batch_corrections.py
+++ b/src/chronovista/api/routers/batch_corrections.py
@@ -10,7 +10,7 @@ import logging
 import uuid
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import case, func, or_, select
+from sqlalchemy import case, func, literal, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid_utils import uuid7
 
@@ -82,6 +82,27 @@ logger = logging.getLogger(__name__)
 # The cap exists so the work stays bounded if the correction corpus grows. It
 # is logged when it bites rather than silently truncating.
 _PATTERN_TOKENISE_CAP = 1000
+
+# Ceiling on the per-token remaining-match count in diff-analysis.
+#
+# A short error token yields few trigrams, so the pg_trgm index returns a large
+# candidate set that the recheck mostly discards. Measured on the live corpus
+# for a 3-character token: 99,210 candidates and 27,970 heap blocks fetched to
+# find 3,333 rows — 96.6% discarded. Because the block reads dominate, the same
+# query ranged from 0.47s to 3.58s depending on what happened to be cached, and
+# it was 30-65% of the whole request.
+#
+# RAISING THIS SILENTLY DISABLES IT. A ceiling only bounds work when it sits
+# BELOW the real match count. #212 originally proposed 5,000, which measured
+# identically to no cap at all — the token matches 3,333, so it never tripped.
+# At 1,000: 7,913 heap blocks instead of 27,970.
+#
+# Chosen over a tighter 500 for headroom. Of the 45 tokens currently produced,
+# exactly one exceeds 1,000 and the next-largest is 286, so one row is affected
+# and the ordering is untouched. Two tokens above the ceiling would tie there,
+# and their relative order would become arbitrary — so it should stay well
+# clear of the bulk of the distribution.
+_REMAINING_MATCH_CAP = 1000
 
 _batch_service = BatchCorrectionService(
     correction_service=_correction_service,
@@ -603,8 +624,8 @@ async def get_diff_analysis(
         if not error_token:
             remaining = 0
         else:
-            remaining_stmt = (
-                select(func.count())
+            matching_rows = (
+                select(literal(1))
                 .select_from(TranscriptSegmentDB)
                 .where(
                     # Index-eligible super-set on the RAW columns so PostgreSQL
@@ -621,9 +642,22 @@ async def get_diff_analysis(
                     # removed the token must not be counted, so this stays.
                     effective_text.contains(error_token),
                 )
+                # The ceiling is what bounds the heap fetch (#212). A short
+                # token yields few trigrams, so the index returns a huge
+                # candidate set that the recheck mostly discards: measured at
+                # 99,210 candidates and 27,970 heap blocks to find 3,333 rows,
+                # 96.6% thrown away. Stopping early caps that work.
+                .limit(_REMAINING_MATCH_CAP)
+                .subquery()
             )
-            remaining_result = await session.execute(remaining_stmt)
+            remaining_result = await session.execute(
+                select(func.count()).select_from(matching_rows)
+            )
             remaining = remaining_result.scalar_one()
+
+        # A count equal to the ceiling means counting stopped, not that exactly
+        # that many remain. Reported rather than silently presented as exact.
+        remaining_capped = remaining >= _REMAINING_MATCH_CAP
 
         # Apply show_completed filter at the token level
         if not show_completed and remaining == 0:
@@ -647,6 +681,7 @@ async def get_diff_analysis(
                 canonical_form=canonical_form,
                 frequency=freq,
                 remaining_matches=remaining,
+                remaining_matches_capped=remaining_capped,
                 entity_id=entity_id,
                 entity_name=matched_entity_name,
             )

--- a/src/chronovista/api/schemas/batch_corrections.py
+++ b/src/chronovista/api/schemas/batch_corrections.py
@@ -421,7 +421,12 @@ class DiffErrorPatternResponse(BaseModel):
     frequency : int
         Number of times this correction has been applied.
     remaining_matches : int
-        Number of un-corrected instances remaining.
+        Number of un-corrected instances remaining. When
+        ``remaining_matches_capped`` is true this is a floor, not a total.
+    remaining_matches_capped : bool
+        True when counting stopped at the ceiling and the real figure is
+        higher. Present because a bare ``1000`` would be indistinguishable
+        from exactly one thousand remaining, and clients render "1000+".
     entity_id : uuid.UUID | None
         Associated named entity UUID, if any.
     entity_name : str | None
@@ -434,6 +439,7 @@ class DiffErrorPatternResponse(BaseModel):
     canonical_form: str
     frequency: int
     remaining_matches: int
+    remaining_matches_capped: bool = False
     entity_id: uuid.UUID | None = None
     entity_name: str | None = None
 

--- a/tests/unit/api/test_diff_analysis_endpoint.py
+++ b/tests/unit/api/test_diff_analysis_endpoint.py
@@ -28,7 +28,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from chronovista.api.deps import get_db, require_auth
 from chronovista.api.main import app
-from chronovista.api.routers.batch_corrections import _PATTERN_TOKENISE_CAP
+from chronovista.api.routers.batch_corrections import (
+    _PATTERN_TOKENISE_CAP,
+    _REMAINING_MATCH_CAP,
+)
 from chronovista.models.batch_correction_models import CorrectionPattern
 
 # CRITICAL: This line ensures async tests work with coverage
@@ -464,3 +467,151 @@ class TestGetDiffAnalysis:
         """limit=501 returns 422."""
         response = await client.get(self.BASE_URL, params={"limit": 501})
         assert response.status_code == 422
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Remaining-match ceiling (#212)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRemainingMatchCap:
+    """The per-token count stops at a ceiling, and says so.
+
+    A short error token yields few trigrams, so the pg_trgm index returns a
+    large candidate set the recheck mostly discards — measured at 99,210
+    candidates and 27,970 heap blocks fetched to find 3,333 rows. The block
+    reads dominate, so the same query ranged from 0.47s to 3.58s depending on
+    what was cached.
+
+    The ceiling bounds that fetch. Because it changes a reported number, the
+    response says when it was reached rather than presenting the ceiling as an
+    exact count.
+    """
+
+    BASE_URL = "/api/v1/corrections/batch/diff-analysis"
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_count_below_the_ceiling_is_not_flagged(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+    ) -> None:
+        mock_service.get_patterns = AsyncMock(return_value=[_make_pattern()])
+        mock_find_entity.return_value = (None, None)
+
+        async for ac in _make_client_with_remaining(_REMAINING_MATCH_CAP - 1):
+            response = await ac.get(self.BASE_URL)
+
+        data = response.json()["data"]
+        assert data[0]["remaining_matches"] == _REMAINING_MATCH_CAP - 1
+        assert data[0]["remaining_matches_capped"] is False
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_count_at_the_ceiling_is_flagged(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+    ) -> None:
+        """Reaching the ceiling means "at least this many", not "exactly"."""
+        mock_service.get_patterns = AsyncMock(return_value=[_make_pattern()])
+        mock_find_entity.return_value = (None, None)
+
+        async for ac in _make_client_with_remaining(_REMAINING_MATCH_CAP):
+            response = await ac.get(self.BASE_URL)
+
+        data = response.json()["data"]
+        assert data[0]["remaining_matches"] == _REMAINING_MATCH_CAP
+        assert data[0]["remaining_matches_capped"] is True
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_zero_remaining_is_not_flagged(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+    ) -> None:
+        """Guards against a `>=` that treats 0 as having hit the ceiling."""
+        mock_service.get_patterns = AsyncMock(return_value=[_make_pattern()])
+        mock_find_entity.return_value = (None, None)
+
+        async for ac in _make_client_with_remaining(0):
+            response = await ac.get(self.BASE_URL, params={"show_completed": "true"})
+
+        data = response.json()["data"]
+        assert data[0]["remaining_matches"] == 0
+        assert data[0]["remaining_matches_capped"] is False
+
+    @patch(
+        "chronovista.api.routers.batch_corrections._find_entity_by_name",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "chronovista.api.routers.batch_corrections._batch_service",
+        new_callable=MagicMock,
+    )
+    async def test_the_query_carries_a_limit(
+        self,
+        mock_service: MagicMock,
+        mock_find_entity: AsyncMock,
+    ) -> None:
+        """The ceiling must reach the database, not just the response.
+
+        Counting everything and then clamping the number would report the same
+        values while doing all the work the ceiling exists to avoid — and no
+        assertion on the response could tell the difference.
+        """
+        mock_service.get_patterns = AsyncMock(return_value=[_make_pattern()])
+        mock_find_entity.return_value = (None, None)
+
+        captured: list[str] = []
+        mock = AsyncMock(spec=AsyncSession)
+        result = MagicMock()
+        result.scalar_one.return_value = 5
+
+        async def _execute(stmt: object, *a: object, **kw: object) -> object:
+            captured.append(" ".join(str(stmt).split()).lower())
+            return result
+
+        mock.execute = AsyncMock(side_effect=_execute)
+
+        async def _get_db() -> AsyncGenerator[AsyncSession, None]:
+            yield mock
+
+        async def _require_auth() -> None:
+            return None
+
+        app.dependency_overrides[get_db] = _get_db
+        app.dependency_overrides[require_auth] = _require_auth
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                await ac.get(self.BASE_URL)
+        finally:
+            app.dependency_overrides.clear()
+
+        count_sql = [s for s in captured if "count(" in s]
+        assert count_sql, "expected a remaining-match count query"
+        assert any("limit" in s for s in count_sql), (
+            "the count query has no LIMIT — the heap fetch is unbounded again, "
+            f"got: {count_sql[0][:200]}"
+        )


### PR DESCRIPTION
Fixes #212 — see [the correction on that issue](https://github.com/aucontraire/chronovista/issues/212#issuecomment-5248517378), which revises both its measurements and its proposed fix.

## The mechanism

A short error token yields few trigrams, so the pg_trgm index returns a large candidate set that the recheck mostly discards. `EXPLAIN (ANALYZE, BUFFERS)` on the live corpus (1,964,881 segments) for a 3-character token:

```
Bitmap Index Scan             →  99,210 candidate rows
Rows Removed by Index Recheck →  95,366        (96.6% discarded)
Heap Blocks: exact=27,970      (read=27,354 — from disk, not cache)
Final result                  →   3,333 rows
```

The block reads dominate, which is why the same query ranged from **0.47s to 3.58s** depending on what happened to be cached, and why it was 30–65% of the whole request.

A `LIMIT` inside the count subquery bounds that fetch: **27,970 heap blocks → 7,913**.

## What this does not do

**It does not make the warm case faster.** Measured against production, warm:

| | before | after |
|---|---|---|
| endpoint | 0.50–0.64 s | 0.44–0.56 s |
| heap blocks (worst token) | **27,970** | **7,913** |

The ranges overlap. Once those blocks are cached there is little to save, and I would rather state that than claim a speedup that is not there.

The value is the **cold** case and the trajectory. Block reads scale with corpus size rather than with match count, and they are what produced the multi-second outliers. Today's worst case sits under the frontend's 10s request timeout; at roughly double the corpus it would not — which is the state #203 started from.

## The ceiling only works below the distribution

#212 originally proposed `LIMIT 5000`. Measured, that is **identical to no cap at all** — the token matches 3,333, so it never trips:

| variant | time | heap blocks |
|---|---|---|
| uncapped | 152 ms | 27,970 |
| capped 5000 | 149 ms | 27,970 |
| **capped 1000** | **50 ms** | **7,913** |

A ceiling bounds work only when it sits *below* the real match count — the opposite of how a safety limit is usually chosen. The constant carries that warning, because raising it silently disables the fix.

**1,000 rather than a tighter 500:** of the 45 tokens currently produced, exactly one exceeds 1,000 and the next-largest is 286. One row is affected and the ordering is untouched. Two tokens above the ceiling would tie there and their relative order would become arbitrary, so it should stay clear of the bulk of the distribution.

## Reporting

`remaining_matches_capped: bool` is added to `DiffErrorPatternResponse`. A bare `1000` would be indistinguishable from exactly one thousand remaining — the same defect as the skipped-count case in #213 — so clients can render `1000+`. It defaults to `false`, so existing consumers are unaffected.

Verified against production: **46 tokens, exactly one capped**, max uncapped 286, and the capped row still sorts first.

## Testing

Four tests, and one of them is the point: **the `LIMIT` must reach the database, not just the response.** Clamping the number in Python returns identical values while doing all the work the ceiling exists to avoid, and no assertion on the response could tell the difference — so that test inspects the emitted SQL. Both mutations (Python clamp; flag hard-coded false) fail exactly one test each.

Also covered: zero remaining is not flagged as capped, guarding a `>=` that would treat 0 as having hit the ceiling.

## Checks

`ruff` · `black --check` (550 files) · `mypy --strict` (249 files) · backend unit (**6,896 passed**) · backend integration (**1,284 passed**) — all green.

No migration, no schema change. Frontend untouched; rendering `1000+` from the new field is a follow-up.
