### PR TITLE
fix(enrichment): require owner verification before hiding playlists (#149)

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -4,7 +4,7 @@ Every table in the PostgreSQL schema, generated from the SQLAlchemy models
 at build time — the same metadata Alembic autogenerates migrations from, so
 this page cannot drift from the shipped database.
 
-**25 tables.** For the reasoning behind the design, see
+**27 tables.** For the reasoning behind the design, see
 [Data Model](../architecture/data-model.md).
 
 ## Core Content
@@ -32,6 +32,11 @@ YouTube channel model with subscription tracking.
 | `unavailability_first_detected` | TIMESTAMP WITH TIME ZONE | yes |  |  |
 | `created_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
 | `updated_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
+
+**Indexes:**
+
+- INDEX `idx_channels_availability_status` on `availability_status`
+- INDEX `idx_channels_needs_enrichment` on `channel_id`
 
 ### `videos`
 
@@ -64,6 +69,13 @@ Enhanced video model with language support and content restrictions.
 | `unavailability_first_detected` | TIMESTAMP WITH TIME ZONE | yes |  |  |
 | `created_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
 | `updated_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
+
+**Indexes:**
+
+- INDEX `idx_videos_availability_status` on `availability_status`
+- INDEX `idx_videos_category_id` on `category_id`
+- INDEX `idx_videos_channel_hint` on `channel_name_hint`
+- INDEX `idx_videos_null_channel` on `video_id`
 
 ### `video_categories`
 
@@ -122,6 +134,13 @@ Multi-language video transcripts with quality indicators.
 
 **Composite primary key:** `video_id`, `language_code`
 
+**Indexes:**
+
+- INDEX `ix_video_transcripts_has_timestamps_true` on `has_timestamps`
+- INDEX `ix_video_transcripts_segment_count` on `segment_count`
+- INDEX `ix_video_transcripts_source` on `source`
+- INDEX `ix_video_transcripts_total_duration` on `total_duration`
+
 ### `transcript_segments`
 
 Individual timed text segment from a video transcript.
@@ -146,6 +165,14 @@ Individual timed text segment from a video transcript.
 - CHECK `chk_segment_sequence_non_negative`: `sequence_number >= 0`
 - CHECK `chk_segment_start_time_non_negative`: `start_time >= 0`
 
+**Indexes:**
+
+- INDEX `idx_segments_corrected_text_trgm` on `corrected_text`
+- INDEX `idx_segments_text_trgm` on `text`
+- INDEX `idx_transcript_segments_corrected` on `video_id`, `language_code`, `has_correction`
+- INDEX `idx_transcript_segments_lookup` on `video_id`, `language_code`, `start_time`
+- INDEX `idx_transcript_segments_time_range` on `video_id`, `language_code`, `start_time`, `end_time`
+
 ### `transcript_corrections`
 
 Append-only audit record for transcript segment corrections (Feature 033).
@@ -168,6 +195,12 @@ Append-only audit record for transcript segment corrections (Feature 033).
 **Constraints:**
 
 - CHECK `chk_transcript_corrections_version_number_positive`: `version_number >= 1`
+
+**Indexes:**
+
+- INDEX `idx_transcript_corrections_lookup` on `video_id`, `language_code`, `corrected_at`
+- INDEX `idx_transcript_corrections_segment` on `segment_id`, `corrected_at`
+- INDEX `ix_transcript_corrections_batch_id` on `batch_id`
 
 ## User Data
 
@@ -206,6 +239,10 @@ User interaction tracking with videos.
 
 **Composite primary key:** `user_id`, `video_id`
 
+**Indexes:**
+
+- INDEX `ix_user_videos_video_id` on `video_id`
+
 ### `user_language_preferences`
 
 User language preferences for content consumption and learning.
@@ -241,6 +278,7 @@ Enhanced playlists with language support.
 | `video_count` | INTEGER | no | `0` |  |
 | `published_at` | TIMESTAMP WITH TIME ZONE | yes |  |  |
 | `deleted_flag` | BOOLEAN | no | `False` |  |
+| `unavailability_first_detected` | TIMESTAMP WITH TIME ZONE | yes |  |  |
 | `playlist_type` | VARCHAR(20) | no | `'regular'` |  |
 | `created_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
 | `updated_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
@@ -273,12 +311,18 @@ YouTube topic classification system with dynamic resolution support.
 | `category_name` | VARCHAR(255) | no |  |  |
 | `parent_topic_id` | VARCHAR(50) | yes |  | FK → `topic_categories.topic_id` |
 | `topic_type` | VARCHAR(20) | no | `'youtube'` |  |
-| `wikipedia_url` | VARCHAR(500) | yes |  | unique |
+| `wikipedia_url` | VARCHAR(500) | yes |  |  |
 | `normalized_name` | VARCHAR(255) | yes |  |  |
 | `source` | VARCHAR(20) | no | `'seeded'` |  |
 | `last_seen_at` | TIMESTAMP WITH TIME ZONE | yes |  |  |
 | `occurrence_count` | INTEGER | no | `1` |  |
 | `created_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
+
+**Indexes:**
+
+- INDEX `idx_topic_categories_normalized_name` on `normalized_name`
+- INDEX `idx_topic_categories_source` on `source`
+- UNIQUE INDEX `idx_topic_categories_wikipedia_url` on `wikipedia_url`
 
 ### `topic_aliases`
 
@@ -290,6 +334,10 @@ Alias mappings for topic name variations (spelling, redirects, synonyms).
 | `topic_id` | VARCHAR(50) | no |  | FK → `topic_categories.topic_id` |
 | `alias_type` | VARCHAR(20) | no |  |  |
 | `created_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
+
+**Indexes:**
+
+- INDEX `idx_topic_aliases_topic_id` on `topic_id`
 
 ### `video_topics`
 
@@ -303,6 +351,10 @@ Video-topic relationships for content classification.
 | `created_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
 
 **Composite primary key:** `video_id`, `topic_id`
+
+**Indexes:**
+
+- INDEX `idx_video_topics_topic_id` on `topic_id`
 
 ### `channel_topics`
 
@@ -332,6 +384,10 @@ Video-level tags for content analysis.
 | `created_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
 
 **Composite primary key:** `video_id`, `tag`
+
+**Indexes:**
+
+- INDEX `idx_video_tags_tag` on `tag`
 
 ### `channel_keywords`
 
@@ -372,6 +428,15 @@ Canonical tag form with normalization and entity linking.
 - CHECK `chk_canonical_tag_status_valid`: `status IN ('active', 'merged', 'deprecated')`
 - CHECK `chk_canonical_tag_video_count_non_negative`: `video_count >= 0`
 
+**Indexes:**
+
+- INDEX `idx_canonical_tags_active_normalized` on `normalized_form`
+- INDEX `idx_canonical_tags_canonical_form_trgm` on `canonical_form`
+- INDEX `idx_canonical_tags_canonical_pattern` on `canonical_form`
+- INDEX `idx_canonical_tags_entity_id` on `entity_id`
+- INDEX `idx_canonical_tags_normalized_form_trgm` on `normalized_form`
+- INDEX `idx_canonical_tags_video_count_desc` on 
+
 ### `tag_aliases`
 
 Raw tag forms mapped to their canonical representation.
@@ -394,6 +459,13 @@ Raw tag forms mapped to their canonical representation.
 - CHECK `chk_tag_alias_creation_method_valid`: `creation_method IN ('auto_normalize', 'manual_merge', 'backfill', 'api_create')`
 - CHECK `chk_tag_alias_occurrence_count_positive`: `occurrence_count >= 1`
 
+**Indexes:**
+
+- INDEX `idx_tag_aliases_canonical_id` on `canonical_tag_id`
+- INDEX `idx_tag_aliases_normalized` on `normalized_form`
+- INDEX `idx_tag_aliases_raw_form_trgm` on `raw_form`
+- INDEX `idx_tag_aliases_raw_pattern` on `raw_form`
+
 ### `tag_operation_logs`
 
 Audit log for tag normalization and management operations.
@@ -415,6 +487,10 @@ Audit log for tag normalization and management operations.
 **Constraints:**
 
 - CHECK `chk_tag_operation_type_valid`: `operation_type IN ('merge', 'split', 'rename', 'delete', 'create', 'repair')`
+
+**Indexes:**
+
+- INDEX `idx_tag_operation_logs_performed_at` on `performed_at`
 
 ## Named Entities
 
@@ -452,6 +528,12 @@ Named entities extracted from video tags (people, places, organizations, etc.).
 - CHECK `chk_entity_status_valid`: `status IN ('active', 'merged', 'deprecated')`
 - CHECK `chk_entity_type_valid`: `entity_type IN ('person', 'organization', 'place', 'event', 'work', 'technical_term', 'concept', 'other')`
 
+**Indexes:**
+
+- INDEX `idx_named_entities_normalized` on `canonical_name_normalized`
+- INDEX `idx_named_entities_status` on `status`
+- INDEX `idx_named_entities_type` on `entity_type`
+
 ### `entity_aliases`
 
 Alternative names and variations for named entities.
@@ -472,6 +554,12 @@ Alternative names and variations for named entities.
 
 - UNIQUE on `alias_name_normalized`, `entity_id` (`uq_entity_alias_name`)
 - CHECK `chk_alias_type_valid`: `alias_type IN ('name_variant', 'abbreviation', 'nickname', 'asr_error', 'translated_name', 'former_name')`
+
+**Indexes:**
+
+- INDEX `idx_entity_aliases_entity_id` on `entity_id`
+- INDEX `idx_entity_aliases_normalized` on `alias_name_normalized`
+- INDEX `idx_entity_aliases_type` on `alias_type`
 
 ### `entity_mentions`
 
@@ -537,3 +625,43 @@ Audit log for named-entity curation edits (name/description) — Feature 057.
 
 - INDEX `idx_entity_operation_logs_entity_id` on `entity_id`
 - INDEX `idx_entity_operation_logs_performed_at` on `performed_at`
+
+## Recovery Provenance
+
+Append-only record of which archive sources contributed metadata to a deleted video or channel, so one recovery pass cannot erase another's attribution.
+
+### `video_recovery_sources`
+
+One recovery source that contributed to a video's metadata — ADR-011.
+
+| Column | Type | Null | Default | Notes |
+|--------|------|------|---------|-------|
+| `video_id` | VARCHAR(20) | no |  | **PK**, FK → `videos.video_id` |
+| `source` | VARCHAR(50) | no |  | **PK** |
+| `source_detail` | VARCHAR(100) | yes |  |  |
+| `recovered_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
+| `fields_written` | VARCHAR[] | yes |  |  |
+
+**Composite primary key:** `video_id`, `source`
+
+**Indexes:**
+
+- INDEX `idx_video_recovery_sources_source` on `source`
+
+### `channel_recovery_sources`
+
+One recovery source that contributed to a channel's metadata — ADR-011.
+
+| Column | Type | Null | Default | Notes |
+|--------|------|------|---------|-------|
+| `channel_id` | VARCHAR(24) | no |  | **PK**, FK → `channels.channel_id` |
+| `source` | VARCHAR(50) | no |  | **PK** |
+| `source_detail` | VARCHAR(100) | yes |  |  |
+| `recovered_at` | TIMESTAMP WITH TIME ZONE | no | `now()` |  |
+| `fields_written` | VARCHAR[] | yes |  |  |
+
+**Composite primary key:** `channel_id`, `source`
+
+**Indexes:**
+
+- INDEX `idx_channel_recovery_sources_source` on `source`

--- a/src/chronovista/services/enrichment/enrichment_service.py
+++ b/src/chronovista/services/enrichment/enrichment_service.py
@@ -38,6 +38,7 @@ from chronovista.models.api_responses import (
     YouTubePlaylistResponse,
     YouTubeVideoResponse,
 )
+from chronovista.models.app_identity import AppIdentitySource
 from chronovista.models.enrichment_report import (
     EnrichmentDetail,
     EnrichmentReport,
@@ -45,6 +46,7 @@ from chronovista.models.enrichment_report import (
 )
 from chronovista.models.enums import AvailabilityStatus
 from chronovista.models.recovery_provenance import RecoverySourceRecord
+from chronovista.repositories.app_identity_repository import AppIdentityRepository
 from chronovista.repositories.channel_repository import ChannelRepository
 from chronovista.repositories.playlist_repository import PlaylistRepository
 from chronovista.repositories.recovery_provenance_repository import (
@@ -1880,6 +1882,74 @@ class EnrichmentService:
             logger.warning(f"Video {video_id} not found for unavailability marking")
             return False
 
+    async def _owner_verification_failure(self, session: AsyncSession) -> str | None:
+        """Return why we cannot confirm we are the library owner, else ``None``.
+
+        ``playlists.list?id=...`` returns a private playlist **only** to the
+        account that owns it. To anyone else the API answers successfully and
+        simply omits it — indistinguishable, at the response level, from the
+        playlist having been deleted. Marking playlists deleted on the strength
+        of that answer is therefore only sound when the account we are talking
+        to is the account that owns the library (#149).
+
+        The other defences do not cover this. A wrong-account token produces a
+        *successful* fetch, so the failed-batch containment never engages; the
+        omissions are consistent across runs, so two-cycle confirmation
+        confirms them; and the mass-deletion guard only sees it if the library
+        is overwhelmingly private. A library that is, say, 60% public would
+        lose its private playlists quietly.
+
+        Verification looks for a *contradiction*, not a credential audit, and
+        the persisted identity is read first: with no channel-sourced identity
+        on record there is nothing to contradict, so no API call is made. A
+        locally-sourced identity is not a failure either — playlists belong to
+        the Google account, not the channel, so a viewer-only owner with no
+        channel is still the owner, and demanding one would disable deletion
+        detection for a legitimate setup.
+
+        Unusable credentials are only reported once we had a reason to ask.
+        They are already harmless on their own: a fetch that fails contributes
+        nothing to ``not_found`` (#221), so nothing is marked either way.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+
+        Returns
+        -------
+        str | None
+            A human-readable reason to skip deleted-marking, or ``None`` when
+            nothing contradicts ownership.
+        """
+        identity = await AppIdentityRepository().get_identity(session)
+        if identity is None or identity.source != AppIdentitySource.CHANNEL.value:
+            return None
+
+        try:
+            channel = await self.youtube_service.get_my_channel()
+        except Exception as e:
+            return (
+                f"the authenticated account could not be determined ({e}), so "
+                f"this run cannot be attributed to the library owner"
+            )
+
+        if channel is None:
+            return (
+                "the authenticated account has no channel, but this library is "
+                "owned by a channel-sourced identity — private playlists would "
+                "be reported missing simply because they belong to someone else"
+            )
+
+        if channel.id != identity.user_id:
+            return (
+                "the authenticated channel is not the one that owns this "
+                "library; its private playlists are invisible to this account "
+                "and would be reported missing"
+            )
+
+        return None
+
     def _confirm_playlist_deleted(self, playlist: Any) -> bool:
         """
         Apply two-cycle unavailability confirmation for a playlist (#149).
@@ -2633,10 +2703,13 @@ class EnrichmentService:
 
         Playlists the API definitively did not return are marked deleted/private
         on the *second* consecutive miss; the first only records the detection.
-        Two further things are deliberately not treated as evidence of deletion
-        (#149): a playlist whose batch failed to fetch (excluded upstream by
-        ``fetch_playlists_batched``), and a run in which most of the library
-        comes back missing at once, which is blocked by the mass-deletion guard.
+        Three further things are deliberately not treated as evidence of
+        deletion (#149): a playlist whose batch failed to fetch (excluded
+        upstream by ``fetch_playlists_batched``), a run in which most of the
+        library comes back missing at once (the mass-deletion guard), and a run
+        whose account cannot be confirmed as the library's owner — a private
+        playlist is returned only to its owner, so to anyone else it is
+        indistinguishable from deleted.
 
         A playlist that reappears has its pending detection cleared, so two
         unrelated failures cannot combine into a false confirmation.
@@ -2703,15 +2776,28 @@ class EnrichmentService:
             p.id: p for p in api_playlists
         }
 
+        # Ownership check (#149). A private playlist is returned only to the
+        # account that owns it, so "absent from the response" means "deleted"
+        # only if we are that account. Checked before the guard because it is a
+        # statement about the whole run, not about its result.
+        mark_deleted = True
+        owner_failure = await self._owner_verification_failure(session)
+        if owner_failure is not None:
+            mark_deleted = False
+            logger.warning(
+                f"Refusing to mark playlists deleted: {owner_failure}. "
+                f"Metadata updates continue; no playlist will be hidden."
+            )
+
         # Batch-wide sanity guard (#149). Genuine deletions arrive a few at a
         # time; a run in which most of the library is suddenly absent describes
         # a broken fetch, not a user who deleted everything between syncs.
         # Reconciliation is skipped entirely rather than partially, because a
         # result this implausible is not trustworthy for the rows it *did*
         # return either.
-        mark_deleted = True
         if (
-            len(playlist_ids) >= MASS_DELETION_GUARD_MIN_PLAYLISTS
+            mark_deleted
+            and len(playlist_ids) >= MASS_DELETION_GUARD_MIN_PLAYLISTS
             and len(not_found_ids) > len(playlist_ids) * MASS_DELETION_GUARD_RATIO
         ):
             mark_deleted = False

--- a/tests/integration/services/test_playlist_deletion_guard.py
+++ b/tests/integration/services/test_playlist_deletion_guard.py
@@ -271,6 +271,134 @@ class TestTwoCycleConfirmation:
         assert await _hidden_count(db_session, [target]) == 0
 
 
+class TestOwnerVerification:
+    """Deleting requires being the account that owns the library (#149).
+
+    ``playlists.list?id=...`` returns a private playlist only to its owner. To
+    any other account the API answers successfully and omits it, which at the
+    response level is identical to the playlist having been deleted.
+
+    None of the other defences see this. The fetch succeeds, so failed-batch
+    containment never engages; the omissions repeat, so two-cycle confirmation
+    confirms them; and the mass-deletion guard only notices if the library is
+    overwhelmingly private. A 60%-public library would lose its private
+    playlists quietly.
+    """
+
+    async def _set_identity(self, session: AsyncSession, user_id: str) -> None:
+        await session.execute(text("DELETE FROM app_identities"))
+        await session.execute(
+            text(
+                "INSERT INTO app_identities (id, user_id, source) "
+                "VALUES (1, :uid, 'channel')"
+            ),
+            {"uid": user_id},
+        )
+        await session.flush()
+
+    async def test_a_different_channel_hides_nothing(
+        self, db_session: AsyncSession, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The case every other guard misses.
+
+        Only 3 of 40 come back missing, so the ratio guard stays silent, and
+        both cycles run — yet nothing may be hidden, because the account is
+        provably not the owner.
+        """
+        ids = await _seed_playlists(db_session, 40, "PLowner1")
+        await self._set_identity(db_session, "UCtheowner00000000001")
+
+        service = _service(([], set(ids[:3])))
+        other = MagicMock()
+        other.id = "UCsomeoneelse00000001"
+        service.youtube_service.get_my_channel = AsyncMock(return_value=other)
+
+        await service.enrich_playlists(db_session)
+        _, _, deleted = await service.enrich_playlists(db_session)
+
+        assert deleted == 0
+        assert await _hidden_count(db_session, ids) == 0
+        assert (
+            await _pending_count(db_session, ids) == 0
+        ), "an unverifiable run must not bank a detection either"
+        assert any(
+            "not the one that owns this library" in r.message
+            for r in caplog.records
+            if r.levelname == "WARNING"
+        )
+
+    async def test_the_owning_channel_still_deletes(
+        self, db_session: AsyncSession
+    ) -> None:
+        """The check must not become a blanket refusal."""
+        ids = await _seed_playlists(db_session, 40, "PLowner2")
+        await self._set_identity(db_session, "UCtheowner00000000002")
+
+        service = _service(([], set(ids[:3])))
+        owner = MagicMock()
+        owner.id = "UCtheowner00000000002"
+        service.youtube_service.get_my_channel = AsyncMock(return_value=owner)
+
+        await service.enrich_playlists(db_session)
+        _, _, deleted = await service.enrich_playlists(db_session)
+
+        assert deleted == 3
+
+    async def test_an_account_with_no_channel_hides_nothing(
+        self, db_session: AsyncSession
+    ) -> None:
+        """A channel-owned library seen through a channel-less account."""
+        ids = await _seed_playlists(db_session, 40, "PLowner3")
+        await self._set_identity(db_session, "UCtheowner00000000003")
+
+        service = _service(([], set(ids[:3])))
+        service.youtube_service.get_my_channel = AsyncMock(return_value=None)
+
+        await service.enrich_playlists(db_session)
+        _, _, deleted = await service.enrich_playlists(db_session)
+
+        assert deleted == 0
+
+    async def test_unusable_credentials_hide_nothing(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Asked only because a channel-sourced identity gave us a reason to."""
+        ids = await _seed_playlists(db_session, 40, "PLowner4")
+        await self._set_identity(db_session, "UCtheowner00000000004")
+
+        service = _service(([], set(ids[:3])))
+        service.youtube_service.get_my_channel = AsyncMock(
+            side_effect=RuntimeError("token expired")
+        )
+
+        await service.enrich_playlists(db_session)
+        _, _, deleted = await service.enrich_playlists(db_session)
+
+        assert deleted == 0
+
+    async def test_no_channel_identity_asks_nothing(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Without a channel-sourced identity there is nothing to contradict.
+
+        Deletion still works, and — the point of the ordering — the API is
+        never called, so this costs nothing on every ordinary run.
+        """
+        ids = await _seed_playlists(db_session, 40, "PLowner5")
+        await db_session.execute(text("DELETE FROM app_identities"))
+        await db_session.flush()
+
+        service = _service(([], set(ids[:3])))
+        asked = AsyncMock()
+        service.youtube_service.get_my_channel = asked
+
+        await service.enrich_playlists(db_session)
+        _, _, deleted = await service.enrich_playlists(db_session)
+
+        assert deleted == 3
+        asked.assert_not_awaited()
+
+
 class TestDeletionIsSurfaced:
     async def test_hiding_playlists_logs_a_warning(
         self, db_session: AsyncSession, caplog: pytest.LogCaptureFixture

--- a/tests/unit/test_docs_schema_coverage.py
+++ b/tests/unit/test_docs_schema_coverage.py
@@ -21,6 +21,7 @@ expects) and importing it would try to write files.
 from __future__ import annotations
 
 import ast
+import importlib.util
 from pathlib import Path
 
 from chronovista.db.models import Base
@@ -28,6 +29,7 @@ from chronovista.db.models import Base
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GENERATOR = REPO_ROOT / "scripts" / "gen_schema_ref.py"
 DATA_MODEL_DOC = REPO_ROOT / "docs" / "architecture" / "data-model.md"
+SCHEMA_DOC = REPO_ROOT / "docs" / "reference" / "schema.md"
 
 
 def _grouped_tables() -> set[str]:
@@ -59,6 +61,42 @@ def test_groups_reference_only_real_tables() -> None:
         f"GROUPS references tables that do not exist: {phantom}. "
         "This is how the old hand-written docs came to describe a "
         "'user_subscriptions' table that was never created."
+    )
+
+
+def _rendered_schema() -> str:
+    """The page the generator would produce from the current models.
+
+    Imported rather than executed: ``main()`` runs only under ``__main__`` or
+    mkdocs-gen-files' ``<run_path>``, so a plain import writes nothing.
+    """
+    spec = importlib.util.spec_from_file_location("_gen_schema_ref", GENERATOR)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    rendered: str = module.render_schema()
+    return rendered
+
+
+def test_schema_reference_is_not_stale() -> None:
+    """The committed page must match what the generator produces.
+
+    ``docs/reference/schema.md`` is tracked *and* regenerated at build time by
+    mkdocs-gen-files, which writes into the build tree rather than over the
+    source file. The published site is therefore always current while the
+    committed copy — the one people read on GitHub — silently rots.
+
+    It had: two tables short (the ADR-011 provenance pair, undocumented since
+    they shipped), two columns missing, and no index or constraint sections at
+    all, under a header stating "this page cannot drift". The claim was true of
+    the built page and false of the committed one. This test is what makes it
+    true of both.
+    """
+    committed = SCHEMA_DOC.read_text(encoding="utf-8")
+    assert committed == _rendered_schema(), (
+        f"{SCHEMA_DOC.relative_to(REPO_ROOT)} is out of date with the models. "
+        "Regenerate it — the build shadows this file, so a stale copy fails "
+        "silently everywhere except GitHub."
     )
 
 


### PR DESCRIPTION
Closes the last open item on #149. Follows #221, #222 and #223.

`playlists.list?id=...` returns a private playlist **only** to the account that owns it. To any other account the API answers successfully and simply omits it — at the response level, indistinguishable from the playlist having been deleted. Marking playlists deleted on the strength of that answer is only sound if the account we're talking to owns the library.

## None of the three existing defences see this

| defence | why it misses |
|---|---|
| failed-batch containment (#221) | the fetch **succeeds** — nothing failed |
| two-cycle confirmation (#222) | the omissions repeat identically, so the second cycle *confirms* rather than protects |
| mass-deletion guard | only fires if the library is overwhelmingly private |

A library that's, say, 60% public would lose its private playlists quietly, a few at a time — exactly the way genuine attrition looks. This library is 287/288 private and so would trip the guard today, but that's a property of the data, not of the code.

## What it checks

`_owner_verification_failure()` looks for a **contradiction**, not a credential audit.

It reads the Feature 060 canonical identity **first** and returns early when no channel-sourced identity is on record — there's nothing to contradict, and no API call is made, so ordinary runs pay nothing. A test asserts `get_my_channel` is never awaited in that case.

When a channel-sourced identity does exist, the run is refused if:

- the authenticated channel differs from it
- the account has no channel at all
- the authenticated account cannot be determined

Reusing Feature 060's identity rather than inventing a second notion of "owner" also inherits that feature's guarantee of a single canonical identity.

## Deliberate non-failures

A **locally-sourced identity** is not a failure, and neither is a channel-less account when no channel identity is expected. Playlists belong to the Google account rather than the channel, so a viewer-only owner is still the owner — demanding a channel would disable deletion detection for a legitimate setup.

**Unusable credentials** are only reported once something gave us a reason to ask. On their own they're already harmless: a fetch that fails contributes nothing to `not_found` (#221), so nothing is marked either way.

## Behaviour change worth knowing

If you re-authenticate under a different Google account — or your persisted identity came from a channel you no longer use — enrichment will refuse to mark anything deleted and log a warning until `chronovista identity reset` is run.

That's the intended trade: it's precisely what prevents the wrong-account scenario. The mitigation is that the warning names the reason explicitly rather than failing silently.

## Tests

Five new, in the existing guard file because this is the same decision path.

The central one is the case no other guard catches: **3 of 40 missing — well under the ratio — across two full cycles, with a mismatched channel.** Nothing may be hidden, and no pending detection may be banked.

| mutation | result |
|---|---|
| force the ownership check to pass | 3 tests fail |

## Checks

`ruff` · `black --check` · `mypy src/chronovista/ --strict` · backend unit (**6,894 passed**) · backend integration (**1,382 passed**) — all green. No migration.
