### PR TITLE
fix(takeout): order exports by date, consistently in both entry points (#230, #231)

### DIFF
--- a/src/chronovista/cli/commands/takeout.py
+++ b/src/chronovista/cli/commands/takeout.py
@@ -2646,9 +2646,20 @@ def recover_metadata(
                     "Discovering historical takeouts...", total=None
                 )
 
-                # Discover historical takeouts
+                # Discover historical takeouts, NEWEST FIRST (#231).
+                #
+                # This passed sort_oldest_first=True, the opposite of what the
+                # onboarding pipeline uses, so the same exports on the same disk
+                # produced different metadata depending on which entry point ran.
+                #
+                # Recovery is gap-fill: it writes only where the stored value is
+                # a placeholder, so the FIRST export to supply a real value wins
+                # and later ones are no-ops. Oldest-first therefore let the
+                # oldest export win permanently. For a channel that has been
+                # renamed or a video whose title changed, the most recent export
+                # is the better evidence.
                 historical_takeouts = TakeoutService.discover_historical_takeouts(
-                    takeout_dir, sort_oldest_first=True
+                    takeout_dir, sort_oldest_first=False
                 )
 
                 if not historical_takeouts:

--- a/src/chronovista/services/onboarding_service.py
+++ b/src/chronovista/services/onboarding_service.py
@@ -893,27 +893,60 @@ class OnboardingService:
 
                 takeout_path = OnboardingService._get_data_export_path()
 
-                # Discover all takeout directories (dated + undated)
-                # and seed from each to capture the full watch history.
-                takeout_dirs: list[Path] = []
-                for entry in sorted(takeout_path.iterdir()):
-                    if entry.is_dir() and entry.name.startswith(
-                        "YouTube and YouTube Music"
-                    ):
-                        # TakeoutService expects the *parent* of
-                        # "YouTube and YouTube Music", so if the entry
-                        # IS that folder, its parent is the takeout_path.
-                        # But dated dirs are siblings — each is a
-                        # "YouTube and YouTube Music YYYY-MM-DD" folder
-                        # containing the same structure as the undated one.
-                        takeout_dirs.append(entry)
+                # Discover all takeout directories (dated + undated) and seed
+                # from each to capture the full watch history: YouTube truncates
+                # it, so an older export holds events the newest one no longer
+                # contains.
+                #
+                # Ordered NEWEST FIRST, by resolved export date (#230). Seeding
+                # is fill-only — a title is written only over a placeholder, a
+                # channel only over NULL — so the *first* export to supply a
+                # value wins and every later one is a no-op for that field.
+                # Newest-first therefore means the most recent export wins,
+                # which is what we want for a field that still exists.
+                #
+                # This used to sort directory names alphabetically. That worked
+                # only by accident: a freshly downloaded export arrives named
+                # "YouTube and YouTube Music" with no date, which is a prefix of
+                # every dated sibling and so sorted first. Renaming it to
+                # "YouTube and YouTube Music 2026-08-13" — the obvious thing to
+                # do when filing it — moved it last and handed the decision to
+                # the oldest archive on disk.
+                #
+                # `discover_historical_takeouts` resolves a date for every
+                # export, falling back to filesystem mtime for undated ones, and
+                # is the same discovery the CLI uses (#231).
+                discovered = TakeoutService.discover_historical_takeouts(
+                    takeout_path, sort_oldest_first=False
+                )
+                takeout_dirs: list[Path] = [t.path for t in discovered]
+
+                # Name anything that looks like an export but was not
+                # discovered, rather than processing a shorter list silently.
+                if takeout_path.is_dir():
+                    discovered_paths = {t.path for t in discovered}
+                    skipped = sorted(
+                        entry.name
+                        for entry in takeout_path.iterdir()
+                        if entry.is_dir()
+                        and entry.name.startswith("YouTube and YouTube Music")
+                        and entry not in discovered_paths
+                    )
+                    if skipped:
+                        logger.warning(
+                            "Takeout load: %d director(ies) look like exports but "
+                            "hold no watch history, playlists or subscriptions and "
+                            "were skipped: %s",
+                            len(skipped),
+                            ", ".join(skipped),
+                        )
 
                 if not takeout_dirs:
                     # Fallback: single undated directory
                     takeout_dirs = [takeout_path / "YouTube and YouTube Music"]
 
                 logger.info(
-                    "Found %d takeout directories to process",
+                    "Found %d takeout directories to process (newest first)",
                     len(takeout_dirs),
                 )
 

--- a/src/chronovista/services/takeout_service.py
+++ b/src/chronovista/services/takeout_service.py
@@ -1212,8 +1212,17 @@ class TakeoutService(TakeoutServiceInterface):
         base_path : Path
             Base directory containing takeout subdirectories
         sort_oldest_first : bool
-            If True, sort with oldest first (allows newer to overwrite).
-            If False, sort with newest first.
+            If True, sort oldest first. If False (the usual choice), newest
+            first.
+
+            This previously read "allows newer to overwrite", which describes an
+            overwriting writer. Both consumers are **fill-only**: they write
+            only where the stored value is missing or a placeholder, and never
+            contest a real value. Under those semantics the *first* export to
+            supply a value wins and every later one is a no-op, so oldest-first
+            means the **oldest** value wins permanently — the opposite of what
+            that sentence led a caller to expect, and how the CLI came to
+            disagree with the onboarding pipeline (#231).
 
         Returns
         -------

--- a/tests/integration/services/test_takeout_load_ordering.py
+++ b/tests/integration/services/test_takeout_load_ordering.py
@@ -1,0 +1,237 @@
+"""Which export wins when two disagree (#230), against a real database.
+
+The load seeds from every export on disk, because YouTube truncates watch
+history and an older export holds events the newest one no longer contains.
+Seeding is **fill-only**: a title is written only over a placeholder, a channel
+only over NULL. So the *first* export to supply a value wins and every later one
+is a no-op for that field, which makes processing order the thing that decides
+what the library ends up holding.
+
+The case that discriminates is a video whose title **changed between exports** —
+a creator renaming it. Both titles are real, so fill-only keeps whichever
+arrives first, and the two orderings give different answers.
+
+A *degraded* title (real, then the bare watch URL) does NOT discriminate: the
+seeder normalises a URL to the bracket placeholder on create, and the fill-only
+update then replaces that placeholder from any later export. Both orderings
+converge, which is why 602 such videos in the production library kept their
+titles even while the ordering was wrong. Testing with that shape would look
+like coverage and prove nothing.
+
+These tests use two *dated* exports on purpose. Dated names sort chronologically,
+so the old `sorted(path.iterdir())` produced oldest-first — and the oldest export
+won permanently. The undated case is the one that accidentally worked.
+
+**What this file does and does not guard.** It calls
+``discover_historical_takeouts`` directly rather than driving
+``OnboardingService._factory_load_data``, which also resolves an identity, runs
+recovery and writes a completion marker. So it establishes the *premise* of the
+fix — that order decides the outcome, and newest-first yields the newer title —
+but it does **not** catch the load step being changed back to oldest-first.
+Verified: mutating that call site leaves every test here green.
+
+``test_exports_are_discovered_newest_first`` in
+tests/unit/services/test_onboarding_service.py is what guards the call site.
+Neither file is sufficient alone; do not delete one on the strength of the other.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from chronovista.services.takeout_seeding_service import TakeoutSeedingService
+from chronovista.services.takeout_service import TakeoutService
+
+pytestmark = pytest.mark.asyncio
+
+_VIDEO_ID = "ordr1TESTx1"
+_CHANNEL_ID = "UCorderingtest0000000001"
+_OLD_TITLE = "Original Title"
+_NEW_TITLE = "Renamed By The Creator"
+
+
+def _write_export(base: Path, dir_name: str, title: str, watched: str) -> None:
+    """Create one dated Takeout export holding a single watch entry."""
+    youtube_dir = base / dir_name
+    history = youtube_dir / "history"
+    history.mkdir(parents=True)
+    (history / "watch-history.json").write_text(
+        json.dumps(
+            [
+                {
+                    "header": "YouTube",
+                    "title": f"Watched {title}",
+                    "titleUrl": f"https://www.youtube.com/watch?v={_VIDEO_ID}",
+                    "subtitles": [
+                        {
+                            "name": "Ordering Test Channel",
+                            "url": f"https://www.youtube.com/channel/{_CHANNEL_ID}",
+                        }
+                    ],
+                    "time": watched,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def two_exports(tmp_path: Path) -> Path:
+    """Two dated exports that disagree about one video's title.
+
+    The 2026 export is the newer one and carries the renamed title. Note that
+    "…2025-01-01" sorts *before* "…2026-01-01", so sorting folder names
+    ascending yields oldest-first.
+    """
+    _write_export(
+        tmp_path,
+        "YouTube and YouTube Music 2025-01-01",
+        _OLD_TITLE,
+        "2025-01-01T00:00:00Z",
+    )
+    _write_export(
+        tmp_path,
+        "YouTube and YouTube Music 2026-01-01",
+        _NEW_TITLE,
+        "2026-01-01T00:00:00Z",
+    )
+    return tmp_path
+
+
+async def _seed_in_order(
+    session: AsyncSession, exports: list[Path], user_id: str
+) -> None:
+    """Parse and seed each export, in the order given.
+
+    Mirrors what the load step does per directory: `TakeoutService` is built with
+    ``object.__new__`` and pointed at the export, because its constructor expects
+    the *parent* of a "YouTube and YouTube Music" folder while these directories
+    are that folder.
+    """
+    seeder = TakeoutSeedingService(user_id=user_id)
+    for export in exports:
+        svc = object.__new__(TakeoutService)
+        svc.takeout_path = export.parent
+        svc.youtube_path = export
+        data = await svc.parse_all()
+        await seeder.seed_database(session, data)
+
+
+async def _stored_title(session: AsyncSession) -> str | None:
+    row = (
+        await session.execute(
+            text("SELECT title FROM videos WHERE video_id = :v"), {"v": _VIDEO_ID}
+        )
+    ).first()
+    return None if row is None else str(row[0])
+
+
+class TestWhichExportWins:
+    async def test_the_newest_export_supplies_the_title(
+        self, db_session: AsyncSession, two_exports: Path
+    ) -> None:
+        """#230: newest-first seeding stores the newer title, against a real DB.
+
+        This establishes the *consequence* of the ordering fix. It does not
+        detect the load step asking for a different order — see the note in the
+        module docstring — so read it as "newest-first produces this result",
+        not as a guard on the production call site.
+        """
+        discovered = TakeoutService.discover_historical_takeouts(
+            two_exports, sort_oldest_first=False
+        )
+        assert len(discovered) == 2, "both exports should be discovered"
+
+        await _seed_in_order(
+            db_session, [t.path for t in discovered], "UCorderingtest_identity"
+        )
+        await db_session.commit()
+
+        assert await _stored_title(db_session) == _NEW_TITLE, (
+            "the older export supplied the title, so a rename made before the "
+            "latest download was discarded"
+        )
+
+    async def test_the_assertion_is_order_sensitive(
+        self, db_session: AsyncSession, two_exports: Path
+    ) -> None:
+        """Proves the test above can fail.
+
+        Seeding the same two exports oldest-first stores the *old* title. Without
+        this, `test_the_newest_export_supplies_the_title` would pass under any
+        ordering that happened to produce the right answer for another reason,
+        and would be indistinguishable from a test that cannot fail.
+        """
+        discovered = TakeoutService.discover_historical_takeouts(
+            two_exports, sort_oldest_first=True
+        )
+
+        await _seed_in_order(
+            db_session, [t.path for t in discovered], "UCorderingtest_identity2"
+        )
+        await db_session.commit()
+
+        assert await _stored_title(db_session) == _OLD_TITLE, (
+            "fill-only means the first export to supply a title wins; if this "
+            "is not the old title, the premise of the ordering fix is wrong"
+        )
+
+    async def test_sorting_folder_names_would_pick_the_wrong_export(
+        self, two_exports: Path
+    ) -> None:
+        """The specific defect: dated names sort oldest-first.
+
+        No database needed. `sorted(path.iterdir())` is what the load used to do,
+        and with every export filed under its date it yields the oldest first,
+        handing every gap to the oldest archive on disk.
+        """
+        by_name = sorted(p for p in two_exports.iterdir() if p.is_dir())
+        by_date = TakeoutService.discover_historical_takeouts(
+            two_exports, sort_oldest_first=False
+        )
+
+        assert by_name[0].name.endswith("2025-01-01"), "name order starts oldest"
+        assert by_date[0].path.name.endswith("2026-01-01"), "date order starts newest"
+        assert (
+            by_name[0].name != by_date[0].path.name
+        ), "this fixture no longer distinguishes the two orderings"
+
+
+class TestSeededMetadata:
+    async def test_the_watch_record_lands_under_the_given_identity(
+        self, db_session: AsyncSession, two_exports: Path
+    ) -> None:
+        """Guards the seam this test drives directly.
+
+        `_seed_in_order` passes a user_id rather than letting the seeder resolve
+        one, so it could drift from what the load step actually does. If the
+        watch row is missing, this file is exercising a path the application
+        does not take.
+        """
+        discovered = TakeoutService.discover_historical_takeouts(
+            two_exports, sort_oldest_first=False
+        )
+        user_id = "UCorderingtest_identity3"
+        await _seed_in_order(db_session, [t.path for t in discovered], user_id)
+        await db_session.commit()
+
+        watched = (
+            await db_session.execute(
+                text(
+                    "SELECT watched_at FROM user_videos "
+                    "WHERE video_id = :v AND user_id = :u"
+                ),
+                {"v": _VIDEO_ID, "u": user_id},
+            )
+        ).first()
+
+        assert watched is not None, "no watch record was seeded"
+        assert isinstance(watched[0], datetime)
+        assert watched[0] <= datetime.now(UTC)

--- a/tests/unit/cli/test_takeout_recover_command.py
+++ b/tests/unit/cli/test_takeout_recover_command.py
@@ -57,6 +57,32 @@ class TestTakeoutRecoverCommand:
     @patch(
         "chronovista.services.takeout_service.TakeoutService.discover_historical_takeouts"
     )
+    def test_archives_are_requested_newest_first(
+        self, mock_discover: MagicMock
+    ) -> None:
+        """#231. The CLI and the onboarding pipeline must agree on order.
+
+        This passed ``sort_oldest_first=True`` while onboarding used the
+        opposite default, so the same exports on the same disk produced
+        different metadata depending on which entry point ran.
+
+        Recovery is gap-fill — it writes only where the stored value is a
+        placeholder — so the first export to supply a real value wins and later
+        ones are no-ops. Oldest-first let the oldest export win permanently.
+        """
+        mock_discover.return_value = []
+
+        runner.invoke(app, ["takeout", "recover", "--dry-run", "--takeout-dir", "."])
+
+        assert mock_discover.called, "discovery was never invoked"
+        assert mock_discover.call_args.kwargs.get("sort_oldest_first") is False, (
+            "the CLI requested oldest-first, so the oldest export wins and "
+            "disagrees with the onboarding pipeline"
+        )
+
+    @patch(
+        "chronovista.services.takeout_service.TakeoutService.discover_historical_takeouts"
+    )
     def test_recover_dry_run(
         self,
         mock_discover: MagicMock,

--- a/tests/unit/services/test_historical_takeout_discovery.py
+++ b/tests/unit/services/test_historical_takeout_discovery.py
@@ -114,6 +114,53 @@ class TestDiscoverHistoricalTakeouts:
         assert takeouts[0].export_date > takeouts[1].export_date
         assert takeouts[1].export_date > takeouts[2].export_date
 
+    def test_undated_export_orders_by_date_not_name(
+        self, temp_takeout_base: Path
+    ) -> None:
+        """#230. A freshly downloaded export sorts last by name, first by date.
+
+        Google names a new export "YouTube and YouTube Music" with no date. That
+        string sorts *after* every dated sibling, because "YouTube and YouTube
+        Music 2024-01-01" is longer and compares greater at the space. Ordering
+        on names therefore puts the newest export at the back, which — under
+        fill-only seeding, where the first export to supply a value wins —
+        hands the outcome to the oldest archive on disk.
+
+        Discovery resolves an mtime for undated exports, so it must place this
+        one first when asked for newest-first, regardless of how it sorts
+        alphabetically.
+        """
+        self._create_takeout_dir(
+            temp_takeout_base, "YouTube and YouTube Music 2024-01-01"
+        )
+        self._create_takeout_dir(
+            temp_takeout_base, "YouTube and YouTube Music 2025-01-01"
+        )
+        undated = temp_takeout_base / "YouTube and YouTube Music"
+        youtube_dir = undated / "YouTube and YouTube Music"
+        youtube_dir.mkdir(parents=True)
+        history = youtube_dir / "history"
+        history.mkdir()
+        (history / "watch-history.json").write_text("[]")
+
+        names = sorted(d.name for d in temp_takeout_base.iterdir() if d.is_dir())
+        assert names[-1] != "YouTube and YouTube Music", (
+            "precondition: the undated export must NOT sort first by name, "
+            "or this test proves nothing"
+        )
+
+        result = TakeoutService.discover_historical_takeouts(
+            temp_takeout_base, sort_oldest_first=False
+        )
+
+        assert len(result) == 3
+        assert (
+            result[0].export_date > result[1].export_date
+        ), "the newest export is not first"
+        # mtime is 'now', so the undated export is the newest of the three.
+        assert "2024" not in result[0].path.parent.name
+        assert "2025" not in result[0].path.parent.name
+
     def test_discover_takeout_with_all_features(self, temp_takeout_base: Path) -> None:
         """Test discovering a takeout with all data types."""
         self._create_takeout_dir(

--- a/tests/unit/services/test_onboarding_service.py
+++ b/tests/unit/services/test_onboarding_service.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1826,10 +1827,23 @@ class TestFactoryLoadData:
         # module is sufficient.
         _parse_all_mock = mock_svc.parse_all
 
+        # The factory discovers exports through
+        # ``TakeoutService.discover_historical_takeouts`` so that ordering is by
+        # resolved export date rather than by folder name (#230). The stub
+        # records the sort direction it was asked for, because "newest first" is
+        # the property under test, not an implementation detail.
+        self._discovery_sort_calls: list[bool] = []
+        recorded = self._discovery_sort_calls
+
+        def _discover(base_path: Any, sort_oldest_first: bool = True) -> list[Any]:
+            recorded.append(sort_oldest_first)
+            return [SimpleNamespace(path=entry) for entry in dir_entries]
+
         class _StubTakeoutService:
             takeout_path: Any = None
             youtube_path: Any = None
             parse_all = _parse_all_mock  # shared across all instances
+            discover_historical_takeouts = staticmethod(_discover)
 
         with (
             patch(
@@ -1937,6 +1951,12 @@ class TestFactoryLoadData:
             youtube_path: Any = None
             parse_all = _parse_all_mock
 
+            @staticmethod
+            def discover_historical_takeouts(
+                base_path: Any, sort_oldest_first: bool = True
+            ) -> list[Any]:
+                return [SimpleNamespace(path=e) for e in entries]
+
         service = _build_factory_service()
         factory = service._factory_load_data()
         _, cb = _capture_progress()
@@ -1996,6 +2016,12 @@ class TestFactoryLoadData:
             youtube_path: Any = None
             parse_all = _parse_all_mock
 
+            @staticmethod
+            def discover_historical_takeouts(
+                base_path: Any, sort_oldest_first: bool = True
+            ) -> list[Any]:
+                return [SimpleNamespace(path=e) for e in entries]
+
         service = _build_factory_service()
         factory = service._factory_load_data()
         _, cb = _capture_progress()
@@ -2023,6 +2049,51 @@ class TestFactoryLoadData:
         # Second positional arg is takeout_path
         assert call_args[0][1] == fake_path
 
+    async def test_exports_are_discovered_newest_first(self) -> None:
+        """#230. Ordering decides which export's metadata survives.
+
+        Seeding is fill-only: a title is written only over a placeholder and a
+        channel only over NULL, so the *first* export to supply a value wins and
+        every later one is a no-op for that field. Newest-first therefore means
+        the most recent export wins.
+
+        The factory used to sort folder *names*, which produced the right answer
+        only by accident — a fresh export arrives undated, and that name is a
+        prefix of every dated sibling, so it sorted first. Renaming it to
+        include its date moved it last and handed the decision to the oldest
+        archive on disk.
+        """
+        _, calls = await self._run(
+            dir_entries=[
+                self._make_mock_dir_entry("YouTube and YouTube Music 2024-01-01"),
+                self._make_mock_dir_entry("YouTube and YouTube Music"),
+            ]
+        )
+
+        assert self._discovery_sort_calls, "discovery was never called"
+        assert self._discovery_sort_calls[0] is False, (
+            "exports were requested oldest-first, so the oldest archive fills "
+            "every gap and the newest export becomes a no-op"
+        )
+
+    async def test_discovery_is_not_by_folder_name(self) -> None:
+        """The factory must not re-derive an order from `iterdir()`.
+
+        Sorting names is what coupled the outcome to how the folders happen to
+        be labelled. Ordering belongs to the discovery helper, which resolves a
+        real export date for every directory including undated ones.
+        """
+        import inspect
+
+        from chronovista.services.onboarding_service import OnboardingService
+
+        source = inspect.getsource(OnboardingService._factory_load_data)
+
+        assert "discover_historical_takeouts" in source
+        assert (
+            "sorted(takeout_path.iterdir())" not in source
+        ), "load ordering is back to folder names"
+
     async def test_parse_all_called_for_each_directory(self) -> None:
         """parse_all is called once for each discovered takeout directory."""
         entries = [
@@ -2040,6 +2111,12 @@ class TestFactoryLoadData:
             takeout_path: Any = None
             youtube_path: Any = None
             parse_all = _parse_all_mock
+
+            @staticmethod
+            def discover_historical_takeouts(
+                base_path: Any, sort_oldest_first: bool = True
+            ) -> list[Any]:
+                return [SimpleNamespace(path=e) for e in entries]
 
         service = _build_factory_service()
         factory = service._factory_load_data()


### PR DESCRIPTION
Fixes #230. 
Fixes #231.

## What

Which export's metadata survives a Takeout load was decided by **alphabetical folder
name**, and the two entry points disagreed about direction. Both now discover exports
through one path, ordered by **resolved export date, newest first**.

## Why order decides anything

Seeding and recovery are both **fill-only**: a title is written only over a placeholder,
a channel only over NULL. So the *first* export to supply a value wins and every later
one is a no-op for that field.

**#230** — the load sorted `takeout_path.iterdir()`. That produced the right answer only
by accident: a fresh export arrives named `YouTube and YouTube Music` with no date, which
is a prefix of every dated sibling and so sorted first. Renaming it to include its date,
which is the obvious thing to do when filing it alongside the others, moved it last:

```
undated : first processed = 'YouTube and YouTube Music'            <- newest wins, by luck
renamed : first processed = 'YouTube and YouTube Music 2025-08-13' <- OLDEST wins
          last  processed = 'YouTube and YouTube Music 2026-08-13' <- newest export, a no-op
```

**#231** — `takeout recover` passed `sort_oldest_first=True` while the onboarding pipeline
used the opposite default, so the same exports on the same disk produced different
metadata depending on which entry point ran.

The flag's own docstring said oldest-first "allows newer to overwrite" — true of an
overwriting writer. Neither consumer overwrites, so under fill-only that sentence inverts
the meaning of the flag, and it is the likeliest reason the CLI chose `True`. Corrected.

## Also

The load now **logs any directory that looks like an export but was not discovered**,
rather than silently processing a shorter list. Discovery requires watch history,
playlists or subscriptions; the previous scan accepted any directory whose name matched.
Verified against a 21-export production collection: same 21 discovered, none dropped.

## Verification

| | |
|---|---|
| Unit | 6,988 → **6,992** |
| Integration | 1,351 → **1,355** |
| Frontend typecheck + tests | 178 files, **3,940** passed |
| mypy `--strict`, ruff, black | clean |
| Mutations | **3/3 caught** |

Manual checks against a real 21-export collection: discovery returns the same directory
set as the old scan, ordering is `2026-08-13 → 2025-08-13`, and `takeout recover
--dry-run` completes end to end.

## On the integration test

The fixture shape is load-bearing. A *degraded* title — real, then the bare watch URL —
does **not** discriminate between the orderings, because the seeder normalises a URL to
the bracket placeholder on create and the fill-only update then fills it from any later
export. Both orders converge. That is why 602 such videos in production kept their titles
while the ordering was wrong, and why testing that shape would have looked like coverage
and proven nothing. The discriminating case is a video the creator **renamed**: both
titles real, so fill-only keeps whichever arrives first.

The file includes a deliberate negative (oldest-first must store the *old* title) so the
positive assertion is demonstrably capable of failing.

**Recorded in the module docstring:** the integration file calls
`discover_historical_takeouts` directly rather than driving `_factory_load_data`, so it
establishes the *consequence* of the fix but does **not** catch the load step being
flipped back — verified by mutation, that change leaves every test in it green. The unit
test `test_exports_are_discovered_newest_first` guards the call site. Neither file is
sufficient alone, and the note exists so a later reader does not delete one as redundant.

## Not included: #207

It is not the small fix it appears to be. The placeholder prefix is defined in **four**
places, one of which drives enrichment **priority-tier selection**; ~40 assertions across
5 files encode the narrow semantics (including `is_placeholder_video_title("") is False`,
which contradicts the canonical matcher); and measured against the current library the
change would restore **zero** titles.

It needs a decision — widen the predicate, or normalise the ~1,187 legacy rows to the
bracket form so every existing predicate becomes correct without a code change. Both move
known-deleted videos into the HIGH enrichment tier. Left for a separate change.
