### PR TITLE
feat(playlists): restore playlists hidden by a bad enrichment run (#149)

### DIFF
--- a/src/chronovista/api/routers/playlists.py
+++ b/src/chronovista/api/routers/playlists.py
@@ -17,10 +17,14 @@ from sqlalchemy.orm import selectinload
 from chronovista.api.deps import get_db, require_auth
 from chronovista.api.routers.responses import GET_ITEM_ERRORS, LIST_ERRORS
 from chronovista.api.schemas.playlists import (
+    HiddenPlaylistItem,
+    HiddenPlaylistListResponse,
     PlaylistDetail,
     PlaylistDetailResponse,
     PlaylistListItem,
     PlaylistListResponse,
+    PlaylistRestoreRequest,
+    PlaylistRestoreResponse,
     PlaylistVideoListItem,
     PlaylistVideoListResponse,
     PlaylistWatchStats,
@@ -38,6 +42,7 @@ from chronovista.db.models import (
 from chronovista.db.models import Video as VideoDB
 from chronovista.exceptions import BadRequestError, NotFoundError
 from chronovista.models.enums import AvailabilityStatus, PlaylistType, WatchedStatus
+from chronovista.repositories.playlist_repository import PlaylistRepository
 from chronovista.repositories.user_video_repository import watched_video_ids
 
 router = APIRouter(dependencies=[Depends(require_auth)])
@@ -238,6 +243,81 @@ async def list_playlists(
     )
 
     return PlaylistListResponse(data=items, pagination=pagination)
+
+
+@router.get(
+    "/playlists/hidden",
+    response_model=HiddenPlaylistListResponse,
+    responses=LIST_ERRORS,
+)
+async def list_hidden_playlists(
+    session: AsyncSession = Depends(get_db),
+) -> HiddenPlaylistListResponse:
+    """List playlists hidden from every other view by ``deleted_flag``.
+
+    Declared before ``/playlists/{playlist_id}`` deliberately: FastAPI matches
+    routes in definition order, and "hidden" is a valid playlist-id shape, so
+    the reverse order would send every request here to the detail handler and
+    return a 404.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session from dependency.
+
+    Returns
+    -------
+    HiddenPlaylistListResponse
+        Hidden playlists, most recently hidden first.
+    """
+    playlists = await PlaylistRepository().get_hidden_playlists(session)
+    return HiddenPlaylistListResponse(
+        data=[HiddenPlaylistItem.model_validate(p) for p in playlists],
+        total=len(playlists),
+    )
+
+
+@router.post(
+    "/playlists/restore",
+    response_model=PlaylistRestoreResponse,
+    responses=LIST_ERRORS,
+)
+async def restore_playlists(
+    request: PlaylistRestoreRequest,
+    session: AsyncSession = Depends(get_db),
+) -> PlaylistRestoreResponse:
+    """Un-hide playlists that were marked deleted.
+
+    A hidden playlist never returns on its own — enrichment selects only live
+    rows, so it leaves the population permanently. Until this endpoint the only
+    route back was a hand-written UPDATE (#149).
+
+    IDs that are not currently hidden are reported in ``skipped`` rather than
+    raising: a partial restore is a useful outcome, and failing the whole
+    request because one id was already visible would be worse than saying so.
+
+    Parameters
+    ----------
+    request : PlaylistRestoreRequest
+        Playlist IDs to restore (non-empty).
+    session : AsyncSession
+        Database session from dependency.
+
+    Returns
+    -------
+    PlaylistRestoreResponse
+        Count restored, plus any requested IDs that were not hidden.
+    """
+    repository = PlaylistRepository()
+    hidden_ids = {p.playlist_id for p in await repository.get_hidden_playlists(session)}
+
+    targets = [pid for pid in request.playlist_ids if pid in hidden_ids]
+    skipped = [pid for pid in request.playlist_ids if pid not in hidden_ids]
+
+    restored = await repository.restore_playlists(session, targets)
+    await session.commit()
+
+    return PlaylistRestoreResponse(restored=restored, skipped=skipped)
 
 
 @router.get(

--- a/src/chronovista/api/schemas/playlists.py
+++ b/src/chronovista/api/schemas/playlists.py
@@ -182,6 +182,97 @@ class PlaylistDetailResponse(BaseModel):
     data: PlaylistDetail
 
 
+class HiddenPlaylistItem(PlaylistListItem):
+    """A playlist hidden from every other view by ``deleted_flag`` (#149).
+
+    Carries ``hidden_at_approx`` rather than a real deletion timestamp: no
+    column records when a playlist was hidden, so this is the row's
+    last-modified time. For a hidden playlist that *is* when it was hidden,
+    because nothing writes to one afterwards — enrichment selects only live
+    rows. The name says "approx" because that is a property of current
+    behaviour, not a guarantee, and a consumer must not treat it as an audit
+    record.
+    """
+
+    model_config = ConfigDict(strict=True, from_attributes=True)
+
+    hidden_at_approx: datetime = Field(
+        ...,
+        description=(
+            "Row last-modified time, which for a hidden playlist approximates "
+            "when it was hidden. Not an audit timestamp."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def derive_is_linked(cls, data: Any) -> Any:
+        """Map an ORM row to this schema's fields.
+
+        Written standalone rather than delegating to the parent's validator:
+        that attribute is a Pydantic descriptor proxy, and calling it through
+        the class is not a supported, type-checkable call even though it
+        happens to resolve at runtime. The parent also drops ``updated_at``
+        when it builds its dict, so there would be nothing left to read the
+        hidden time from afterwards.
+        """
+        if isinstance(data, dict):
+            playlist_id = data.get("playlist_id", "")
+            data["is_linked"] = playlist_id.startswith(("PL", "LL", "WL", "HL"))
+            return data
+        if hasattr(data, "playlist_id"):
+            playlist_id = getattr(data, "playlist_id", "")
+            return {
+                "playlist_id": playlist_id,
+                "title": getattr(data, "title", ""),
+                "description": getattr(data, "description", None),
+                "video_count": getattr(data, "video_count", 0),
+                "privacy_status": getattr(data, "privacy_status", "private"),
+                "is_linked": playlist_id.startswith(("PL", "LL", "WL", "HL")),
+                "playlist_type": getattr(data, "playlist_type", "regular"),
+                "hidden_at_approx": getattr(data, "updated_at", None),
+            }
+        return data
+
+
+class HiddenPlaylistListResponse(BaseModel):
+    """Response wrapper for the hidden-playlist list."""
+
+    model_config = ConfigDict(strict=True)
+
+    data: list[HiddenPlaylistItem]
+    total: int = Field(..., description="Number of hidden playlists")
+
+
+class PlaylistRestoreRequest(BaseModel):
+    """Playlists to un-hide.
+
+    ``playlist_ids`` is required and must be non-empty: there is deliberately
+    no "restore everything" request shape, because an empty body is exactly
+    what an accidental POST sends, and un-hiding the whole library must be an
+    explicit act. A caller wanting all of them lists them from
+    ``GET /playlists/hidden`` first.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    playlist_ids: list[str] = Field(
+        ..., min_length=1, description="Playlist IDs to restore"
+    )
+
+
+class PlaylistRestoreResponse(BaseModel):
+    """Outcome of a restore request."""
+
+    model_config = ConfigDict(strict=True)
+
+    restored: int = Field(..., description="Number of playlists actually un-hidden")
+    skipped: list[str] = Field(
+        default_factory=list,
+        description="Requested IDs that were not hidden (already visible or unknown)",
+    )
+
+
 class PlaylistWatchStats(BaseModel):
     """Watched/unwatched breakdown for one playlist (Feature 061).
 

--- a/src/chronovista/cli/commands/playlist.py
+++ b/src/chronovista/cli/commands/playlist.py
@@ -522,6 +522,203 @@ async def _reclassify(
 
 
 @playlist_app.command()
+def hidden() -> None:
+    """Show playlists hidden from the UI by ``deleted_flag``.
+
+    Every other view filters these out, so without this command the only way
+    to see them is a psql prompt. That is how an enrichment run once hid 288
+    playlists for two months without anyone being able to name which ones.
+
+    The "Hidden" column is approximate: it is the row's last-modified time,
+    which for a hidden playlist is when it was hidden, because nothing writes
+    to one afterwards.
+
+    Examples:
+        chronovista playlist hidden
+
+    Exit Codes:
+        0: Success
+        2: System error - database failure
+        3: Cancelled - Ctrl+C pressed
+    """
+
+    async def hidden_async() -> None:
+        repository = PlaylistRepository()
+        db_manager = DatabaseManager()
+
+        try:
+            async for session in db_manager.get_session(echo=False):
+                playlists = await repository.get_hidden_playlists(session)
+
+                if not playlists:
+                    console.print("[green]No hidden playlists.[/green]")
+                    sys.exit(EXIT_SUCCESS)
+
+                table = Table(title=f"Hidden playlists ({len(playlists)})")
+                table.add_column("Playlist ID", style="cyan", no_wrap=False)
+                table.add_column("Title", style="white")
+                table.add_column("Videos", justify="right", style="green")
+                table.add_column("Hidden (approx)", style="dim")
+                table.add_column("Privacy", justify="center")
+
+                for playlist in playlists:
+                    table.add_row(
+                        _truncate_id(playlist.playlist_id),
+                        playlist.title,
+                        str(playlist.video_count),
+                        playlist.updated_at.strftime("%Y-%m-%d"),
+                        playlist.privacy_status,
+                    )
+
+                console.print(table)
+                console.print(
+                    "\n[dim]Restore with: chronovista playlist restore --all[/dim]"
+                )
+                sys.exit(EXIT_SUCCESS)
+
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Operation cancelled by user[/yellow]")
+            sys.exit(EXIT_CANCELLED)
+
+        except Exception as e:
+            console.print(
+                Panel(
+                    f"[red]Database error:[/red]\n{str(e)}",
+                    title="Listing Failed",
+                    border_style="red",
+                )
+            )
+            sys.exit(EXIT_SYSTEM_ERROR)
+
+    asyncio.run(hidden_async())
+
+
+@playlist_app.command()
+def restore(
+    playlist_id: builtins.list[str] = typer.Option(
+        [],
+        "--id",
+        help="Restore a specific playlist. Repeatable.",
+    ),
+    all_hidden: bool = typer.Option(
+        False,
+        "--all",
+        help="Restore every hidden playlist.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be restored without writing.",
+    ),
+) -> None:
+    """Un-hide playlists that were marked deleted.
+
+    A playlist hidden by ``deleted_flag`` never comes back on its own:
+    enrichment selects only live rows, so a hidden playlist leaves the
+    population permanently. Until this command the only route back was a
+    hand-written UPDATE (#149).
+
+    Requires either --all or at least one --id, so that a bare `restore`
+    cannot un-hide the entire library by accident.
+
+    Examples:
+        chronovista playlist restore --all
+        chronovista playlist restore --id PLxxxx --id PLyyyy
+        chronovista playlist restore --all --dry-run
+
+    Exit Codes:
+        0: Success
+        1: User error - neither --all nor --id given, or both
+        2: System error - database failure
+        3: Cancelled - Ctrl+C pressed
+    """
+    if all_hidden and playlist_id:
+        console.print(
+            "[red]Use either --all or --id, not both.[/red]\n"
+            "[dim]--all restores everything hidden; --id restores only what "
+            "you name.[/dim]"
+        )
+        raise typer.Exit(EXIT_USER_ERROR)
+
+    if not all_hidden and not playlist_id:
+        console.print(
+            "[red]Nothing to restore.[/red]\n"
+            "[dim]Pass --all to restore every hidden playlist, or --id to "
+            "name specific ones. Run 'chronovista playlist hidden' to see "
+            "what is hidden.[/dim]"
+        )
+        raise typer.Exit(EXIT_USER_ERROR)
+
+    async def restore_async() -> None:
+        repository = PlaylistRepository()
+        db_manager = DatabaseManager()
+
+        try:
+            async for session in db_manager.get_session(echo=False):
+                hidden_playlists = await repository.get_hidden_playlists(session)
+                hidden_ids = {p.playlist_id for p in hidden_playlists}
+
+                if all_hidden:
+                    targets = sorted(hidden_ids)
+                    unknown: builtins.list[str] = []
+                else:
+                    targets = [pid for pid in playlist_id if pid in hidden_ids]
+                    unknown = [pid for pid in playlist_id if pid not in hidden_ids]
+
+                for pid in unknown:
+                    console.print(
+                        f"[yellow]Skipping {pid}: not hidden "
+                        f"(already visible, or no such playlist).[/yellow]"
+                    )
+
+                if not targets:
+                    console.print("[dim]Nothing to restore.[/dim]")
+                    sys.exit(EXIT_SUCCESS)
+
+                if dry_run:
+                    console.print(
+                        Panel(
+                            "[bold]Restore (dry-run)[/bold] — no changes written",
+                            border_style="yellow",
+                        )
+                    )
+                    for pid in targets:
+                        console.print(f"  would restore {pid}")
+                    console.print(
+                        f"\n[bold]Would restore {len(targets)} playlist(s).[/bold]\n"
+                        "[dim]Re-run without --dry-run to apply.[/dim]"
+                    )
+                    sys.exit(EXIT_SUCCESS)
+
+                restored = await repository.restore_playlists(session, targets)
+                await session.commit()
+
+                console.print(
+                    f"[green]Restored {restored} playlist(s).[/green]\n"
+                    "[dim]They will reappear in the UI immediately. If an "
+                    "enrichment run hid them in error, fix the cause before "
+                    "re-running it.[/dim]"
+                )
+                sys.exit(EXIT_SUCCESS)
+
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Operation cancelled by user[/yellow]")
+            sys.exit(EXIT_CANCELLED)
+
+        except Exception as e:
+            console.print(
+                Panel(
+                    f"[red]Database error:[/red]\n{str(e)}",
+                    title="Restore Failed",
+                    border_style="red",
+                )
+            )
+            sys.exit(EXIT_SYSTEM_ERROR)
+
+    asyncio.run(restore_async())
+
+
+@playlist_app.command()
 def reclassify(
     dry_run: bool = typer.Option(
         False,

--- a/src/chronovista/repositories/playlist_repository.py
+++ b/src/chronovista/repositories/playlist_repository.py
@@ -324,6 +324,74 @@ class PlaylistRepository(
             .values(playlist_type=new_type.value)
         )
 
+    async def get_hidden_playlists(self, session: AsyncSession) -> list[PlaylistDB]:
+        """Return every playlist currently hidden by ``deleted_flag``.
+
+        The counterpart to every other query in this class, which filter hidden
+        playlists *out*. This one exists so a user can see what an enrichment
+        run removed from the UI (#149) — otherwise the only way to find them is
+        to open a psql prompt, which is how the original incident was diagnosed
+        two months after the fact.
+
+        Ordered by ``updated_at`` descending so the most recently hidden appear
+        first, which is nearly always what someone investigating wants.
+
+        Note on ``updated_at``: for a hidden playlist it is effectively the time
+        it was hidden, because nothing writes to a hidden playlist — enrichment
+        selects only live rows and the takeout seeder's update path is a no-op.
+        That is a property of current behaviour rather than a guarantee, which
+        is why it is presented as approximate and never used as a filter.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+
+        Returns
+        -------
+        list[PlaylistDB]
+            Hidden playlists, most recently hidden first.
+        """
+        result = await session.execute(
+            select(PlaylistDB)
+            .where(PlaylistDB.deleted_flag.is_(True))
+            .order_by(PlaylistDB.updated_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def restore_playlists(
+        self, session: AsyncSession, playlist_ids: list[str]
+    ) -> int:
+        """Clear ``deleted_flag`` on the given playlists, returning the count.
+
+        Restricted to rows that are actually hidden, so the returned count is
+        the number of playlists genuinely restored rather than the number of
+        ids supplied. A caller passing an id that is already visible — or one
+        that does not exist — gets an honest zero for it.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        playlist_ids : list[str]
+            Playlists to restore. An empty list is a no-op.
+
+        Returns
+        -------
+        int
+            Number of rows changed.
+        """
+        if not playlist_ids:
+            return 0
+
+        result = await session.execute(
+            update(PlaylistDB)
+            .where(PlaylistDB.playlist_id.in_(playlist_ids))
+            .where(PlaylistDB.deleted_flag.is_(True))
+            .values(deleted_flag=False)
+        )
+        return int(result.rowcount)
+
     async def get_with_channel(
         self, session: AsyncSession, playlist_id: str
     ) -> PlaylistDB | None:

--- a/tests/integration/api/test_playlist_restore.py
+++ b/tests/integration/api/test_playlist_restore.py
@@ -1,0 +1,238 @@
+"""Restoring playlists hidden by a bad enrichment run (#149).
+
+A playlist hidden by ``deleted_flag`` never returns on its own: every query
+filters it out, and ``enrich_playlists`` selects only live rows, so it leaves
+the population permanently. Before this endpoint the sole route back was a
+hand-written UPDATE at a psql prompt — which is what the original incident
+required, two months after the fact.
+
+These go through the real database rather than a mocked repository, because
+the thing worth checking is that the row is visible again afterwards.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+_CHANNEL_ID = "UCrestore00000000001"
+
+
+@pytest.fixture
+async def test_data_session(
+    integration_session_factory: Any,
+) -> AsyncGenerator[AsyncSession, None]:
+    """A session for seeding, from the API conftest's factory.
+
+    Deliberately **not** the top-level ``db_session`` fixture. That one calls
+    ``Base.metadata.drop_all`` at teardown, while this package creates the
+    schema once per session (``integration_db_schema_setup``, ``scope="session"``)
+    and never recreates it. An API test that touches ``db_session`` therefore
+    drops the tables out from under every test that follows — 331 of them,
+    all reporting ``relation "channels" does not exist``, none of them at fault.
+    """
+    async with integration_session_factory() as session:
+        yield session
+
+
+@pytest.fixture(autouse=True)
+async def cleanup_seeded_rows(
+    test_data_session: AsyncSession,
+) -> AsyncGenerator[None, None]:
+    """Remove this file's rows after each test.
+
+    Required, not tidiness. The schema in this package is created once per
+    session and never reset, so committed rows outlive the test that made
+    them — and other files clean up with a bare ``DELETE FROM channels``,
+    which a leftover playlist blocks outright with a foreign-key violation.
+    Leaking rows here fails tests that have nothing to do with playlists.
+
+    Playlists go first: they hold the foreign key.
+    """
+    yield
+    await test_data_session.execute(
+        text("DELETE FROM playlists WHERE channel_id = :cid"), {"cid": _CHANNEL_ID}
+    )
+    await test_data_session.execute(
+        text("DELETE FROM channels WHERE channel_id = :cid"), {"cid": _CHANNEL_ID}
+    )
+    await test_data_session.commit()
+
+
+async def _seed(
+    session: AsyncSession, playlist_id: str, *, hidden: bool, title: str = "Seeded"
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO channels (channel_id, title, is_subscribed,
+                                  availability_status)
+            VALUES (:cid, 'Restore Test Channel', false, 'available')
+            ON CONFLICT (channel_id) DO NOTHING
+            """
+        ),
+        {"cid": _CHANNEL_ID},
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO playlists (playlist_id, title, privacy_status, channel_id,
+                                   video_count, deleted_flag, playlist_type)
+            VALUES (:pid, :title, 'private', :cid, 7, :hidden, 'regular')
+            ON CONFLICT (playlist_id) DO UPDATE SET deleted_flag = :hidden
+            """
+        ),
+        {"pid": playlist_id, "cid": _CHANNEL_ID, "hidden": hidden, "title": title},
+    )
+    await session.commit()
+
+
+async def _is_hidden(session: AsyncSession, playlist_id: str) -> bool:
+    row = await session.execute(
+        text("SELECT deleted_flag FROM playlists WHERE playlist_id = :p"),
+        {"p": playlist_id},
+    )
+    return bool(row.scalar_one())
+
+
+class TestRouteOrdering:
+    async def test_hidden_is_not_swallowed_by_the_detail_route(
+        self, async_client: AsyncClient, test_data_session: AsyncSession
+    ) -> None:
+        """``/playlists/hidden`` must not be parsed as a playlist id.
+
+        FastAPI matches in definition order and "hidden" satisfies the detail
+        route's path constraints, so declaring the routes the other way round
+        returns 404 for every request here. Nothing else in the suite would
+        catch it, because the handler would still exist and still be correct.
+        """
+        response = await async_client.get("/api/v1/playlists/hidden")
+
+        assert response.status_code == 200, (
+            "the hidden listing was routed to the detail handler — check that "
+            "it is declared before /playlists/{playlist_id}"
+        )
+        assert "data" in response.json()
+
+
+class TestHiddenListing:
+    async def test_a_hidden_playlist_is_listed(
+        self, async_client: AsyncClient, test_data_session: AsyncSession
+    ) -> None:
+        await _seed(test_data_session, "PLhiddenlisted01", hidden=True)
+
+        body = (await async_client.get("/api/v1/playlists/hidden")).json()
+
+        ids = [p["playlist_id"] for p in body["data"]]
+        assert "PLhiddenlisted01" in ids
+        assert body["total"] == len(body["data"])
+
+    async def test_a_visible_playlist_is_not_listed(
+        self, async_client: AsyncClient, test_data_session: AsyncSession
+    ) -> None:
+        await _seed(test_data_session, "PLvisible000001", hidden=False)
+
+        body = (await async_client.get("/api/v1/playlists/hidden")).json()
+
+        ids = [p["playlist_id"] for p in body["data"]]
+        assert "PLvisible000001" not in ids
+
+    async def test_the_hidden_time_is_reported(
+        self, async_client: AsyncClient, test_data_session: AsyncSession
+    ) -> None:
+        """Approximate, and named so — there is no deletion timestamp column."""
+        await _seed(test_data_session, "PLhiddentime001", hidden=True)
+
+        body = (await async_client.get("/api/v1/playlists/hidden")).json()
+
+        entry = next(p for p in body["data"] if p["playlist_id"] == "PLhiddentime001")
+        assert entry["hidden_at_approx"] is not None
+
+
+class TestRestore:
+    async def test_restoring_makes_a_playlist_visible_again(
+        self, async_client: AsyncClient, test_data_session: AsyncSession
+    ) -> None:
+        """The whole point: assert against the row, not the response."""
+        await _seed(test_data_session, "PLrestoreme0001", hidden=True)
+
+        response = await async_client.post(
+            "/api/v1/playlists/restore",
+            json={"playlist_ids": ["PLrestoreme0001"]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["restored"] == 1
+        assert await _is_hidden(test_data_session, "PLrestoreme0001") is False
+
+    async def test_a_playlist_that_was_not_hidden_is_skipped(
+        self, async_client: AsyncClient, test_data_session: AsyncSession
+    ) -> None:
+        """Reported, not fatal — a partial restore is a useful outcome."""
+        await _seed(test_data_session, "PLalreadyvis001", hidden=False)
+        await _seed(test_data_session, "PLmixedhidden1", hidden=True)
+
+        body = (
+            await async_client.post(
+                "/api/v1/playlists/restore",
+                json={"playlist_ids": ["PLalreadyvis001", "PLmixedhidden1"]},
+            )
+        ).json()
+
+        assert body["restored"] == 1
+        assert body["skipped"] == ["PLalreadyvis001"]
+
+    async def test_an_unknown_id_is_skipped_not_an_error(
+        self, async_client: AsyncClient, test_data_session: AsyncSession
+    ) -> None:
+        body = (
+            await async_client.post(
+                "/api/v1/playlists/restore",
+                json={"playlist_ids": ["PLdoesnotexist9"]},
+            )
+        ).json()
+
+        assert body["restored"] == 0
+        assert body["skipped"] == ["PLdoesnotexist9"]
+
+    async def test_an_empty_request_is_rejected(
+        self, async_client: AsyncClient
+    ) -> None:
+        """There is deliberately no restore-everything request shape.
+
+        An empty body is exactly what an accidental POST sends, and un-hiding
+        the whole library must be an explicit act.
+        """
+        response = await async_client.post(
+            "/api/v1/playlists/restore", json={"playlist_ids": []}
+        )
+
+        assert response.status_code == 422
+
+    async def test_a_restored_playlist_is_reachable_again(
+        self, async_client: AsyncClient, test_data_session: AsyncSession
+    ) -> None:
+        """The cross-feature check: restoring must actually undo the hiding.
+
+        The detail endpoint filters ``deleted_flag IS FALSE``, so a 404 before
+        and a 200 after is the user-visible meaning of this operation.
+        """
+        await _seed(test_data_session, "PLreachable0001", hidden=True)
+
+        before = await async_client.get("/api/v1/playlists/PLreachable0001")
+        assert before.status_code == 404
+
+        await async_client.post(
+            "/api/v1/playlists/restore",
+            json={"playlist_ids": ["PLreachable0001"]},
+        )
+
+        after = await async_client.get("/api/v1/playlists/PLreachable0001")
+        assert after.status_code == 200

--- a/tests/integration/repositories/test_playlist_restore_queries.py
+++ b/tests/integration/repositories/test_playlist_restore_queries.py
@@ -1,0 +1,116 @@
+"""The two queries that make a hidden playlist findable again (#149).
+
+Every other query in ``PlaylistRepository`` filters hidden playlists out.
+These two are the only way to see them and the only way to bring them back,
+so their edge behaviour is worth pinning: what counts as restored, and what a
+caller is told when it asks for something that was not hidden.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.repositories.playlist_repository import PlaylistRepository
+
+pytestmark = pytest.mark.asyncio
+
+_CHANNEL_ID = "UCrepohidden0000001"
+
+
+async def _seed(session: AsyncSession, playlist_id: str, *, hidden: bool) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO channels (channel_id, title, is_subscribed,
+                                  availability_status)
+            VALUES (:cid, 'Repo Hidden Channel', false, 'available')
+            ON CONFLICT (channel_id) DO NOTHING
+            """
+        ),
+        {"cid": _CHANNEL_ID},
+    )
+    await session.execute(
+        text(
+            """
+            INSERT INTO playlists (playlist_id, title, privacy_status, channel_id,
+                                   video_count, deleted_flag, playlist_type)
+            VALUES (:pid, 'Repo Hidden Playlist', 'private', :cid, 3, :hidden,
+                    'regular')
+            ON CONFLICT (playlist_id) DO UPDATE SET deleted_flag = :hidden
+            """
+        ),
+        {"pid": playlist_id, "cid": _CHANNEL_ID, "hidden": hidden},
+    )
+    await session.flush()
+
+
+class TestGetHiddenPlaylists:
+    async def test_it_returns_hidden_and_only_hidden(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed(db_session, "PLrepohidden01", hidden=True)
+        await _seed(db_session, "PLrepovisible1", hidden=False)
+
+        found = await PlaylistRepository().get_hidden_playlists(db_session)
+
+        ids = {p.playlist_id for p in found}
+        assert "PLrepohidden01" in ids
+        assert "PLrepovisible1" not in ids
+
+
+class TestRestorePlaylists:
+    async def test_it_clears_the_flag(self, db_session: AsyncSession) -> None:
+        await _seed(db_session, "PLrepoclear001", hidden=True)
+
+        changed = await PlaylistRepository().restore_playlists(
+            db_session, ["PLrepoclear001"]
+        )
+
+        assert changed == 1
+        still_hidden = await db_session.execute(
+            text("SELECT deleted_flag FROM playlists WHERE playlist_id = :p"),
+            {"p": "PLrepoclear001"},
+        )
+        assert still_hidden.scalar_one() is False
+
+    async def test_an_already_visible_playlist_does_not_count(
+        self, db_session: AsyncSession
+    ) -> None:
+        """The count is playlists restored, not ids supplied.
+
+        A caller that gets back "1" for two ids has been told something true
+        and useful; returning len(ids) would be a lie that hides a typo.
+        """
+        await _seed(db_session, "PLrepovis00001", hidden=False)
+        await _seed(db_session, "PLrepohid00001", hidden=True)
+
+        changed = await PlaylistRepository().restore_playlists(
+            db_session, ["PLrepovis00001", "PLrepohid00001"]
+        )
+
+        assert changed == 1
+
+    async def test_an_unknown_id_counts_zero(self, db_session: AsyncSession) -> None:
+        changed = await PlaylistRepository().restore_playlists(
+            db_session, ["PLrepodoesnotexist"]
+        )
+
+        assert changed == 0
+
+    async def test_an_empty_list_is_a_no_op(self, db_session: AsyncSession) -> None:
+        """Guarded explicitly: an unguarded IN () is a SQL error in some
+        dialects and a full-table match in others, and this statement writes."""
+        await _seed(db_session, "PLrepoempty001", hidden=True)
+
+        changed = await PlaylistRepository().restore_playlists(db_session, [])
+
+        assert changed == 0
+        still_hidden = await db_session.execute(
+            text("SELECT deleted_flag FROM playlists WHERE playlist_id = :p"),
+            {"p": "PLrepoempty001"},
+        )
+        assert (
+            still_hidden.scalar_one() is True
+        ), "an empty restore list must not touch any row"

--- a/tests/unit/cli/test_playlist_restore.py
+++ b/tests/unit/cli/test_playlist_restore.py
@@ -1,0 +1,68 @@
+"""Guard rails on `chronovista playlist restore` (#149).
+
+The command un-hides playlists, and ``--all`` un-hides every one of them. The
+argument checks run before any database work, so they are testable on their
+own — and they are the part worth testing hardest, because the failure mode is
+a bare ``restore`` quietly restoring the entire library.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from chronovista.cli.commands.playlist import playlist_app
+from chronovista.cli.constants import EXIT_USER_ERROR
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestArgumentGuards:
+    """These exit before touching the database.
+
+    ``DatabaseManager`` is patched anyway: if a guard regressed, the command
+    would fall through to real database work, and the assertion that would
+    then fail should be the exit code — not a connection error that happens to
+    look like a failure for the wrong reason.
+    """
+
+    def test_a_bare_restore_is_rejected(self, runner: CliRunner) -> None:
+        """Without this, `restore` with no arguments could un-hide everything."""
+        with patch("chronovista.cli.commands.playlist.DatabaseManager") as db:
+            result = runner.invoke(playlist_app, ["restore"])
+
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "Nothing to restore" in result.output
+        db.assert_not_called()
+
+    def test_all_and_id_together_are_rejected(self, runner: CliRunner) -> None:
+        """They mean different things; silently preferring one would surprise."""
+        with patch("chronovista.cli.commands.playlist.DatabaseManager") as db:
+            result = runner.invoke(playlist_app, ["restore", "--all", "--id", "PLx"])
+
+        assert result.exit_code == EXIT_USER_ERROR
+        assert "not both" in result.output
+        db.assert_not_called()
+
+    def test_the_rejection_points_at_the_listing_command(
+        self, runner: CliRunner
+    ) -> None:
+        """Someone who typed the wrong thing needs to know what is hidden."""
+        with patch("chronovista.cli.commands.playlist.DatabaseManager"):
+            result = runner.invoke(playlist_app, ["restore"])
+
+        assert "playlist hidden" in result.output
+
+
+class TestHelp:
+    def test_restore_is_registered(self, runner: CliRunner) -> None:
+        result = runner.invoke(playlist_app, ["--help"])
+
+        assert result.exit_code == 0
+        assert "restore" in result.output
+        assert "hidden" in result.output


### PR DESCRIPTION
Closes the soft-undo item on #149. Follows #221 and #222.

A playlist hidden by `deleted_flag` **never comes back on its own**. Every query filters it out, `enrich_playlists` selects only live rows, and nothing in the codebase ever sets the flag back to false — so a hidden playlist leaves the population permanently. The only route back was a hand-written `UPDATE` at a psql prompt: what the original incident required two months after the fact, and what restoring four more playlists required last week.

#221 and #222 stop playlists being hidden wrongly. This makes it recoverable when they are anyway — the last of the five fixes proposed on the issue.

## What lands

**Repository**

| method | purpose |
|---|---|
| `get_hidden_playlists()` | the only query in the class that *returns* hidden rows instead of filtering them out |
| `restore_playlists(ids)` | clears the flag, returning rows actually changed |

**CLI**

```
chronovista playlist hidden
chronovista playlist restore --all
chronovista playlist restore --id PLxxxx --id PLyyyy
chronovista playlist restore --dry-run
```

**API**

```
GET  /api/v1/playlists/hidden
POST /api/v1/playlists/restore
```

## Design decisions worth reviewing

**No time window, and no migration.** The issue proposed restoring "playlists flagged within a time window," but no column records *when* a playlist was hidden — `deleted_flag` is a bare boolean. `updated_at` happens to be that time today, because nothing writes to a hidden playlist, but that's a property of two unrelated behaviours (enrichment excludes them; the takeout seeder's update path is a no-op) rather than a guarantee. So it's surfaced as `hidden_at_approx` for a human to read and **never used as a filter**. Listing and naming what to restore needs neither the column nor the window.

**The count is rows changed, not ids supplied.** A caller that passes two ids and gets back `1` has been told something true and useful; returning `len(ids)` would conceal a typo.

**Neither entry point can restore everything by accident.** The CLI requires `--all` or at least one `--id`, so a bare `restore` is a user error. The API has no restore-everything request shape at all — `playlist_ids` is required and non-empty, because an empty body is exactly what an accidental POST sends.

**Ids that aren't hidden are reported, not raised.** A partial restore is a useful outcome; failing the whole request because one id was already visible would be worse than saying so.

## Route ordering

`/playlists/hidden` is declared **before** `/playlists/{playlist_id}`. FastAPI matches in definition order and `hidden` satisfies the detail route's path constraints, so the reverse order sends every request to the detail handler and 404s.

There's a test for exactly this, because nothing else would catch it — the handler would still exist and still be correct, and every other test would pass.

## Tests

18 new. The API and repository tests go through the real database and assert against the row, not the response.

That includes a cross-feature check: a hidden playlist returns **404** from the detail endpoint before restore and **200** after, which is the user-visible meaning of the operation.

| mutation | result |
|---|---|
| serve the listing at a different path (the failure wrong route ordering produces) | 4 tests fail |
| drop the hidden-only filter from the `UPDATE` | count test fails |

## Checks

`ruff` · `black --check` · `mypy src/chronovista/ --strict` · backend unit · backend integration — all green. No migration.
