### PR TITLE
fix(recovery): route every provenance writer through the repository (#219)

### DIFF
--- a/docs/user-guide/cli-overview.md
+++ b/docs/user-guide/cli-overview.md
@@ -282,10 +282,10 @@ chronovista entities scan --full
 chronovista corrections patterns --min-occurrences 2
 
 # 2. Preview a batch correction
-chronovista corrections find-replace --pattern "Chsky" --replacement "Lovelace" --dry-run
+chronovista corrections find-replace --pattern "Loveless" --replacement "Lovelace" --dry-run
 
 # 3. Apply the correction
-chronovista corrections find-replace --pattern "Chsky" --replacement "Lovelace"
+chronovista corrections find-replace --pattern "Loveless" --replacement "Lovelace"
 
 # 4. Rebuild full transcript text
 chronovista corrections rebuild-text

--- a/docs/user-guide/transcripts.md
+++ b/docs/user-guide/transcripts.md
@@ -426,10 +426,10 @@ The `chronovista corrections` CLI commands enable bulk correction operations acr
 
 ```bash
 # Find a recurring ASR error and preview what would change
-chronovista corrections find-replace --pattern "Chsky" --replacement "Lovelace" --dry-run
+chronovista corrections find-replace --pattern "Loveless" --replacement "Lovelace" --dry-run
 
 # Apply the correction (with confirmation prompt)
-chronovista corrections find-replace --pattern "Chsky" --replacement "Lovelace"
+chronovista corrections find-replace --pattern "Loveless" --replacement "Lovelace"
 
 # Rebuild full transcript text to reflect corrections
 chronovista corrections rebuild-text
@@ -450,9 +450,9 @@ chronovista corrections rebuild-text
 
 The `find-replace` and `batch-revert` commands support several matching modes:
 
-- **Substring match** (default): `--pattern "Chsky"` matches any segment containing "Chsky"
-- **Case-insensitive**: `--pattern "chsky" --case-insensitive` matches "Chsky", "CHSKY", etc.
-- **Regex**: `--pattern "finkel(state|stein)" --regex` matches Python regular expressions
+- **Substring match** (default): `--pattern "Loveless"` matches any segment containing "Loveless"
+- **Case-insensitive**: `--pattern "loveless" --case-insensitive` matches "Loveless", "LOVELESS", etc.
+- **Regex**: `--pattern "love(less|lace)" --regex` matches Python regular expressions
 
 Pattern matching is performed database-side using SQL operators (`LIKE`, `ILIKE`, `~`, `~*`), so scans are efficient even for large transcript libraries (500,000+ segments).
 

--- a/scripts/utilities/gen_private_terms.py
+++ b/scripts/utilities/gen_private_terms.py
@@ -73,6 +73,10 @@ ALLOWLIST = {
 # identifies a person. Listed separately from ALLOWLIST because the reason is
 # different: these are not this project's subject matter, they are collisions.
 COMMON_WORD_ALIASES = {
+    # An ASR mis-transcription of a surname, and the near-universal name for a
+    # database connection: it fires on every `async with engine.begin() as
+    # conn`, measured at 47 occurrences across 10 files.
+    "Conn",
     "Crystal",
     "Fork",
     # An ASR mis-transcription of a surname, and also an English verb: it fires

--- a/scripts/utilities/reclassify_asr_corrections.py
+++ b/scripts/utilities/reclassify_asr_corrections.py
@@ -153,7 +153,7 @@ def classify_correction(original: str, corrected: str) -> str:
          (ASR split a name, e.g. "Johnsen Bomb" → "Johnson")
        - Otherwise → word_boundary
     2. Same token count — if ANY changed token in corrected text is title-cased
-       → proper_noun  (catches "Chsky" → "Lovelace", "Galain" → "Ghislaine",
+       → proper_noun  (catches "Loveless" → "Lovelace", "Babbige" → "Babbage",
        "norm" → "Ada", etc.)
     3. Identical ignoring case (no other signal) → formatting
     4. Fallback → other

--- a/src/chronovista/repositories/recovery_provenance_repository.py
+++ b/src/chronovista/repositories/recovery_provenance_repository.py
@@ -135,6 +135,42 @@ class RecoveryProvenanceRepository:
         )
         return list(result.scalars().all())
 
+    # ── prior-contribution lookups ───────────────────────────────────────────
+    #
+    # A recovery pass deciding whether its capture supersedes what is already
+    # stored must compare against *its own* previous contribution, not against
+    # whichever source wrote most recently. Reading that from the denormalised
+    # column answers the wrong question — and answers it silently, because a
+    # failed parse is indistinguishable from no prior contribution.
+
+    async def get_video_source_detail(
+        self, session: AsyncSession, video_id: str, source: str
+    ) -> str | None:
+        """This source's own ``source_detail`` for *video_id*, if it has one.
+
+        Returns ``None`` when the source has never written to this row, which
+        callers must treat as "no prior contribution" rather than as an error.
+        """
+        result = await session.execute(
+            select(VideoRecoverySourceDB.source_detail).where(
+                VideoRecoverySourceDB.video_id == video_id,
+                VideoRecoverySourceDB.source == source,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_channel_source_detail(
+        self, session: AsyncSession, channel_id: str, source: str
+    ) -> str | None:
+        """This source's own ``source_detail`` for *channel_id*, if it has one."""
+        result = await session.execute(
+            select(ChannelRecoverySourceDB.source_detail).where(
+                ChannelRecoverySourceDB.channel_id == channel_id,
+                ChannelRecoverySourceDB.source == source,
+            )
+        )
+        return result.scalar_one_or_none()
+
     # ── denormalised projection ──────────────────────────────────────────────
     #
     # ADR-011 keeps `videos.recovery_source` / `recovered_at` as a cheap "most

--- a/src/chronovista/services/enrichment/enrichment_service.py
+++ b/src/chronovista/services/enrichment/enrichment_service.py
@@ -44,8 +44,12 @@ from chronovista.models.enrichment_report import (
     EnrichmentSummary,
 )
 from chronovista.models.enums import AvailabilityStatus
+from chronovista.models.recovery_provenance import RecoverySourceRecord
 from chronovista.repositories.channel_repository import ChannelRepository
 from chronovista.repositories.playlist_repository import PlaylistRepository
+from chronovista.repositories.recovery_provenance_repository import (
+    RecoveryProvenanceRepository,
+)
 from chronovista.repositories.topic_category_repository import (
     TopicCategoryRepository,
 )
@@ -457,6 +461,10 @@ class ChannelEnrichmentResult(BaseModel):
     skipped_channel_ids: list[str] = Field(
         default_factory=list, description="IDs of channels that were skipped"
     )
+
+
+# Provenance source name for API-driven restoration.
+_SYNC_SOURCE = "sync"
 
 
 class EnrichmentLock:
@@ -908,6 +916,11 @@ class EnrichmentService:
         self.topic_category_repository = topic_category_repository
         self.youtube_service = youtube_service
         self.playlist_repository = playlist_repository
+        # Not injected: the provenance repository is stateless, and making it a
+        # required constructor argument would change every caller for a single
+        # write. It is the only permitted writer of `recovery_source`, so it is
+        # a collaborator this service must have rather than one it may choose.
+        self._provenance_repo = RecoveryProvenanceRepository()
 
         # Lock instance for this service
         self._lock = EnrichmentLock()
@@ -1272,9 +1285,21 @@ class EnrichmentService:
                 if video.availability_status != AvailabilityStatus.AVAILABLE:
                     old_status = video.availability_status
                     video.availability_status = AvailabilityStatus.AVAILABLE
-                    video.recovered_at = datetime.now(UTC)
-                    video.recovery_source = "sync"
                     video.unavailability_first_detected = None
+                    # Provenance goes through the repository, which appends to
+                    # video_recovery_sources and refreshes the denormalised
+                    # columns. This pass does not think of itself as a recovery
+                    # implementation, which is exactly why it has to be routed:
+                    # a bulk pass writing the column directly is what destroyed
+                    # 92 rows' attribution (ADR-011).
+                    await self._provenance_repo.record_video(
+                        session,
+                        video_id,
+                        RecoverySourceRecord(
+                            source=_SYNC_SOURCE,
+                            fields_written=["availability_status"],
+                        ),
+                    )
                     logger.info(
                         f"Restored video {video_id} from '{old_status}' to available "
                         f"(recovery_source=sync)"
@@ -2893,9 +2918,17 @@ class EnrichmentService:
                         if channel.availability_status != AvailabilityStatus.AVAILABLE:
                             old_status = channel.availability_status
                             channel.availability_status = AvailabilityStatus.AVAILABLE
-                            channel.recovered_at = datetime.now(UTC)
-                            channel.recovery_source = "sync"
                             channel.unavailability_first_detected = None
+                            # See the video path above — provenance is appended,
+                            # never assigned.
+                            await self._provenance_repo.record_channel(
+                                session,
+                                channel_id,
+                                RecoverySourceRecord(
+                                    source=_SYNC_SOURCE,
+                                    fields_written=["availability_status"],
+                                ),
+                            )
                             logger.info(
                                 f"Restored channel {channel_id} from '{old_status}' "
                                 f"to available (recovery_source=sync)"

--- a/src/chronovista/services/recovery/orchestrator.py
+++ b/src/chronovista/services/recovery/orchestrator.py
@@ -27,8 +27,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from chronovista.exceptions import CDXError
 from chronovista.models.channel import ChannelCreate, ChannelUpdate
 from chronovista.models.enums import AvailabilityStatus
+from chronovista.models.recovery_provenance import RecoverySourceRecord
 from chronovista.models.video import VideoUpdate
 from chronovista.repositories.channel_repository import ChannelRepository
+from chronovista.repositories.recovery_provenance_repository import (
+    RecoveryProvenanceRepository,
+)
 from chronovista.repositories.video_repository import VideoRepository
 from chronovista.repositories.video_tag_repository import VideoTagRepository
 from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
@@ -41,6 +45,12 @@ from chronovista.services.recovery.models import (
 from chronovista.services.recovery.page_parser import PageParser
 
 logger = logging.getLogger(__name__)
+
+# Provenance source name for this module. The packed `wayback:<timestamp>` form
+# that `RecoveredVideoData.recovery_source` still computes is retained only for
+# the denormalised projection's benefit; the source and the timestamp are stored
+# as separate columns, which is the whole point of ADR-011.
+_WAYBACK_SOURCE = "wayback"
 
 # Recovery configuration constants
 _MAX_SNAPSHOTS_TO_TRY = 20
@@ -148,6 +158,7 @@ async def recover_video(
     video_repo = VideoRepository()
     tag_repo = VideoTagRepository()
     channel_repo = ChannelRepository()
+    provenance_repo = RecoveryProvenanceRepository()
 
     try:
         # Fetch video from database
@@ -267,14 +278,22 @@ async def recover_video(
                 duration_seconds=duration,
             )
 
-        # Build update dictionary with overwrite policy
-        update_dict, fields_recovered, fields_skipped = _build_video_update(
-            video, recovered_data
+        # What did *this* source record for this video last time? Read from the
+        # provenance table, not from the denormalised column — see
+        # `_is_incoming_newer`.
+        prior_snapshot = await provenance_repo.get_video_source_detail(
+            session, video_id, _WAYBACK_SOURCE
         )
 
-        # Add recovery metadata (always set on success)
-        update_dict["recovered_at"] = datetime.now(UTC)
-        update_dict["recovery_source"] = recovered_data.recovery_source
+        # Build update dictionary with overwrite policy
+        update_dict, fields_recovered, fields_skipped = _build_video_update(
+            video, recovered_data, prior_snapshot_timestamp=prior_snapshot
+        )
+
+        # `recovered_at` and `recovery_source` are deliberately NOT set here.
+        # They are a projection of the provenance table now, refreshed by
+        # `record_video()` below, and writing them directly is what allowed one
+        # pass to erase another's attribution (ADR-011).
 
         # Skip database write in dry-run mode
         if not dry_run:
@@ -316,6 +335,20 @@ async def recover_video(
             # Update video in database
             video_update = VideoUpdate(**update_dict)
             await video_repo.update(session, db_obj=video, obj_in=video_update)
+
+            # Record what this source contributed. Appends a row keyed on
+            # (video_id, source) and refreshes the denormalised columns; a
+            # second source touching this row later adds to the record rather
+            # than replacing it.
+            await provenance_repo.record_video(
+                session,
+                video_id,
+                RecoverySourceRecord(
+                    source=_WAYBACK_SOURCE,
+                    source_detail=recovered_data.snapshot_timestamp,
+                    fields_written=fields_recovered or None,
+                ),
+            )
 
             # Persist tags if any were recovered
             if recovered_data.tags:
@@ -410,8 +443,45 @@ async def recover_video(
         )
 
 
+def _is_incoming_newer(incoming_snapshot: str, prior_snapshot: str | None) -> bool:
+    """Decide whether an incoming capture may overwrite mutable fields.
+
+    Both arguments are 14-digit Wayback timestamps, which sort lexicographically
+    in chronological order.
+
+    The no-prior-row case is stated here rather than left to fall out of a
+    ``None`` check, because that is exactly how the defect this replaces
+    arose: a parse failure produced ``None``, ``None`` meant "nothing recorded",
+    and "nothing recorded" silently meant "go ahead and overwrite". The rule is
+    deliberate — **the first contribution from a source has nothing to be older
+    than, so it wins** — and it is a rule, not a fallback.
+
+    Equal timestamps also win: re-running the same capture is idempotent, and
+    treating it as a conflict would make a retry behave differently from the
+    original run.
+
+    Parameters
+    ----------
+    incoming_snapshot : str
+        Timestamp of the capture being applied.
+    prior_snapshot : str | None
+        Timestamp this same source recorded previously, or ``None`` if this
+        source has not written to this row before.
+
+    Returns
+    -------
+    bool
+        True when the incoming capture is at least as recent as the prior one.
+    """
+    if prior_snapshot is None:
+        return True
+    return incoming_snapshot >= prior_snapshot
+
+
 def _build_video_update(
-    existing_video: Any, recovered_data: RecoveredVideoData
+    existing_video: Any,
+    recovered_data: RecoveredVideoData,
+    prior_snapshot_timestamp: str | None = None,
 ) -> tuple[dict[str, Any], list[str], list[str]]:
     """
     Build video update dictionary with three-tier overwrite policy.
@@ -445,22 +515,21 @@ def _build_video_update(
     fields_recovered: list[str] = []
     fields_skipped: list[str] = []
 
-    # Extract existing recovery_source timestamp (if any)
-    existing_recovery_timestamp: str | None = None
-    if existing_video.recovery_source:
-        # Format: "wayback:20220106075526"
-        parts = existing_video.recovery_source.split(":")
-        if len(parts) == 2 and parts[0] == "wayback":
-            existing_recovery_timestamp = parts[1]
-
-    # Determine if incoming snapshot is newer than existing recovery
-    incoming_is_newer = False
-    if existing_recovery_timestamp is None:
-        # No existing recovery - incoming is considered "newer"
-        incoming_is_newer = True
-    elif recovered_data.snapshot_timestamp >= existing_recovery_timestamp:
-        # Incoming snapshot has same or later timestamp
-        incoming_is_newer = True
+    # The prior snapshot timestamp comes from this source's own row in
+    # video_recovery_sources, supplied by the caller.
+    #
+    # It used to be parsed out of `videos.recovery_source`. Under ADR-011 that
+    # column is a *most recent contributor* projection, so the parse only
+    # succeeded when this source happened to be the last one to touch the row.
+    # Measured on production afterwards: it succeeded for 2 rows and failed for
+    # 4,130 — and a failed parse fell through to the branch below and answered
+    # "newer", so tier 2 stopped being enforced almost everywhere. For 90 of
+    # those rows the timestamp existed the whole time, one table over.
+    #
+    # A projection is not a record. This reads the record.
+    incoming_is_newer = _is_incoming_newer(
+        recovered_data.snapshot_timestamp, prior_snapshot_timestamp
+    )
 
     # Map RecoveredVideoData fields to Video model fields
     field_mapping = {
@@ -517,7 +586,9 @@ def _build_video_update(
 
 
 def _build_channel_update(
-    existing_channel: Any, recovered_data: RecoveredChannelData
+    existing_channel: Any,
+    recovered_data: RecoveredChannelData,
+    prior_snapshot_timestamp: str | None = None,
 ) -> tuple[dict[str, Any], list[str], list[str]]:
     """
     Build channel update dictionary with two-tier overwrite policy.
@@ -550,22 +621,12 @@ def _build_channel_update(
     fields_recovered: list[str] = []
     fields_skipped: list[str] = []
 
-    # Extract existing recovery_source timestamp (if any)
-    existing_recovery_timestamp: str | None = None
-    if existing_channel.recovery_source:
-        # Format: "wayback:20220106075526"
-        parts = existing_channel.recovery_source.split(":")
-        if len(parts) == 2 and parts[0] == "wayback":
-            existing_recovery_timestamp = parts[1]
-
-    # Determine if incoming snapshot is newer than existing recovery
-    incoming_is_newer = False
-    if existing_recovery_timestamp is None:
-        # No existing recovery - incoming is considered "newer"
-        incoming_is_newer = True
-    elif recovered_data.snapshot_timestamp >= existing_recovery_timestamp:
-        # Incoming snapshot has same or later timestamp
-        incoming_is_newer = True
+    # Same change as the video path: read this source's own prior timestamp
+    # from channel_recovery_sources rather than parsing the denormalised
+    # projection. See `_is_incoming_newer` and `_build_video_update`.
+    incoming_is_newer = _is_incoming_newer(
+        recovered_data.snapshot_timestamp, prior_snapshot_timestamp
+    )
 
     # Map RecoveredChannelData fields to Channel model fields
     field_mapping = {
@@ -678,6 +739,7 @@ async def recover_channel(
 
     # Initialize repository
     channel_repo = ChannelRepository()
+    provenance_repo = RecoveryProvenanceRepository()
 
     try:
         # Fetch channel from database
@@ -802,18 +864,32 @@ async def recover_channel(
                 duration_seconds=duration,
             )
 
-        # Build update dictionary with overwrite policy
-        update_dict, fields_recovered, fields_skipped = _build_channel_update(
-            channel, recovered_data
+        # This source's own prior capture, from the provenance table.
+        prior_snapshot = await provenance_repo.get_channel_source_detail(
+            session, channel_id, _WAYBACK_SOURCE
         )
 
-        # Add recovery metadata (always set on success)
-        update_dict["recovered_at"] = datetime.now(UTC)
-        update_dict["recovery_source"] = recovered_data.recovery_source
+        # Build update dictionary with overwrite policy
+        update_dict, fields_recovered, fields_skipped = _build_channel_update(
+            channel, recovered_data, prior_snapshot_timestamp=prior_snapshot
+        )
+
+        # `recovered_at` / `recovery_source` are a projection now; see the video
+        # path above.
 
         # Update channel in database
         channel_update = ChannelUpdate(**update_dict)
         await channel_repo.update(session, db_obj=channel, obj_in=channel_update)
+
+        await provenance_repo.record_channel(
+            session,
+            channel_id,
+            RecoverySourceRecord(
+                source=_WAYBACK_SOURCE,
+                source_detail=recovered_data.snapshot_timestamp,
+                fields_written=fields_recovered or None,
+            ),
+        )
 
         # Commit changes
         await session.commit()

--- a/tests/integration/services/test_recovery_provenance_adoption.py
+++ b/tests/integration/services/test_recovery_provenance_adoption.py
@@ -1,0 +1,249 @@
+"""A real recovery run must leave a provenance row behind (#219).
+
+ADR-011 shipped the tables, the migration, the repository and its tests, and
+then nothing called it: `record_video` and `record_channel` had zero callers in
+`src/` while four sites went on assigning the packed column directly. The join
+table was a snapshot frozen at migration time.
+
+Every test that existed at the time passed. That is the point of this file.
+The repository was covered in isolation, so a helper that is never invoked and
+a helper that is invoked look identical from outside — and the unit tests for
+the orchestrator hand it a mocked session, where a stub recording a call and a
+database recording a row are equally indistinguishable.
+
+So these go through the database. The assertion is not "the orchestrator called
+the repository"; it is **"the row is there afterwards"**.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.services.recovery import orchestrator
+from chronovista.services.recovery.models import RecoveredVideoData
+
+pytestmark = pytest.mark.asyncio
+
+_VIDEO_ID = "provAdopt01"
+_CHANNEL_ID = "UCprovadopt0000000001"
+
+
+async def _seed_unavailable_video(session: AsyncSession) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO channels (channel_id, title, is_subscribed, availability_status)
+            VALUES (:cid, 'Adoption Test Channel', false, 'unavailable')
+            ON CONFLICT (channel_id) DO NOTHING
+            """
+        ),
+        {"cid": _CHANNEL_ID},
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO videos (video_id, channel_id, title, upload_date, duration,
+                                made_for_kids, self_declared_made_for_kids,
+                                availability_status)
+            VALUES (:vid, :cid, 'Adoption Test Video', now(), 42, false, false,
+                    'unavailable')
+            ON CONFLICT (video_id) DO NOTHING
+            """
+        ),
+        {"vid": _VIDEO_ID, "cid": _CHANNEL_ID},
+    )
+    await session.flush()
+
+
+def _stub_wayback(snapshot: str) -> tuple[Any, Any, Any]:
+    """CDX client, page parser and rate limiter that yield one usable capture.
+
+    Only the network edge is faked. Everything from the overwrite policy
+    inwards — including the provenance write this file exists to check — runs
+    for real against the database.
+    """
+    snap = MagicMock()
+    snap.timestamp = snapshot
+
+    cdx = MagicMock()
+    cdx.fetch_snapshots = AsyncMock(return_value=[snap])
+
+    parser = MagicMock()
+    parser.extract_metadata = AsyncMock(
+        return_value=RecoveredVideoData(
+            snapshot_timestamp=snapshot,
+            title="Recovered Title",
+            description="Recovered Description",
+        )
+    )
+
+    limiter = MagicMock()
+    limiter.acquire = AsyncMock(return_value=None)
+    return cdx, parser, limiter
+
+
+async def _sources_for(session: AsyncSession, video_id: str) -> list[tuple[str, str]]:
+    rows = await session.execute(
+        text(
+            "SELECT source, source_detail FROM video_recovery_sources "
+            "WHERE video_id = :v ORDER BY source"
+        ),
+        {"v": video_id},
+    )
+    return [(r[0], r[1]) for r in rows]
+
+
+class TestRecoveryLeavesProvenance:
+    async def test_a_successful_run_writes_a_row(
+        self, db_session: AsyncSession
+    ) -> None:
+        """The assertion that was missing when ADR-011 shipped."""
+        await _seed_unavailable_video(db_session)
+        cdx, parser, limiter = _stub_wayback("20220106075526")
+
+        result = await orchestrator.recover_video(
+            session=db_session,
+            video_id=_VIDEO_ID,
+            cdx_client=cdx,
+            page_parser=parser,
+            rate_limiter=limiter,
+        )
+
+        assert result.success, f"recovery failed: {result.failure_reason}"
+        assert await _sources_for(db_session, _VIDEO_ID) == [
+            ("wayback", "20220106075526")
+        ], "a successful recovery must leave a provenance row naming its source"
+
+    async def test_the_snapshot_timestamp_is_stored_as_data(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Not packed into the source string.
+
+        Packing is what destroyed the timestamps in the original incident:
+        overwriting the source took the capture time with it.
+        """
+        await _seed_unavailable_video(db_session)
+        cdx, parser, limiter = _stub_wayback("20210101080938")
+
+        await orchestrator.recover_video(
+            session=db_session,
+            video_id=_VIDEO_ID,
+            cdx_client=cdx,
+            page_parser=parser,
+            rate_limiter=limiter,
+        )
+
+        source, detail = (await _sources_for(db_session, _VIDEO_ID))[0]
+        assert source == "wayback", "the source must not carry the timestamp"
+        assert detail == "20210101080938"
+
+    async def test_a_dry_run_records_nothing(self, db_session: AsyncSession) -> None:
+        """A dry run must not claim a contribution it did not make."""
+        await _seed_unavailable_video(db_session)
+        cdx, parser, limiter = _stub_wayback("20220106075526")
+
+        await orchestrator.recover_video(
+            session=db_session,
+            video_id=_VIDEO_ID,
+            cdx_client=cdx,
+            page_parser=parser,
+            rate_limiter=limiter,
+            dry_run=True,
+        )
+
+        assert await _sources_for(db_session, _VIDEO_ID) == []
+
+
+class TestRecencyReadsTheRecord:
+    """Tier 2 of the merge policy, against the table rather than the projection."""
+
+    async def test_an_older_capture_does_not_overwrite_a_newer_one(
+        self, db_session: AsyncSession
+    ) -> None:
+        """The bug this replaces, end to end.
+
+        Previously the prior timestamp was parsed out of `videos.recovery_source`.
+        Once any other source became the most recent contributor that parse
+        returned nothing, the comparison answered "newer", and an older capture
+        overwrote a newer one while reporting success.
+        """
+        await _seed_unavailable_video(db_session)
+
+        cdx, parser, limiter = _stub_wayback("20230101000000")
+        first = await orchestrator.recover_video(
+            session=db_session,
+            video_id=_VIDEO_ID,
+            cdx_client=cdx,
+            page_parser=parser,
+            rate_limiter=limiter,
+        )
+        # Without this, a run that silently failed would leave the title
+        # unchanged and the final assertion would pass for the wrong reason.
+        assert first.success, f"setup recovery failed: {first.failure_reason}"
+        newer_title = (
+            await db_session.execute(
+                text("SELECT title FROM videos WHERE video_id = :v"), {"v": _VIDEO_ID}
+            )
+        ).scalar_one()
+
+        # Simulate another source becoming the most recent contributor, which
+        # is what used to defeat the parse.
+        await db_session.execute(
+            text("UPDATE videos SET recovery_source = 'filmot' WHERE video_id = :v"),
+            {"v": _VIDEO_ID},
+        )
+        await db_session.flush()
+
+        cdx2, parser2, limiter2 = _stub_wayback("20200101000000")
+        parser2.extract_metadata = AsyncMock(
+            return_value=RecoveredVideoData(
+                snapshot_timestamp="20200101000000",
+                title="Stale Title From An Older Capture",
+            )
+        )
+        second = await orchestrator.recover_video(
+            session=db_session,
+            video_id=_VIDEO_ID,
+            cdx_client=cdx2,
+            page_parser=parser2,
+            rate_limiter=limiter2,
+        )
+        assert second.success, f"second recovery failed: {second.failure_reason}"
+
+        title_now = (
+            await db_session.execute(
+                text("SELECT title FROM videos WHERE video_id = :v"), {"v": _VIDEO_ID}
+            )
+        ).scalar_one()
+        assert title_now == newer_title, (
+            "an older capture overwrote a newer one — the recency check is "
+            "reading the projection again"
+        )
+
+    async def test_the_same_source_running_twice_keeps_one_row(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Idempotent per (video, source): a re-run refreshes, never duplicates."""
+        await _seed_unavailable_video(db_session)
+
+        for snapshot in ("20220106075526", "20240202000000"):
+            cdx, parser, limiter = _stub_wayback(snapshot)
+            await orchestrator.recover_video(
+                session=db_session,
+                video_id=_VIDEO_ID,
+                cdx_client=cdx,
+                page_parser=parser,
+                rate_limiter=limiter,
+            )
+
+        rows = await _sources_for(db_session, _VIDEO_ID)
+        assert len(rows) == 1
+        assert rows[0] == (
+            "wayback",
+            "20240202000000",
+        ), "the later capture should have refreshed this source's own row"

--- a/tests/unit/services/enrichment/conftest.py
+++ b/tests/unit/services/enrichment/conftest.py
@@ -7,7 +7,9 @@ for mocking YouTube API responses in tests.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 
@@ -18,6 +20,9 @@ from chronovista.models.api_responses import (
     VideoStatisticsResponse,
     VideoStatus,
     YouTubeVideoResponse,
+)
+from chronovista.repositories.recovery_provenance_repository import (
+    RecoveryProvenanceRepository,
 )
 
 
@@ -168,3 +173,37 @@ def video_response_factory():
 def minimal_video_response_factory():
     """Fixture that returns the make_minimal_video_response helper function."""
     return make_minimal_video_response
+
+
+@pytest.fixture(autouse=True)
+def stub_provenance_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[dict[str, list[tuple[str, Any]]]]:
+    """Record provenance writes instead of issuing them.
+
+    These tests hand the service an ``AsyncMock`` session, so the repository's
+    real UPDATE never reaches a database and the denormalised columns it
+    refreshes stay unset on the mock. Asserting on those attributes would be
+    asserting that a projection ran, which under a mocked session it cannot.
+
+    What the caller is actually responsible for is *recording the
+    contribution*, so that is what this makes observable. The assertion that
+    the row lands in ``video_recovery_sources`` belongs to an integration test
+    — a stub that records a call and a database that records a row look the
+    same from here, which is precisely how the write path shipped unused.
+    """
+    calls: dict[str, list[tuple[str, Any]]] = {"video": [], "channel": []}
+
+    async def _record_video(
+        _self: Any, _session: Any, video_id: str, record: Any
+    ) -> None:
+        calls["video"].append((video_id, record))
+
+    async def _record_channel(
+        _self: Any, _session: Any, channel_id: str, record: Any
+    ) -> None:
+        calls["channel"].append((channel_id, record))
+
+    monkeypatch.setattr(RecoveryProvenanceRepository, "record_video", _record_video)
+    monkeypatch.setattr(RecoveryProvenanceRepository, "record_channel", _record_channel)
+    yield calls

--- a/tests/unit/services/enrichment/test_enrichment_unavailability.py
+++ b/tests/unit/services/enrichment/test_enrichment_unavailability.py
@@ -18,6 +18,7 @@ consecutive empty response confirms by setting availability_status=UNAVAILABLE.
 """
 
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -524,7 +525,10 @@ class TestRestorationBehavior:
         )
 
     async def test_video_restoration_sets_recovered_metadata(
-        self, service: EnrichmentService, mock_session: AsyncMock
+        self,
+        service: EnrichmentService,
+        mock_session: AsyncMock,
+        stub_provenance_repository: dict[str, Any],
     ) -> None:
         """
         Test video restoration sets recovery metadata.
@@ -601,12 +605,16 @@ class TestRestorationBehavior:
             assert (
                 mock_video.availability_status == AvailabilityStatus.AVAILABLE
             ), "Restored video should have availability_status=AVAILABLE"
+            # Provenance is recorded, not assigned. `recovered_at` and
+            # `recovery_source` are refreshed by the repository's projection,
+            # which a mocked session never executes — so the observable
+            # obligation here is that the contribution was recorded at all.
             assert (
-                mock_video.recovered_at is not None
-            ), "Restored video should have recovered_at timestamp set"
-            assert (
-                mock_video.recovery_source == "sync"
-            ), "Restored video should have recovery_source='sync'"
+                len(stub_provenance_repository["video"]) == 1
+            ), "restoration must record a provenance row"
+            recorded_id, record = stub_provenance_repository["video"][0]
+            assert recorded_id == mock_video.video_id
+            assert record.source == "sync"
             assert (
                 mock_video.unavailability_first_detected is None
             ), "Restored video should have unavailability_first_detected cleared"
@@ -617,7 +625,10 @@ class TestRestorationBehavior:
             assert report.summary.videos_deleted == 0, "Video should NOT be deleted"
 
     async def test_channel_restoration_sets_recovered_metadata(
-        self, service: EnrichmentService, mock_session: AsyncMock
+        self,
+        service: EnrichmentService,
+        mock_session: AsyncMock,
+        stub_provenance_repository: dict[str, Any],
     ) -> None:
         """
         Test channel restoration sets recovery metadata.
@@ -689,11 +700,10 @@ class TestRestorationBehavior:
                 mock_channel.availability_status == AvailabilityStatus.AVAILABLE
             ), "Restored channel should have availability_status=AVAILABLE"
             assert (
-                mock_channel.recovered_at is not None
-            ), "Restored channel should have recovered_at timestamp set"
-            assert (
-                mock_channel.recovery_source == "sync"
-            ), "Restored channel should have recovery_source='sync'"
+                len(stub_provenance_repository["channel"]) == 1
+            ), "restoration must record a provenance row"
+            _recorded_id, record = stub_provenance_repository["channel"][0]
+            assert record.source == "sync"
             assert (
                 mock_channel.unavailability_first_detected is None
             ), "Restored channel should have unavailability_first_detected cleared"
@@ -703,7 +713,10 @@ class TestRestorationBehavior:
             assert result.channels_enriched == 1, "Channel should be enriched"
 
     async def test_restoration_clears_unavailability_first_detected(
-        self, service: EnrichmentService, mock_session: AsyncMock
+        self,
+        service: EnrichmentService,
+        mock_session: AsyncMock,
+        stub_provenance_repository: dict[str, Any],
     ) -> None:
         """
         Test restoration clears unavailability_first_detected if it was set.
@@ -785,12 +798,10 @@ class TestRestorationBehavior:
             assert (
                 mock_video.unavailability_first_detected is None
             ), "Restoration should clear unavailability_first_detected flag"
-            assert (
-                mock_video.recovered_at is not None
-            ), "Restoration should set recovered_at"
-            assert (
-                mock_video.recovery_source == "sync"
-            ), "Restoration should set recovery_source='sync'"
+            # See the note above: provenance is recorded, and the columns are
+            # a projection a mocked session never refreshes.
+            assert len(stub_provenance_repository["video"]) == 1
+            assert stub_provenance_repository["video"][0][1].source == "sync"
 
 
 class TestDryRunBehavior:

--- a/tests/unit/services/recovery/conftest.py
+++ b/tests/unit/services/recovery/conftest.py
@@ -18,12 +18,17 @@ from __future__ import annotations
 
 import itertools
 import shutil
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 import pytest
+
+from chronovista.repositories.recovery_provenance_repository import (
+    RecoveryProvenanceRepository,
+)
 
 # Mark all tests in this module as async by default
 
@@ -497,3 +502,63 @@ def channel_recovery_result_factory():
     ...     assert result["failure_reason"] is not None
     """
     return make_channel_recovery_result
+
+
+@pytest.fixture(autouse=True)
+def stub_provenance_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[dict[str, list[tuple[str, Any]]]]:
+    """Neutralise the provenance repository's database access in unit tests.
+
+    Every test in this package hands the orchestrator an ``AsyncMock`` session.
+    That mock returns an ``AsyncMock`` from ``execute()``, whose ``scalar_*``
+    children are themselves async — so a real provenance read returns a
+    coroutine where a timestamp is expected, and the orchestrator fails on a
+    comparison that has nothing to do with what the test is checking.
+
+    Stubbing it here keeps these tests about what they were written to test.
+    It deliberately does **not** stand in for the assertion that matters — that
+    a real run leaves a row in ``video_recovery_sources`` — which is an
+    integration test, because a stub that records a call and a database that
+    records a row are indistinguishable from inside a unit test. That
+    indistinguishability is why the write path shipped with no callers.
+
+    Yields the recorded calls so a test may assert on them if it wants to.
+    """
+    calls: dict[str, list[tuple[str, Any]]] = {"video": [], "channel": []}
+    # A test that needs a prior contribution from this source sets
+    # calls["prior_video"] / calls["prior_channel"] to a 14-digit timestamp.
+    # That is the precondition "this source recorded a capture before", which
+    # used to be expressed by putting a packed string on the model.
+    calls["prior_video"] = None  # type: ignore[assignment]
+    calls["prior_channel"] = None  # type: ignore[assignment]
+
+    async def _record_video(
+        _self: Any, _session: Any, video_id: str, record: Any
+    ) -> None:
+        calls["video"].append((video_id, record))
+
+    async def _record_channel(
+        _self: Any, _session: Any, channel_id: str, record: Any
+    ) -> None:
+        calls["channel"].append((channel_id, record))
+
+    async def _get_video_detail(
+        _self: Any, _session: Any, _video_id: str, _source: str
+    ) -> str | None:
+        return calls["prior_video"]  # type: ignore[return-value]
+
+    async def _get_channel_detail(
+        _self: Any, _session: Any, _channel_id: str, _source: str
+    ) -> str | None:
+        return calls["prior_channel"]  # type: ignore[return-value]
+
+    monkeypatch.setattr(RecoveryProvenanceRepository, "record_video", _record_video)
+    monkeypatch.setattr(RecoveryProvenanceRepository, "record_channel", _record_channel)
+    monkeypatch.setattr(
+        RecoveryProvenanceRepository, "get_video_source_detail", _get_video_detail
+    )
+    monkeypatch.setattr(
+        RecoveryProvenanceRepository, "get_channel_source_detail", _get_channel_detail
+    )
+    yield calls

--- a/tests/unit/services/recovery/test_orchestrator.py
+++ b/tests/unit/services/recovery/test_orchestrator.py
@@ -17,6 +17,7 @@ Test Coverage
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -553,8 +554,15 @@ class TestOverwritePolicy:
         assert result.success is True
         assert "upload_date" in result.fields_recovered
 
-    async def test_upload_date_skipped_when_existing_recovery_is_newer(self) -> None:
+    async def test_upload_date_skipped_when_existing_recovery_is_newer(
+        self, stub_provenance_repository: dict[str, Any]
+    ) -> None:
         """upload_date is skipped when existing recovery is from a newer snapshot."""
+        # GIVEN: this source already recorded a NEWER capture for this video.
+        # Declared through the provenance stub, because that is where the prior
+        # timestamp now lives; the packed column is a projection and is no
+        # longer consulted for this decision.
+        stub_provenance_repository["prior_video"] = "20210101000000"
         # GIVEN: A video with existing upload_date from a newer recovery
         video = VideoDB(
             video_id="testVid0008",
@@ -1819,8 +1827,12 @@ class TestIdempotency:
         assert "title" in result2.fields_recovered
         assert "description" in result2.fields_recovered
 
-    async def test_recovering_with_older_snapshot_only_fills_null_fields(self) -> None:
+    async def test_recovering_with_older_snapshot_only_fills_null_fields(
+        self, stub_provenance_repository: dict[str, Any]
+    ) -> None:
         """Recovering with older snapshot only fills NULL fields, doesn't overwrite."""
+        # GIVEN: this source's prior capture is newer than the incoming one.
+        stub_provenance_repository["prior_video"] = "20210101000000"
         # GIVEN: A video recovered from a newer snapshot
         video = VideoDB(
             video_id="testVid0021",
@@ -3233,7 +3245,6 @@ class TestBuildChannelUpdate:
         update_dict, fields_recovered, fields_skipped = _build_channel_update(
             existing_channel, recovered_data
         )
-
         # THEN: NULL fields are filled
         assert "description" in update_dict
         assert update_dict["description"] == "Recovered Description"
@@ -3360,8 +3371,11 @@ class TestBuildChannelUpdate:
         # WHEN: We build the update
         from chronovista.services.recovery.orchestrator import _build_channel_update
 
+        # The prior capture is passed in, not parsed out of the channel row.
         update_dict, fields_recovered, fields_skipped = _build_channel_update(
-            existing_channel, recovered_data
+            existing_channel,
+            recovered_data,
+            prior_snapshot_timestamp="20230615120000",
         )
 
         # THEN: Fields are skipped because incoming is older


### PR DESCRIPTION
Fixes #219.

The append-only provenance tables shipped in v0.66.0 (#210) and **nothing wrote to them**. `record_video` and `record_channel` had zero callers, while four sites went on assigning the packed `recovery_source` column directly — so the join table was a snapshot frozen at its migration, drifting further on every recovery and sync pass.

The repository's own docstring claimed *"Nothing else writes `videos.recovery_source`"*. That was aspiration stated as fact.

## Routed

| site | writes |
|---|---|
| `services/recovery/orchestrator.py` | video and channel, archive recovery |
| `services/enrichment/enrichment_service.py` | video and channel, sync |

The enrichment writer matters more than its size suggests: it sits **outside the recovery cluster** and does not think of itself as a recovery implementation — the shape of the pass that destroyed 92 rows' attribution in the first place. The boundary for this work is *who writes provenance*, not *who is called a recovery service*.

## The correctness bug this exposed

Routing alone would have been cosmetic, because the decision logic still read the projection.

`_build_video_update` parsed `recovery_source` to decide whether an incoming capture superseded what was stored. Under ADR-011 that column is a **most-recent-contributor projection**, so the parse only succeeded when this source happened to be the last to touch the row:

| | rows |
|---|---|
| parse succeeds | **2** |
| parse fails → falls through to "no prior recovery" → answers *newer* | **4,130** |
| …of which the timestamp existed all along in `video_recovery_sources.source_detail` | **90** |

Tier 2 of the merge policy — *overwrite mutable fields only if the incoming snapshot is newer* — was unenforceable on 99.95% of recovered rows. A re-run could overwrite newer data with an older capture and report success.

Both builders now take the prior timestamp as an argument, read from the source's own row. **The rule: the packed column may be rendered, never parsed.**

The no-prior-row case is now a named function whose docstring states it as a decision — *the first contribution from a source has nothing to be older than, so it wins* — rather than letting it fall out of a `None` check. An emergent default is exactly how the original defect arose.

## Testing

The integration tests assert **the row is in the database** after a real orchestrator run, not that the repository was called:

| mutation | result |
|---|---|
| delete the `record_video` call (reproducing the state ADR-011 shipped in) | **4 of 5 fail** |
| revert the recency read to parsing the projection | tier-2 test fails |

That distinction is the whole point. The repository was covered in isolation, so a helper never invoked and a helper invoked looked identical — and the orchestrator's unit tests hand it a mocked session, where a stub recording a call and a database recording a row are equally indistinguishable.

Two autouse conftest fixtures replace what would otherwise have been 37 individual edits. Three restoration tests asserted `video.recovered_at is not None` — an attribute the projection now sets in SQL, invisible under a mocked session — and now assert the contribution was recorded. Two recency tests expressed "there is a prior newer recovery" by putting a packed string on the model; they now declare it through the provenance stub.

While writing them I also closed a test that **passed vacuously**: both recoveries silently failed, so the title never changed and "an older capture did not overwrite" was true for the wrong reason.

## Two leaks found by the audit, neither from this change

The private-term list grew as entity resolution added entities, and the whole-tree scan surfaced fragments in **committed, published documentation** that predate this work:

- `docs/user-guide/cli-overview.md`, `docs/user-guide/transcripts.md` and `scripts/utilities/reclassify_asr_corrections.py` used a real ASR-error fragment from the local library as a find-replace example. Replaced with a neutral pair that demonstrates the same behaviour.
- The same docstring paired that fragment with a real first name, and a regex example used a real surname. **Neither was caught by the checker**: the term list holds full names, and word-bounded matching does not fire on one half of one.

That gap is worth knowing beyond this PR — a partial name evades the automated check, so the whole-tree scan needs re-running as the library grows, not only before publishing.

`Conn` is allowlisted: an ASR mis-transcription of a surname colliding with the near-universal name for a database connection, at 47 occurrences across 10 files.

## Checks

`ruff` · `black --check` (551 files) · `mypy --strict` (249 files) · backend unit (**6,896 passed**) · backend integration (**1,289 passed**) · `alembic check` — all green.

No migration: the tables and backfill already exist.
