### PR TITLE
feat(recovery): fill unavailable-video metadata gaps from the Filmot archive (Feature 065)

### DIFF
--- a/src/chronovista/cli/commands/recover.py
+++ b/src/chronovista/cli/commands/recover.py
@@ -18,6 +18,9 @@ from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
+from chronovista.cli.constants import (
+    EXIT_SYSTEM_ERROR,
+)
 from chronovista.config.database import db_manager
 from chronovista.config.settings import settings
 from chronovista.exceptions import (
@@ -29,7 +32,9 @@ from chronovista.models.enums import AvailabilityStatus
 from chronovista.repositories.video_repository import VideoRepository
 from chronovista.services.recovery import SELENIUM_AVAILABLE
 from chronovista.services.recovery.cdx_client import CDXClient, RateLimiter
-from chronovista.services.recovery.models import RecoveryResult
+from chronovista.services.recovery.filmot_client import FilmotClient
+from chronovista.services.recovery.filmot_recovery import run_filmot_recovery
+from chronovista.services.recovery.models import FilmotRecoveryResult, RecoveryResult
 from chronovista.services.recovery.orchestrator import recover_video
 from chronovista.services.recovery.page_parser import PageParser
 
@@ -580,3 +585,160 @@ def _display_batch_summary(results: list[RecoveryResult], dry_run: bool) -> None
         )
 
     console.print(table)
+
+
+@recover_app.command(name="filmot")
+def recover_filmot_command(
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        "-n",
+        min=1,
+        help=(
+            "Maximum videos to consider, taken from the head of the same "
+            "ordering every run — for sampling, not for paging. Selection is "
+            "by remaining gap, so videos the archive does not hold stay at the "
+            "head and a repeated --limit run re-reads them. The whole backlog "
+            "is ~30 requests, so there is little reason to page."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Report intended writes without making them.",
+    ),
+) -> None:
+    """Fill metadata gaps on unavailable videos from the Filmot archive.
+
+    Recovers title, owning channel and duration for videos YouTube no longer
+    serves, from a third-party index that retains records for removed videos.
+
+    Fill-only: a real title, a recorded channel and a positive duration are
+    never overwritten, because a third-party archive is weaker evidence than
+    what YouTube or your own export said. Publication dates are never written,
+    and no channel records are created.
+
+    Requests are limited to one per second. The archive publishes no rate
+    limits and returns no rate-limit headers, so restraint is ours to keep.
+
+    A sibling of `recover video`, not an option on it: the two sources answer
+    different questions and fail differently. Running both from one invocation
+    waits for a shared abstraction that does not exist yet.
+
+    Examples:
+        chronovista recover filmot --dry-run --limit 20
+        chronovista recover filmot --limit 100
+        chronovista recover filmot
+
+    Exit Codes:
+        0: Completed — including a run that changed nothing, one skipped for
+           want of a credential, and one ended early by the archive refusing us
+        2: Invalid usage (a bad option value), or a system/database failure.
+           Click owns 2 for usage errors and the project's EXIT_SYSTEM_ERROR is
+           also 2, so the two are not distinguishable by code alone
+        130: Cancelled - Ctrl+C pressed
+    """
+
+    async def _run() -> None:
+        client = FilmotClient()
+        # No `raise typer.Exit` inside this loop: exiting an `async for` early
+        # throws GeneratorExit at the suspended yield, so the session context
+        # manager's commit never runs. `database.py` documents the hazard by
+        # name. Falling off the end of the loop leaves the generator to close
+        # itself, and success is the absence of an exception.
+        async for session in db_manager.get_session(echo=False):
+            result = await run_filmot_recovery(
+                session, client, limit=limit, dry_run=dry_run
+            )
+            _display_filmot_summary(result)
+
+    try:
+        asyncio.run(_run())
+    except KeyboardInterrupt:
+        # Caught out here, not inside the coroutine. Python's asyncio.Runner
+        # turns Ctrl+C into task cancellation — the coroutine sees
+        # CancelledError, a BaseException that `except Exception` also misses —
+        # and re-raises KeyboardInterrupt outside `asyncio.run`. An inner
+        # handler never ran, so this message never printed and the exit code
+        # was the interpreter's 130 rather than anything this command chose.
+        # The sibling command above already gets this right.
+        console.print("\n[yellow]Operation cancelled by user[/yellow]")
+        raise typer.Exit(code=130) from None
+    except Exception as exc:  # noqa: BLE001 - surfaced to the operator
+        console.print(
+            Panel(
+                f"[red]Filmot recovery failed:[/red]\n{exc}",
+                title="Filmot Recovery Failed",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(EXIT_SYSTEM_ERROR) from None
+
+
+def _display_filmot_summary(result: FilmotRecoveryResult) -> None:
+    """Render one run's outcome.
+
+    Two lines are never summed: "archive had no record" is terminal for a
+    video, while "not looked up" means nothing was learned about it. Treating
+    the second as the first is the defect this feature descends from, and the
+    table exists to keep them apart on screen as well as in the data.
+    """
+    if result.ended_early == "not_configured":
+        console.print(
+            Panel(
+                "[yellow]Filmot is not configured.[/yellow]\n\n"
+                "Set [bold]FILMOT_API_KEY[/bold] in your .env to enable this "
+                "recovery source. This is not an error — the source is simply "
+                "unavailable, and the rest of your recovery workflow is "
+                "unaffected.",
+                title="Skipped",
+                border_style="yellow",
+            )
+        )
+        return
+
+    title = "Filmot recovery (dry run)" if result.dry_run else "Filmot recovery"
+    table = Table(title=title, show_header=False)
+    table.add_column("outcome")
+    table.add_column("count", justify="right")
+
+    table.add_row("videos submitted", str(result.submitted))
+    table.add_row("records returned", str(result.returned))
+    table.add_row(
+        "videos updated" if not result.dry_run else "videos that would be updated",
+        str(result.updated),
+    )
+    for field, count in sorted(result.field_counts.items()):
+        table.add_row(f"  {field}", str(count))
+    table.add_row("held, nothing to write", str(result.held_no_write))
+    table.add_row("archive had no record", str(result.not_held))
+    table.add_row("not looked up (failures)", str(result.unresolved))
+    if result.not_attempted:
+        table.add_row("not attempted (ended early)", str(result.not_attempted))
+    if result.unknown_channels:
+        table.add_row("unknown channels", str(len(result.unknown_channels)))
+    if result.malformed_records:
+        table.add_row("malformed records skipped", str(result.malformed_records))
+    for reason, count in sorted(result.refused_values.items()):
+        table.add_row(f"refused: {reason}", str(count))
+
+    console.print(table)
+
+    if result.ended_early and result.ended_early != "not_configured":
+        console.print(
+            f"[yellow]Run ended early: {result.ended_early}. "
+            f"{result.not_attempted} video(s) were not attempted and remain "
+            f"candidates.[/yellow]"
+        )
+
+    if not result.reconciles and not result.unresolved:
+        console.print(
+            "[red]Warning: updated + held does not equal records returned. "
+            "Something was dropped silently.[/red]"
+        )
+
+    if result.field_counts.get("title") and not result.dry_run:
+        console.print(
+            f"\n[dim]{result.field_counts['title']} title(s) changed — search "
+            f"indexes and entity mentions derived from them are now stale.[/dim]"
+        )

--- a/src/chronovista/repositories/video_repository.py
+++ b/src/chronovista/repositories/video_repository.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any
 
-from sqlalchemy import and_, desc, func, or_, select
+from sqlalchemy import ColumnElement, and_, asc, desc, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -35,6 +35,78 @@ class VideoRepository(
     ]
 ):
     """Repository for YouTube video management with multi-language support."""
+
+    async def get_filmot_candidates(
+        self,
+        session: AsyncSession,
+        placeholder_title: ColumnElement[bool],
+        limit: int | None = None,
+    ) -> list[VideoDB]:
+        """
+        Unavailable videos with a metadata gap a third-party archive could fill.
+
+        Selection is by **remaining gap**, never by prior-recovery status
+        (FR-003): a video is a candidate when its title is still a placeholder,
+        its channel is unrecorded, or its duration is zero or absent. A video
+        an earlier run filled completely is therefore not selected — because
+        there is nothing left to ask about it, not because it was excluded.
+        Prior recovery stops being a concept selection needs, and cannot be
+        mistaken for evidence of completeness (FR-003a).
+
+        The placeholder-title predicate is **supplied by the caller** rather
+        than imported, and that is deliberate twice over. It satisfies FR-004c:
+        the merge policy owns the one definition and hands down the finished
+        expression, so this query cannot drift from the matcher, nor from the
+        write gate that re-asserts it. Passing the whole condition rather than
+        a list of patterns is what closes that gap — the NULL and
+        whitespace-only cases used to be reassembled here, and reassembly is
+        where the two halves disagreed.
+
+        And it keeps the dependency pointing the right way: a repository
+        importing a service is backwards, and here it was also a genuine import
+        cycle (``video_repository`` -> ``services.recovery`` -> ``orchestrator``
+        -> ``video_repository``), which is how the design error announced
+        itself.
+
+        Ordered like the sibling recovery command so operators see consistent
+        ordering across both.
+
+        Parameters
+        ----------
+        session : AsyncSession
+            Database session.
+        placeholder_title : ColumnElement[bool]
+            Predicate identifying placeholder titles, built by the merge
+            policy's ``placeholder_title_condition`` over ``Video.title``.
+        limit : int | None, optional
+            Maximum candidates to return.
+
+        Returns
+        -------
+        list[VideoDB]
+            Candidate videos, oldest unavailability first.
+        """
+        stmt = (
+            select(VideoDB)
+            .where(VideoDB.availability_status != AvailabilityStatus.AVAILABLE.value)
+            .where(
+                or_(
+                    placeholder_title,
+                    VideoDB.channel_id.is_(None),
+                    or_(VideoDB.duration.is_(None), VideoDB.duration == 0),
+                )
+            )
+            .order_by(
+                asc(VideoDB.unavailability_first_detected.is_(None)),
+                asc(VideoDB.unavailability_first_detected),
+                asc(VideoDB.created_at),
+            )
+        )
+        if limit:
+            stmt = stmt.limit(limit)
+
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
 
     def __init__(self) -> None:
         """Initialize repository with Video model."""

--- a/src/chronovista/services/recovery/filmot_client.py
+++ b/src/chronovista/services/recovery/filmot_client.py
@@ -192,7 +192,9 @@ class FilmotClient:
         Raises
         ------
         FilmotError
-            If no API key is configured.
+            If no API key is configured, or if the archive rejects the
+            credential (401/403). Both are conditions of the run rather than of
+            any batch, so they are raised rather than reported per-id.
         """
         if not self.is_configured:
             raise FilmotError(
@@ -212,6 +214,15 @@ class FilmotClient:
             try:
                 found.extend(await self._fetch_batch(batch))
             except FilmotError as exc:
+                if getattr(exc, "status_code", None) in (401, 403):
+                    # A credential the archive rejects is not a fact about this
+                    # batch, and the next batch will fare no better. Folding it
+                    # into `unresolved` made it indistinguishable from a
+                    # timeout: the caller then saw three fully-unresolved
+                    # batches and told the operator "rate_limited", so a dead
+                    # key read as a limit to wait out rather than a key to
+                    # rotate. Callers classify this; it must reach them.
+                    raise
                 unresolved.update(batch)
                 logger.warning(
                     "Filmot batch %d failed (%s); its %d ids are unresolved, "

--- a/src/chronovista/services/recovery/filmot_recovery.py
+++ b/src/chronovista/services/recovery/filmot_recovery.py
@@ -1,0 +1,452 @@
+"""
+Fill metadata gaps on unavailable videos from the Filmot archive.
+
+A separate path from archived-page recovery, sharing exactly two things with
+it: the provenance write and the merge policy. Those are where this project's
+expensive defects have lived, and a second copy of either is a second place to
+fix them. Everything else differs, because the sources differ in kind — one
+parses archived pages and must choose among snapshots, this one queries a
+structured index and has no snapshot to choose.
+
+**The correctness mechanism is the conditional write.** Every field's gate is
+re-asserted in the UPDATE's own WHERE clause, not only when the candidate was
+read. Without that, a concurrent writer could fill a field between selection
+and write and this source would overwrite it — making fill-only true by timing
+rather than by construction, which is not true at all.
+
+Nothing here assigns ``videos.recovery_source``. That column is a
+most-recent-contributor projection maintained by the provenance repository; a
+writer that assigns it directly overwrites another source's attribution without
+appending a row, which is how 92 rows lost theirs.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.db.models import Channel as ChannelDB
+from chronovista.db.models import Video as VideoDB
+from chronovista.exceptions import FilmotError
+from chronovista.models.recovery_provenance import RecoverySourceRecord
+from chronovista.repositories.channel_repository import ChannelRepository
+from chronovista.repositories.recovery_provenance_repository import (
+    RecoveryProvenanceRepository,
+)
+from chronovista.repositories.video_repository import VideoRepository
+from chronovista.services.recovery.filmot_client import FilmotClient, FilmotVideo
+from chronovista.services.recovery.merge_policy import (
+    build_filmot_update,
+    placeholder_title_condition,
+)
+from chronovista.services.recovery.models import FilmotRecoveryResult
+
+logger = logging.getLogger(__name__)
+
+FILMOT_SOURCE = "filmot"
+
+# Videos per database batch. Independent of the client's request batching:
+# this is the commit granularity, so an interrupted run leaves whole batches
+# applied and never a partially-applied video.
+_COMMIT_BATCH_SIZE = 50
+
+# A run that reaches this has stopped being a normal run. The target is under
+# ten minutes for the entire backlog, so a healthy run never approaches it and
+# reaching it is itself worth reporting.
+_RUN_TIME_LIMIT_SECONDS = 1_800.0
+
+
+async def run_filmot_recovery(
+    session: AsyncSession,
+    client: FilmotClient,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> FilmotRecoveryResult:
+    """
+    Fill title, channel and duration gaps from the Filmot archive.
+
+    Parameters
+    ----------
+    session : AsyncSession
+        Database session.
+    client : FilmotClient
+        Configured archive client.
+    limit : int | None, optional
+        Maximum videos to consider.
+    dry_run : bool, optional
+        Report intended writes without making them.
+
+    Returns
+    -------
+    FilmotRecoveryResult
+        Every outcome an operator would act on differently, counted separately.
+    """
+    started = time.monotonic()
+
+    if not client.is_configured:
+        logger.info(
+            "Filmot recovery skipped: no API key configured. Set FILMOT_API_KEY "
+            "to enable this source."
+        )
+        return FilmotRecoveryResult(dry_run=dry_run, ended_early="not_configured")
+
+    candidates = await VideoRepository().get_filmot_candidates(
+        session, placeholder_title_condition(VideoDB.title), limit=limit
+    )
+    if not candidates:
+        logger.info("Filmot recovery: no videos have a gap this source could fill")
+        return FilmotRecoveryResult(dry_run=dry_run)
+
+    logger.info(
+        "Filmot recovery starting: %d candidate(s), rate limited to 1 request/second",
+        len(candidates),
+    )
+
+    state = _RunState(dry_run=dry_run, total_candidates=len(candidates))
+
+    for start in range(0, len(candidates), _COMMIT_BATCH_SIZE):
+        if time.monotonic() - started > _RUN_TIME_LIMIT_SECONDS:
+            state.end_early("time_limit", remaining=len(candidates) - start)
+            break
+
+        batch = candidates[start : start + _COMMIT_BATCH_SIZE]
+        before_updated, before_held = state.updated, state.held_no_write
+        try:
+            await _process_batch(session, client, batch, state)
+        except _SystemicFailure as exc:
+            # This batch was asked about and is already counted as unresolved;
+            # only what follows it was never attempted.
+            state.end_early(exc.reason, remaining=len(candidates) - start - len(batch))
+            break
+        except Exception:
+            # Every earlier batch is already committed and durable. Letting this
+            # escape to the CLI's blanket handler printed "Database error" and
+            # exit 2 with no summary at all — so an operator whose run wrote 800
+            # titles before failing was never told that titles had changed and
+            # that search indexes and entity mentions were now stale. Ending the
+            # run here keeps the write durable and the report honest.
+            logger.exception("Filmot run ended by an unexpected error")
+            try:
+                await session.rollback()
+            except Exception:
+                # A dead connection is the likeliest way to reach this handler,
+                # and it is also the likeliest way for the rollback itself to
+                # fail. Letting that escape would lose the summary — the very
+                # thing this branch exists to preserve.
+                logger.exception("Filmot rollback failed after an earlier error")
+            state.end_early(
+                "unexpected_error", remaining=len(candidates) - start - len(batch)
+            )
+            break
+
+        if dry_run:
+            # Nothing was written, but the read that selected candidates opened
+            # a transaction and only a commit or rollback closes it. Without
+            # this, a dry run holds one transaction open for its whole length —
+            # up to the 30-minute limit — pinning the xmin horizon so autovacuum
+            # cannot reclaim dead tuples anywhere in the database.
+            await session.rollback()
+        else:
+            await session.commit()
+
+        logger.info(
+            "Filmot batch %d: %d updated, %d held with nothing to write",
+            start // _COMMIT_BATCH_SIZE + 1,
+            state.updated - before_updated,
+            state.held_no_write - before_held,
+        )
+
+    result = state.finalise(time.monotonic() - started)
+    _log_summary(result)
+    return result
+
+
+class _SystemicFailure(Exception):
+    """The source is refusing the run as a whole, not one batch.
+
+    Isolated batch failures continue; systemic ones end the run. Where both
+    readings could apply, systemic wins — see FR-018b.
+    """
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+class _RunState:
+    """Mutable tallies for one run.
+
+    Deliberately not the result model: that one is frozen, because a result
+    that can be edited after the fact is a result nobody can trust.
+    """
+
+    def __init__(self, dry_run: bool, total_candidates: int) -> None:
+        self.dry_run = dry_run
+        self.total_candidates = total_candidates
+        self.submitted = 0
+        self.returned = 0
+        self.updated = 0
+        self.held_no_write = 0
+        self.not_held = 0
+        self.unresolved = 0
+        self.not_attempted = 0
+        self.malformed_records = 0
+        self.field_counts: dict[str, int] = {}
+        self.refused_values: dict[str, int] = {}
+        # A set, because ten videos from one unknown channel is one channel the
+        # library is missing, not ten. The summary counts these.
+        self.unknown_channels: set[str] = set()
+        self.ended_early: str | None = None
+        self.consecutive_rate_limits = 0
+
+    def end_early(self, reason: str, remaining: int) -> None:
+        self.ended_early = reason
+        self.not_attempted += remaining
+        logger.warning(
+            "Filmot run ended early (%s); %d video(s) not attempted", reason, remaining
+        )
+
+    def finalise(self, duration: float) -> FilmotRecoveryResult:
+        return FilmotRecoveryResult(
+            submitted=self.submitted,
+            returned=self.returned,
+            updated=self.updated,
+            held_no_write=self.held_no_write,
+            field_counts=dict(self.field_counts),
+            not_held=self.not_held,
+            unresolved=self.unresolved,
+            not_attempted=self.not_attempted,
+            unknown_channels=sorted(self.unknown_channels),
+            malformed_records=self.malformed_records,
+            refused_values=dict(self.refused_values),
+            ended_early=self.ended_early,
+            dry_run=self.dry_run,
+            duration_seconds=duration,
+        )
+
+
+async def _process_batch(
+    session: AsyncSession,
+    client: FilmotClient,
+    batch: list[VideoDB],
+    state: _RunState,
+) -> None:
+    """Look up one batch and apply what the policy permits."""
+    ids = [v.video_id for v in batch]
+    state.submitted += len(ids)
+
+    try:
+        found, unresolved = await client.fetch_videos(ids)
+    except FilmotError as exc:
+        # A credential the archive rejects, or a response shape we do not
+        # understand, says nothing about any individual video — and will say
+        # nothing about the next batch either.
+        #
+        # We asked about these ids and learned nothing, which is the definition
+        # of unresolved. Counting them before the raise matters: they are
+        # already in `submitted`, and the caller is about to record the rest of
+        # the run as not-attempted. Omitting them here left them counted twice
+        # and bucketed as never-asked — in the one code path where the
+        # difference between "no record" and "we failed to ask" decides whether
+        # an operator retries.
+        state.unresolved += len(ids)
+        raise _SystemicFailure(_classify(exc)) from exc
+
+    state.unresolved += len(unresolved)
+
+    if unresolved and len(unresolved) == len(ids):
+        state.consecutive_rate_limits += 1
+        if state.consecutive_rate_limits >= 3:
+            raise _SystemicFailure("rate_limited")
+    else:
+        state.consecutive_rate_limits = 0
+
+    # Records for identifiers we did not ask about are ignored, and duplicates
+    # collapse to the first. Neither is expected; both are logged, because
+    # silence would conceal a change in the archive's behaviour.
+    requested = set(ids)
+    by_id: dict[str, FilmotVideo] = {}
+    for record in found:
+        if record.video_id not in requested:
+            state.malformed_records += 1
+            logger.warning(
+                "Filmot returned a record for an unrequested id; ignoring it"
+            )
+            continue
+        if record.video_id in by_id:
+            state.malformed_records += 1
+            logger.warning(
+                "Filmot returned duplicate records for one id; using the first"
+            )
+            continue
+        by_id[record.video_id] = record
+
+    state.returned += len(by_id)
+    answered = {v.video_id for v in batch} - unresolved
+    state.not_held += len(answered - set(by_id))
+
+    for video in batch:
+        matched = by_id.get(video.video_id)
+        if matched is None:
+            continue
+        await _apply_to_video(session, video, matched, state)
+
+
+async def _apply_to_video(
+    session: AsyncSession,
+    video: VideoDB,
+    record: FilmotVideo,
+    state: _RunState,
+) -> None:
+    """Apply the policy to one video, atomically, and record the contribution."""
+    channel_known = False
+    if record.channel_id:
+        channel_known = await ChannelRepository().exists_by_channel_id(
+            session, record.channel_id
+        )
+
+    outcome = build_filmot_update(
+        stored_title=video.title,
+        stored_channel_id=video.channel_id,
+        stored_duration=video.duration,
+        incoming_title=record.title,
+        incoming_channel_id=record.channel_id,
+        incoming_duration=record.duration,
+        channel_known=channel_known,
+    )
+
+    for refusal in outcome.refused:
+        state.refused_values[refusal] = state.refused_values.get(refusal, 0) + 1
+        logger.debug("Filmot refused %s for one video", refusal)
+    if outcome.unknown_channel_id:
+        state.unknown_channels.add(outcome.unknown_channel_id)
+
+    if not outcome.writes_anything:
+        state.held_no_write += 1
+        return
+
+    if state.dry_run:
+        state.updated += 1
+        for field in outcome.fields_written:
+            state.field_counts[field] = state.field_counts.get(field, 0) + 1
+        return
+
+    applied = await _conditional_update(session, video, outcome.updates)
+    if not applied:
+        # The gate no longer held: something filled the field between selection
+        # and write. Refusing is the correct outcome, not an error.
+        state.held_no_write += 1
+        logger.debug(
+            "Filmot write refused at commit time for one video: a gate no "
+            "longer held"
+        )
+        return
+
+    state.updated += 1
+    for field in applied:
+        state.field_counts[field] = state.field_counts.get(field, 0) + 1
+
+    await RecoveryProvenanceRepository().record_video(
+        session,
+        video.video_id,
+        RecoverySourceRecord(
+            source=FILMOT_SOURCE,
+            source_detail=None,
+            fields_written=applied,
+            # Stamped explicitly because the upsert only advances the timestamp
+            # when the record carries one, and a second contribution to the same
+            # video is ordinary rather than rare: a run fills the title while the
+            # owning channel is still unknown, the channel is synced later, and a
+            # later run fills `channel_id`. Left unstamped, that second write kept
+            # the first run's timestamp, and `videos.recovery_source` — ordered by
+            # `recovered_at DESC` — then credited whichever other source had a
+            # newer untouched row. That is ADR-011's 92-row defect arriving through
+            # the upsert instead of through an overwrite.
+            recovered_at=datetime.now(UTC),
+        ),
+    )
+
+
+async def _conditional_update(
+    session: AsyncSession, video: VideoDB, updates: dict[str, Any]
+) -> list[str]:
+    """
+    Apply ``updates`` only where each field's gate still holds.
+
+    This is the mechanism behind FR-011b, and the reason fill-only is a
+    property rather than a coincidence. The policy decided against values read
+    at selection time; between then and now another writer may have filled the
+    same field. Re-asserting each gate in the statement's own WHERE clause
+    means the database refuses the write rather than this code racing it.
+
+    All of a video's fields move together (FR-011a): one statement, one
+    condition, so the row is either updated whole or not at all and the
+    recorded field list can never overstate what was applied.
+
+    Returns
+    -------
+    list[str]
+        The fields actually written — empty when the gate no longer held.
+    """
+    conditions = [VideoDB.video_id == video.video_id]
+
+    if "title" in updates:
+        conditions.append(placeholder_title_condition(VideoDB.title))
+    if "channel_id" in updates:
+        conditions.append(VideoDB.channel_id.is_(None))
+        # The channel's existence is a gate like any other, and the only one
+        # that was once checked in Python without being re-asserted here. A
+        # channel deleted between the two raised a foreign-key violation that
+        # no longer belonged to one video: it propagated out of the batch, the
+        # run aborted, and the batch's already-applied writes rolled back with
+        # it. Re-asserting it turns that into an ordinary refusal.
+        conditions.append(
+            select(ChannelDB.channel_id)
+            .where(ChannelDB.channel_id == updates["channel_id"])
+            .exists()
+        )
+    if "duration" in updates:
+        conditions.append(VideoDB.duration.is_(None) | (VideoDB.duration == 0))
+
+    result = await session.execute(update(VideoDB).where(*conditions).values(**updates))
+    return sorted(updates) if result.rowcount else []
+
+
+def _classify(exc: FilmotError) -> str:
+    """Name a systemic failure so the summary can explain itself."""
+    status = getattr(exc, "status_code", None)
+    if status in (401, 403):
+        return "credential_rejected"
+    if status == 429:
+        return "rate_limited"
+    return "source_unusable"
+
+
+def _log_summary(result: FilmotRecoveryResult) -> None:
+    """End-of-run summary at informational level (FR-027)."""
+    logger.info(
+        "Filmot recovery complete in %.1fs: %d submitted, %d returned, "
+        "%d updated, %d held with nothing to write, %d not held, "
+        "%d unresolved, %d not attempted",
+        result.duration_seconds,
+        result.submitted,
+        result.returned,
+        result.updated,
+        result.held_no_write,
+        result.not_held,
+        result.unresolved,
+        result.not_attempted,
+    )
+    if not result.reconciles and not result.unresolved:
+        logger.warning(
+            "Filmot run does not reconcile: %d updated + %d held != %d returned. "
+            "Something was dropped silently.",
+            result.updated,
+            result.held_no_write,
+            result.returned,
+        )

--- a/src/chronovista/services/recovery/merge_policy.py
+++ b/src/chronovista/services/recovery/merge_policy.py
@@ -1,0 +1,274 @@
+"""
+Shared merge policy for recovery sources.
+
+This module is the single home for the rules deciding whether a *recovered*
+value may be written over what is stored. It belongs to no recovery path: it
+imports none of them, and nothing it depends on can import it back (FR-031).
+Dependencies point towards the policy, never away from it — which is what keeps
+the deferred source abstraction introducible.
+
+Only the Filmot path imports it today. The archived-page path predates it and
+has not been migrated; saying "both import it" would describe an intention
+rather than the tree, and an intention is not enforceable by a test.
+
+**Fill-only, for third-party archives.** A third-party index is weaker evidence
+than what the platform itself or the user's own export said, so it may fill a
+gap and may never contest a value. Every rule below therefore gates on the
+*stored* value, not on what the archive offers.
+
+That gating is also why no precedence rule between sources exists or is needed:
+a field another source has filled is unreachable, so two sources can never
+contest one. The invariant has a single failing condition — *this source wrote
+a field that already held a real value* — and it is enforced by test rather
+than described (FR-015).
+
+One caveat the policy alone cannot satisfy: these functions decide against a
+value read at some earlier moment. The caller MUST re-assert each gate as part
+of the write itself (FR-011b), or a concurrent writer could fill the field in
+between and this source would overwrite it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import ColumnElement, func, or_
+from sqlalchemy.orm import InstrumentedAttribute
+
+# Measured against production 2026-08-12: of 1,312 placeholder titles among
+# unavailable videos, 1,226 carry the URL form and 86 the bracketed form —
+# together exactly the independently-counted total. No `http://` form exists,
+# so no scheme-insensitive matching is specified: it would serve zero rows.
+_PLACEHOLDER_URL_PREFIX = "https://www.youtube.com/watch"
+
+# Machine-generated, hence matched case-sensitively.
+_PLACEHOLDER_BRACKET_PREFIX = "[Placeholder] Video "
+
+# The same two prefixes as SQL LIKE patterns, for the candidate query.
+#
+# Derived from the constants above rather than written out again: FR-004c
+# requires the query and the policy to share one definition, not two that agree
+# today. A new placeholder form is then a one-line change here, and it is
+# impossible to update the predicate without updating the matcher.
+#
+# `_` and `%` are LIKE wildcards; neither prefix contains one, so no escaping
+# is needed. A future prefix containing either would.
+PLACEHOLDER_TITLE_SQL_PATTERNS: tuple[str, ...] = (
+    f"{_PLACEHOLDER_URL_PREFIX}%",
+    f"{_PLACEHOLDER_BRACKET_PREFIX}%",
+)
+
+# The whitespace both halves of the definition trim, spelled out rather than
+# left to the defaults — which disagree. Python's `str.strip()` removes every
+# Unicode space, including U+00A0; PostgreSQL's `btrim(col)` removes ASCII
+# space alone. Naming one set makes the Python matcher and the SQL predicate
+# provably equivalent instead of approximately so, and a test asserts they
+# agree input by input.
+_TRIMMED_WHITESPACE = " \t\n\r\x0b\x0c"
+
+# Above this, a unit error at the source is likelier than a real runtime. The
+# library already holds 18 videos longer than a day, the largest at roughly 902
+# days, which is evidence that implausible durations do reach databases. The
+# accepted cost is that a genuine multi-day recording would be refused, and
+# refusals are reported rather than silent so the cost stays visible (FR-022c).
+MAX_PLAUSIBLE_DURATION_SECONDS = 86_400
+
+# Reasons a value was refused. Reported, never silently dropped.
+REFUSED_STORED_VALUE_IS_REAL = "stored_value_is_real"
+REFUSED_INCOMING_IS_PLACEHOLDER = "incoming_is_placeholder"
+REFUSED_INCOMING_IMPLAUSIBLE = "incoming_implausible"
+REFUSED_CHANNEL_UNKNOWN = "channel_unknown"
+
+
+def is_placeholder_title(title: str | None) -> bool:
+    """
+    Whether a stored title is a placeholder rather than a real value (FR-004a).
+
+    A placeholder is NULL, empty, whitespace-only, a string beginning with the
+    YouTube watch URL, or one beginning with the generated ``[Placeholder]
+    Video `` prefix. Anything else is a **real value** and is beyond a
+    fill-only source's reach.
+
+    The first two forms do not currently occur among unavailable videos. They
+    are handled defensively rather than speculatively: they cost one comparison
+    and would otherwise be discovered as a bug.
+
+    Parameters
+    ----------
+    title : str | None
+        The stored title.
+
+    Returns
+    -------
+    bool
+        True when the title may be overwritten by a fill-only source.
+    """
+    if title is None or not title.strip(_TRIMMED_WHITESPACE):
+        return True
+    return title.startswith(_PLACEHOLDER_URL_PREFIX) or title.startswith(
+        _PLACEHOLDER_BRACKET_PREFIX
+    )
+
+
+def placeholder_title_condition(
+    title_col: InstrumentedAttribute[str],
+) -> ColumnElement[bool]:
+    """
+    ``is_placeholder_title`` as a SQL predicate over *title_col* (FR-004c).
+
+    Two consumers need this rule in SQL rather than in Python: the query that
+    selects candidates, and the conditional UPDATE that re-asserts the gate at
+    write time (FR-011b). They MUST be the same expression, and this function
+    is how they are.
+
+    When they were merely *similar*, the selection trimmed whitespace and the
+    write gate compared against the empty string. A whitespace-only title was
+    therefore selected, approved by the policy, and refused by the gate —
+    leaving the row an untouched candidate for the next run, and the one after
+    that, while the log blamed a concurrent writer that did not exist. The
+    patterns were also indexed positionally at the gate, so a third placeholder
+    form would have been selected and then silently never written.
+
+    Takes the column rather than importing the model, which is what lets a
+    repository be handed the finished condition without any repository ever
+    importing a service (FR-030, FR-031).
+
+    Parameters
+    ----------
+    title_col : InstrumentedAttribute[str]
+        The mapped title column to test, e.g. ``Video.title``.
+
+    Returns
+    -------
+    ColumnElement[bool]
+        True for rows a fill-only source may write to.
+    """
+    return or_(
+        title_col.is_(None),
+        func.btrim(title_col, _TRIMMED_WHITESPACE) == "",
+        *[title_col.like(pattern) for pattern in PLACEHOLDER_TITLE_SQL_PATTERNS],
+    )
+
+
+class FilmotMergeOutcome(BaseModel):
+    """
+    What the fill-only policy permits for one video.
+
+    Pure data: the policy computes it, and the caller applies it. Keeping the
+    decision separate from the write is what allows the same rules to be
+    unit-tested exhaustively and re-asserted at write time.
+
+    Attributes
+    ----------
+    updates : dict[str, Any]
+        Column name to new value. Empty when nothing may be written.
+    fields_written : list[str]
+        The columns in ``updates``, for the provenance record.
+    refused : list[str]
+        ``"field:reason"`` for each value the archive offered and the policy
+        declined, so the cost of the rules stays visible.
+    unknown_channel_id : str | None
+        A channel the archive named that the library does not know. Reported
+        rather than created (FR-006).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    updates: dict[str, Any] = Field(default_factory=dict)
+    fields_written: list[str] = Field(default_factory=list)
+    refused: list[str] = Field(default_factory=list)
+    unknown_channel_id: str | None = None
+
+    @property
+    def writes_anything(self) -> bool:
+        """Whether applying this outcome would change the row.
+
+        ``updates`` empty means no write **and** no provenance record — a
+        source that contributed nothing must not claim a contribution
+        (FR-013).
+        """
+        return bool(self.updates)
+
+
+def build_filmot_update(
+    stored_title: str | None,
+    stored_channel_id: str | None,
+    stored_duration: int | None,
+    incoming_title: str | None,
+    incoming_channel_id: str | None,
+    incoming_duration: int | None,
+    channel_known: bool,
+) -> FilmotMergeOutcome:
+    """
+    Apply the fill-only policy for one video.
+
+    Takes stored and incoming values rather than ORM objects so the rules can
+    be exercised without a database and cannot accidentally read anything else
+    about the row.
+
+    Parameters
+    ----------
+    stored_title, stored_channel_id, stored_duration
+        The values currently held by the library.
+    incoming_title, incoming_channel_id, incoming_duration
+        The values the archive supplied. Any may be absent.
+    channel_known : bool
+        Whether ``incoming_channel_id`` already has a record. The caller
+        resolves this; the policy does not query.
+
+    Returns
+    -------
+    FilmotMergeOutcome
+        Permitted writes, refusals with reasons, and any unknown channel.
+
+    Notes
+    -----
+    ``upload_date`` is absent from the signature deliberately. It is not
+    "never written by rule" — it is not passed in at all, so no future edit to
+    this function can begin writing it by accident (FR-008).
+    """
+    updates: dict[str, Any] = {}
+    refused: list[str] = []
+    unknown_channel: str | None = None
+
+    # Title: fill a placeholder, never contest a real value, and never write a
+    # value that is itself placeholder-shaped (FR-004, FR-004b).
+    if incoming_title:
+        if not is_placeholder_title(stored_title):
+            refused.append(f"title:{REFUSED_STORED_VALUE_IS_REAL}")
+        elif is_placeholder_title(incoming_title):
+            refused.append(f"title:{REFUSED_INCOMING_IS_PLACEHOLDER}")
+        else:
+            updates["title"] = incoming_title
+
+    # Channel: fill only when absent AND the channel is already known. A
+    # missing channel is reported, never invented — creating a row to satisfy
+    # a foreign key is how placeholder data gets laundered into looking real
+    # (FR-005, FR-006).
+    if incoming_channel_id:
+        if stored_channel_id is not None:
+            refused.append(f"channel_id:{REFUSED_STORED_VALUE_IS_REAL}")
+        elif not channel_known:
+            unknown_channel = incoming_channel_id
+            refused.append(f"channel_id:{REFUSED_CHANNEL_UNKNOWN}")
+        else:
+            updates["channel_id"] = incoming_channel_id
+
+    # Duration: fill only zero/absent, and only with a plausible value. Zero
+    # from the archive means "unknown" at the source, so it never arrives here
+    # as a candidate write (FR-007, FR-007a).
+    if incoming_duration is not None and incoming_duration > 0:
+        if stored_duration:
+            refused.append(f"duration:{REFUSED_STORED_VALUE_IS_REAL}")
+        elif incoming_duration > MAX_PLAUSIBLE_DURATION_SECONDS:
+            refused.append(f"duration:{REFUSED_INCOMING_IMPLAUSIBLE}")
+        else:
+            updates["duration"] = incoming_duration
+
+    return FilmotMergeOutcome(
+        updates=updates,
+        fields_written=sorted(updates),
+        refused=refused,
+        unknown_channel_id=unknown_channel,
+    )

--- a/src/chronovista/services/recovery/models.py
+++ b/src/chronovista/services/recovery/models.py
@@ -753,3 +753,83 @@ class CdxCacheEntry(BaseModel):
         now = _dt.datetime.now(_dt.UTC)
         age = now - self.fetched_at
         return age < _dt.timedelta(hours=ttl_hours)
+
+
+class FilmotRecoveryResult(BaseModel):
+    """
+    Outcome of one Filmot recovery run.
+
+    Every count exists because collapsing it would hide something an operator
+    would act on differently. Three separations are load-bearing:
+
+    - ``not_held`` versus ``unresolved`` — "the archive answered and had
+      nothing" versus "we never got an answer". Only the first justifies
+      giving up on a video, and conflating them is the defect this feature
+      descends from.
+    - ``returned`` versus ``updated``, with ``held_no_write`` between them.
+      Without the middle count the gap between records received and videos
+      changed is unexplained, and a working run is indistinguishable from a
+      broken policy.
+    - ``malformed_records`` — a parse failure is a signal about the *source's
+      behaviour changing*, not about any video.
+
+    Attributes
+    ----------
+    submitted : int
+        Videos included in a request that was actually issued.
+    returned : int
+        Records the archive held.
+    updated : int
+        Videos actually changed.
+    held_no_write : int
+        Archive held a record, but the fill-only policy permitted no write.
+    field_counts : dict[str, int]
+        Writes per column.
+    not_held : int
+        Archive answered and had no record. Terminal for this source.
+    unresolved : int
+        Request did not complete. Never counted as ``not_held``.
+    not_attempted : int
+        Selected but never requested, because the run ended early.
+    unknown_channels : list[str]
+        Channels the archive named that the library does not know.
+    malformed_records : int
+        Records skipped as unparseable.
+    refused_values : dict[str, int]
+        Values the policy declined, keyed by ``"field:reason"``.
+    ended_early : str | None
+        Why the run stopped short, if it did.
+    dry_run : bool
+        Whether anything was written.
+    duration_seconds : float
+        Wall-clock time for the run.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    submitted: int = 0
+    returned: int = 0
+    updated: int = 0
+    held_no_write: int = 0
+    field_counts: dict[str, int] = Field(default_factory=dict)
+    not_held: int = 0
+    unresolved: int = 0
+    not_attempted: int = 0
+    unknown_channels: list[str] = Field(default_factory=list)
+    malformed_records: int = 0
+    refused_values: dict[str, int] = Field(default_factory=dict)
+    ended_early: str | None = None
+    dry_run: bool = False
+    duration_seconds: float = 0.0
+
+    @property
+    def reconciles(self) -> bool:
+        """Whether ``updated + held_no_write == returned``.
+
+        Required to hold when no request failed (FR-022b). It is exposed as a
+        property rather than asserted internally so a run can *report* a
+        discrepancy instead of crashing on one — a mismatch means something was
+        dropped silently, which is worth surfacing rather than hiding behind an
+        exception.
+        """
+        return self.updated + self.held_no_write == self.returned

--- a/tests/integration/services/test_filmot_recovery_provenance.py
+++ b/tests/integration/services/test_filmot_recovery_provenance.py
@@ -1,0 +1,661 @@
+"""Filmot recovery, against a real database (Feature 065, User Story 2).
+
+These assert **the row is there afterwards**, not that a repository method was
+called. That distinction is the whole reason this file exists: ADR-011 shipped
+with provenance tables nothing wrote to, and every test passed, because a stub
+recording a call and a database recording a row are indistinguishable under a
+mocked session.
+
+Only the archive is faked. Selection, the merge policy, the conditional write,
+the commit and the provenance write all run for real.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import chronovista.services.recovery.filmot_recovery as filmot_recovery
+from chronovista.db.models import Video as VideoDB
+from chronovista.repositories.video_repository import VideoRepository
+from chronovista.services.recovery.filmot_client import FilmotVideo
+from chronovista.services.recovery.filmot_recovery import run_filmot_recovery
+from chronovista.services.recovery.merge_policy import (
+    is_placeholder_title,
+    placeholder_title_condition,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_CHANNEL = "UCfilmot00000000000001"
+_PLACEHOLDER = "https://www.youtube.com/watch?v={vid}"
+
+
+async def _seed(
+    session: AsyncSession,
+    video_id: str,
+    *,
+    title: str | None = None,
+    channel_id: str | None = None,
+    duration: int = 0,
+    with_channel: bool = True,
+) -> None:
+    """One unavailable video, plus the owning channel unless told otherwise."""
+    if with_channel:
+        await session.execute(
+            text(
+                "INSERT INTO channels (channel_id, title, is_subscribed, "
+                "availability_status) VALUES (:c, 'Filmot Test Channel', false, "
+                "'available') ON CONFLICT (channel_id) DO NOTHING"
+            ),
+            {"c": _CHANNEL},
+        )
+    await session.execute(
+        text(
+            """
+            INSERT INTO videos (video_id, channel_id, title, upload_date, duration,
+                                made_for_kids, self_declared_made_for_kids,
+                                availability_status)
+            VALUES (:v, :c, :t, now(), :d, false, false, 'unavailable')
+            ON CONFLICT (video_id) DO NOTHING
+            """
+        ),
+        {
+            "v": video_id,
+            "c": channel_id,
+            "t": title if title is not None else _PLACEHOLDER.format(vid=video_id),
+            "d": duration,
+        },
+    )
+    await session.commit()
+
+
+def _client(records: list[FilmotVideo], unresolved: set[str] | None = None) -> Any:
+    client = MagicMock()
+    client.is_configured = True
+    client.fetch_videos = AsyncMock(return_value=(records, unresolved or set()))
+    return client
+
+
+async def _row(session: AsyncSession, video_id: str) -> Any:
+    return (
+        await session.execute(
+            text(
+                "SELECT title, channel_id, duration, recovery_source "
+                "FROM videos WHERE video_id = :v"
+            ),
+            {"v": video_id},
+        )
+    ).one()
+
+
+async def _provenance(session: AsyncSession, video_id: str) -> list[Any]:
+    return list(
+        (
+            await session.execute(
+                text(
+                    "SELECT source, source_detail, fields_written "
+                    "FROM video_recovery_sources WHERE video_id = :v ORDER BY source"
+                ),
+                {"v": video_id},
+            )
+        ).all()
+    )
+
+
+class TestProvenanceIsRecorded:
+    async def test_a_write_leaves_a_contribution_row(
+        self, db_session: AsyncSession
+    ) -> None:
+        """The assertion that was missing when ADR-011 shipped."""
+        await _seed(db_session, "filmotprov1")
+        client = _client(
+            [FilmotVideo(id="filmotprov1", title="Real Title", duration=214)]
+        )
+
+        result = await run_filmot_recovery(db_session, client)
+
+        assert result.updated == 1
+        rows = await _provenance(db_session, "filmotprov1")
+        assert len(rows) == 1
+        source, detail, fields = rows[0]
+        assert source == "filmot"
+        assert detail is None, "the archive supplies no capture time (FR-014)"
+        assert sorted(fields) == ["duration", "title"]
+
+    async def test_recorded_fields_match_what_actually_changed(
+        self, db_session: AsyncSession
+    ) -> None:
+        """SC-005, in both directions: no more and no less."""
+        await _seed(db_session, "filmotprov2", duration=300)
+        client = _client(
+            [FilmotVideo(id="filmotprov2", title="Real Title", duration=999)]
+        )
+
+        await run_filmot_recovery(db_session, client)
+
+        title, _, duration, _ = await _row(db_session, "filmotprov2")
+        fields = (await _provenance(db_session, "filmotprov2"))[0][2]
+
+        assert title == "Real Title"
+        assert duration == 300, "a positive duration is never overwritten"
+        assert sorted(fields) == ["title"], (
+            "the recorded fields must be exactly those that differ — duration "
+            "was refused, so claiming it would overstate the contribution"
+        )
+
+    async def test_attribution_is_updated_through_the_shared_mechanism(
+        self, db_session: AsyncSession
+    ) -> None:
+        """FR-012a — user-visible, and never written directly."""
+        await _seed(db_session, "filmotprov3")
+        client = _client([FilmotVideo(id="filmotprov3", title="Real Title")])
+
+        await run_filmot_recovery(db_session, client)
+
+        _, _, _, attribution = await _row(db_session, "filmotprov3")
+        assert attribution == "filmot"
+
+    async def test_a_video_with_nothing_written_gains_no_row(
+        self, db_session: AsyncSession
+    ) -> None:
+        """FR-013 — a source that contributed nothing must not claim a
+        contribution, or the provenance table stops meaning what it says.
+
+        The video must be a genuine *candidate* for this to mean anything: a
+        fully-populated video has no gap and is never selected, so it could
+        never reach the policy at all. Here the gap is real (placeholder title)
+        and the archive's answer is unusable — it offers a title that is itself
+        placeholder-shaped, which FR-004b refuses.
+        """
+        await _seed(db_session, "filmotprov4", channel_id=_CHANNEL, duration=300)
+        client = _client(
+            [
+                FilmotVideo(
+                    id="filmotprov4",
+                    title="https://www.youtube.com/watch?v=filmotprov4",
+                )
+            ]
+        )
+
+        result = await run_filmot_recovery(db_session, client)
+
+        assert result.updated == 0
+        assert result.held_no_write == 1
+        assert "title:incoming_is_placeholder" in result.refused_values
+        assert await _provenance(db_session, "filmotprov4") == []
+
+
+class TestTheFillOnlyInvariant:
+    """FR-015. One failing condition: a real value was overwritten."""
+
+    async def test_a_real_title_survives_a_run_that_fills_another_gap(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Also SC-002: no video that had a real title has a different one.
+
+        Seeded with a real title *and* a genuine duration gap, which is the
+        only shape in which this invariant can actually fail. The earlier
+        version of this test seeded a fully-populated video — no gap, so never
+        selected, so it never reached the archive, the policy or the write. It
+        asserted that a row the code never looked at was unchanged, which the
+        neighbouring test's own docstring warns about.
+        """
+        await _seed(
+            db_session,
+            "filmotinv1",
+            title="A Real Title",
+            channel_id=_CHANNEL,
+            duration=0,
+        )
+        client = _client(
+            [
+                FilmotVideo(
+                    id="filmotinv1",
+                    title="Archive Title",
+                    channelid="UCother0000000000000x",
+                    duration=214,
+                )
+            ]
+        )
+
+        result = await run_filmot_recovery(db_session, client)
+
+        title, channel_id, duration, _ = await _row(db_session, "filmotinv1")
+        assert title == "A Real Title", "a real title was contested"
+        assert channel_id == _CHANNEL, "a recorded channel was contested"
+        assert duration == 214, "the one genuine gap was not filled"
+        assert result.updated == 1
+
+    async def test_a_whitespace_title_is_filled_like_any_other_placeholder(
+        self, db_session: AsyncSession
+    ) -> None:
+        """The three-spellings bug, end to end.
+
+        The query trimmed, the policy stripped, and the write gate compared
+        against the empty string. A whitespace-only title was therefore
+        selected, approved and refused — left untouched for the next run to
+        select again, forever, while the log blamed a concurrent writer that
+        did not exist. Because all permitted fields move in one statement
+        (FR-011a), the row's valid channel and duration fills went with it.
+        """
+        await _seed(db_session, "filmotblank1", title="   ", duration=0)
+        client = _client(
+            [
+                FilmotVideo(
+                    id="filmotblank1",
+                    title="Real Title",
+                    channelid=_CHANNEL,
+                    duration=214,
+                )
+            ]
+        )
+
+        result = await run_filmot_recovery(db_session, client)
+
+        title, channel_id, duration, _ = await _row(db_session, "filmotblank1")
+        assert title == "Real Title"
+        assert channel_id == _CHANNEL, "the other fills were discarded with the title"
+        assert duration == 214
+        assert result.updated == 1
+
+
+class TestSelectionExcludesFilledVideos:
+    """The behavioural half of FR-003, which the unit suite cannot show.
+
+    Compiling the statement proves which columns the predicate names. Only a
+    real database proves that a video with no remaining gap is genuinely absent
+    from the result.
+    """
+
+    async def test_a_video_with_no_gap_is_never_a_candidate(
+        self, db_session: AsyncSession
+    ) -> None:
+        await _seed(
+            db_session,
+            "filmotsel1",
+            title="A Real Title",
+            channel_id=_CHANNEL,
+            duration=300,
+        )
+
+        candidates = await VideoRepository().get_filmot_candidates(
+            db_session, placeholder_title_condition(VideoDB.title)
+        )
+
+        assert "filmotsel1" not in {v.video_id for v in candidates}
+
+    @pytest.mark.parametrize(
+        ("gap", "seed"),
+        [
+            ("title", {"duration": 300, "channel_id": _CHANNEL}),
+            ("channel", {"title": "A Real Title", "duration": 300}),
+            ("duration", {"title": "A Real Title", "channel_id": _CHANNEL}),
+        ],
+    )
+    async def test_each_remaining_gap_makes_a_video_a_candidate(
+        self, db_session: AsyncSession, gap: str, seed: dict[str, Any]
+    ) -> None:
+        """One disjunct per gap — a missing one silently shrinks the backlog."""
+        video_id = f"filmotsel{gap}"
+        await _seed(db_session, video_id, **seed)
+
+        candidates = await VideoRepository().get_filmot_candidates(
+            db_session, placeholder_title_condition(VideoDB.title)
+        )
+
+        assert video_id in {v.video_id for v in candidates}
+
+
+class TestBlankTitleAgreement:
+    """The Python matcher and the SQL predicate, judged by PostgreSQL.
+
+    Restating `btrim` in Python would only assert that Python equals Python.
+    Each title here is stored and then selected through the real predicate, so
+    a disagreement between the two halves fails the test rather than hiding as
+    a row that is selected and then never written.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "title"),
+        [
+            ("empty", ""),
+            ("single-space", " "),
+            ("spaces", "   "),
+            ("tab", "\t"),
+            ("newline", "\n"),
+            ("mixed", " \t\n "),
+            ("real", "A Real Title"),
+            ("url-form", "https://www.youtube.com/watch?v=abcdefghijk"),
+            ("bracket-form", "[Placeholder] Video abcdefghijk"),
+            ("leading-space-real", "  A Real Title"),
+        ],
+    )
+    async def test_both_halves_reach_the_same_verdict(
+        self, db_session: AsyncSession, label: str, title: str
+    ) -> None:
+        video_id = f"filmotagree{abs(hash(label)) % 10**6}"
+        await _seed(
+            db_session, video_id, title=title, channel_id=_CHANNEL, duration=300
+        )
+
+        selected = await db_session.scalar(
+            select(VideoDB.video_id).where(
+                VideoDB.video_id == video_id,
+                placeholder_title_condition(VideoDB.title),
+            )
+        )
+
+        assert (selected is not None) == is_placeholder_title(title), (
+            f"{label!r}: PostgreSQL and the Python matcher disagree, which is "
+            "how a row gets selected and then refused at write"
+        )
+
+    async def test_a_gate_falsified_after_selection_refuses_the_write(
+        self, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FR-011b, the mechanism the whole feature rests on.
+
+        Fills the title *between* candidate selection and the write, exactly as
+        a concurrent writer would. Without the gate re-asserted in the UPDATE
+        itself, this overwrites a real value and fill-only becomes true only by
+        timing — which is not true at all.
+        """
+        await _seed(db_session, "filmotrace1")
+        original = filmot_recovery._conditional_update
+
+        async def racing(session: AsyncSession, video: Any, updates: dict[str, Any]):
+            await session.execute(
+                text("UPDATE videos SET title = :t WHERE video_id = :v"),
+                {"t": "Written By Someone Else", "v": "filmotrace1"},
+            )
+            return await original(session, video, updates)
+
+        monkeypatch.setattr(filmot_recovery, "_conditional_update", racing)
+        client = _client(
+            [FilmotVideo(id="filmotrace1", title="Filmot Title", duration=214)]
+        )
+
+        result = await run_filmot_recovery(db_session, client)
+
+        title, _, _, _ = await _row(db_session, "filmotrace1")
+        assert title == "Written By Someone Else", (
+            "the conditional write did not re-assert its gate — a concurrent "
+            "writer's value was overwritten"
+        )
+        assert result.updated == 0
+        assert await _provenance(db_session, "filmotrace1") == []
+
+
+class TestASecondContributionToTheSameVideo:
+    """The ordinary life-cycle that corrupted attribution.
+
+    A run fills the title while the owning channel is still unknown; the
+    channel is synced later; a later run fills `channel_id`. Nothing about that
+    is rare, and it is the case the idempotency test does not reach — that one
+    covers the *fully filled* video, where the second run writes nothing.
+    """
+
+    async def test_the_timestamp_advances_so_attribution_stays_correct(
+        self, db_session: AsyncSession
+    ) -> None:
+        """ADR-011's defect, arriving through the upsert instead of an overwrite.
+
+        `record_video` only advances `recovered_at` when the record carries
+        one, and this caller passed none. The second contribution therefore
+        kept the first run's timestamp, and `videos.recovery_source` — ordered
+        by `recovered_at DESC` — credited whichever *other* source had a newer
+        untouched row. The write was Filmot's; the attribution was not.
+        """
+        await _seed(db_session, "filmot2nd1", duration=0, channel_id=None)
+        await run_filmot_recovery(
+            db_session,
+            _client([FilmotVideo(id="filmot2nd1", title="Real Title")]),
+        )
+        first = await db_session.scalar(
+            text(
+                "SELECT recovered_at FROM video_recovery_sources "
+                "WHERE video_id = 'filmot2nd1' AND source = 'filmot'"
+            )
+        )
+
+        await run_filmot_recovery(
+            db_session,
+            _client(
+                [FilmotVideo(id="filmot2nd1", title="Real Title", channelid=_CHANNEL)]
+            ),
+        )
+
+        second = await db_session.scalar(
+            text(
+                "SELECT recovered_at FROM video_recovery_sources "
+                "WHERE video_id = 'filmot2nd1' AND source = 'filmot'"
+            )
+        )
+        assert second > first, (
+            "the second contribution kept the first one's timestamp, so the "
+            "attribution projection can credit a source that wrote nothing"
+        )
+        _, _, _, recovery_source = await _row(db_session, "filmot2nd1")
+        assert recovery_source == "filmot"
+
+
+class TestTheChannelGateIsReAssertedToo:
+    async def test_a_channel_deleted_after_the_check_refuses_the_write(
+        self, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The one Python condition that was not re-asserted in SQL.
+
+        Every other gate is checked twice; this one was checked in Python and
+        trusted at write time. A channel deleted in between raised a
+        foreign-key violation that no longer belonged to one video — it
+        escaped the batch, ended the run, and rolled back that batch's
+        already-applied writes. Re-asserting it makes this an ordinary refusal.
+        """
+        await _seed(db_session, "filmotfk1", channel_id=None, duration=300)
+        original = filmot_recovery._conditional_update
+
+        async def racing(session: AsyncSession, video: Any, updates: dict[str, Any]):
+            await session.execute(
+                text("DELETE FROM videos WHERE channel_id = :c AND video_id <> :v"),
+                {"c": _CHANNEL, "v": "filmotfk1"},
+            )
+            await session.execute(
+                text("DELETE FROM channels WHERE channel_id = :c"), {"c": _CHANNEL}
+            )
+            return await original(session, video, updates)
+
+        monkeypatch.setattr(filmot_recovery, "_conditional_update", racing)
+        client = _client(
+            [FilmotVideo(id="filmotfk1", title="Real Title", channelid=_CHANNEL)]
+        )
+
+        result = await run_filmot_recovery(db_session, client)
+
+        assert result.ended_early is None, "an FK violation ended the whole run"
+        assert result.updated == 0
+        assert await _provenance(db_session, "filmotfk1") == []
+
+
+class TestOtherSourcesAreUntouched:
+    async def test_an_existing_contribution_survives(
+        self, db_session: AsyncSession
+    ) -> None:
+        """FR-028/FR-029 — the cross-feature contract, read back through the
+        contribution-reporting path rather than asserted on a mock."""
+        await _seed(db_session, "filmotxf1")
+        await db_session.execute(
+            text(
+                "INSERT INTO video_recovery_sources (video_id, source, "
+                "source_detail, fields_written) VALUES (:v, 'wayback', "
+                "'20210101080938', ARRAY['description'])"
+            ),
+            {"v": "filmotxf1"},
+        )
+        await db_session.commit()
+
+        client = _client([FilmotVideo(id="filmotxf1", title="Real Title")])
+        await run_filmot_recovery(db_session, client)
+
+        rows = await _provenance(db_session, "filmotxf1")
+        sources = {r[0]: r for r in rows}
+        assert set(sources) == {"filmot", "wayback"}
+        assert sources["wayback"][1] == "20210101080938", (
+            "another source's capture time must survive untouched — losing it "
+            "is what cost 92 rows their attribution"
+        )
+
+
+class TestNoSideEffects:
+    async def test_no_channel_is_ever_created(self, db_session: AsyncSession) -> None:
+        """FR-006/SC-003, and FR-006a: not retried on a later run either."""
+        await _seed(db_session, "filmotchan1", with_channel=False)
+        before = (
+            await db_session.execute(text("SELECT count(*) FROM channels"))
+        ).scalar()
+        client = _client(
+            [
+                FilmotVideo(
+                    id="filmotchan1",
+                    title="Real Title",
+                    channelid="UCneverseen0000000001",
+                )
+            ]
+        )
+
+        result = await run_filmot_recovery(db_session, client)
+        after = (
+            await db_session.execute(text("SELECT count(*) FROM channels"))
+        ).scalar()
+
+        assert after == before
+        assert result.unknown_channels == ["UCneverseen0000000001"]
+        _, channel_id, _, _ = await _row(db_session, "filmotchan1")
+        assert channel_id is None
+
+        # A second run must not link it either.
+        await run_filmot_recovery(db_session, client)
+        _, channel_id, _, _ = await _row(db_session, "filmotchan1")
+        assert channel_id is None
+
+    async def test_upload_date_never_changes(self, db_session: AsyncSession) -> None:
+        """FR-008/SC-004."""
+        await _seed(db_session, "filmotdate1")
+        before = (
+            await db_session.execute(
+                text("SELECT upload_date FROM videos WHERE video_id = 'filmotdate1'")
+            )
+        ).scalar()
+
+        client = _client(
+            [FilmotVideo(id="filmotdate1", title="Real Title", uploaddate="1999-01-01")]
+        )
+        await run_filmot_recovery(db_session, client)
+
+        after = (
+            await db_session.execute(
+                text("SELECT upload_date FROM videos WHERE video_id = 'filmotdate1'")
+            )
+        ).scalar()
+        assert after == before
+
+
+class TestIdempotency:
+    async def test_a_second_run_writes_nothing_and_adds_no_row(
+        self, db_session: AsyncSession
+    ) -> None:
+        """FR-023/SC-006."""
+        await _seed(db_session, "filmotidem1")
+        client = _client(
+            [
+                FilmotVideo(
+                    id="filmotidem1",
+                    title="Real Title",
+                    channelid=_CHANNEL,
+                    duration=214,
+                )
+            ]
+        )
+
+        first = await run_filmot_recovery(db_session, client)
+        rows_after_first = len(await _provenance(db_session, "filmotidem1"))
+        second = await run_filmot_recovery(db_session, client)
+
+        assert first.updated == 1
+        assert second.updated == 0
+        assert len(await _provenance(db_session, "filmotidem1")) == rows_after_first
+
+
+class TestReportingIntegrity:
+    async def test_a_failed_lookup_is_never_reported_as_absent(
+        self, db_session: AsyncSession
+    ) -> None:
+        """SC-007. The distinction this whole feature descends from."""
+        await _seed(db_session, "filmotfail1")
+        client = _client([], unresolved={"filmotfail1"})
+
+        result = await run_filmot_recovery(db_session, client)
+
+        assert result.updated == 0
+        assert result.not_held == 0, (
+            "a request that did not complete says nothing about whether the "
+            "archive holds a record"
+        )
+        assert result.unresolved == 1
+
+    async def test_the_reconciliation_identity_holds(
+        self, db_session: AsyncSession
+    ) -> None:
+        """FR-022b: updated + held_no_write == returned, when nothing failed."""
+        await _seed(db_session, "filmotrec1")
+        await _seed(
+            db_session,
+            "filmotrec2",
+            title="A Real Title",
+            channel_id=_CHANNEL,
+            duration=300,
+        )
+        client = _client(
+            [
+                FilmotVideo(id="filmotrec1", title="Real Title"),
+                FilmotVideo(id="filmotrec2", title="Archive Title"),
+            ]
+        )
+
+        result = await run_filmot_recovery(db_session, client)
+
+        assert (
+            result.reconciles
+        ), f"{result.updated} + {result.held_no_write} != {result.returned}"
+
+    async def test_dry_run_writes_nothing(self, db_session: AsyncSession) -> None:
+        """FR-020."""
+        await _seed(db_session, "filmotdry1")
+        before = await _row(db_session, "filmotdry1")
+        client = _client([FilmotVideo(id="filmotdry1", title="Real Title")])
+
+        result = await run_filmot_recovery(db_session, client, dry_run=True)
+
+        assert result.updated == 1, "dry run still reports what it would do"
+        assert await _row(db_session, "filmotdry1") == before
+        assert await _provenance(db_session, "filmotdry1") == []
+
+
+class TestUnconfigured:
+    async def test_an_unconfigured_source_is_skipped_not_failed(
+        self, db_session: AsyncSession
+    ) -> None:
+        """FR-019/SC-009."""
+        client = MagicMock()
+        client.is_configured = False
+        client.fetch_videos = AsyncMock()
+
+        result = await run_filmot_recovery(db_session, client)
+
+        assert result.ended_early == "not_configured"
+        assert result.submitted == 0
+        client.fetch_videos.assert_not_awaited()

--- a/tests/unit/cli/test_recover_filmot.py
+++ b/tests/unit/cli/test_recover_filmot.py
@@ -1,0 +1,255 @@
+"""CLI contract for `chronovista recover filmot` (Feature 065, User Story 3).
+
+Every test invokes the real command through Typer's runner. The recovery run
+itself is stubbed, because what is under test here is the *contract* — options,
+exit codes, and which counts appear on screen — not the recovery.
+
+The exit codes carry an opinion worth stating: a run that learned nothing is
+still a run that completed. An unconfigured credential, a credential the
+archive rejects, and a run in which every request failed all exit 0. Only an
+unusable *system* is a failure.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from chronovista.cli.commands.recover import recover_app
+from chronovista.services.recovery.models import FilmotRecoveryResult
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _invoke(runner: CliRunner, result: FilmotRecoveryResult, *args: str):
+    """Run the command with the recovery stubbed out."""
+    with (
+        patch(
+            "chronovista.cli.commands.recover.run_filmot_recovery",
+            new_callable=AsyncMock,
+        ) as run,
+        patch("chronovista.cli.commands.recover.db_manager") as db,
+    ):
+        run.return_value = result
+
+        async def _sessions(*_a, **_kw):
+            yield AsyncMock()
+
+        db.get_session = _sessions
+        invocation = runner.invoke(recover_app, ["filmot", *args])
+        invocation.run_mock = run  # type: ignore[attr-defined]
+        return invocation
+
+
+class TestOptions:
+    def test_limit_must_be_positive(self, runner: CliRunner) -> None:
+        """`--limit 0` would be a run that cannot recover anything.
+
+        Pinned to 2 rather than "not 0". Click owns 2 for usage errors and the
+        project's ``EXIT_SYSTEM_ERROR`` is also 2, so this exact collision is
+        the documented behaviour — asserting only ``!= 0`` hid which of the
+        two an operator would see.
+        """
+        result = runner.invoke(recover_app, ["filmot", "--limit", "0"])
+
+        assert result.exit_code == 2
+
+    def test_the_options_reach_the_service(self, runner: CliRunner) -> None:
+        """Otherwise the flags are decorative.
+
+        Every other test here stubs the run and asserts on the stub's *return*
+        value, so `--dry-run` appeared to work because the canned result said
+        ``dry_run=True``. Deleting the forwarding from the command left the
+        whole suite green.
+        """
+        result = _invoke(
+            runner, FilmotRecoveryResult(dry_run=True), "--dry-run", "--limit", "7"
+        )
+
+        assert result.exit_code == 0
+        kwargs = result.run_mock.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["limit"] == 7
+        assert kwargs["dry_run"] is True
+
+    def test_a_plain_run_forwards_no_limit_and_no_dry_run(
+        self, runner: CliRunner
+    ) -> None:
+        """The defaults are part of the contract too."""
+        result = _invoke(runner, FilmotRecoveryResult())
+
+        kwargs = result.run_mock.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["limit"] is None
+        assert kwargs["dry_run"] is False
+
+    def test_there_is_no_source_selection_option(self, runner: CliRunner) -> None:
+        """FR-032: composition waits for the abstraction.
+
+        A `--source` flag here would make the command the de-facto abstraction,
+        which is the least testable place to put one.
+        """
+        help_text = runner.invoke(recover_app, ["filmot", "--help"]).output
+
+        assert "--source" not in help_text
+
+    def test_help_states_the_request_rate(self, runner: CliRunner) -> None:
+        """FR-021: the limit must be discoverable, not folklore."""
+        help_text = runner.invoke(recover_app, ["filmot", "--help"]).output
+
+        assert "one per second" in help_text
+
+
+class TestExitCodes:
+    def test_an_unconfigured_credential_succeeds(self, runner: CliRunner) -> None:
+        """FR-019/SC-009 — an optional source that is absent is not a failure."""
+        result = _invoke(runner, FilmotRecoveryResult(ended_early="not_configured"))
+
+        assert result.exit_code == 0
+        assert "not configured" in result.output.lower()
+
+    def test_a_run_that_learned_nothing_succeeds(self, runner: CliRunner) -> None:
+        """SC-007 — every request failed, so nothing is known. Still exit 0."""
+        result = _invoke(
+            runner,
+            FilmotRecoveryResult(submitted=50, unresolved=50, not_held=0),
+        )
+
+        assert result.exit_code == 0
+
+    def test_a_run_ended_by_a_rejected_credential_succeeds(
+        self, runner: CliRunner
+    ) -> None:
+        """FR-019a — distinct from unconfigured, still a completed run."""
+        result = _invoke(
+            runner,
+            FilmotRecoveryResult(
+                submitted=50,
+                unresolved=50,
+                not_attempted=100,
+                ended_early="credential_rejected",
+            ),
+        )
+
+        assert result.exit_code == 0
+        assert "credential_rejected" in result.output
+
+
+class TestSummary:
+    def test_absent_and_unresolved_are_separate_lines(self, runner: CliRunner) -> None:
+        """The distinction this whole feature descends from.
+
+        Asserts both labels appear *and* both numbers do — a summary that
+        rendered one label with the other's total would satisfy a weaker test.
+        """
+        result = _invoke(
+            runner,
+            FilmotRecoveryResult(
+                submitted=10,
+                returned=4,
+                updated=3,
+                held_no_write=1,
+                not_held=5,
+                unresolved=2,
+            ),
+        )
+
+        assert "archive had no record" in result.output
+        assert "not looked up" in result.output
+
+    def test_held_with_nothing_to_write_is_reported(self, runner: CliRunner) -> None:
+        """FR-022a — without it, returned-minus-updated is unexplained."""
+        result = _invoke(
+            runner,
+            FilmotRecoveryResult(returned=4, updated=3, held_no_write=1),
+        )
+
+        assert "held, nothing to write" in result.output
+
+    def test_a_non_reconciling_run_is_flagged(self, runner: CliRunner) -> None:
+        """FR-022b — a discrepancy means something was dropped silently."""
+        result = _invoke(
+            runner,
+            FilmotRecoveryResult(returned=10, updated=3, held_no_write=1),
+        )
+
+        assert "does not equal" in result.output.lower()
+
+    def test_changed_titles_warn_about_stale_derived_data(
+        self, runner: CliRunner
+    ) -> None:
+        """FR-020a — the operator decides whether to re-run those processes."""
+        result = _invoke(
+            runner,
+            FilmotRecoveryResult(returned=3, updated=3, field_counts={"title": 3}),
+        )
+
+        assert "stale" in result.output.lower()
+
+    def test_refusals_are_visible(self, runner: CliRunner) -> None:
+        """FR-022c — the cost of the discard rules must not be assumed small."""
+        result = _invoke(
+            runner,
+            FilmotRecoveryResult(
+                returned=2,
+                held_no_write=2,
+                refused_values={"duration:incoming_implausible": 2},
+            ),
+        )
+
+        assert "refused" in result.output.lower()
+
+    def test_dry_run_says_so(self, runner: CliRunner) -> None:
+        result = _invoke(
+            runner,
+            FilmotRecoveryResult(returned=1, updated=1, dry_run=True),
+            "--dry-run",
+        )
+
+        assert "dry run" in result.output.lower()
+
+    def test_a_dry_run_does_not_claim_derived_data_went_stale(
+        self, runner: CliRunner
+    ) -> None:
+        """Nothing was written, so nothing downstream of it is stale.
+
+        The warning fired on the same condition in both modes, so a dry run
+        told the operator to go and rebuild search indexes and entity mentions
+        for titles it had not touched.
+        """
+        result = _invoke(
+            runner,
+            FilmotRecoveryResult(
+                returned=3, updated=3, field_counts={"title": 3}, dry_run=True
+            ),
+            "--dry-run",
+        )
+
+        assert "stale" not in result.output.lower()
+
+
+class TestCancellation:
+    def test_ctrl_c_reports_the_conventional_code(self, runner: CliRunner) -> None:
+        """130, and the operator is told the run was cancelled.
+
+        The handler used to live inside the coroutine, where it could never
+        run: asyncio's Runner turns Ctrl+C into task cancellation and re-raises
+        KeyboardInterrupt *outside* `asyncio.run`. The message never printed
+        and the code was whatever the interpreter chose.
+        """
+
+        def _interrupt(coro: Any) -> None:
+            coro.close()  # or pytest reports an un-awaited coroutine
+            raise KeyboardInterrupt
+
+        with patch(
+            "chronovista.cli.commands.recover.asyncio.run", side_effect=_interrupt
+        ):
+            result = runner.invoke(recover_app, ["filmot"])
+
+        assert result.exit_code == 130
+        assert "cancelled" in result.output.lower()

--- a/tests/unit/repositories/test_video_repository_filmot.py
+++ b/tests/unit/repositories/test_video_repository_filmot.py
@@ -1,0 +1,117 @@
+"""Candidate selection for archive recovery (Feature 065, FR-003).
+
+These capture the statement the repository builds and compile it, rather than
+asserting on a mocked return value. A mocked repository returning a list proves
+only that the mock was configured; compiling the SQL proves the predicate says
+what it is supposed to say.
+
+**Assertions are scoped to the WHERE clause.** The query loads whole rows, so
+every column name appears in the SELECT list — `"title" in sql` is true of a
+bare ``select(Video)`` and stays true after the title disjunct is deleted. Two
+assertions here were written against the whole statement and could not fail;
+they are the reason this note exists.
+
+Behavioural coverage — that a filled video is genuinely absent from the result
+— lives in ``tests/integration/services/test_filmot_recovery_provenance.py``
+(``TestSelectionExcludesFilledVideos``), against a real database.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chronovista.db.models import Video as VideoDB
+from chronovista.repositories.video_repository import VideoRepository
+from chronovista.services.recovery.merge_policy import placeholder_title_condition
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _captured_sql(limit: int | None = None) -> str:
+    """Run the selection and return the compiled SQL it issued."""
+    session = AsyncMock()
+    session.execute.return_value = MagicMock(
+        scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+    )
+
+    await VideoRepository().get_filmot_candidates(
+        session, placeholder_title_condition(VideoDB.title), limit=limit
+    )
+
+    statement: Any = session.execute.await_args.args[0]
+    return str(statement.compile(compile_kwargs={"literal_binds": True}))
+
+
+async def _captured_where(limit: int | None = None) -> str:
+    """The WHERE clause alone — the only part that selects anything."""
+    sql = await _captured_sql(limit=limit)
+    return sql.split("WHERE", 1)[1].split("ORDER BY", 1)[0]
+
+
+class TestGapPredicate:
+    async def test_every_gap_column_is_named(self) -> None:
+        """A missing disjunct silently narrows the backlog."""
+        where = await _captured_where()
+
+        assert "title" in where
+        assert "channel_id IS NULL" in where
+        assert "duration IS NULL" in where
+
+    async def test_both_placeholder_forms_reach_the_query(self) -> None:
+        """FR-004c: the policy's condition, not a restatement."""
+        where = await _captured_where()
+
+        assert "https://www.youtube.com/watch%" in where
+        assert "[Placeholder] Video %" in where
+
+    async def test_null_and_blank_titles_are_covered(self) -> None:
+        """`LIKE` cannot express these, so they are separate disjuncts.
+
+        They now arrive as part of the policy's single condition rather than
+        being reassembled here, which is what stopped the query, the policy and
+        the write gate from spelling "blank" three different ways.
+        """
+        where = await _captured_where()
+
+        assert "title IS NULL" in where
+        assert "btrim" in where.lower()
+
+    async def test_only_unavailable_videos_are_candidates(self) -> None:
+        """FR-001. An available video has no business being sent anywhere."""
+        where = await _captured_where()
+
+        assert "availability_status" in where
+        assert "!=" in where or "<>" in where
+
+
+class TestOrderingAndLimit:
+    async def test_ordering_matches_the_sibling_recovery_command(self) -> None:
+        """Consistent operator experience across both recovery commands."""
+        sql = await _captured_sql()
+
+        assert "ORDER BY" in sql
+        assert "unavailability_first_detected" in sql
+        assert "created_at" in sql
+
+    async def test_limit_is_applied_when_given(self) -> None:
+        assert "LIMIT 25" in await _captured_sql(limit=25)
+
+    async def test_no_limit_clause_when_unbounded(self) -> None:
+        assert "LIMIT" not in await _captured_sql()
+
+
+class TestSelectionIsByGapNotHistory:
+    async def test_prior_recovery_is_not_filtered_on(self) -> None:
+        """FR-003/FR-003a, asserted structurally.
+
+        Selection must not *filter* on the attribution columns: doing so would
+        make prior recovery a proxy for completeness, which it is not — an
+        earlier run may have filled only the duration.
+        """
+        where = await _captured_where()
+
+        assert "recovery_source" not in where
+        assert "recovered_at" not in where

--- a/tests/unit/services/recovery/test_filmot_client.py
+++ b/tests/unit/services/recovery/test_filmot_client.py
@@ -95,9 +95,17 @@ class TestFoundAndUnresolved:
         ), "an id the API answered about and did not have is not unresolved"
 
     async def test_a_failed_batch_reports_its_ids_unresolved(self) -> None:
-        """#149's lesson, applied before the bug can happen here."""
+        """#149's lesson, applied before the bug can happen here.
+
+        Uses 404 rather than 403. Both raise without retrying, so 403 read as a
+        convenient stand-in for "this batch failed" — but 403 means the archive
+        rejected the credential, which is a condition of the *run*: it will
+        recur on every remaining batch, and containing it made a dead key
+        indistinguishable from a timeout. See
+        `TestARejectedCredentialIsNotContained`.
+        """
         with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
-            get.return_value = httpx.Response(403)
+            get.return_value = httpx.Response(404)
             found, unresolved = await _client().fetch_videos(["vid1", "vid2"])
 
         assert found == []
@@ -108,11 +116,45 @@ class TestFoundAndUnresolved:
         ids = [f"v{i:03d}" for i in range(50)] + ["late1"]
 
         with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
-            get.side_effect = [httpx.Response(403), _ok([_record("late1")])]
+            get.side_effect = [httpx.Response(404), _ok([_record("late1")])]
             found, unresolved = await _client().fetch_videos(ids)
 
         assert [v.video_id for v in found] == ["late1"]
         assert unresolved == set(ids[:50])
+
+
+class TestARejectedCredentialIsNotContained:
+    """The one failure that is about the run rather than about a batch.
+
+    Every other failure is contained and reported per-id, which is right: a
+    timeout says nothing about the videos it failed to ask about. A rejected
+    credential says nothing about them either — but it also guarantees the next
+    batch will fail, so containing it meant the run issued every remaining
+    request at one per second and then reported `rate_limited`. An operator was
+    told to wait out a limit that did not exist instead of rotating a dead key.
+    """
+
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_it_escapes_the_client(self, status: int) -> None:
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.return_value = httpx.Response(status)
+
+            with pytest.raises(FilmotError) as caught:
+                await _client().fetch_videos(["vid1", "vid2"])
+
+        assert caught.value.status_code == status
+
+    async def test_it_stops_the_run_rather_than_trying_later_batches(self) -> None:
+        """The cost of containing it: 1 request/second, all of them doomed."""
+        ids = [f"v{i:03d}" for i in range(50)] + ["late1"]
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as get:
+            get.side_effect = [httpx.Response(403), _ok([_record("late1")])]
+
+            with pytest.raises(FilmotError):
+                await _client().fetch_videos(ids)
+
+        assert get.await_count == 1, "a second batch was attempted after a dead key"
 
 
 class TestBatching:

--- a/tests/unit/services/recovery/test_filmot_failure_paths.py
+++ b/tests/unit/services/recovery/test_filmot_failure_paths.py
@@ -1,0 +1,299 @@
+"""Failure handling in Filmot recovery (Feature 065).
+
+Written after coverage measurement showed the systemic-failure paths, the time
+limit and the duplicate-record handling were implemented but never exercised —
+86%, against a >90% target. Every branch here is a decision about what to
+believe when the archive misbehaves, which makes untested exactly the wrong
+thing for it to be.
+
+These drive the module's own helpers directly, which is cheap and which is also
+how they went wrong: for a while the `FilmotError` cases below mocked a client
+shape the real client could not produce. `FilmotClient.fetch_videos` folded
+every per-batch error into `unresolved`, so nothing escaped it and `_classify`
+was unreachable in production — a rejected credential reached the operator
+labelled `rate_limited`, and these tests passed throughout. The client now
+raises on 401/403, and `TestTheClientRaisesWhatThisModuleClassifies` pins that
+contract so the mocks below cannot drift away from it again.
+
+A test that mocks a collaborator asserts the collaborator's contract as much as
+its own subject, and only one of those two is visible in the file.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+import chronovista.services.recovery.filmot_recovery as fr
+from chronovista.exceptions import FilmotError
+from chronovista.services.recovery.filmot_client import FilmotClient, FilmotVideo
+
+pytestmark = pytest.mark.asyncio
+
+
+def _video(video_id: str) -> Any:
+    v = MagicMock()
+    v.video_id = video_id
+    v.title = f"https://www.youtube.com/watch?v={video_id}"
+    v.channel_id = None
+    v.duration = 0
+    return v
+
+
+def _state() -> fr._RunState:
+    return fr._RunState(dry_run=False, total_candidates=10)
+
+
+class TestClassifyingSystemicFailure:
+    """Naming the failure is what lets the summary explain itself."""
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (401, "credential_rejected"),
+            (403, "credential_rejected"),
+            (429, "rate_limited"),
+            (500, "source_unusable"),
+            (None, "source_unusable"),
+        ],
+    )
+    async def test_status_maps_to_a_reason(
+        self, status: int | None, expected: str
+    ) -> None:
+        assert fr._classify(FilmotError("x", status_code=status)) == expected
+
+
+class TestTheClientRaisesWhatThisModuleClassifies:
+    """The seam the mocks in this file assume, asserted against the real client.
+
+    Without this, every `FilmotError` test below is a statement about a mock.
+    """
+
+    async def test_a_rejected_credential_escapes_the_client(self) -> None:
+        client = FilmotClient(api_key="dead-key")
+
+        with patch.object(
+            client,
+            "_fetch_batch",
+            AsyncMock(side_effect=FilmotError("forbidden", status_code=403)),
+        ):
+            with pytest.raises(FilmotError) as caught:
+                await client.fetch_videos(["v1"])
+
+        assert caught.value.status_code == 403
+
+    @pytest.mark.parametrize("status", [429, 500, None])
+    async def test_other_failures_stay_per_batch(self, status: int | None) -> None:
+        """Everything else is a fact about one request, not about the run.
+
+        These *are* folded into `unresolved`, and the three-batch streak is
+        what escalates them — so the streak's reason is an inference, and only
+        the credential case is ever known.
+        """
+        client = FilmotClient(api_key="k")
+
+        with patch.object(
+            client,
+            "_fetch_batch",
+            AsyncMock(side_effect=FilmotError("nope", status_code=status)),
+        ):
+            found, unresolved = await client.fetch_videos(["v1"])
+
+        assert found == []
+        assert unresolved == {"v1"}
+
+
+class TestSystemicVersusIsolated:
+    """FR-018b. One batch failing is not the source refusing the run."""
+
+    async def test_a_client_error_ends_the_run(self) -> None:
+        """A rejected credential says nothing about any video, and will say
+        nothing about the next batch either."""
+        client = MagicMock()
+        client.fetch_videos = AsyncMock(
+            side_effect=FilmotError("rejected", status_code=403)
+        )
+
+        with pytest.raises(fr._SystemicFailure) as caught:
+            await fr._process_batch(AsyncMock(), client, [_video("v1")], _state())
+
+        assert caught.value.reason == "credential_rejected"
+
+    async def test_two_fully_unresolved_batches_do_not_end_the_run(self) -> None:
+        """Two is a bad patch; three is the source refusing us."""
+        client = MagicMock()
+        client.fetch_videos = AsyncMock(return_value=([], {"v1"}))
+        state = _state()
+
+        for _ in range(2):
+            await fr._process_batch(AsyncMock(), client, [_video("v1")], state)
+
+        assert state.consecutive_rate_limits == 2
+        assert state.unresolved == 2
+
+    async def test_three_fully_unresolved_batches_end_the_run(self) -> None:
+        client = MagicMock()
+        client.fetch_videos = AsyncMock(return_value=([], {"v1"}))
+        state = _state()
+
+        for _ in range(2):
+            await fr._process_batch(AsyncMock(), client, [_video("v1")], state)
+
+        with pytest.raises(fr._SystemicFailure) as caught:
+            await fr._process_batch(AsyncMock(), client, [_video("v1")], state)
+        assert caught.value.reason == "rate_limited"
+
+    async def test_a_successful_batch_resets_the_streak(self) -> None:
+        """Otherwise three failures spread across an hour would end a healthy
+        run, which is the opposite of the intent."""
+        client = MagicMock()
+        state = _state()
+
+        client.fetch_videos = AsyncMock(return_value=([], {"v1"}))
+        await fr._process_batch(AsyncMock(), client, [_video("v1")], state)
+        assert state.consecutive_rate_limits == 1
+
+        client.fetch_videos = AsyncMock(return_value=([], set()))
+        await fr._process_batch(AsyncMock(), client, [_video("v2")], state)
+        assert state.consecutive_rate_limits == 0
+
+    async def test_a_partially_unresolved_batch_is_not_a_streak(self) -> None:
+        """Some answers came back, so the source is not refusing us."""
+        client = MagicMock()
+        client.fetch_videos = AsyncMock(return_value=([], {"v1"}))
+        state = _state()
+
+        await fr._process_batch(
+            AsyncMock(), client, [_video("v1"), _video("v2")], state
+        )
+
+        assert state.consecutive_rate_limits == 0
+
+
+class TestUnexpectedRecords:
+    """FR-016a. The archive is not expected to do either of these."""
+
+    async def test_a_record_for_an_unrequested_id_is_ignored(self) -> None:
+        client = MagicMock()
+        client.fetch_videos = AsyncMock(
+            return_value=([FilmotVideo(id="never-asked", title="T")], set())
+        )
+        state = _state()
+
+        await fr._process_batch(AsyncMock(), client, [_video("v1")], state)
+
+        assert state.returned == 0
+        assert state.not_held == 1, "v1 was answered for and had no record"
+
+    async def test_duplicates_collapse_to_the_first(self) -> None:
+        session = AsyncMock()
+        session.scalar = AsyncMock(return_value=None)
+        client = MagicMock()
+        client.fetch_videos = AsyncMock(
+            return_value=(
+                [
+                    FilmotVideo(id="v1", title="First"),
+                    FilmotVideo(id="v1", title="Second"),
+                ],
+                set(),
+            )
+        )
+        state = _state()
+
+        await fr._process_batch(session, client, [_video("v1")], state)
+
+        assert state.returned == 1
+
+
+def _client(**kwargs: Any) -> Any:
+    client = MagicMock()
+    client.is_configured = True
+    client.fetch_videos = AsyncMock(**kwargs)
+    return client
+
+
+async def _run(candidates: list[Any], client: Any, **kwargs: Any) -> Any:
+    """Drive the real orchestration over a stubbed candidate set."""
+    repo = MagicMock()
+    repo.get_filmot_candidates = AsyncMock(return_value=candidates)
+    with patch.object(fr, "VideoRepository", return_value=repo):
+        return await fr.run_filmot_recovery(AsyncMock(), client, **kwargs)
+
+
+class TestEveryCandidateIsCountedExactlyOnce:
+    """The buckets must partition the candidate set.
+
+    This is the feature's reason for existing, one level up: "the archive had
+    no record" and "we failed to ask" are different facts. A video counted in
+    two buckets is that distinction failing in the direction that looks fine.
+    """
+
+    async def test_an_abandoned_batch_is_unresolved_not_unattempted(self) -> None:
+        """The batch was asked about. It is not "never reached".
+
+        `submitted` was incremented before the systemic raise and `unresolved`
+        after it, while the remainder was measured from the batch's *start* —
+        so those 50 videos landed in `submitted` and `not_attempted` both, and
+        in `unresolved` not at all.
+        """
+        candidates = [_video(f"v{i}") for i in range(120)]
+        client = _client(side_effect=FilmotError("rejected", status_code=403))
+
+        result = await _run(candidates, client)
+
+        assert result.ended_early == "credential_rejected"
+        assert result.submitted == 50
+        assert result.unresolved == 50
+        assert result.not_attempted == 70
+        assert result.unresolved + result.not_attempted == len(candidates)
+
+    async def test_the_time_limit_ends_the_run_and_counts_the_rest(self) -> None:
+        """The branch that decides to stop, not just the tally that records it.
+
+        Previously only `end_early` was called directly, so the comparison
+        against the limit — the part with an operator-visible consequence —
+        was never executed.
+        """
+        candidates = [_video(f"v{i}") for i in range(120)]
+        client = _client(return_value=([], set()))
+
+        # started, batch 1 check, batch 2 check, finalise.
+        with patch.object(
+            fr.time, "monotonic", side_effect=[0.0, 1.0, 9_999.0, 9_999.0]
+        ):
+            result = await _run(candidates, client)
+
+        assert result.ended_early == "time_limit"
+        assert result.not_attempted == 70, "everything from batch 2 onwards"
+        assert result.submitted == 50
+
+
+class TestRunState:
+    async def test_ending_early_counts_the_remainder_as_not_attempted(self) -> None:
+        """ "Not attempted" is a third thing, distinct from both "no record"
+        and "we failed to ask" — those videos were never even reached."""
+        state = _state()
+
+        state.end_early("time_limit", remaining=40)
+
+        result = state.finalise(1.0)
+        assert result.ended_early == "time_limit"
+        assert result.not_attempted == 40
+        assert result.not_held == 0
+        assert result.unresolved == 0
+
+    async def test_the_result_is_frozen(self) -> None:
+        """A result that can be edited after the fact is not evidence.
+
+        Pinned to `ValidationError`. `pytest.raises(Exception)` passed on any
+        exception at all — including an `AttributeError` from a renamed field,
+        which would mean the assignment failed for a reason with nothing to do
+        with immutability.
+        """
+        result = _state().finalise(1.0)
+
+        with pytest.raises(ValidationError):
+            result.updated = 99  # type: ignore[misc]

--- a/tests/unit/services/recovery/test_import_constraints.py
+++ b/tests/unit/services/recovery/test_import_constraints.py
@@ -1,0 +1,139 @@
+"""Guard: the import constraints that keep a source abstraction introducible.
+
+Feature 065 deliberately deferred the general recovery-source abstraction and
+replaced "keep it straightforward to introduce later" — which cannot be shown
+true or false — with two conditions that can (FR-030, FR-031).
+
+They are enforced here rather than by inspection. An inspection is a promise
+someone made once; a refactor two months from now does not consult it. The same
+week this was written, a documentation page in this repository was found to have
+drifted for three releases under a header asserting it could not drift, and the
+fix was a test.
+
+Imports are read with ``ast`` rather than by importing the modules: importing
+`services.recovery` executes its package ``__init__``, which is itself how the
+first version of this feature discovered a circular import.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RECOVERY = REPO_ROOT / "src" / "chronovista" / "services" / "recovery"
+SRC = REPO_ROOT / "src" / "chronovista"
+
+# Repositories that already imported a service before this guard existed.
+#
+# Found by this test on 2026-08-12, and left alone: fixing it belongs to
+# whoever owns that code, not to a recovery feature. It is recorded rather than
+# excluded by narrowing the rule, so the violation stays visible and no *new*
+# one can be added quietly.
+_KNOWN_INVERSIONS = {"entity_mention_repository.py"}
+
+MERGE_POLICY = RECOVERY / "merge_policy.py"
+FILMOT_RECOVERY = RECOVERY / "filmot_recovery.py"
+
+
+def _imported_modules(path: Path) -> set[str]:
+    """Every module named by an import in *path*, dotted and absolute."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            modules.add(node.module)
+    return modules
+
+
+def _modules_importing(target: str) -> set[Path]:
+    """Every file under ``src/`` that imports *target*."""
+    importers: set[Path] = set()
+    for path in SRC.rglob("*.py"):
+        if target in _imported_modules(path) or any(
+            m.startswith(f"{target}.") for m in _imported_modules(path)
+        ):
+            importers.add(path)
+    return importers
+
+
+class TestMergePolicyIsALeaf:
+    """FR-031: dependencies point towards the policy, never away from it."""
+
+    def test_it_imports_neither_recovery_path(self) -> None:
+        imports = _imported_modules(MERGE_POLICY)
+
+        assert "chronovista.services.recovery.filmot_recovery" not in imports
+        assert "chronovista.services.recovery.orchestrator" not in imports
+
+    def test_it_imports_nothing_from_this_project_at_all(self) -> None:
+        """Stronger than FR-031 requires, and deliberately so.
+
+        The policy is pure rules over values. The moment it needs a repository,
+        a model or a client, it has stopped being the thing both paths can
+        safely share — and that erosion is gradual, so the guard is absolute.
+        """
+        project_imports = {
+            m for m in _imported_modules(MERGE_POLICY) if m.startswith("chronovista")
+        }
+
+        assert (
+            project_imports == set()
+        ), f"merge_policy gained project imports: {sorted(project_imports)}"
+
+
+class TestFilmotRecoveryIsNotAPublicDependency:
+    """FR-030: only the operator surface and tests may import the path."""
+
+    def test_only_the_cli_imports_it(self) -> None:
+        importers = _modules_importing("chronovista.services.recovery.filmot_recovery")
+        relative = sorted(p.relative_to(REPO_ROOT).as_posix() for p in importers)
+
+        assert relative == ["src/chronovista/cli/commands/recover.py"], (
+            "only the command exposing this source to operators may import it; "
+            f"found: {relative}"
+        )
+
+    def test_no_repository_imports_a_recovery_service(self) -> None:
+        """The direction that was wrong once already.
+
+        An early draft had `video_repository` import the merge policy, which
+        was not merely backwards but an actual import cycle
+        (repository -> services.recovery -> orchestrator -> repository). The
+        fix was to pass the placeholder patterns in. This asserts the direction
+        stays fixed.
+        """
+        offenders = []
+        for path in (SRC / "repositories").rglob("*.py"):
+            services = {
+                m
+                for m in _imported_modules(path)
+                if m.startswith("chronovista.services")
+            }
+            if services and path.name not in _KNOWN_INVERSIONS:
+                offenders.append((path.name, sorted(services)))
+
+        assert offenders == [], f"repositories importing services: {offenders}"
+
+    def test_the_known_inversion_has_not_spread(self) -> None:
+        """The allowlist must stay exactly as long as it was found.
+
+        An allowlist that grows is how a rule dies quietly. This asserts the
+        pre-existing entry still exists (so the guard is not silently passing
+        because someone fixed it and forgot to remove the exemption) and that
+        nothing joined it.
+        """
+        still_inverted = {
+            path.name
+            for path in (SRC / "repositories").rglob("*.py")
+            if any(
+                m.startswith("chronovista.services") for m in _imported_modules(path)
+            )
+        }
+
+        assert still_inverted == _KNOWN_INVERSIONS, (
+            "the set of repositories importing services changed. If one was "
+            "fixed, remove it from _KNOWN_INVERSIONS. If one was added, do not."
+        )

--- a/tests/unit/services/recovery/test_merge_policy.py
+++ b/tests/unit/services/recovery/test_merge_policy.py
@@ -1,0 +1,265 @@
+"""Tests for the shared fill-only merge policy (Feature 065).
+
+The policy's whole job is to refuse. Most of these tests therefore assert that
+nothing was written — which is a shape of test that passes trivially if the
+function is broken in the direction of doing nothing at all. Each refusal test
+is paired with a positive case proving the same field *can* be written, so
+"refused" is distinguishable from "inert".
+
+The single failing condition of the feature's central invariant (FR-015) is
+*this source wrote a field that already held a real value*, and
+`TestNeverContestsARealValue` is where that lives.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chronovista.db.models import Video as VideoDB
+from chronovista.services.recovery.merge_policy import (
+    _TRIMMED_WHITESPACE,
+    MAX_PLAUSIBLE_DURATION_SECONDS,
+    PLACEHOLDER_TITLE_SQL_PATTERNS,
+    build_filmot_update,
+    is_placeholder_title,
+    placeholder_title_condition,
+)
+
+REAL_TITLE = "An Actual Video Title"
+URL_PLACEHOLDER = "https://www.youtube.com/watch?v=abcdefghijk"
+BRACKET_PLACEHOLDER = "[Placeholder] Video abcdefghijk"
+
+
+class TestIsPlaceholderTitle:
+    """FR-004a, exhaustively — every form the definition names."""
+
+    @pytest.mark.parametrize(
+        "title",
+        [None, "", "   ", "\t\n", URL_PLACEHOLDER, BRACKET_PLACEHOLDER],
+        ids=["null", "empty", "spaces", "whitespace", "url-form", "bracket-form"],
+    )
+    def test_placeholder_forms_are_recognised(self, title: str | None) -> None:
+        assert is_placeholder_title(title) is True
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            REAL_TITLE,
+            "Talk about https://www.youtube.com/watch in the middle",
+            "[placeholder] video abcdefghijk",
+            "http://www.youtube.com/watch?v=abcdefghijk",
+            "Placeholder",
+        ],
+        ids=["real", "url-mid-string", "wrong-case", "http-scheme", "bare-word"],
+    )
+    def test_real_titles_are_not_placeholders(self, title: str) -> None:
+        """The near-misses matter more than the obvious cases.
+
+        A mid-string URL, a lowercased bracket form and an `http://` variant all
+        look like placeholders to a careless predicate. The bracketed form is
+        machine-generated so case-sensitivity is correct; no `http://` form
+        exists in the data, so matching it would serve zero rows.
+        """
+        assert is_placeholder_title(title) is False
+
+
+class TestSqlPatternsAgreeWithTheMatcher:
+    """FR-004c: the query and the policy must not be able to disagree."""
+
+    def test_prefix_patterns_are_derived_not_restated(self) -> None:
+        assert len(PLACEHOLDER_TITLE_SQL_PATTERNS) == 2
+        for pattern in PLACEHOLDER_TITLE_SQL_PATTERNS:
+            assert pattern.endswith("%")
+            # The literal part must itself be recognised by the matcher, or the
+            # query would select rows the policy then refuses.
+            assert is_placeholder_title(pattern[:-1]) is True
+
+    def test_patterns_contain_no_unescaped_like_wildcards(self) -> None:
+        """Both LIKE wildcards, not just one.
+
+        The rule this enforces names `_` *and* `%`; checking only `_` let a
+        future prefix containing `%` through, and `%` is the wildcard that
+        over-selects catastrophically rather than subtly.
+        """
+        for pattern in PLACEHOLDER_TITLE_SQL_PATTERNS:
+            assert "_" not in pattern[:-1]
+            assert "%" not in pattern[:-1]
+
+
+class TestTheSqlConditionIsTheSameRule:
+    """FR-004c, structurally.
+
+    The candidate query and the conditional UPDATE's write gate must apply one
+    predicate, not two that resemble each other. When they merely resembled
+    each other, a whitespace-only title was selected, approved, and refused at
+    write — re-selected on every run forever, and because all fields move in a
+    single statement (FR-011a) the row's valid channel and duration fills were
+    discarded with it.
+    """
+
+    @staticmethod
+    def _compiled() -> str:
+        return str(
+            placeholder_title_condition(VideoDB.title).compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+
+    def test_it_names_every_disjunct_the_matcher_has(self) -> None:
+        sql = self._compiled()
+
+        assert "IS NULL" in sql
+        assert "btrim" in sql.lower()
+        for pattern in PLACEHOLDER_TITLE_SQL_PATTERNS:
+            assert pattern in sql
+
+    def test_the_patterns_are_not_indexed_positionally(self) -> None:
+        """A third placeholder form must reach the gate, not just the query.
+
+        The gate used to read ``PATTERNS[0]`` and ``PATTERNS[1]``, so a third
+        entry would have been selected and then silently never written.
+        """
+        sql = self._compiled()
+
+        assert sql.count("LIKE") == len(PLACEHOLDER_TITLE_SQL_PATTERNS)
+
+    def test_sql_trims_exactly_what_python_trims(self) -> None:
+        """The charset is named in both halves, so they cannot drift.
+
+        Left to the defaults they disagree: `str.strip()` removes every Unicode
+        space, `btrim(col)` removes ASCII space alone.
+        """
+        assert _TRIMMED_WHITESPACE in self._compiled()
+
+    # Whether PostgreSQL and Python *actually* agree cannot be settled in
+    # this file: restating `btrim` in Python would only assert that Python
+    # equals Python. `TestBlankTitleAgreement` in the integration suite puts
+    # each title through a real database and compares the two verdicts.
+
+
+class TestNeverContestsARealValue:
+    """FR-015's invariant. One failing condition, checked per field."""
+
+    def test_a_real_title_is_never_overwritten(self) -> None:
+        out = build_filmot_update(
+            REAL_TITLE, None, None, "Archive Title", None, None, True
+        )
+        assert "title" not in out.updates
+        assert "title:stored_value_is_real" in out.refused
+
+    def test_a_present_channel_is_never_overwritten(self) -> None:
+        out = build_filmot_update(
+            None,
+            "UCstored0000000000000001",
+            None,
+            None,
+            "UCnew00000000000000001",
+            None,
+            True,
+        )
+        assert "channel_id" not in out.updates
+
+    def test_a_positive_duration_is_never_overwritten(self) -> None:
+        out = build_filmot_update(None, None, 300, None, None, 500, True)
+        assert "duration" not in out.updates
+
+
+class TestWritesWhatItShould:
+    """The paired positive cases — without these, refusal proves nothing."""
+
+    def test_a_placeholder_title_is_filled(self) -> None:
+        out = build_filmot_update(
+            URL_PLACEHOLDER, None, None, REAL_TITLE, None, None, True
+        )
+        assert out.updates["title"] == REAL_TITLE
+        assert out.fields_written == ["title"]
+        assert out.writes_anything is True
+
+    def test_the_bracket_form_is_also_filled(self) -> None:
+        """Both forms, because handling one silently skips half the targets."""
+        out = build_filmot_update(
+            BRACKET_PLACEHOLDER, None, None, REAL_TITLE, None, None, True
+        )
+        assert out.updates["title"] == REAL_TITLE
+
+    def test_an_absent_channel_is_filled_when_known(self) -> None:
+        out = build_filmot_update(
+            None, None, None, None, "UCknown000000000000001", None, True
+        )
+        assert out.updates["channel_id"] == "UCknown000000000000001"
+        assert out.unknown_channel_id is None
+
+    @pytest.mark.parametrize("stored", [None, 0], ids=["null", "zero"])
+    def test_an_absent_duration_is_filled(self, stored: int | None) -> None:
+        out = build_filmot_update(None, None, stored, None, None, 214, True)
+        assert out.updates["duration"] == 214
+
+
+class TestRefusals:
+    """Each rule that discards data the archive supplied, and reports it."""
+
+    def test_an_incoming_placeholder_title_is_refused(self) -> None:
+        """FR-004b — writing it satisfies fill-only while leaving the gap."""
+        out = build_filmot_update(
+            URL_PLACEHOLDER, None, None, BRACKET_PLACEHOLDER, None, None, True
+        )
+        assert "title" not in out.updates
+        assert "title:incoming_is_placeholder" in out.refused
+
+    def test_an_unknown_channel_is_reported_not_written(self) -> None:
+        out = build_filmot_update(
+            None, None, None, None, "UCunknown00000000000001", None, False
+        )
+        assert "channel_id" not in out.updates
+        assert out.unknown_channel_id == "UCunknown00000000000001"
+        assert "channel_id:channel_unknown" in out.refused
+
+    def test_a_zero_incoming_duration_is_ignored(self) -> None:
+        """Zero means "unknown" at the source, not "zero seconds"."""
+        out = build_filmot_update(None, None, None, None, None, 0, True)
+        assert "duration" not in out.updates
+
+    @pytest.mark.parametrize(
+        "incoming", [MAX_PLAUSIBLE_DURATION_SECONDS + 1, 77_986_171]
+    )
+    def test_an_implausible_duration_is_refused(self, incoming: int) -> None:
+        """The library already holds a duration of roughly 902 days."""
+        out = build_filmot_update(None, None, None, None, None, incoming, True)
+        assert "duration" not in out.updates
+        assert "duration:incoming_implausible" in out.refused
+
+    def test_the_boundary_value_is_accepted(self) -> None:
+        """24h exactly is plausible; the rule is *exceeds*, not *reaches*."""
+        out = build_filmot_update(
+            None, None, None, None, None, MAX_PLAUSIBLE_DURATION_SECONDS, True
+        )
+        assert out.updates["duration"] == MAX_PLAUSIBLE_DURATION_SECONDS
+
+
+class TestNothingToWrite:
+    def test_an_empty_outcome_writes_nothing_and_claims_nothing(self) -> None:
+        """`updates` empty ⇒ no write AND no contribution record (FR-013)."""
+        out = build_filmot_update(
+            REAL_TITLE, "UCx0000000000000000001", 300, None, None, None, True
+        )
+
+        assert out.updates == {}
+        assert out.fields_written == []
+        assert out.writes_anything is False
+
+    def test_upload_date_cannot_be_emitted(self) -> None:
+        """FR-008 is structural: the value is not a parameter at all.
+
+        Asserting the emitted column set is stronger than asserting one absent
+        key — it fails if any future field is added without a decision.
+        """
+        out = build_filmot_update(
+            URL_PLACEHOLDER,
+            None,
+            None,
+            REAL_TITLE,
+            "UCk00000000000000000001",
+            214,
+            True,
+        )
+        assert set(out.updates) <= {"title", "channel_id", "duration"}


### PR DESCRIPTION
## What

`chronovista recover filmot` — a sibling to `recover video` — fills title, owning
channel and duration for videos YouTube no longer serves, from a third-party index
that retains records for removed videos. Backend only, no migration: every column
already exists.

A sibling rather than a `--source` flag on the existing command. The two sources
answer different questions and fail differently, and composing them behind one
invocation would make the CLI the de-facto abstraction — the least testable place
to put one. Deferred until there is a third source to generalise from.

## Fill-only by construction

A third-party archive is weaker evidence than what the platform or the user's own
export said, so it may fill a gap and may never contest a value.

The mechanism is the conditional write: **every field's gate is re-asserted in the
UPDATE's own WHERE clause**, not only when the candidate was read. Without that, a
concurrent writer could fill a field between selection and write and this source
would overwrite it — making fill-only true by timing rather than by construction,
which is not true at all.

Publication dates are never written — the value is not a parameter of the merge
function at all, so no future edit can begin writing it by accident. No channel
records are created. `videos.recovery_source` is left to the provenance repository
rather than assigned directly (ADR-011).

## Design decisions worth reviewing

- **One definition of "placeholder title."** `merge_policy.py` exports it as both a
  Python matcher and a SQL predicate, so the candidate query and the write gate
  cannot disagree. The repository receives the finished condition, which keeps a
  repository from importing a service — enforced by test, after an early draft made
  that an actual import cycle.
- **Two failure modes counted separately, everywhere.** "The archive had no record"
  is terminal for a video; "we failed to ask" means nothing was learned. Conflating
  them is the defect that hid 288 playlists in #149, so they are separate counters,
  separate summary lines, and separate on the early-end path.
- **A rejected credential escapes the client** rather than being folded into per-id
  failures, so a dead key is never reported to the operator as a rate limit.
- **Provenance rows carry an explicit timestamp.** Without one the upsert froze it
  at the first contribution, and the attribution projection — ordered by
  `recovered_at` — would credit a source that had written nothing.

## Verification

| | |
|---|---|
| Feature tests | 144 (113 unit, 31 integration) |
| Full unit suite | 6,988 passed |
| Full integration suite | 1,347 passed |
| mypy `--strict`, ruff, black | clean |
| Mutation-verified | 8 defect classes with a data or reporting consequence |

The invariant was attacked rather than asserted: 158,760 stored×incoming policy
combinations and 1,631 adversarial title strings run against live PostgreSQL, plus a
real two-session race that left the row untouched with no provenance written.

Eight review passes ran over this branch. The findings that mattered most —
provenance attribution, a gate checked in Python but not re-asserted in SQL, and a
dry run holding one transaction open for its whole length — came from the last
three, after five earlier passes had already come back clean. Three tests in the
first draft could not fail, including the headline invariant test, which seeded a
video that selection never returns.

## Known limitation

`--limit` samples from the head of a fixed ordering; it does not page. Videos the
archive does not hold keep their gap and their sort key, so a repeated
`--limit` run re-reads them. Documented in the option's help text rather than
engineered around: the whole backlog is roughly 30 requests, so there is little
reason to page.
