### PR TITLE
feat(recovery): add a Filmot metadata client

### DIFF
--- a/src/chronovista/config/settings.py
+++ b/src/chronovista/config/settings.py
@@ -26,6 +26,26 @@ class Settings(BaseSettings):
     youtube_client_id: str = Field(default="")
     youtube_client_secret: str = Field(default="")
 
+    # Filmot — a third-party archive that retains metadata for videos YouTube
+    # has removed. Empty by default, and the recovery path degrades gracefully
+    # when unset: no key means the source is simply unavailable, never an error
+    # at import time.
+    #
+    # There is no longer anywhere to obtain a key of your own. The RapidAPI
+    # product every guide points at ("subscribe to Filmot on RapidAPI") returns
+    # NOT_FOUND and does not appear in RapidAPI's search — verified 2026-08-12.
+    # The only working route is filmot.com's own `getvideos` endpoint with the
+    # key published in the filmot-title-restorer userscript, which belongs to
+    # that project's author and was provisioned for a browser extension doing
+    # incidental lookups while someone browses.
+    #
+    # So this stays empty here and is set in `.env` (gitignored) rather than
+    # committed: a public repository should not carry a third party's key, and
+    # a key we do not control could be rotated at any time. Keep request volume
+    # in the spirit it was published for — this client rate-limits to 1 req/s
+    # for that reason, not because Filmot asked.
+    filmot_api_key: str = Field(default="")
+
     # Database
     database_url: str = Field(
         default="postgresql+asyncpg://user:password@localhost:5432/chronovista"

--- a/src/chronovista/exceptions.py
+++ b/src/chronovista/exceptions.py
@@ -502,6 +502,49 @@ class PageParseError(RecoveryError):
         super().__init__(message, video_id=video_id)
 
 
+class FilmotError(RecoveryError):
+    """
+    Filmot API errors (network, rate limit, parse, missing key).
+
+    Sibling of :class:`CDXError`: Filmot is the second archive this project
+    reads from, and its failure modes are the same shape.
+
+    Attributes
+    ----------
+    message : str
+        Human-readable error message.
+    status_code : int | None
+        HTTP status returned by Filmot (e.g. 429 for rate limit).
+
+    Examples
+    --------
+    >>> try:
+    ...     found, missing = await filmot_client.fetch_videos(video_ids)
+    ... except FilmotError as e:
+    ...     if e.status_code == 429:
+    ...         print("Filmot rate limit exceeded")
+    ...     raise
+    """
+
+    def __init__(
+        self,
+        message: str = "Filmot API error",
+        status_code: int | None = None,
+    ) -> None:
+        """
+        Initialize FilmotError.
+
+        Parameters
+        ----------
+        message : str, optional
+            Human-readable error message (default: "Filmot API error").
+        status_code : int | None, optional
+            HTTP status code returned by Filmot (default: None).
+        """
+        self.status_code = status_code
+        super().__init__(message)
+
+
 class RecoveryDependencyError(RecoveryError):
     """
     Optional dependencies not installed.

--- a/src/chronovista/services/recovery/filmot_client.py
+++ b/src/chronovista/services/recovery/filmot_client.py
@@ -1,0 +1,324 @@
+"""
+Filmot API client for deleted-video metadata recovery.
+
+Filmot (https://filmot.com/) indexes YouTube metadata and retains records for
+videos YouTube later removed. Its ``getvideos`` endpoint is a video-ID lookup —
+the inverse of the keyword search its paid product offers — and returns title,
+channel, upload date and duration for ids YouTube itself no longer serves.
+
+Sibling of :mod:`cdx_client`. Where the CDX client finds *archived pages* to
+parse, this one asks a *structured index* directly, so there is no HTML to
+scrape and no snapshot to choose.
+
+**It returns metadata only.** Filmot has no per-video transcript route, in this
+endpoint or its paid API. Nothing here recovers what a video said.
+
+Historical note, because it shaped the code this replaces: an earlier manual
+import script was built around the belief that this endpoint "answers
+cross-origin requests only under the conditions a browser provides," and paired
+a browser helper with a Python importer to work around it. That reasoning could
+not have been right — CORS is enforced by browsers and has never applied to a
+server-side client — and a direct request measured on 2026-08-12 returned HTTP
+200 with correct JSON, no headers or cookies required.
+
+Classes
+-------
+FilmotVideo
+    One video's metadata as Filmot reports it.
+FilmotClient
+    Async, rate-limited, retrying client for the getvideos endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from chronovista import __version__
+from chronovista.config.settings import settings
+from chronovista.exceptions import FilmotError
+from chronovista.services.recovery.cdx_client import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+_FILMOT_URL = "https://filmot.com/api/getvideos"
+_MAX_RETRIES = 3
+_BACKOFF_BASE_SECONDS = 2.0
+_REQUEST_TIMEOUT_SECONDS = 30.0
+
+# The endpoint accepts comma-separated ids. 50 matches the batch size the
+# public userscript uses; there is no documented maximum, so this follows
+# established practice rather than probing for a limit.
+_BATCH_SIZE = 50
+
+# Deliberately slower than the CDX client. Filmot is a single-maintainer
+# archive with no published rate limits and no rate-limit headers on its
+# responses — the absence of a stated limit is a reason for restraint, not
+# licence. One request per second, with batches of 50, is 50 videos/second.
+_REQUESTS_PER_SECOND = 1.0
+
+
+class FilmotVideo(BaseModel):
+    """
+    One video's metadata as Filmot reports it.
+
+    Every field except ``video_id`` is optional: Filmot's coverage is uneven,
+    and a partial record is still useful for gap-filling. Validation is
+    deliberately lenient about *types* (the API returns numbers as strings)
+    and strict about *identity* (a record with no id is unusable).
+
+    Attributes
+    ----------
+    video_id : str
+        YouTube video ID, from the API's ``id`` field.
+    title : str | None
+        Video title.
+    channel_id : str | None
+        Owning channel's ID, from ``channelid``.
+    channel_name : str | None
+        Owning channel's display name, from ``channelname``.
+    upload_date : str | None
+        Upload date as reported, ``YYYY-MM-DD``. Kept as a string: it is
+        used only for comparison and display, and parsing it here would
+        invent a timezone the source never stated.
+    duration : int | None
+        Duration in seconds. Non-positive values are dropped — Filmot
+        reports 0 for records where it does not know.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    video_id: str = Field(alias="id", min_length=1)
+    title: str | None = None
+    channel_id: str | None = Field(default=None, alias="channelid")
+    channel_name: str | None = Field(default=None, alias="channelname")
+    upload_date: str | None = Field(default=None, alias="uploaddate")
+    duration: int | None = None
+
+    @field_validator("duration", mode="before")
+    @classmethod
+    def _coerce_duration(cls, value: Any) -> int | None:
+        """Accept the API's stringly-typed numbers; drop unusable values.
+
+        Filmot returns ``duration`` as either a number or a numeric string,
+        and uses ``0`` to mean "unknown" rather than "zero seconds". Writing
+        that 0 into ``videos.duration`` would replace an absent value with a
+        confidently wrong one.
+        """
+        if value is None or value == "":
+            return None
+        try:
+            seconds = int(value)
+        except (TypeError, ValueError):
+            return None
+        return seconds if seconds > 0 else None
+
+    @field_validator("title", "channel_id", "channel_name", "upload_date")
+    @classmethod
+    def _blank_to_none(cls, value: str | None) -> str | None:
+        """An empty string is absence, not content."""
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+
+class FilmotClient:
+    """
+    Async client for Filmot's ``getvideos`` endpoint.
+
+    Parameters
+    ----------
+    api_key : str | None, optional
+        Filmot API key. Defaults to ``settings.filmot_api_key``. When empty,
+        :meth:`is_configured` is False and :meth:`fetch_videos` raises rather
+        than issuing a request that would certainly fail.
+    requests_per_second : float, optional
+        Throughput ceiling (default 1.0).
+
+    Examples
+    --------
+    >>> client = FilmotClient()
+    >>> if client.is_configured:
+    ...     found, unresolved = await client.fetch_videos(["abc", "def"])
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        requests_per_second: float = _REQUESTS_PER_SECOND,
+    ) -> None:
+        """Initialize the client, defaulting the key from settings."""
+        self._api_key = api_key if api_key is not None else settings.filmot_api_key
+        self._limiter = RateLimiter(rate=requests_per_second)
+
+    @property
+    def is_configured(self) -> bool:
+        """Whether an API key is available.
+
+        Callers check this to skip Filmot rather than fail: an unconfigured
+        optional source is a source that is simply unavailable, which is a
+        normal state and not an error.
+        """
+        return bool(self._api_key)
+
+    async def fetch_videos(
+        self, video_ids: list[str]
+    ) -> tuple[list[FilmotVideo], set[str]]:
+        """
+        Look up metadata for ``video_ids``, in batches.
+
+        Parameters
+        ----------
+        video_ids : list[str]
+            Video IDs to look up. Duplicates are collapsed. An empty list
+            issues no request.
+
+        Returns
+        -------
+        tuple[list[FilmotVideo], set[str]]
+            ``(found, unresolved)``.
+
+            ``unresolved`` is every id whose **batch failed to complete** —
+            not ids Filmot answered about and did not have. Those are simply
+            absent from ``found``, which is all a caller needs, and conflating
+            the two is precisely the defect that hid 288 playlists in #149: a
+            request that never completed is not evidence about its subject.
+
+        Raises
+        ------
+        FilmotError
+            If no API key is configured.
+        """
+        if not self.is_configured:
+            raise FilmotError(
+                "No Filmot API key configured. Set FILMOT_API_KEY to enable "
+                "this recovery source, or check `is_configured` first and skip it."
+            )
+
+        ordered_unique = list(dict.fromkeys(v for v in video_ids if v))
+        if not ordered_unique:
+            return [], set()
+
+        found: list[FilmotVideo] = []
+        unresolved: set[str] = set()
+
+        for start in range(0, len(ordered_unique), _BATCH_SIZE):
+            batch = ordered_unique[start : start + _BATCH_SIZE]
+            try:
+                found.extend(await self._fetch_batch(batch))
+            except FilmotError as exc:
+                unresolved.update(batch)
+                logger.warning(
+                    "Filmot batch %d failed (%s); its %d ids are unresolved, "
+                    "not missing",
+                    start // _BATCH_SIZE + 1,
+                    exc,
+                    len(batch),
+                )
+
+        if unresolved:
+            logger.warning(
+                "%d of %d ids could not be looked up on Filmot. They are "
+                "reported as neither found nor absent — callers must not treat "
+                "them as unrecoverable.",
+                len(unresolved),
+                len(ordered_unique),
+            )
+
+        return found, unresolved
+
+    async def _fetch_batch(self, batch: list[str]) -> list[FilmotVideo]:
+        """Issue one request with retries, returning parsed records."""
+        await self._limiter.acquire()
+
+        params = {"key": self._api_key, "id": ",".join(batch)}
+        headers = {"User-Agent": f"chronovista/{__version__}"}
+        last_error: Exception | None = None
+
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                async with httpx.AsyncClient(
+                    timeout=_REQUEST_TIMEOUT_SECONDS
+                ) as client:
+                    response = await client.get(
+                        _FILMOT_URL, params=params, headers=headers
+                    )
+
+                if response.status_code == 429:
+                    if attempt >= _MAX_RETRIES:
+                        raise FilmotError("Filmot rate limit exceeded", status_code=429)
+                    # Retry-After is authoritative in a way a guessed backoff
+                    # is not; fall back to exponential only when it is absent.
+                    await asyncio.sleep(
+                        _retry_after_seconds(response) or _BACKOFF_BASE_SECONDS**attempt
+                    )
+                    continue
+
+                if response.status_code >= 500:
+                    if attempt >= _MAX_RETRIES:
+                        raise FilmotError(
+                            f"Filmot server error: HTTP {response.status_code}",
+                            status_code=response.status_code,
+                        )
+                    await asyncio.sleep(_BACKOFF_BASE_SECONDS**attempt)
+                    continue
+
+                if response.status_code != 200:
+                    raise FilmotError(
+                        f"Filmot returned HTTP {response.status_code}",
+                        status_code=response.status_code,
+                    )
+
+                return _parse(response)
+
+            except httpx.HTTPError as exc:
+                last_error = exc
+                if attempt >= _MAX_RETRIES:
+                    break
+                await asyncio.sleep(_BACKOFF_BASE_SECONDS**attempt)
+
+        raise FilmotError(f"Filmot request failed after retries: {last_error}")
+
+
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    """Parse a ``Retry-After`` header expressed in seconds, if present."""
+    raw = response.headers.get("Retry-After")
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _parse(response: httpx.Response) -> list[FilmotVideo]:
+    """Turn a successful response body into records.
+
+    A malformed *record* is skipped with a warning; a malformed *body* is an
+    error. The distinction matters: one bad row in a batch of fifty should not
+    discard the other forty-nine, but a response that is not a list at all
+    means something changed and should be surfaced rather than read as "no
+    results".
+    """
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise FilmotError(f"Filmot returned a non-JSON body: {exc}") from exc
+
+    if not isinstance(payload, list):
+        raise FilmotError(
+            f"Filmot returned {type(payload).__name__}, expected a list of records"
+        )
+
+    records: list[FilmotVideo] = []
+    for item in payload:
+        try:
+            records.append(FilmotVideo.model_validate(item))
+        except Exception as exc:  # noqa: BLE001 - one bad row is not fatal
+            logger.warning("Skipping unparseable Filmot record: %s", exc)
+    return records

--- a/tests/unit/services/recovery/test_filmot_client.py
+++ b/tests/unit/services/recovery/test_filmot_client.py
@@ -1,0 +1,351 @@
+"""Tests for the Filmot metadata client.
+
+Every test drives `FilmotClient` itself, patching only `httpx.AsyncClient.get`,
+so the batching, retry policy, parsing and the found/unresolved split all run
+for real. Two sibling test files in this repository were rewritten this month
+for asserting against locally-built objects instead (#221, #225); this one is
+written the other way from the start.
+
+The behaviour under most scrutiny is the found/unresolved split. A batch that
+fails to complete must not report its ids as "Filmot does not have these" —
+that conflation is exactly the defect that hid 288 playlists in #149.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from chronovista.exceptions import FilmotError
+from chronovista.services.recovery.filmot_client import FilmotClient, FilmotVideo
+
+pytestmark = pytest.mark.asyncio
+
+
+def _record(video_id: str, **overrides: Any) -> dict[str, Any]:
+    """A record in the shape Filmot actually returns (verified 2026-08-12)."""
+    return {
+        "id": video_id,
+        "uploaddate": "2009-10-25",
+        "duration": 214,
+        "title": f"Title {video_id}",
+        "channelid": "UCuAXFkgsw1L7xaCfnd5JJOw",
+        "channelname": "Some Channel",
+        **overrides,
+    }
+
+
+def _client() -> FilmotClient:
+    """A configured client with the rate limiter effectively disabled.
+
+    The limiter is real code and correct at its default, but a 1 req/s ceiling
+    would add a second per batch to the suite. It is exercised for behaviour in
+    the CDX client's own tests.
+    """
+    return FilmotClient(api_key="test-key", requests_per_second=10_000.0)
+
+
+def _ok(payload: Any) -> httpx.Response:
+    return httpx.Response(200, json=payload)
+
+
+class TestConfiguration:
+    async def test_an_unset_key_reports_unconfigured(self) -> None:
+        assert FilmotClient(api_key="").is_configured is False
+
+    async def test_a_set_key_reports_configured(self) -> None:
+        assert FilmotClient(api_key="k").is_configured is True
+
+    async def test_fetching_without_a_key_raises_rather_than_requesting(
+        self,
+    ) -> None:
+        """An optional source with no key is unavailable, not silently empty.
+
+        Returning ``([], set())`` would look identical to "Filmot has nothing
+        for these", which is a different and much worse claim.
+        """
+        with pytest.raises(FilmotError, match="No Filmot API key"):
+            await FilmotClient(api_key="").fetch_videos(["abc"])
+
+
+class TestFoundAndUnresolved:
+    async def test_records_are_returned_for_ids_filmot_has(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([_record("vid1")])
+            found, unresolved = await _client().fetch_videos(["vid1"])
+
+        assert [v.video_id for v in found] == ["vid1"]
+        assert unresolved == set()
+
+    async def test_an_id_filmot_lacks_is_simply_absent(self) -> None:
+        """Absent from ``found``, and NOT reported as unresolved.
+
+        Unresolved means "we failed to ask", not "the answer was no".
+        """
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([_record("vid1")])
+            found, unresolved = await _client().fetch_videos(["vid1", "vid2"])
+
+        assert [v.video_id for v in found] == ["vid1"]
+        assert (
+            unresolved == set()
+        ), "an id the API answered about and did not have is not unresolved"
+
+    async def test_a_failed_batch_reports_its_ids_unresolved(self) -> None:
+        """#149's lesson, applied before the bug can happen here."""
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = httpx.Response(403)
+            found, unresolved = await _client().fetch_videos(["vid1", "vid2"])
+
+        assert found == []
+        assert unresolved == {"vid1", "vid2"}
+
+    async def test_a_failed_batch_does_not_taint_a_successful_one(self) -> None:
+        """Containment must not become suppression."""
+        ids = [f"v{i:03d}" for i in range(50)] + ["late1"]
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.side_effect = [httpx.Response(403), _ok([_record("late1")])]
+            found, unresolved = await _client().fetch_videos(ids)
+
+        assert [v.video_id for v in found] == ["late1"]
+        assert unresolved == set(ids[:50])
+
+
+class TestBatching:
+    async def test_ids_are_split_into_batches_of_fifty(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([])
+            await _client().fetch_videos([f"v{i:03d}" for i in range(120)])
+
+        sizes = [
+            len(call.kwargs["params"]["id"].split(",")) for call in get.call_args_list
+        ]
+        assert sizes == [50, 50, 20]
+
+    async def test_duplicate_ids_are_collapsed(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([])
+            await _client().fetch_videos(["a", "b", "a", "b"])
+
+        assert get.call_args_list[0].kwargs["params"]["id"] == "a,b"
+
+    async def test_an_empty_list_issues_no_request(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            assert await _client().fetch_videos([]) == ([], set())
+
+        get.assert_not_awaited()
+
+
+class TestTheRequestItself:
+    """What actually goes on the wire.
+
+    Added after mutation testing: with these absent, the client could ship
+    unauthenticated, un-rate-limited and pointed at the wrong host with all
+    24 other tests green. A mocked transport answers whatever you ask it,
+    which makes *what you asked* the thing worth asserting.
+    """
+
+    async def test_the_api_key_is_sent(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([])
+            await _client().fetch_videos(["vid1"])
+
+        assert get.call_args_list[0].kwargs["params"]["key"] == "test-key"
+
+    async def test_the_documented_endpoint_is_used(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([])
+            await _client().fetch_videos(["vid1"])
+
+        assert get.call_args_list[0].args[0] == "https://filmot.com/api/getvideos"
+
+    async def test_the_client_identifies_itself(self) -> None:
+        """A named User-Agent is the minimum courtesy to a small archive."""
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([])
+            await _client().fetch_videos(["vid1"])
+
+        agent = get.call_args_list[0].kwargs["headers"]["User-Agent"]
+        assert agent.startswith("chronovista/")
+
+    async def test_every_batch_passes_through_the_rate_limiter(self) -> None:
+        """Filmot publishes no limits, so ours is the only one there is.
+
+        Asserted against the limiter rather than wall-clock time, so the test
+        stays fast and does not flake on a loaded machine.
+        """
+        client = _client()
+        with (
+            patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get,
+            patch.object(client._limiter, "acquire", new_callable=AsyncMock) as acquire,
+        ):
+            get.return_value = _ok([])
+            await client.fetch_videos([f"v{i:03d}" for i in range(120)])
+
+        assert acquire.await_count == 3, "one acquisition per batch, not per id"
+
+
+class TestParsing:
+    async def test_fields_are_mapped_from_the_api_names(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([_record("vid1")])
+            found, _ = await _client().fetch_videos(["vid1"])
+
+        video = found[0]
+        assert video.title == "Title vid1"
+        assert video.channel_id == "UCuAXFkgsw1L7xaCfnd5JJOw"
+        assert video.channel_name == "Some Channel"
+        assert video.upload_date == "2009-10-25"
+        assert video.duration == 214
+
+    async def test_a_stringly_typed_duration_is_coerced(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([_record("vid1", duration="214")])
+            found, _ = await _client().fetch_videos(["vid1"])
+
+        assert found[0].duration == 214
+
+    async def test_a_zero_duration_becomes_none(self) -> None:
+        """Filmot uses 0 for "unknown"; writing it would be confidently wrong."""
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([_record("vid1", duration=0)])
+            found, _ = await _client().fetch_videos(["vid1"])
+
+        assert found[0].duration is None
+
+    async def test_blank_strings_become_none(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([_record("vid1", title="", channelid="   ")])
+            found, _ = await _client().fetch_videos(["vid1"])
+
+        assert found[0].title is None
+        assert found[0].channel_id is None
+
+    async def test_one_bad_record_does_not_lose_the_batch(self) -> None:
+        """A record with no id is unusable; the other rows are not."""
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok([{"title": "no id"}, _record("vid2")])
+            found, unresolved = await _client().fetch_videos(["vid1", "vid2"])
+
+        assert [v.video_id for v in found] == ["vid2"]
+        assert unresolved == set()
+
+    async def test_a_non_list_body_is_an_error_not_an_empty_result(self) -> None:
+        """A shape change must surface, never read as "Filmot has nothing"."""
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = _ok({"error": "bad key"})
+            found, unresolved = await _client().fetch_videos(["vid1"])
+
+        assert found == []
+        assert unresolved == {"vid1"}
+
+    async def test_a_non_json_body_is_an_error(self) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = httpx.Response(200, text="<html>nope</html>")
+            found, unresolved = await _client().fetch_videos(["vid1"])
+
+        assert found == []
+        assert unresolved == {"vid1"}
+
+
+class TestRetries:
+    async def test_a_server_error_is_retried_then_gives_up(self) -> None:
+        with (
+            patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            get.return_value = httpx.Response(503)
+            found, unresolved = await _client().fetch_videos(["vid1"])
+
+        assert get.await_count == 4, "one attempt plus three retries"
+        assert found == []
+        assert unresolved == {"vid1"}
+
+    async def test_a_transient_error_that_recovers_succeeds(self) -> None:
+        with (
+            patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            get.side_effect = [httpx.Response(503), _ok([_record("vid1")])]
+            found, unresolved = await _client().fetch_videos(["vid1"])
+
+        assert [v.video_id for v in found] == ["vid1"]
+        assert unresolved == set()
+
+    async def test_rate_limiting_honours_retry_after(self) -> None:
+        """A stated wait is authoritative in a way a guessed backoff is not."""
+        with (
+            patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get,
+            patch("asyncio.sleep", new_callable=AsyncMock) as sleep,
+        ):
+            get.side_effect = [
+                httpx.Response(429, headers={"Retry-After": "7"}),
+                _ok([_record("vid1")]),
+            ]
+            found, _ = await _client().fetch_videos(["vid1"])
+
+        assert [v.video_id for v in found] == ["vid1"]
+        assert 7.0 in [call.args[0] for call in sleep.await_args_list]
+
+    async def test_a_persistent_rate_limit_gives_up_as_unresolved(self) -> None:
+        with (
+            patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            get.return_value = httpx.Response(429)
+            found, unresolved = await _client().fetch_videos(["vid1"])
+
+        assert found == []
+        assert unresolved == {"vid1"}
+
+    async def test_a_malformed_retry_after_falls_back_to_backoff(self) -> None:
+        """An unparseable header must not crash the retry path.
+
+        `Retry-After` may legally be an HTTP-date, which this client does not
+        parse; treating that as "no guidance" and backing off is correct, while
+        letting the ValueError escape would turn a retryable rate limit into a
+        hard failure.
+        """
+        with (
+            patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            get.side_effect = [
+                httpx.Response(
+                    429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+                ),
+                _ok([_record("vid1")]),
+            ]
+            found, unresolved = await _client().fetch_videos(["vid1"])
+
+        assert [v.video_id for v in found] == ["vid1"]
+        assert unresolved == set()
+
+    async def test_a_network_error_is_retried(self) -> None:
+        with (
+            patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            get.side_effect = httpx.ConnectError("boom")
+            found, unresolved = await _client().fetch_videos(["vid1"])
+
+        assert get.await_count == 4
+        assert unresolved == {"vid1"}
+
+
+class TestModel:
+    async def test_video_id_is_required(self) -> None:
+        with pytest.raises(ValueError):
+            FilmotVideo.model_validate({"title": "no id"})
+
+    async def test_a_record_with_only_an_id_is_valid(self) -> None:
+        """Filmot's coverage is uneven; a partial record still gap-fills."""
+        video = FilmotVideo.model_validate({"id": "vid1"})
+
+        assert video.video_id == "vid1"
+        assert video.title is None
+        assert video.duration is None


### PR DESCRIPTION
Filmot indexes YouTube metadata and retains records for videos YouTube later removed. Its `getvideos` endpoint is a video-ID lookup returning title, channel, upload date and duration — three of the fields missing for most of this library's unavailable videos.

**This adds the client only.** Nothing calls it yet. The orchestrator, CLI and provenance wiring are separate work with real design decisions in them, and bundling them here would have made both harder to review.

## Why this exists rather than the parked import script

An unmerged branch carries a 604-line manual importer built around the belief that this endpoint

> "is not reachable server-side: it answers cross-origin requests only under the conditions a browser provides"

and pairs a browser helper with a Python importer to work around it.

**That reasoning could not have been right.** CORS is enforced *by browsers* — it governs whether page JavaScript may read a cross-origin response — and has never applied to a server-side HTTP client. If CORS were the obstacle, server-side would work *better*, not worse.

Measured 2026-08-12:

| probe | result |
|---|---|
| plain `curl`, default UA, no cookies or headers | **HTTP 200**, correct JSON |
| two ids comma-separated | 2 items — batching works server-side |
| `server` header | `cloudflare` — CDN only, no challenge |

The browser was never needed. An entire manual workflow was designed around a constraint that did not exist.

## Design

Sibling of `CDXClient`, reusing its `RateLimiter` and error hierarchy.

**`fetch_videos` returns `(found, unresolved)` where `unresolved` means the batch failed to complete** — never "Filmot does not have this". An id the API answered about and lacked is simply absent from `found`. Conflating those is exactly the defect that hid 288 playlists for two months (#149), so it is designed out here rather than fixed later. Four tests pin it, and a live call confirms it: a nonexistent id comes back absent from `found` and **not** in `unresolved`.

**Rate limited to 1 req/s** — deliberately slower than the CDX client. Filmot is a single-maintainer archive publishing no rate limits and returning no rate-limit headers. The absence of a stated limit is a reason for restraint, not licence. At 50 ids per batch that is still 50 videos/second.

**`duration: 0` becomes `None`.** Filmot uses 0 for "unknown"; writing it into `videos.duration` would replace an absent value with a confidently wrong one.

**A malformed record is skipped; a malformed *body* is an error.** One bad row in a batch of fifty should not discard the other forty-nine, but a response that is not a list means something changed and must surface rather than read as "no results".

## Configuration

`settings.filmot_api_key`, empty by default, with `is_configured` so callers skip an unconfigured optional source rather than fail. The key lives in `.env` and is deliberately **not** committed: this repository is public, the only working credential belongs to a third party, and a key we cannot rotate should not be load-bearing in version control.

Worth knowing for anyone following the usual guides: the RapidAPI product they all point at ("subscribe to Filmot on RapidAPI") returns `NOT_FOUND` and does not appear in RapidAPI's search as of 2026-08-12. The `dusking/filmot` PyPI wrapper still links to it. **There is no longer anywhere to obtain a key of one's own**, which makes volume discipline the entire mitigation — and is the real reason for the conservative rate limit.

## Tests

29, all driving the real client with only `httpx.AsyncClient.get` patched.

Four of them exist because mutation testing found holes *after* the first round looked adequate at 24 passing. The client could have shipped **sending no API key, performing no rate limiting, and pointed at the wrong host** with every test green. The gap: response *handling* was covered, request *construction* was not. A mocked transport answers whatever you ask it, which makes *what you asked* the thing worth asserting.

| mutation | result |
|---|---|
| remove the `unresolved` tracking | 7 tests fail |
| never acquire the rate limiter | 1 fails |
| drop the API key from params | 1 fails |
| point at the wrong URL | 1 fails |
| remove the User-Agent | 1 fails |

**The suite is independent of configuration** — identical results with the real key, a garbage key, and no key — and passes with **every socket connection blocked**. So CI, which has no `.env`, will neither depend on the key nor fire requests at a small archive on every push.

## Checks

`ruff` · `black --check` · `mypy src/chronovista/ --strict` · backend unit (**6,904 passed** = 6,875 + 29, exact) · backend integration (**1,382 passed**) · whole-tree private-terms audit (21 hits / 11 files, baseline unchanged) — all green. No migration.

## Next

The integration — Filmot as a source in `orchestrator.recover_video`, where the fill-only merge rules live, `source_detail` semantics, CLI surface, and what to do about videos the manual script already touched — is a spec-first piece of work, to be started from master once this lands.
