### PR TITLE
fix(recovery): recognise the URL-as-title placeholder form (#207)

### DIFF
--- a/src/chronovista/models/takeout/__init__.py
+++ b/src/chronovista/models/takeout/__init__.py
@@ -19,7 +19,6 @@ from .recovery import (
     VideoRecoveryAction,
     extract_video_id_from_placeholder,
     is_placeholder_channel_name,
-    is_placeholder_video_title,
 )
 from .takeout_analysis import (
     ChannelSummary,
@@ -66,7 +65,6 @@ __all__ = [
     "VIDEO_PLACEHOLDER_PREFIX",
     "CHANNEL_PLACEHOLDER_PREFIX",
     "UNKNOWN_CHANNEL_PREFIX",
-    "is_placeholder_video_title",
     "is_placeholder_channel_name",
     "extract_video_id_from_placeholder",
 ]

--- a/src/chronovista/models/takeout/recovery.py
+++ b/src/chronovista/models/takeout/recovery.py
@@ -231,27 +231,18 @@ class RecoveryOptions(BaseModel):
     )
 
 
-# Constants for placeholder detection
+# Constants for placeholder detection.
+#
+# `VIDEO_PLACEHOLDER_PREFIX` is the form this project *writes*: the takeout
+# seeder normalises a URL-as-title into it on create. It is not the only form a
+# stored title can take, which is why the predicate that used to live here was
+# removed in #207 — it matched this prefix alone and so could not see the ~1,187
+# rows carrying a raw watch URL from an earlier bulk import. Services test
+# titles with `services.recovery.merge_policy.is_placeholder_title`, which
+# recognises the URL form, the bracket form and blank/whitespace.
 VIDEO_PLACEHOLDER_PREFIX = "[Placeholder] Video "
 CHANNEL_PLACEHOLDER_PREFIX = "[Placeholder]"
 UNKNOWN_CHANNEL_PREFIX = "[Unknown"
-
-
-def is_placeholder_video_title(title: str) -> bool:
-    """
-    Check if a video title is a placeholder.
-
-    Parameters
-    ----------
-    title : str
-        The video title to check
-
-    Returns
-    -------
-    bool
-        True if the title is a placeholder pattern
-    """
-    return title.startswith(VIDEO_PLACEHOLDER_PREFIX)
 
 
 def is_placeholder_channel_name(name: str) -> bool:

--- a/src/chronovista/services/enrichment/enrichment_service.py
+++ b/src/chronovista/services/enrichment/enrichment_service.py
@@ -265,7 +265,21 @@ def parse_iso8601_duration(duration_str: str) -> int:
 
 
 def is_placeholder_video_title(title: str) -> bool:
-    """Check if a video title is a placeholder."""
+    """Check if a video title is a placeholder.
+
+    .. deprecated::
+        Unused by this module and narrower than it looks: it matches the
+        bracket form only, so it cannot see a title that is a raw watch URL.
+        Priority selection does not go through here — it builds SQL directly
+        from ``VIDEO_PLACEHOLDER_PREFIX`` (see ``_build_high_priority_filter``).
+
+        New code should use
+        ``services.recovery.merge_policy.is_placeholder_title``, which
+        recognises the URL form, the bracket form and blank/whitespace. The
+        equivalent helper in ``models.takeout.recovery`` was removed in #207
+        for exactly this reason; this copy survives only because tests import
+        it, and should go the same way.
+    """
     return title.startswith(VIDEO_PLACEHOLDER_PREFIX)
 
 

--- a/src/chronovista/services/seeding/video_seeder.py
+++ b/src/chronovista/services/seeding/video_seeder.py
@@ -20,6 +20,7 @@ from ...models.takeout.takeout_data import TakeoutData, TakeoutWatchEntry
 from ...models.video import VideoCreate, VideoUpdate
 from ...repositories.channel_repository import ChannelRepository
 from ...repositories.video_repository import VideoRepository
+from ..recovery.merge_policy import is_placeholder_title
 from .base_seeder import BaseSeeder, ProgressCallback, SeedResult
 
 logger = logging.getLogger(__name__)
@@ -110,11 +111,19 @@ class VideoSeeder(BaseSeeder):
                         update_data["channel_name_hint"] = entry.channel_name
                         needs_update = True
 
-                    # Update placeholder title if we now have real title
+                    # Fill a placeholder title once a real one arrives (#207).
+                    #
+                    # Uses the canonical matcher rather than a local
+                    # `startswith("[Placeholder]")`. The create path below
+                    # normalises a URL-as-title into the bracket form, so this
+                    # branch mostly sees bracket titles — but rows written by
+                    # anything other than this seeder can carry the raw watch
+                    # URL, and a bracket-only check leaves those unfillable
+                    # forever while reporting nothing.
                     if (
-                        existing_video.title.startswith("[Placeholder]")
+                        is_placeholder_title(existing_video.title)
                         and entry.title
-                        and not entry.title.startswith("http")
+                        and not is_placeholder_title(entry.title)
                     ):
                         update_data["title"] = entry.title
                         needs_update = True

--- a/src/chronovista/services/takeout_recovery_service.py
+++ b/src/chronovista/services/takeout_recovery_service.py
@@ -21,11 +21,11 @@ from ..models.takeout import (
     RecoveryResult,
     VideoRecoveryAction,
     is_placeholder_channel_name,
-    is_placeholder_video_title,
 )
 from ..models.video import VideoUpdate
 from ..repositories.channel_repository import ChannelRepository
 from ..repositories.video_repository import VideoRepository
+from .recovery.merge_policy import is_placeholder_title
 from .takeout_service import TakeoutService
 
 logger = logging.getLogger(__name__)
@@ -200,10 +200,10 @@ class TakeoutRecoveryService:
 
             for video in videos:
                 videos_checked += 1
-                is_placeholder_title = is_placeholder_video_title(video.title)
+                is_placeholder = is_placeholder_title(video.title)
                 has_null_channel = video.channel_id is None
 
-                if is_placeholder_title:
+                if is_placeholder:
                     placeholder_count += 1
 
                 if has_null_channel:
@@ -212,7 +212,7 @@ class TakeoutRecoveryService:
                 # Check if we have recovery metadata for this video
                 if video.video_id not in video_metadata:
                     # No recovery data available
-                    if is_placeholder_title:
+                    if is_placeholder:
                         result.videos_not_recovered.append(video.video_id)
                         result.videos_still_missing += 1
                     continue
@@ -220,7 +220,7 @@ class TakeoutRecoveryService:
                 recovered = video_metadata[video.video_id]
 
                 # Determine what needs to be updated
-                needs_title_update = is_placeholder_title and recovered.title
+                needs_title_update = is_placeholder and recovered.title
                 needs_channel_update = has_null_channel and recovered.channel_id
 
                 if not needs_title_update and not needs_channel_update:
@@ -465,7 +465,7 @@ class TakeoutRecoveryService:
                 break
 
             for video in videos:
-                if is_placeholder_video_title(video.title):
+                if is_placeholder_title(video.title):
                     count += 1
 
             after = videos[-1].video_id

--- a/tests/unit/models/test_recovery_models.py
+++ b/tests/unit/models/test_recovery_models.py
@@ -24,7 +24,6 @@ from chronovista.models.takeout.recovery import (
     VideoRecoveryAction,
     extract_video_id_from_placeholder,
     is_placeholder_channel_name,
-    is_placeholder_video_title,
 )
 
 
@@ -305,26 +304,18 @@ class TestRecoveryOptions:
 class TestPlaceholderDetection:
     """Tests for placeholder detection helper functions."""
 
-    def test_is_placeholder_video_title_true(self) -> None:
-        """Test detecting placeholder video titles."""
-        assert is_placeholder_video_title("[Placeholder] Video dQw4w9WgXcQ") is True
-        assert is_placeholder_video_title("[Placeholder] Video abc123XYZ_-") is True
-
-    def test_is_placeholder_video_title_false(self) -> None:
-        """Test detecting non-placeholder video titles."""
-        assert is_placeholder_video_title("Never Gonna Give You Up") is False
-        assert is_placeholder_video_title("Some Random Video Title") is False
-        assert is_placeholder_video_title("[Other] Video Title") is False
-
-    def test_is_placeholder_video_title_edge_cases(self) -> None:
-        """Test edge cases for video placeholder detection."""
-        assert is_placeholder_video_title("") is False
-        assert (
-            is_placeholder_video_title("[Placeholder]") is False
-        )  # No " Video " prefix
-        assert (
-            is_placeholder_video_title("Placeholder Video abc") is False
-        )  # Missing brackets
+    # The video-title predicate that lived here was removed in #207. It matched
+    # the bracket form alone, so it could not see a stored title that is a raw
+    # watch URL — which is what ~1,187 rows in the library actually carry, from
+    # a single bulk import. Its replacement,
+    # `services.recovery.merge_policy.is_placeholder_title`, recognises the URL
+    # form, the bracket form and blank/whitespace, and is covered by
+    # tests/unit/services/recovery/test_merge_policy.py.
+    #
+    # `VIDEO_PLACEHOLDER_PREFIX` survives in the model module because the
+    # takeout seeder still *writes* that exact form when normalising a
+    # URL-as-title on create. Writing one shape and testing for many is the
+    # asymmetry the fix rests on.
 
     def test_is_placeholder_channel_name_true(self) -> None:
         """Test detecting placeholder channel names."""

--- a/tests/unit/services/test_takeout_recovery_service.py
+++ b/tests/unit/services/test_takeout_recovery_service.py
@@ -271,6 +271,102 @@ class TestRecoverVideos:
         assert result.video_actions[0].new_title == "Never Gonna Give You Up"
         video_repo.update.assert_called_once()
 
+    async def test_recovers_a_video_whose_title_is_the_watch_url(
+        self, mock_session: AsyncMock
+    ) -> None:
+        """#207: the URL form is a placeholder too, and it is the common one.
+
+        The predicate this service used matched `"[Placeholder] Video "` alone,
+        so a stored title that is a raw watch URL read as a REAL title and was
+        never eligible for recovery. `needs_title_update` could not become true
+        for it, whatever the archives held.
+
+        This is not a rare shape. Among unavailable videos in the production
+        library, 1,187 carry the URL form against 3 carrying the bracket form,
+        all from a single bulk import that stored the URL verbatim.
+        """
+        mock_video = MagicMock()
+        mock_video.video_id = "dQw4w9WgXcQ"
+        mock_video.title = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        mock_video.channel_id = "UCplaceholder"
+
+        video_repo = MagicMock()
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.update = AsyncMock()
+
+        channel_repo = MagicMock()
+        channel_repo.get = AsyncMock(return_value=None)
+
+        service = TakeoutRecoveryService(
+            video_repository=video_repo,
+            channel_repository=channel_repo,
+        )
+
+        video_metadata = {
+            "dQw4w9WgXcQ": RecoveredVideoMetadata(
+                video_id="dQw4w9WgXcQ",
+                title="Never Gonna Give You Up",
+                channel_name="RickAstleyVEVO",
+                channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+                source_takeout=Path("/takeouts/2024-01-15"),
+                source_date=datetime(2024, 1, 15, tzinfo=UTC),
+            )
+        }
+
+        result = RecoveryResult()
+        await service._recover_videos(
+            mock_session, video_metadata, result, RecoveryOptions()
+        )
+
+        assert result.videos_recovered == 1, (
+            "a watch-URL title was treated as a real title, so the archive's "
+            "title was discarded"
+        )
+        assert result.video_actions[0].new_title == "Never Gonna Give You Up"
+        video_repo.update.assert_called_once()
+
+    async def test_a_real_title_is_still_not_recovered(
+        self, mock_session: AsyncMock
+    ) -> None:
+        """The paired negative: widening the predicate must not widen it too far.
+
+        A title that merely *mentions* a watch URL mid-string, or is an ordinary
+        sentence, is a real value and must stay untouched. Without this, the test
+        above would pass under a predicate that returned True for everything.
+        """
+        mock_video = MagicMock()
+        mock_video.video_id = "dQw4w9WgXcQ"
+        mock_video.title = "Talk about https://www.youtube.com/watch in the middle"
+        mock_video.channel_id = "UCuAXFkgsw1L7xaCfnd5JJOw"
+
+        video_repo = MagicMock()
+        video_repo.get_multi_after = AsyncMock(side_effect=[[mock_video], []])
+        video_repo.update = AsyncMock()
+
+        service = TakeoutRecoveryService(
+            video_repository=video_repo,
+            channel_repository=MagicMock(get=AsyncMock(return_value=None)),
+        )
+
+        video_metadata = {
+            "dQw4w9WgXcQ": RecoveredVideoMetadata(
+                video_id="dQw4w9WgXcQ",
+                title="Something Else Entirely",
+                channel_name="RickAstleyVEVO",
+                channel_id="UCuAXFkgsw1L7xaCfnd5JJOw",
+                source_takeout=Path("/takeouts/2024-01-15"),
+                source_date=datetime(2024, 1, 15, tzinfo=UTC),
+            )
+        }
+
+        result = RecoveryResult()
+        await service._recover_videos(
+            mock_session, video_metadata, result, RecoveryOptions()
+        )
+
+        assert result.videos_recovered == 0
+        video_repo.update.assert_not_called()
+
     async def test_no_recovery_for_non_placeholder_with_channel(
         self, mock_session: AsyncMock
     ) -> None:

--- a/tests/unit/services/test_video_seeder.py
+++ b/tests/unit/services/test_video_seeder.py
@@ -224,7 +224,11 @@ class TestVideoSeederSeeding:
         mock_video = Mock()
         mock_video.channel_id = None  # NULL - needs update
         mock_video.channel_name_hint = None
-        mock_video.title = "[Placeholder] Video"  # Placeholder title
+        # The form the seeders actually write: prefix, space, video id. The
+        # fixture previously used a bare "[Placeholder] Video" with no id, which
+        # the old `startswith("[Placeholder]")` check happened to match but
+        # which nothing in the system produces and no row in the library holds.
+        mock_video.title = f"[Placeholder] Video {TestIds.TEST_VIDEO_1}"
 
         with (
             patch.object(


### PR DESCRIPTION
Fixes #207.

## The measurement

Same production database, same method, only the predicate differing:

| | `count_placeholder_videos()` |
|---|---|
| before | **3** |
| after | **1,193** |

The recovery service reported 3 videos as needing recovery when 1,193 did. A stored
title that is a bare watch URL read as a **real** title, so those videos were treated as
complete and `needs_title_update` could never become true for them.

1,193 reconciles with the census: 1,191 placeholder-titled among unavailable videos, plus
2 available ones.

## The fix

The recovery service and the seeder's update path now use
`services.recovery.merge_policy.is_placeholder_title`, which already recognises the URL
form, the bracket form and blank/whitespace, and is the definition the Filmot recovery
path uses.

Service to service, so the dependency points the right way. The models layer cannot
import it, which is why the narrow copy that lived there is **deleted** rather than
delegated to.

`VIDEO_PLACEHOLDER_PREFIX` stays in the model module: the seeders still write that exact
string when normalising a URL-as-title on create. **Writing one shape while testing for
many** is the asymmetry this fix rests on, and the comment there says so.

## Scope: this does not restore 92% of titles

The issue estimates that fixing the predicate unlocks titles for 92% of deleted videos.
It does not, and the PR should not imply otherwise.

Measured across all 21 Takeout exports: **0 of 1,191** currently-placeholder videos have
a real title in **any** archive. They were already deleted when the earliest export was
generated, so no export ever saw them live.

What this actually fixes is that **the count and the eligibility were silently wrong**. A
source that *does* hold those titles can now reach them. Filmot recovered 122 in a single
run; before this change the Takeout path could not have used them regardless of what it
held.

## A fourth copy, deliberately left

`enrichment_service` defines its own `is_placeholder_video_title`. It is **dead** —
priority selection builds SQL from `VIDEO_PLACEHOLDER_PREFIX` directly and never calls
it. Removing it means touching ~19 references across enrichment's tests, which is scope
creep, so it is marked deprecated with a pointer to the canonical matcher instead of
being silently left as a trap.

That also corrects something I asserted while triaging: this copy does **not** drive
enrichment priority tiers. The SQL filter does.

## One behaviour change beyond widening

The canonical matcher requires the trailing space and id (`[Placeholder] Video <id>`), so
a bare `[Placeholder] Video`, or a channel-style `[Placeholder] Something`, no longer
reads as a placeholder *video* title.

Verified before accepting it: all 3 bracket-form titles in production carry the id, both
seeders write `f"[Placeholder] Video {video_id}"`, and **zero** rows hold the bare form.
One test fixture used the bare string; it was a shape the system never produces, and it
was corrected rather than the matcher loosened.

## Verification

| | |
|---|---|
| Unit | 6,992 → **6,991** (+2 new, −3 removed with the deleted predicate) |
| Integration | **1,355**, unchanged |
| Frontend typecheck + vitest | **3,940** passed, unchanged |
| mypy `--strict`, ruff, black | clean |
| Mutations | **both directions** |
| Manual, against production | 3 → 1,193, read-only |

Mutation detail: restoring the bracket-only predicate fails the new URL test; making the
predicate always-true fails five other tests. The fix is pinned from both sides, so it
cannot be satisfied by a predicate that simply says yes to everything.

The two new tests are paired on purpose — a video whose title *is* a watch URL is
recovered, and a video whose title merely *contains* one mid-string is not.
