### PR TITLE
fix(recovery): accumulate fields_written across repeat contributions (#228)

### DIFF
--- a/src/chronovista/repositories/recovery_provenance_repository.py
+++ b/src/chronovista/repositories/recovery_provenance_repository.py
@@ -38,6 +38,45 @@ from chronovista.db.models import VideoRecoverySource as VideoRecoverySourceDB
 from chronovista.models.recovery_provenance import RecoverySourceRecord
 
 
+def _cumulative_fields(table_name: str) -> TextClause:
+    """The stored and incoming field lists unioned, de-duplicated and sorted.
+
+    ``fields_written`` names everything a source has contributed to a row, so a
+    later pass that fills a *different* field must add to the list rather than
+    replace it.
+
+    Replacing it was the behaviour until #228, and the path to losing data was
+    ordinary rather than rare: a run fills a video's title while its owning
+    channel is not yet in the library, the channel is synced later, and a second
+    run fills ``channel_id``. The row then recorded only ``{channel_id}`` — the
+    same shape of loss ADR-011 exists to prevent, one column further in. It
+    reached 23 rows in the production library before it was noticed.
+
+    Sorted so the column is order-independent: the value now depends on the set
+    of fields a source has written, never on the order of the runs that wrote
+    them.
+
+    Parameters
+    ----------
+    table_name : str
+        The provenance table being upserted into. Supplied from the mapped
+        model's ``__tablename__``, never from user input.
+
+    Returns
+    -------
+    TextClause
+        A scalar subquery for the ``DO UPDATE`` SET clause.
+    """
+    empty = "ARRAY[]::varchar[]"
+    return text(
+        f"(SELECT coalesce(array_agg(DISTINCT f ORDER BY f), {empty}) "
+        f"FROM unnest("
+        f"coalesce({table_name}.fields_written, {empty}) || "
+        f"coalesce(excluded.fields_written, {empty})"
+        f") AS f)"
+    )
+
+
 class RecoveryProvenanceRepository:
     """Append provenance, and keep the denormalised columns in step."""
 
@@ -52,8 +91,12 @@ class RecoveryProvenanceRepository:
         """Record that *record.source* contributed to *video_id*.
 
         Idempotent per (video_id, source). A repeat pass by the same source
-        refreshes its own row's timestamp and fields, and leaves every other
-        source's row untouched — which is the whole point.
+        refreshes its own row's timestamp and *adds to* its field list, and
+        leaves every other source's row untouched — which is the whole point.
+
+        The field list accumulates rather than being replaced (#228): a source
+        that fills a title on one run and a channel on the next has written
+        both, and the row must say so.
         """
         values: dict[str, object] = {
             "video_id": video_id,
@@ -70,7 +113,7 @@ class RecoveryProvenanceRepository:
         # DO NOTHING would silently keep a stale timestamp.
         update_cols: dict[str, object] = {
             "source_detail": stmt.excluded.source_detail,
-            "fields_written": stmt.excluded.fields_written,
+            "fields_written": _cumulative_fields(VideoRecoverySourceDB.__tablename__),
         }
         if record.recovered_at is not None:
             update_cols["recovered_at"] = stmt.excluded.recovered_at
@@ -87,7 +130,11 @@ class RecoveryProvenanceRepository:
         channel_id: str,
         record: RecoverySourceRecord,
     ) -> None:
-        """Record that *record.source* contributed to *channel_id*."""
+        """Record that *record.source* contributed to *channel_id*.
+
+        Same accumulation rule as ``record_video`` (#228) — the two paths must
+        not disagree about what ``fields_written`` means.
+        """
         values: dict[str, object] = {
             "channel_id": channel_id,
             "source": record.source,
@@ -100,7 +147,7 @@ class RecoveryProvenanceRepository:
         stmt = insert(ChannelRecoverySourceDB).values(values)
         update_cols: dict[str, object] = {
             "source_detail": stmt.excluded.source_detail,
-            "fields_written": stmt.excluded.fields_written,
+            "fields_written": _cumulative_fields(ChannelRecoverySourceDB.__tablename__),
         }
         if record.recovered_at is not None:
             update_cols["recovered_at"] = stmt.excluded.recovered_at

--- a/tests/integration/repositories/test_recovery_provenance_repository.py
+++ b/tests/integration/repositories/test_recovery_provenance_repository.py
@@ -117,7 +117,129 @@ class TestAppendNeverOverwrite:
 
         rows = await repo.get_video_sources(db_session, vid)
         assert len(rows) == 1
-        assert rows[0].fields_written == ["title", "duration"]
+        # Sorted, not insertion-ordered: the column is a set of fields this
+        # source has written, so it must not depend on run order (#228).
+        assert sorted(rows[0].fields_written) == ["duration", "title"]
+
+
+class TestFieldListAccumulates:
+    """#228. A repeat contribution adds to the record, it does not replace it.
+
+    The path is ordinary rather than rare, which is why it reached production:
+    a run fills a title while the owning channel is still unknown, the channel
+    is synced later, and a second run fills the channel. Replacing the list
+    meant the row then claimed the source had written only the channel.
+
+    The pre-existing idempotency test could not catch this — it covers the
+    *fully filled* row, where the second pass writes nothing at all.
+    """
+
+    async def test_a_later_pass_filling_a_different_field_keeps_the_earlier_one(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = RecoveryProvenanceRepository()
+        vid, cid = "prov_accum1", "UCprovaccum00000000001"
+        await _seed_video(db_session, vid, cid)
+
+        await repo.record_video(
+            db_session,
+            vid,
+            RecoverySourceRecord(source="filmot", fields_written=["title"]),
+        )
+        await repo.record_video(
+            db_session,
+            vid,
+            RecoverySourceRecord(source="filmot", fields_written=["channel_id"]),
+        )
+
+        rows = await repo.get_video_sources(db_session, vid)
+        assert len(rows) == 1, "still one row per (video, source)"
+        assert sorted(rows[0].fields_written) == ["channel_id", "title"], (
+            "the earlier contribution was discarded — the row now understates "
+            "what this source wrote"
+        )
+
+    async def test_repeating_the_same_field_does_not_duplicate_it(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Accumulating must not mean growing without bound."""
+        repo = RecoveryProvenanceRepository()
+        vid, cid = "prov_accum2", "UCprovaccum00000000002"
+        await _seed_video(db_session, vid, cid)
+
+        for _ in range(3):
+            await repo.record_video(
+                db_session,
+                vid,
+                RecoverySourceRecord(source="filmot", fields_written=["title"]),
+            )
+
+        rows = await repo.get_video_sources(db_session, vid)
+        assert rows[0].fields_written == ["title"]
+
+    async def test_one_source_accumulating_does_not_touch_another(
+        self, db_session: AsyncSession
+    ) -> None:
+        """The union is per (row, source), never across sources."""
+        repo = RecoveryProvenanceRepository()
+        vid, cid = "prov_accum3", "UCprovaccum00000000003"
+        await _seed_video(db_session, vid, cid)
+
+        await repo.record_video(
+            db_session,
+            vid,
+            RecoverySourceRecord(source="wayback", fields_written=["description"]),
+        )
+        await repo.record_video(
+            db_session,
+            vid,
+            RecoverySourceRecord(source="filmot", fields_written=["title"]),
+        )
+        await repo.record_video(
+            db_session,
+            vid,
+            RecoverySourceRecord(source="filmot", fields_written=["duration"]),
+        )
+
+        by_source = {r.source: r for r in await repo.get_video_sources(db_session, vid)}
+        assert sorted(by_source["filmot"].fields_written) == ["duration", "title"]
+        assert by_source["wayback"].fields_written == [
+            "description"
+        ], "another source's field list was absorbed into the union"
+
+    async def test_channel_provenance_accumulates_the_same_way(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Both paths, or the column means two different things."""
+        repo = RecoveryProvenanceRepository()
+        cid = "UCprovaccum00000000004"
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO channels (channel_id, title, is_subscribed,
+                                      availability_status)
+                VALUES (:cid, 'Provenance Channel', false, 'unavailable')
+                ON CONFLICT (channel_id) DO NOTHING
+                """
+            ),
+            {"cid": cid},
+        )
+        await db_session.flush()
+
+        await repo.record_channel(
+            db_session,
+            cid,
+            RecoverySourceRecord(source="wayback", fields_written=["title"]),
+        )
+        await repo.record_channel(
+            db_session,
+            cid,
+            RecoverySourceRecord(source="wayback", fields_written=["description"]),
+        )
+
+        rows = await repo.get_channel_sources(db_session, cid)
+        assert len(rows) == 1
+        assert sorted(rows[0].fields_written) == ["description", "title"]
 
 
 class TestDenormalisedProjection:


### PR DESCRIPTION
Fixes #228.

## What

`fields_written` was replaced wholesale on every repeat contribution by the same
source. A source that filled one field on an early pass and a different field on a
later pass ended up recorded as having written only the later one.

The `DO UPDATE` clause now unions the stored and incoming arrays with
de-duplication, applied to **both** `record_video` and `record_channel` — fixing one
path would leave the column meaning different things depending on which table you
read. Sorted, so the value depends on the *set* of fields a source has written and
never on the order of the runs that wrote them. No migration: existing rows are
already valid subsets.

## How it was reached

Ordinary, not a race:

1. A run fills a video's title while its owning channel is not yet in the library,
   so the channel is refused. Provenance: `{duration, title}`.
2. The video stays a candidate — selection is by *remaining gap*.
3. The channel is synced later.
4. A second run fills `channel_id`. Provenance becomes `{channel_id}`, and the record
   that this source supplied the title is gone.

This happened on 23 production rows.

## Why review did not catch it, twice

The pre-existing idempotency test covers the **fully filled** row, where the second
pass writes nothing at all. Neither this nor the `recovered_at` half (fixed in #227)
can occur in that scenario, so the test looked like coverage of repeat contributions
and was not. The four new tests exercise the partial-fill-then-complete path
directly.

## Verification

| | |
|---|---|
| Integration | 1,347 → **1,351** (+4, reconciles exactly) |
| Unit | **6,988**, unchanged |
| mypy `--strict`, ruff, black | clean |
| Mutation | reverting to `excluded.fields_written` fails 3 of the 4 new tests |

The fourth test (repeating the same field does not duplicate it) passes under both
semantics by design — it guards against unbounded growth, not accumulation.

The merge expression was also evaluated read-only against every row shape that
actually exists in the production table:

| stored | + `channel_id` → | rows |
|---|---|---|
| `(null)` | `channel_id` | 4,222 |
| `channel_id,duration,title` | unchanged | 84 |
| `channel_id` | unchanged | 23 |
| `duration,title` | `channel_id,duration,title` | 6 |
| `title` | `channel_id,title` | 1 |

NULL is coalesced to empty rather than propagating, repeats do not duplicate, and the
union accumulates.

## Scope note, worth reading before merge

**4,222 of 4,359 video provenance rows currently hold NULL `fields_written`**, and all
291 channel rows do — these predate the column being populated. This PR makes any
future contribution to those rows accumulate correctly, but it cannot reconstruct
what was never recorded.

So the 23 rows named in #228 are the part that was noticed, not the extent of the
gap. Retroactive repair is not proposed here: for the 23, `title` is recoverable for
17 from a snapshot taken between the two runs but `duration` is recoverable for none,
and a partial repair would leave rows understating reality while appearing fixed.
Recommend leaving them and recording the real scope on the issue.
